### PR TITLE
Use directory URLs until s3 redirects are fixed

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -49,3 +49,4 @@ markdown_extensions:
 - admonition
 - codehilite:
     linenums: true
+use_directory_urls: false


### PR DESCRIPTION
Fixes directory urls until s3 redirects are fixed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
