### PR TITLE
Create cluster in AWS_DEFAULT_REGION

### DIFF
--- a/development/kops.sh
+++ b/development/kops.sh
@@ -19,6 +19,9 @@ if [ -z "$CLUSTER_NAME" ]; then
     read -r -p "What is the name of your Cluster? " CLUSTER_NAME
 fi
 
+# Make sure a default region was selected
+: ${AWS_DEFAULT_REGION:="us-east-1"}
+
 export CNI_VERSION_URL=https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/plugins/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tar.gz
 export CNI_ASSET_HASH_STRING=sha256:7426431524c2976f481105b80497238030e1c3eedbfcad00e2a9ccbaaf9eef9d
 
@@ -44,8 +47,8 @@ if [ $_bucket_name == "None" ]; then
 fi
 
 kops create cluster $CLUSTER_NAME \
-    --zones "us-west-2a,us-west-2b,us-west-2c" \
-    --master-zones "us-west-2a" \
+    --zones "${AWS_DEFAULT_REGION}a,${AWS_DEFAULT_REGION}b,${AWS_DEFAULT_REGION}c" \
+    --master-zones "${AWS_DEFAULT_REGION}a" \
     --networking kubenet \
     --node-count 3 \
     --node-size m5.xlarge \

--- a/docs/contents/users/index.md
+++ b/docs/contents/users/index.md
@@ -18,6 +18,13 @@ container images.
 
 ## Run the kops.sh script
 
+The kops S3 bucket and Kubernetes cluster will be created by default in
+`us-east-1`. If you want to change this, set a default region as follows:
+
+```
+export AWS_DEFAULT_REGION=eu-north-1
+```
+
 Run the `kops.sh` script, and when prompted supply a FQDN name for your cluster
 for a domain you control. Refer to the [kops
 documentation](https://kops.sigs.k8s.io/getting_started/aws/) for


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

The kops S3 state bucket is create in $AWS_DEFAULT_REGION, however,
the Kubernetes cluster itself is created in `us-east-1`, which is
confusing.

This patch ensures that the kops configuration file creates the cluster
in the same region as the kops bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
