### PR TITLE
Fix occasional problem with delete cluster

### DIFF
--- a/development/kops/delete_cluster.sh
+++ b/development/kops/delete_cluster.sh
@@ -31,8 +31,7 @@ unset KOPS_CLUSTER_NAME
 echo "Deleting cluster $KOPS_STATE_STORE"
 kops get cluster --state "${KOPS_STATE_STORE}" |
   tail -n +2 |
-  cut -f1 -d '  ' 2>/dev/null |
-  while read NAME
+  while read NAME ROL
   do
     set -x
     kops delete cluster --state "${KOPS_STATE_STORE}" --name "${NAME}" --yes


### PR DESCRIPTION
Parsing of the get cluster is failing sometimes, use this other approach seems to work better.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
