### PR TITLE
Use /dev/urandom instead of /dev/random

### DIFF
--- a/development/kops.sh
+++ b/development/kops.sh
@@ -23,7 +23,7 @@ export CNI_VERSION_URL=https://distro.eks.amazonaws.com/kubernetes-1-18/releases
 export CNI_ASSET_HASH_STRING=sha256:7426431524c2976f481105b80497238030e1c3eedbfcad00e2a9ccbaaf9eef9d
 
 # Create a unique s3 bucket name, or use an existing S3_BUCKET environment variable
-export S3_BUCKET=${S3_BUCKET:-"kops-state-store-$(cat /dev/random | LC_ALL=C tr -dc "[:alpha:]" | tr '[:upper:]' '[:lower:]' | head -c 32)"}
+export S3_BUCKET=${S3_BUCKET:-"kops-state-store-$(cat /dev/urandom | LC_ALL=C tr -dc "[:alpha:]" | tr '[:upper:]' '[:lower:]' | head -c 32)"}
 export KOPS_STATE_STORE=s3://$S3_BUCKET
 echo "Using S3 bucket $S3_BUCKET: to use with kops run"
 echo


### PR DESCRIPTION
While trying out EKS-D on Ubuntu 20.04.1 LTS, the script
`./development/kops.sh` got stuck doing `cat /dev/random`.
This happened likely due to entropy exhaustion. EKS-D
needs a source of randomless to generate a kops state S3 bucket
name, hence using `urandom` is acceptable.

*Issue #, if available:* N/A

*Description of changes:*

After this change, `kops.sh` will use `/dev/urandom` instead of `/dev/random` for generating a random name for the kops S3 bucket name. This will likely improve user experience, since `/dev/random` may get stuck when system entropy is low.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
