### PR TITLE
Add base run all script to test Prow

### DIFF
--- a/development/kops/run_all.sh
+++ b/development/kops/run_all.sh
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-echo "This script will create the cluster, run tests and tear it down"
+echo "This script will create a cluster, run tests and tear it down"

--- a/development/kops/run_all.sh
+++ b/development/kops/run_all.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+echo "This script will create the cluster, run tests and tear it down"


### PR DESCRIPTION
Basic run all script that Prow will call. This will allow us to make sure the trigger and Prow are working before actually calling the real test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
