### PR TITLE
change kops script to use template

### DIFF
--- a/development/eks-d.tpl
+++ b/development/eks-d.tpl
@@ -15,13 +15,13 @@ spec:
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:
-    - instanceGroup: master-us-west-2a
+    - instanceGroup: control-plane-{{.awsRegion}}a
       name: a
     memoryRequest: 100Mi
     name: main
   - cpuRequest: 100m
     etcdMembers:
-    - instanceGroup: master-us-west-2a
+    - instanceGroup: control-plane-{{.awsRegion}}a
       name: a
     memoryRequest: 100Mi
     name: events
@@ -42,17 +42,17 @@ spec:
   - 0.0.0.0/0
   subnets:
   - cidr: 172.20.32.0/19
-    name: us-west-2a
+    name: {{.awsRegion}}a
     type: Public
-    zone: us-west-2a
+    zone: {{.awsRegion}}a
   - cidr: 172.20.64.0/19
-    name: us-west-2b
+    name: {{.awsRegion}}b
     type: Public
-    zone: us-west-2b
+    zone: {{.awsRegion}}b
   - cidr: 172.20.96.0/19
-    name: us-west-2c
+    name: {{.awsRegion}}c
     type: Public
-    zone: us-west-2c
+    zone: {{.awsRegion}}c
   topology:
     dns:
       type: Public
@@ -108,17 +108,17 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: {{.clusterName}}
-  name: master-us-west-2a
+  name: control-plane-{{.awsRegion}}a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026
   machineType: t3.medium
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-us-west-2a
+    kops.k8s.io/instancegroup: control-plane-{{.awsRegion}}a
   role: Master
   subnets:
-  - us-west-2a
+  - {{.awsRegion}}a
 
 ---
 
@@ -138,6 +138,6 @@ spec:
     kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
-  - us-west-2a
-  - us-west-2b
-  - us-west-2c
+  - {{.awsRegion}}a
+  - {{.awsRegion}}b
+  - {{.awsRegion}}c

--- a/development/eks-d.tpl
+++ b/development/eks-d.tpl
@@ -1,0 +1,143 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: null
+  name: {{ .clusterName }}
+spec:
+  api:
+    dns: {}
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: {{ .configBase }}
+  containerRuntime: docker
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - instanceGroup: master-us-west-2a
+      name: a
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+    - instanceGroup: master-us-west-2a
+      name: a
+    memoryRequest: 100Mi
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubelet:
+    anonymousAuth: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: {{ .kubernetesVersion }}
+  masterPublicName: api.{{ .clusterName }}
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-west-2a
+    type: Public
+    zone: us-west-2a
+  - cidr: 172.20.64.0/19
+    name: us-west-2b
+    type: Public
+    zone: us-west-2b
+  - cidr: 172.20.96.0/19
+    name: us-west-2c
+    type: Public
+    zone: us-west-2c
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+  kubeAPIServer:
+    image: public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.18.9-eks-1-18-1
+  kubeControllerManager:
+    image: public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.18.9-eks-1-18-1
+  kubeScheduler:
+    image: public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.18.9-eks-1-18-1
+  kubeProxy:
+    image: public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.18.9-eks-1-18-1
+  # Metrics Server will be supported with kops 1.19
+  metricsServer:
+    enabled: true
+    image: public.ecr.aws/eks-distro/kubernetes-sigs/metrics-server:v0.4.0-eks-1-18-1
+  authentication:
+    aws:
+      image: public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.5.2-eks-1-18-1
+  kubeDNS:
+    provider: CoreDNS
+    coreDNSImage: public.ecr.aws/eks-distro/coredns/coredns:v1.7.0-eks-1-18-1
+    externalCoreFile: |
+      .:53 {
+          errors
+          health {
+            lameduck 5s
+          }
+          kubernetes cluster.local. in-addr.arpa ip6.arpa {
+            pods insecure
+            #upstream
+            fallthrough in-addr.arpa ip6.arpa
+          }
+          prometheus :9153
+          forward . /etc/resolv.conf
+          loop
+          cache 30
+          loadbalance
+          reload
+      }
+  masterKubelet:
+    podInfraContainerImage: public.ecr.aws/eks-distro/kubernetes/pause:v1.18.9-eks-1-18-1
+  # kubelet might already be defined, append the following config
+  kubelet:
+    podInfraContainerImage: public.ecr.aws/eks-distro/kubernetes/pause:v1.18.9-eks-1-18-1
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: {{.clusterName}}
+  name: master-us-west-2a
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026
+  machineType: m5.large
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-west-2a
+  role: Master
+  subnets:
+  - us-west-2a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: {{.clusterName}}
+  name: nodes
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026
+  machineType: m5.xlarge
+  maxSize: 3
+  minSize: 3
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  subnets:
+  - us-west-2a
+  - us-west-2b
+  - us-west-2c

--- a/development/eks-d.tpl
+++ b/development/eks-d.tpl
@@ -111,7 +111,7 @@ metadata:
   name: master-us-west-2a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026
-  machineType: m5.large
+  machineType: t3.medium
   maxSize: 1
   minSize: 1
   nodeLabels:
@@ -131,7 +131,7 @@ metadata:
   name: nodes
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026
-  machineType: m5.xlarge
+  machineType: t3.medium
   maxSize: 3
   minSize: 3
   nodeLabels:

--- a/development/kops.sh
+++ b/development/kops.sh
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 set -eo pipefail
-set -x
 
 if [ -z "$CLUSTER_NAME" ]; then
     echo "Cluster name must be an FQDN: <yourcluster>.yourdomain.com or <yourcluster>.sub.yourdomain.com"
@@ -96,13 +95,19 @@ export CREATE_CLUSTER=${CREATE_CLUSTER:-y}
 # Test variable as lowercase
 if [ $(echo ${CREATE_CLUSTER} | tr '[:upper:]' '[:lower:]') == "y" ]; then
 	kops update cluster $CLUSTER_NAME --yes
-	kops validate cluster --wait 10m
-	kubectl apply -f ./aws-iam-authenticator.yaml
+	echo ""
+	echo "You can validate your cluster with"
+	echo "KOPS_STATE_STORE=$KOPS_STATE_STORE kops validate cluster --wait 10m"
 else
 	echo "Skipping cluster create"
 	echo "Run this command whenever you're ready"
 	echo ""
-	echo "kops update cluster $CLUSTER_NAME --yes"
+	echo "KOPS_STATE_STORE=$KOPS_STATE_STORE kops update cluster $CLUSTER_NAME --yes"
 	echo ""
 fi
 
+echo "Kops state is stored in $KOPS_STATE_STORE"
+echo ""
+echo "You will need to manually deploy the aws authenticator config once the cluster is ready with"
+echo ""
+echo "kubectl apply -f ./aws-iam-authenticator.yaml"

--- a/development/kops.sh
+++ b/development/kops.sh
@@ -74,6 +74,7 @@ if [ "$(echo ${DELETE_VALUES} | tr '[:upper:]' '[:lower:]')" == "y" ]; then
 kubernetesVersion: $KUBERNETES_VERSION
 clusterName: $CLUSTER_NAME
 configBase: $KOPS_STATE_STORE
+awsRegion: $AWS_DEFAULT_REGION
 EOF
 else
 	echo "Skipping delete and exiting"

--- a/development/kops.sh
+++ b/development/kops.sh
@@ -13,12 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -eo pipefail
+set -x
 
 if [ -z "$CLUSTER_NAME" ]; then
     echo "Cluster name must be an FQDN: <yourcluster>.yourdomain.com or <yourcluster>.sub.yourdomain.com"
     read -r -p "What is the name of your Cluster? " CLUSTER_NAME
 fi
 
+if [ -z "$AWS_DEFAULT_REGION" ]; then
+	  echo "Please set a default region for the kops config bucket (e.g. us-west-2)"
+	  read -r -p "What region would you like to store the config? " AWS_DEFAULT_REGION
+fi
+
+export KUBERNETES_VERSION=https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/kubernetes/v1.18.9
 export CNI_VERSION_URL=https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/plugins/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tar.gz
 export CNI_ASSET_HASH_STRING=sha256:7426431524c2976f481105b80497238030e1c3eedbfcad00e2a9ccbaaf9eef9d
 
@@ -26,11 +34,6 @@ export CNI_ASSET_HASH_STRING=sha256:7426431524c2976f481105b80497238030e1c3eedbfc
 export S3_BUCKET=${S3_BUCKET:-"kops-state-store-$(cat /dev/urandom | LC_ALL=C tr -dc "[:alpha:]" | tr '[:upper:]' '[:lower:]' | head -c 32)"}
 export KOPS_STATE_STORE=s3://$S3_BUCKET
 echo "Using S3 bucket $S3_BUCKET: to use with kops run"
-echo
-echo "    export KOPS_STATE_STORE=s3://$S3_BUCKET"
-echo "    export CNI_VERSION_URL=$CNI_VERSION_URL"
-echo "    export CNI_ASSET_HASH_STRING=$CNI_ASSET_HASH_STRING"
-echo
 
 # Create the bucket if it doesn't exist
 _bucket_name=$(aws s3api list-buckets  --query "Buckets[?Name=='$S3_BUCKET'].Name | [0]" --out text)
@@ -43,59 +46,63 @@ if [ $_bucket_name == "None" ]; then
     fi
 fi
 
-kops create cluster $CLUSTER_NAME \
-    --zones "us-west-2a,us-west-2b,us-west-2c" \
-    --master-zones "us-west-2a" \
-    --networking kubenet \
-    --node-count 3 \
-    --node-size m5.xlarge \
-    --kubernetes-version https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/kubernetes/v1.18.9 \
-    --master-size m5.large \
-    --dry-run \
-    -o yaml > $CLUSTER_NAME.yaml
-echo "Add the following content to your Cluster spec in $CLUSTER_NAME.yaml"
-echo
-cat << EOF >> /dev/stdout
-  kubeAPIServer:
-    image: public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.18.9-eks-1-18-1
-  kubeControllerManager:
-    image: public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.18.9-eks-1-18-1
-  kubeScheduler:
-    image: public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.18.9-eks-1-18-1
-  kubeProxy:
-    image: public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.18.9-eks-1-18-1
-  # Metrics Server will be supported with kops 1.19
-  metricsServer:
-    enabled: true
-    image: public.ecr.aws/eks-distro/kubernetes-sigs/metrics-server:v0.4.0-eks-1-18-1
-  authentication:
-    aws:
-      image: public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.5.2-eks-1-18-1
-  kubeDNS:
-    provider: CoreDNS
-    coreDNSImage: public.ecr.aws/eks-distro/coredns/coredns:v1.7.0-eks-1-18-1
-    externalCoreFile: |
-      .:53 {
-          errors
-          health {
-            lameduck 5s
-          }
-          kubernetes cluster.local. in-addr.arpa ip6.arpa {
-            pods insecure
-            #upstream
-            fallthrough in-addr.arpa ip6.arpa
-          }
-          prometheus :9153
-          forward . /etc/resolv.conf
-          loop
-          cache 30
-          loadbalance
-          reload
-      }
-  masterKubelet:
-    podInfraContainerImage: public.ecr.aws/eks-distro/kubernetes/pause:v1.18.9-eks-1-18-1
-  # kubelet might already be defined, append the following config
-  kubelet:
-    podInfraContainerImage: public.ecr.aws/eks-distro/kubernetes/pause:v1.18.9-eks-1-18-1
+# Write aws-iam-authenticator.yaml file for later
+cat << EOF > aws-iam-authenticator.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-iam-authenticator
+  namespace: kube-system
+  labels:
+    k8s-app: aws-iam-authenticator
+data:
+  config.yaml: |
+    clusterID: $CLUSTER_NAME
 EOF
+
+# Check if the config file already has config in it
+if [ -f values.yaml ]; then
+	echo "A values.yaml file already exists"
+	read -r -p "Would you like to delete it and create a new cluster? [Y/n] " DELETE_VALUES
+	DELETE_VALUES=${DELETE_VALUES:-y}
+fi
+if [ $(echo ${DELETE_VALUES} | tr '[:upper:]' '[:lower:]') == "y" ]; then
+	rm values.yaml
+	cat << EOF > values.yaml
+kubernetesVersion: $KUBERNETES_VERSION
+clusterName: $CLUSTER_NAME
+configBase: $KOPS_STATE_STORE
+EOF
+else
+	echo "Skipping delete and exiting"
+	exit
+fi
+
+kops toolbox template --template eks-d.tpl --values values.yaml > "${CLUSTER_NAME}".yaml
+
+echo "Creating cluster"
+echo
+kops create -f ./"${CLUSTER_NAME}".yaml
+
+echo "Creating cluster ssh key"
+# Allow users to set an SSH key
+export SSH_KEY_PATH=${SSH_KEY_PATH:-$HOME/.ssh/id_rsa.pub}
+kops create secret --name $CLUSTER_NAME sshpublickey admin -i ${SSH_KEY_PATH}
+
+read -r -p "Do you want to create the cluster now? [Y/n] " CREATE_CLUSTER
+# Set a default value
+export CREATE_CLUSTER=${CREATE_CLUSTER:-y}
+
+# Test variable as lowercase
+if [ $(echo ${CREATE_CLUSTER} | tr '[:upper:]' '[:lower:]') == "y" ]; then
+	kops update cluster $CLUSTER_NAME --yes
+	kops validate cluster --wait 10m
+	kubectl apply -f ./aws-iam-authenticator.yaml
+else
+	echo "Skipping cluster create"
+	echo "Run this command whenever you're ready"
+	echo ""
+	echo "kops update cluster $CLUSTER_NAME --yes"
+	echo ""
+fi
 

--- a/development/kops.sh
+++ b/development/kops.sh
@@ -63,10 +63,13 @@ EOF
 if [ -f values.yaml ]; then
 	echo "A values.yaml file already exists"
 	read -r -p "Would you like to delete it and create a new cluster? [Y/n] " DELETE_VALUES
-	DELETE_VALUES=${DELETE_VALUES:-y}
 fi
-if [ $(echo ${DELETE_VALUES} | tr '[:upper:]' '[:lower:]') == "y" ]; then
-	rm values.yaml
+
+DELETE_VALUES=${DELETE_VALUES:-y}
+if [ "$(echo ${DELETE_VALUES} | tr '[:upper:]' '[:lower:]')" == "y" ]; then
+	if [ -f values.yaml ]; then
+		rm values.yaml
+	fi
 	cat << EOF > values.yaml
 kubernetesVersion: $KUBERNETES_VERSION
 clusterName: $CLUSTER_NAME

--- a/docs/contents/users/index.md
+++ b/docs/contents/users/index.md
@@ -23,31 +23,15 @@ for a domain you control. Refer to the [kops
 documentation](https://kops.sigs.k8s.io/getting_started/aws/) for
 full instructions.
 
-After you run the script, be sure to run the `export KOPS_STATE_STORE=...`
-command specified, and edit the yaml file with the output the script provides.
-
-You will then need to run the following commands:
+You will then need to run the following:
 ```bash
-# Set to your cluster name
-CLUSTER_NAME=my-super-cool-cluster.mydomain.com
-kops create -f ./$CLUSTER_NAME.yaml
-kops create secret --name $CLUSTER_NAME sshpublickey admin -i ~/.ssh/id_rsa.pub
-kops update cluster $CLUSTER_NAME --yes
-kops validate cluster --wait 10m
-cat << EOF > aws-iam-authenticator.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: aws-iam-authenticator
-  namespace: kube-system
-  labels:
-    k8s-app: aws-iam-authenticator
-data:
-  config.yaml: |
-    clusterID: $CLUSTER_NAME
-EOF
-kubectl apply -f aws-iam-authenticator.yaml
+cd development
+./kops.sh
 ```
+
+Your cluster variables will be stored in the values.yaml file.
+If you want to create a new cluster you can delete that file and run `kops.sh` again.
+
 You can verify the pods in your cluster are using the EKS Distro images by running
 the following command:
 ```bash


### PR DESCRIPTION
*Description of changes:*

This change updates the development/kops.sh script to use a template instead of requiring manual editing of the cluster file.

This change uses a [kops cluster template](https://github.com/kubernetes/kops/blob/master/docs/operations/cluster_template.md) and generates a values.yaml file to merge config into a `$CLUSTER.yaml` file.

This also will allow us to separate out more variables from the config to allow users to deploy to different regions and change other config.

You should be able to clone this branch and run `./development/kops.sh` and be prompted for all of the necessary information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
