### PR TITLE
Fix release name in homepage

### DIFF
--- a/docs/contents/index.md
+++ b/docs/contents/index.md
@@ -103,4 +103,4 @@ Machine Images), but it does use the EKS Optimized AMI. See the project
 repository for the [EKS Optimized AMI](https://github.com/awslabs/amazon-eks-ami)
 if you are interested in the AL2 container runtime kernel version.
 
-* [EKS-D v1.18-eks-1 Version Dependencies](releases/v1-18-eks-1.md)
+* [EKS-D v1-18-eks-1 Version Dependencies](releases/v1-18-eks-1.md)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating the name to keep it consistent with the page that it is referring to.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
