### PR TITLE
etcd arm64 support fix

### DIFF
--- a/projects/etcd-io/etcd/docker/linux/Dockerfile
+++ b/projects/etcd-io/etcd/docker/linux/Dockerfile
@@ -13,10 +13,17 @@
 # limitations under the License.
 
 ARG BASE_IMAGE
-FROM $BASE_IMAGE
+FROM $BASE_IMAGE AS base
 
 ARG TARGETARCH
 ARG TARGETOS
+
+FROM base AS branch-version-amd64
+
+FROM base AS branch-version-arm64
+ENV ETCD_UNSUPPORTED_ARCH=arm64
+
+FROM branch-version-${TARGETARCH} AS final
 
 COPY LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt


### PR DESCRIPTION
The etcd container fails immediately on arm64 unless the ETCD_UNSUPPORTED_ARCH environment variable is set. The work around is do something like:

    docker run -e ETCD_UNSUPPORTED_ARCH=arm64  public.ecr.aws/j0a1m4z9/etcd-io/etcd:v3.4.14-eks-1-18-1

This work around does not work when you are using kubeadm because kubeadm doesn't give you a way to set an environment variable for etcd. With this change, etcd just logs a warning that you are using an experimental version of etcd.

Related:
https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/supported-platform.md

