### PR TITLE
Call Kops update with the --name option

### DIFF
--- a/development/kops/create_cluster.sh
+++ b/development/kops/create_cluster.sh
@@ -18,4 +18,4 @@ set -eo pipefail
 BASEDIR=$(dirname "$0")
 source ${BASEDIR}/set_k8s_versions.sh
 
-kops update cluster $KOPS_CLUSTER_NAME --yes
+kops update cluster --name $KOPS_CLUSTER_NAME --yes

--- a/development/kops/create_cluster.sh
+++ b/development/kops/create_cluster.sh
@@ -18,4 +18,4 @@ set -eo pipefail
 BASEDIR=$(dirname "$0")
 source ${BASEDIR}/set_k8s_versions.sh
 
-kops update cluster --name $KOPS_CLUSTER_NAME --yes
+kops update cluster --name ${KOPS_CLUSTER_NAME} --yes


### PR DESCRIPTION
*Issue #, if available:*
While following the eks-d instructions I was receiving an error from Kops: "Found multiple arguments which look like a cluster name"

I cleaned environment and ran through the instructions again, same problem. My kops version is 1.18.2

*Description of changes:*
Updating the create_cluster script to specify the cluster name using "--name" addressed the issue for me. Suggesting it as an update here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
