### PR TITLE
Create cluster and store scripts

### DIFF
--- a/development/kops/cluster_wait.sh
+++ b/development/kops/cluster_wait.sh
@@ -15,7 +15,5 @@
 
 set -eo pipefail
 
-BASEDIR=$(dirname "$0")
-source ${BASEDIR}/set_k8s_versions.sh
-
-kops update cluster $CLUSTER_NAME --yes
+kops validate cluster --wait 10m
+kubectl apply -f ./aws-iam-authenticator.yaml

--- a/development/kops/create_cluster.sh
+++ b/development/kops/create_cluster.sh
@@ -15,16 +15,32 @@
 
 set -eo pipefail
 
+BASEDIR=$(dirname "$0")
+
+if [ -z "$AWS_DEFAULT_REGION" ]; then
+    echo "Please set a default region for the kops config bucket (e.g. us-west-2)"
+    read -r -p "What region would you like to store the config? " AWS_DEFAULT_REGION
+fi
+
+if ! aws sts get-caller-identity --query Account --output text >/dev/null 2>/dev/null
+then
+    echo "Error authtenticating with AWS running: aws sts get-caller-identity"
+    echo "The AWS CLI must be able to run for this script"
+    exit 1
+fi
+
 if [ -z "$CLUSTER_NAME" ]; then
     echo "Cluster name must be an FQDN: <yourcluster>.yourdomain.com or <yourcluster>.sub.yourdomain.com"
     read -r -p "What is the name of your Cluster? " CLUSTER_NAME
 fi
 
-if [ -z "$AWS_DEFAULT_REGION" ]; then
-	  echo "Please set a default region for the kops config bucket (e.g. us-west-2)"
-	  read -r -p "What region would you like to store the config? " AWS_DEFAULT_REGION
+if [ -z "$KOPS_STATE_STORE" ]; then
+    source ${BASEDIR}/create_store_name.sh
+    echo "Please enter the value for the kOps state store"
+    read -r -p "What kOps state store would you like use? " -i "${KOPS_STATE_STORE}" KOPS_STATE_STORE
 fi
 
+exit 0
 export KUBERNETES_VERSION=https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/kubernetes/v1.18.9
 export CNI_VERSION_URL=https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/plugins/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tar.gz
 export CNI_ASSET_HASH_STRING=sha256:7426431524c2976f481105b80497238030e1c3eedbfcad00e2a9ccbaaf9eef9d

--- a/development/kops/create_configuration.sh
+++ b/development/kops/create_configuration.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+BASEDIR=$(dirname "$0")
+source ${BASEDIR}/set_k8s_versions.sh
+
+if [ -z "$AWS_DEFAULT_REGION" ]; then
+    read -r -p "What region would you like to store the config? [us-west-2] " REGION
+    export AWS_DEFAULT_REGION=${REGION:-us-west-2}
+fi
+
+if ! aws sts get-caller-identity --query Account --output text >/dev/null 2>/dev/null
+then
+    echo "Error authtenticating with AWS running: aws sts get-caller-identity"
+    echo "The AWS CLI must be able to run for this script"
+    exit 1
+fi
+
+if [ -z "$KOPS_STATE_STORE" ]; then
+    source ${BASEDIR}/create_store_name.sh >/dev/null
+    read -r -p "What kOps state store would you like use? [${KOPS_STATE_STORE}] " STATE_STORE
+    export KOPS_STATE_STORE=${STATE_STORE:-${KOPS_STATE_STORE}}
+fi
+export BUCKET_NAME=${KOPS_STATE_STORE#"s3://"}
+
+if [ -z "$CLUSTER_NAME" ]; then
+    echo "Cluster name must be an FQDN: <yourcluster>.yourdomain.com or <yourcluster>.sub.yourdomain.com"
+    read -r -p "What is the name of your Cluster? " CLUSTER_NAME
+    export CLUSTER_NAME
+fi
+
+if [ -f values.yaml ]; then
+    read -r -p "A values.yaml file exists. Would you like to delete it? [Y/n] " DELETE_VALUES
+    DELETE_VALUES=${DELETE_VALUES:-y}
+    if [ "$(echo ${DELETE_VALUES} | tr '[:upper:]' '[:lower:]')" == "y" ]; then
+        rm values.yaml
+    else
+        echo "Skipping delete and exiting"
+        exit
+    fi
+fi
+
+# Create the bucket if it doesn't exist
+_bucket_name=$(aws s3api list-buckets  --query "Buckets[?Name=='$BUCKET_NAME'].Name | [0]" --out text)
+if [ $_bucket_name == "None" ]; then
+    echo "Creating kOps state store: $KOPS_STATE_STORE"
+    if [ "$AWS_DEFAULT_REGION" == "us-east-1" ]; then
+        aws s3api create-bucket --bucket $BUCKET_NAME
+    else
+        aws s3api create-bucket --bucket $BUCKET_NAME --create-bucket-configuration LocationConstraint=$AWS_DEFAULT_REGION
+    fi
+else
+    echo "Using kOps state store: $KOPS_STATE_STORE"
+fi
+
+echo "Creating aws-iam-authenticator.yaml"
+cat << EOF > aws-iam-authenticator.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-iam-authenticator
+  namespace: kube-system
+  labels:
+    k8s-app: aws-iam-authenticator
+data:
+  config.yaml: |
+    clusterID: $CLUSTER_NAME
+EOF
+
+echo "Creating values.yaml"
+cat << EOF > values.yaml
+kubernetesVersion: $KUBERNETES_VERSION
+clusterName: $CLUSTER_NAME
+configBase: $KOPS_STATE_STORE
+awsRegion: $AWS_DEFAULT_REGION
+EOF
+
+echo "Creating ${CLUSTER_NAME}.yaml"
+kops toolbox template --template eks-d.tpl --values values.yaml > "${CLUSTER_NAME}.yaml"
+
+echo "Creating cluster configuration"
+kops create -f ./"${CLUSTER_NAME}.yaml"
+
+echo "Creating cluster ssh key"
+export SSH_KEY_PATH=${SSH_KEY_PATH:-$HOME/.ssh/id_rsa.pub}
+kops create secret --name $CLUSTER_NAME sshpublickey admin -i ${SSH_KEY_PATH}
+
+echo
+echo "# Set these values"
+echo "export AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+echo "export CLUSTER_NAME=$CLUSTER_NAME"
+echo "export KOPS_STATE_STORE=$KOPS_STATE_STORE"

--- a/development/kops/create_store_name.sh
+++ b/development/kops/create_store_name.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create a unique s3 bucket name
+export KOPS_STATE_STORE="s3://kops-state-store-$(cat /dev/urandom | LC_ALL=C tr -dc "[:alpha:]" | tr '[:upper:]' '[:lower:]' | head -c 32)"
+echo export KOPS_STATE_STORE="${KOPS_STATE_STORE}"

--- a/development/kops/set_k8s_versions.sh
+++ b/development/kops/set_k8s_versions.sh
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eo pipefail
-
-BASEDIR=$(dirname "$0")
-source ${BASEDIR}/set_k8s_versions.sh
-
-kops update cluster $CLUSTER_NAME --yes
+export KUBERNETES_VERSION=https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/kubernetes/v1.18.9
+export CNI_VERSION_URL=https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/plugins/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tar.gz
+export CNI_ASSET_HASH_STRING=sha256:7426431524c2976f481105b80497238030e1c3eedbfcad00e2a9ccbaaf9eef9d


### PR DESCRIPTION
Break up the monolithic create_cluster script into distinct parts so they can be used independently. There was also a lot of magic to the old script where you could change the behavior if you export a variable, but no documents to make that clear.
