### PR TITLE
Fixed non-inclusive language

### DIFF
--- a/projects/kubernetes/kubernetes/1-18/patches/0001-EKS-PATCH-Added-allowlist-CIDR-flag-use-klog.patch
+++ b/projects/kubernetes/kubernetes/1-18/patches/0001-EKS-PATCH-Added-allowlist-CIDR-flag-use-klog.patch
@@ -1,7 +1,7 @@
 From 86a72356c233c36dab0a6878e20f3e94f2197ab2 Mon Sep 17 00:00:00 2001
 From: Micah Hausler <mhausler@amazon.com>
 Date: Wed, 19 Sep 2018 18:16:23 -0700
-Subject: [PATCH 01/16] --EKS-PATCH-- Added whitelist CIDR flag, use "klog"
+Subject: [PATCH 01/16] --EKS-PATCH-- Added allowlist CIDR flag, use "klog"
 
 Alternative to https://github.com/kubernetes/kubernetes/pull/71980
 
@@ -9,15 +9,19 @@ Cherry-picked from https://github.com/kubernetes/kubernetes/commit/7e814da396692
 
 cmd/kube-apiserver: use "klog" instead of "glog"
 
+To maintain backwards compatibility, the "--proxy-cidr-whitelist" flag must remain, despite containing the non-inclusive
+term "whitelist". The "--proxy-cidr-allowlist" flag has the same functionality and should be used instead of it. Future
+releases should consider removing the non-inclusive flag.
+
 Signed-off-by: Gyuho Lee <leegyuho@amazon.com>
 Signed-off-by: Jackson West <jgw@amazon.com>
 ---
  cmd/kube-apiserver/app/BUILD                 |  1 +
  cmd/kube-apiserver/app/dialer.go             | 46 ++++++++++
  cmd/kube-apiserver/app/options/BUILD         |  1 +
- cmd/kube-apiserver/app/options/options.go    |  6 ++
+ cmd/kube-apiserver/app/options/options.go    |  9 ++
  cmd/kube-apiserver/app/options/validation.go | 15 ++++
- cmd/kube-apiserver/app/options/whitelist.go  |  9 ++
+ cmd/kube-apiserver/app/options/allowlist.go  |  9 ++
  cmd/kube-apiserver/app/server.go             |  6 ++
  pkg/kubeapiserver/options/BUILD              |  3 +
  pkg/kubeapiserver/options/ipnetslice.go      | 93 ++++++++++++++++++++
@@ -25,9 +29,9 @@ Signed-off-by: Jackson West <jgw@amazon.com>
  pkg/kubeapiserver/options/options.go         |  1 +
  pkg/registry/core/node/BUILD                 |  1 +
  pkg/registry/core/node/strategy.go           | 14 +++
- 13 files changed, 232 insertions(+)
+ 13 files changed, 235 insertions(+)
  create mode 100644 cmd/kube-apiserver/app/dialer.go
- create mode 100644 cmd/kube-apiserver/app/options/whitelist.go
+ create mode 100644 cmd/kube-apiserver/app/options/allowlist.go
  create mode 100644 pkg/kubeapiserver/options/ipnetslice.go
  create mode 100644 pkg/kubeapiserver/options/ipnetslice_test.go
 
@@ -68,7 +72,7 @@ index 00000000000..4a0486baa8a
 +)
 +
 +func CreateOutboundDialer(s completedServerRunOptions) (*http.Transport, error) {
-+	proxyDialerFn := createWhitelistDialer(s.ProxyCIDRWhitelist)
++	proxyDialerFn := createAllowlistDialer(s.ProxyCIDRAllowlist)
 +
 +	proxyTLSClientConfig := &tls.Config{InsecureSkipVerify: true}
 +
@@ -79,7 +83,7 @@ index 00000000000..4a0486baa8a
 +	return proxyTransport, nil
 +}
 +
-+func createWhitelistDialer(whitelist kubeoptions.IPNetSlice) func(context.Context, string, string) (net.Conn, error) {
++func createAllowlistDialer(allowlist kubeoptions.IPNetSlice) func(context.Context, string, string) (net.Conn, error) {
 +	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 +		start := time.Now()
 +		id := mathrand.Int63() // So you can match begins/ends in the log.
@@ -88,7 +92,7 @@ index 00000000000..4a0486baa8a
 +			klog.Infof("[%x: %v] Dialed in %v.", id, addr, time.Since(start))
 +		}()
 +
-+		if !whitelist.Contains(strings.Split(addr, ":")[0]) {
++		if !allowlist.Contains(strings.Split(addr, ":")[0]) {
 +			return nil, errors.New("Address is not allowed")
 +		}
 +		dialer := &net.Dialer{}
@@ -103,7 +107,7 @@ index b833a85aeba..e66e8058e4b 100644
          "globalflags_providers.go",
          "options.go",
          "validation.go",
-+        "whitelist.go",
++        "allowlist.go",
      ],
      importpath = "k8s.io/kubernetes/cmd/kube-apiserver/app/options",
      deps = [
@@ -115,7 +119,7 @@ index e64604758db..0fc452410d3 100644
  	KubeletConfig             kubeletclient.KubeletClientConfig
  	KubernetesServiceNodePort int
  	MaxConnectionBytesPerSec  int64
-+	ProxyCIDRWhitelist        kubeoptions.IPNetSlice
++	ProxyCIDRAllowlist        kubeoptions.IPNetSlice
  	// ServiceClusterIPRange is mapped to input provided by user
  	ServiceClusterIPRanges string
  	//PrimaryServiceClusterIPRange and SecondaryServiceClusterIPRange are the results
@@ -124,16 +128,19 @@ index e64604758db..0fc452410d3 100644
  		ServiceNodePortRange: kubeoptions.DefaultServiceNodePortRange,
  	}
 +	s.ServiceClusterIPRanges = kubeoptions.DefaultServiceIPCIDR.String()
-+	s.ProxyCIDRWhitelist = kubeoptions.DefaultProxyCIDRWhitelist
++	s.ProxyCIDRAllowlist = kubeoptions.DefaultProxyCIDRAllowlist
  
  	// Overwrite the default for storage data format.
  	s.Etcd.DefaultStorageMediaType = "application/vnd.kubernetes.protobuf"
-@@ -200,6 +203,9 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
+@@ -200,6 +203,12 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
  		"A CIDR notation IP range from which to assign service cluster IPs. This must not "+
  		"overlap with any IP ranges assigned to nodes for pods.")
  
-+	fs.Var(&s.ProxyCIDRWhitelist, "proxy-cidr-whitelist", ""+
++	fs.Var(&s.ProxyCIDRAllowlist, "proxy-cidr-allowlist", ""+
 +		"A comma-separated list of CIDR IP ranges which the API server can communicate with.")
++
++	fs.Var(&s.ProxyCIDRAllowlist, "proxy-cidr-whitelist", ""+
++		"Deprecated: Use '--proxy-cidr-allowlist' flag instead.")
 +
  	fs.Var(&s.ServiceNodePortRange, "service-node-port-range", ""+
  		"A port range to reserve for services with NodePort visibility. "+
@@ -146,13 +153,13 @@ index 4f94e438d00..5926205e201 100644
  	netutils "k8s.io/utils/net"
  )
  
-+func validateProxyCIDRWhitelist(options *ServerRunOptions) []error {
++func validateProxyCIDRAllowlist(options *ServerRunOptions) []error {
 +	errors := []error{}
 +
 +	// if its empty, don't add any IPs to the list
-+	for _, cidr := range options.ProxyCIDRWhitelist {
++	for _, cidr := range options.ProxyCIDRAllowlist {
 +		if cidr.IP == nil {
-+			errors = append(errors, fmt.Errorf("invalid --proxy-cidr-whitelist specified"))
++			errors = append(errors, fmt.Errorf("invalid --proxy-cidr-allowlist (or --proxy-cidr-whitelist) specified"))
 +		}
 +	}
 +	return errors
@@ -165,17 +172,17 @@ index 4f94e438d00..5926205e201 100644
  		errs = append(errs, fmt.Errorf("--apiserver-count should be a positive number, but value '%d' provided", s.MasterCount))
  	}
  	errs = append(errs, s.Etcd.Validate()...)
-+	if es := validateProxyCIDRWhitelist(s); len(es) > 0 {
++	if es := validateProxyCIDRAllowlist(s); len(es) > 0 {
 +		errs = append(errs, es...)
 +	}
  	errs = append(errs, validateClusterIPFlags(s)...)
  	errs = append(errs, validateServiceNodePort(s)...)
  	errs = append(errs, s.SecureServing.Validate()...)
-diff --git a/cmd/kube-apiserver/app/options/whitelist.go b/cmd/kube-apiserver/app/options/whitelist.go
+diff --git a/cmd/kube-apiserver/app/options/allowlist.go b/cmd/kube-apiserver/app/options/allowlist.go
 new file mode 100644
 index 00000000000..6accbd0ab2c
 --- /dev/null
-+++ b/cmd/kube-apiserver/app/options/whitelist.go
++++ b/cmd/kube-apiserver/app/options/allowlist.go
 @@ -0,0 +1,9 @@
 +package options
 +
@@ -184,7 +191,7 @@ index 00000000000..6accbd0ab2c
 +)
 +
 +var (
-+	ProxyCIDRWhitelist kubeoptions.IPNetSlice = kubeoptions.DefaultProxyCIDRWhitelist
++	ProxyCIDRAllowlist kubeoptions.IPNetSlice = kubeoptions.DefaultProxyCIDRAllowlist
 +)
 diff --git a/cmd/kube-apiserver/app/server.go b/cmd/kube-apiserver/app/server.go
 index 70a496913fd..e7d3a51767c 100644
@@ -284,7 +291,7 @@ index 00000000000..c38fa6cd3ce
 +	return "[]net.IPNet"
 +}
 +
-+// ContainsHost checks if all the IPs for a given hostname are in the whitelist
++// ContainsHost checks if all the IPs for a given hostname are in the allowlist
 +func (netSlice *IPNetSlice) ContainsHost(ctx context.Context, host string) (bool, error) {
 +	r := net.Resolver{}
 +	resp, err := r.LookupIPAddr(ctx, host)
@@ -292,7 +299,7 @@ index 00000000000..c38fa6cd3ce
 +		return false, err
 +	}
 +	for _, host := range resp {
-+		// reject if any of the IPs for a hostname are not in the whitelist
++		// reject if any of the IPs for a hostname are not in the allowlist
 +		if !netSlice.Contains(host.String()) {
 +			return false, nil
 +		}
@@ -300,9 +307,9 @@ index 00000000000..c38fa6cd3ce
 +	return true, nil
 +}
 +
-+// Contains checks if a given IP is in the whitelist
++// Contains checks if a given IP is in the allowlist
 +func (netSlice *IPNetSlice) Contains(ip string) bool {
-+	// if there are no whitelists, everything is allowed
++	// if there are no allowlists, everything is allowed
 +	if len(*netSlice) == 0 {
 +		return true
 +	}
@@ -373,7 +380,7 @@ index e38bd99996d..e8b141016e2 100644
  var DefaultServiceIPCIDR net.IPNet = net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}
  
  const DefaultEtcdPathPrefix = "/registry"
-+var DefaultProxyCIDRWhitelist IPNetSlice = NewIPNetSlice("0.0.0.0/0")
++var DefaultProxyCIDRAllowlist IPNetSlice = NewIPNetSlice("0.0.0.0/0")
 diff --git a/pkg/registry/core/node/BUILD b/pkg/registry/core/node/BUILD
 index 0a76925b89b..dffe8ddd95e 100644
 --- a/pkg/registry/core/node/BUILD
@@ -404,7 +411,7 @@ index 1ca914b6a49..7a5c7b49ae7 100644
  
 +	// REVIEW NOTE:
 +	// I didn't see a better way to plumb this down here. Feature gates are globals too, but I'd be happy to get the CIDRs here another way
-+	included, err := kubeapiserveroptions.ProxyCIDRWhitelist.ContainsHost(
++	included, err := kubeapiserveroptions.ProxyCIDRAllowlist.ContainsHost(
 +		ctx,
 +		info.Hostname,
 +	)

--- a/projects/kubernetes/kubernetes/1-18/patches/0004-EKS-PATCH-volume-plugin-requests-patch.patch
+++ b/projects/kubernetes/kubernetes/1-18/patches/0004-EKS-PATCH-volume-plugin-requests-patch.patch
@@ -5,14 +5,18 @@ Subject: [PATCH 04/16] --EKS-PATCH-- volume plugin requests patch
 
 Mitigation for CVE-2020-8555
 
+To maintain backwards compatibility, the "EXTRA_PROXY_BLACKLIST_CIDR" env var must be accepted, despite containing the
+non-inclusive term "BLACKLIST". The "EXTRA_PROXY_DENYLIST_CIDR" env var has the same functionality and should be used
+instead of it. Future releases should consider supporting only the inclusive variable.
+
 Signed-off-by: Jackson West <jgw@amazon.com>
 ---
- pkg/proxy/util/utils.go                       | 59 ++++++++++++++++++-
+ pkg/proxy/util/utils.go                       | 63 +++++++++++++++++++-
  .../heketi/client/api/go-client/client.go     | 19 +++++-
  vendor/github.com/quobyte/api/quobyte.go      | 18 +++++-
  vendor/github.com/storageos/go-api/client.go  |  5 +-
- .../github.com/thecodeteam/goscaleio/api.go   | 11 +++-
- 5 files changed, 106 insertions(+), 6 deletions(-)
+ .../github.com/thecodeteam/goscaleio/api.go   |  9 +++
+ 5 files changed, 109 insertions(+), 5 deletions(-)
 
 diff --git a/pkg/proxy/util/utils.go b/pkg/proxy/util/utils.go
 index b4f1b4304c1..df18630ef00 100644
@@ -31,21 +35,22 @@ index b4f1b4304c1..df18630ef00 100644
  
  	v1 "k8s.io/api/core/v1"
  	"k8s.io/apimachinery/pkg/types"
-@@ -39,7 +43,8 @@ const (
+@@ -39,7 +43,9 @@ const (
  	IPv4ZeroCIDR = "0.0.0.0/0"
  
  	// IPv6ZeroCIDR is the CIDR block for the whole IPv6 address space
 -	IPv6ZeroCIDR = "::/0"
 +	IPv6ZeroCIDR               = "::/0"
-+	EnvExtraProxyBlackListCIDR = "EXTRA_PROXY_BLACKLIST_CIDR"
++	EnvExtraProxyBlackListCIDR = "EXTRA_PROXY_BLACKLIST_CIDR" // Use the more inclusive EnvExtraProxyDenyListCIDR instead
++	EnvExtraProxyDenyListCIDR = "EXTRA_PROXY_DENYLIST_CIDR"
  )
  
  var (
-@@ -123,6 +128,29 @@ func IsProxyableHostname(ctx context.Context, resolv Resolver, hostname string)
+@@ -123,6 +129,29 @@ func IsProxyableHostname(ctx context.Context, resolv Resolver, hostname string)
  	return nil
  }
  
-+func IsProxyableHostnameV2(ctx context.Context, resolv Resolver, blackListNetworks []*net.IPNet, hostname string) error {
++func IsProxyableHostnameV2(ctx context.Context, resolv Resolver, denyListNetworks []*net.IPNet, hostname string) error {
 +	resp, err := resolv.LookupIPAddr(ctx, hostname)
 +	if err != nil {
 +		return err
@@ -59,7 +64,7 @@ index b4f1b4304c1..df18630ef00 100644
 +		if err := isProxyableIP(host.IP); err != nil {
 +			return err
 +		}
-+		for _, network := range blackListNetworks {
++		for _, network := range denyListNetworks {
 +			if network.Contains(host.IP) {
 +				return ErrAddressNotAllowed
 +			}
@@ -71,17 +76,20 @@ index b4f1b4304c1..df18630ef00 100644
  // GetLocalAddrs returns a list of all network addresses on the local system
  func GetLocalAddrs() ([]net.IP, error) {
  	var localAddrs []net.IP
-@@ -159,6 +187,35 @@ func ShouldSkipService(svcName types.NamespacedName, service *v1.Service) bool {
+@@ -159,6 +188,38 @@ func ShouldSkipService(svcName types.NamespacedName, service *v1.Service) bool {
  	return false
  }
  
 +func NewSafeDialContext(dialContext func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {
-+	var blackListNetworks []*net.IPNet
-+	blackListCIDRs := os.Getenv(EnvExtraProxyBlackListCIDR)
-+	if blackListCIDRs != "" {
-+		for _, cidr := range strings.Split(blackListCIDRs, ",") {
++	var denyListNetworks []*net.IPNet
++	denyListCIDRs := os.Getenv(EnvExtraProxyDenyListCIDR)
++	if denyListCIDRs == "" {
++   	denyListCIDRs = os.Getenv(EnvExtraProxyBlackListCIDR) // Use the more inclusive EnvExtraProxyDenyListCIDR instead
++   }
++	if denyListCIDRs != "" {
++		for _, cidr := range strings.Split(denyListCIDRs, ",") {
 +			_, ipNet, _ := net.ParseCIDR(cidr)
-+			blackListNetworks = append(blackListNetworks, ipNet)
++			denyListNetworks = append(denyListNetworks, ipNet)
 +		}
 +	}
 +
@@ -97,7 +105,7 @@ index b4f1b4304c1..df18630ef00 100644
 +		if err != nil {
 +			return nil, err
 +		}
-+		if err := IsProxyableHostnameV2(ctx, &net.Resolver{}, blackListNetworks, host); err != nil {
++		if err := IsProxyableHostnameV2(ctx, &net.Resolver{}, denyListNetworks, host); err != nil {
 +			return nil, err
 +		}
 +		return dialContext(ctx, network, addr)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Changed non-inclusive language wherever possible. The letter cases were preserved. Changes reflect what was advised in the Naming Working Group [guidelines](https://github.com/kubernetes/community/blob/master/wg-naming/language-evaluation-framework.md) for the Kubernetes community.
* Most changes were along the lines of the following:
  * whitelist -> allowlist
  * blacklist -> denylist

*Scope*
Not all instances of non-inclusive language could be easily fixed at this time, as they often were outside the control of this repo. For example, some urls to other GitHub repos included "master". Changing those in this PR would break the link. Also, some upstream Kubernetes packages include non-inclusive terminology, like "master" and "slave". This problematic language should be addressed in upstream Kubernetes or in future patches to this repo if possible.

As this PR may not resolve all the non-inclusive language problems, additional revisions should be made  to adhere to any future changes in the Kubernetes community's guidelines about inclusion and in accordance to open source best practices.  

*Testing*
`make binaries` and `make tarballs` worked for kubernetes/kubernetes. Additional testing may be needed. **Please hold until this is confirmed.**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
