### PR TITLE
Remove old repository name

### DIFF
--- a/docs/contents/users/build.md
+++ b/docs/contents/users/build.md
@@ -31,7 +31,7 @@ make docker-push
 ## Build Remaining Containers
 
 The second step of the build is to build the rest of the containers out
-of the [EKS Distro Container Repository](https://github.com/aws/eks-distro).
+of the [EKS Distro Repository](https://github.com/aws/eks-distro).
 In the project root directory is a `Makefile` which assumes
 you are using ECR and have created ECR repositories. Run the script with:
 

--- a/docs/contents/users/build.md
+++ b/docs/contents/users/build.md
@@ -31,7 +31,7 @@ make docker-push
 ## Build Remaining Containers
 
 The second step of the build is to build the rest of the containers out
-of the [EKS Distro Build Steps Repository](https://github.com/aws/eks-distro).
+of the [EKS Distro Container Repository](https://github.com/aws/eks-distro).
 In the project root directory is a `Makefile` which assumes
 you are using ECR and have created ECR repositories. Run the script with:
 


### PR DESCRIPTION
Remove old repository name from docs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
