### PR TITLE
Fix version file and checksum creation for new kubernetes versions

### DIFF
--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -28,11 +28,11 @@ PAUSE_IMAGE_TAG?=$(IMAGE_TAG)
 PAUSE_IMAGE?=$(IMAGE_REPO)/$(IMAGE_REPO_PREFIX)/$(PAUSE_IMAGE_NAME):$(PAUSE_IMAGE_TAG)
 
 .PHONY: update-version
-update-version:
+update-version: binaries
 	build/create_version_file.sh $(GIT_TAG) $(RELEASE_BRANCH)
 
 .PHONY: update-checksums
-update-checksums:
+update-checksums: binaries
 	build/update_checksums.sh $(RELEASE_BRANCH)
 
 .PHONY: binaries

--- a/projects/kubernetes/kubernetes/build/create_version_file.sh
+++ b/projects/kubernetes/kubernetes/build/create_version_file.sh
@@ -22,8 +22,9 @@ RELEASE_BRANCH=$2
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 source "${MAKE_ROOT}/build/lib/init.sh"
-if [ ! -d ${MAKE_ROOT}/_bin ] ;  then
-    echo "${MAKE_ROOT}/_bin not present! Run 'make binaries'"
+BIN_DIR="${OUTPUT_DIR}/${RELEASE_BRANCH}/bin"
+if [ ! -d ${BIN_DIR} ] ;  then
+    echo "${BIN_DIR} not present! Run 'make binaries'"
     exit 1
 fi
 
@@ -31,4 +32,4 @@ VERSION_FILE="${MAKE_ROOT}/${RELEASE_BRANCH}/KUBE_GIT_VERSION_FILE"
 rm -f $VERSION_FILE
 touch $VERSION_FILE
 RELEASE_FILE="${MAKE_ROOT}/${RELEASE_BRANCH}/RELEASE"
-build::version::create_env_file "$TAG" "$VERSION_FILE" "$RELEASE_FILE" "kubernetes"
+build::version::create_env_file "$TAG" "$VERSION_FILE" "$RELEASE_FILE" "kubernetes" "$RELEASE_BRANCH"

--- a/projects/kubernetes/kubernetes/build/lib/version.sh
+++ b/projects/kubernetes/kubernetes/build/lib/version.sh
@@ -19,6 +19,7 @@ function build::version::create_env_file() {
     local -r version_file="$2"
     local -r release_file="$3"
     local -r repository="$4"
+    local -r release_branch="$5"
 
     git -C $repository checkout $tag
     local -r source_date_epoch=$(git -C $repository show -s --format=format:%ct HEAD)
@@ -32,7 +33,7 @@ function build::version::create_env_file() {
 
     local -r version_file_cleaned=$version_file.tmp
     local -r release_version=$(cat $release_file)
-    local -r kube_git_version="${tag}-eks-distro-${release_version}"
+    local -r kube_git_version="${tag}-eks-${release_branch}-${release_version}"
 
     cat $version_file | sed -e "s/${tag}/${kube_git_version}/g"| grep -v "KUBE_GIT_TREE_STATE" > $version_file_cleaned
 

--- a/projects/kubernetes/kubernetes/build/update_checksums.sh
+++ b/projects/kubernetes/kubernetes/build/update_checksums.sh
@@ -22,8 +22,9 @@ RELEASE_BRANCH="$1"
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 source "${MAKE_ROOT}/build/lib/init.sh"
-if [ ! -d ${BIN_DIR}/${RELEASE_BRANCH}] ;  then
-    echo "${BIN_DIR}/${RELEASE_BRANCH} not present!"
+BIN_DIR="${OUTPUT_DIR}/${RELEASE_BRANCH}/bin"
+if [ ! -d ${BIN_DIR} ] ;  then
+    echo "${BIN_DIR} not present! Run 'make binaries'"
     exit 1
 fi
 
@@ -33,9 +34,9 @@ if [ "$(go env GOROOT)" != "/usr/local/go" ]; then
     echo "This is required for reproducible builds"
 fi
 
-rm ${MAKE_ROOT}/${RELEASE_BRANCH}/checksums
+rm ${MAKE_ROOT}/${RELEASE_BRANCH}/checksums || true
 # TODO: come up with a beter filter than 'kube*'
-for file in $(find ${MAKE_ROOT}/_bin -name 'kube*' -type file ); do
+for file in $(find ${BIN_DIR} -name 'kube*' -type file ); do
     filepath=$(realpath --relative-base=$MAKE_ROOT $file)
     sha256sum $filepath >> ${MAKE_ROOT}/${RELEASE_BRANCH}/checksums
 done


### PR DESCRIPTION
While working through updating to kubernetes 1.19.4, I was testing out the scripts that generate the version file and checksums.  There were a couple of changes needed due to some of the later bin directory changes I assume.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
