### PR TITLE
Modify prow build badge reference to only look at postsubmits in eks-distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## EKS Distro Repository
 
-[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=*[!-base]-postsubmit)](https://prow.eks.amazonaws.com/?type=postsubmit)
+[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=*[!-tooling]-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro&type=postsubmit)
 
 Amazon **EKS Distro** (EKS-D) is a Kubernetes distribution based on and used by
 Amazon Elastic Kubernetes Service (EKS) to create reliable and secure Kubernetes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently the badge is referencing some jobs in our eks-distro-build-tooling repo, so modifying it to point to jobs related to this repo. This PR is dependent on the following PR: https://github.com/aws/eks-distro-prow-jobs/pull/36

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
