### PR TITLE
Tag pause container 3.2

### DIFF
--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -86,11 +86,13 @@ docker: binaries pause
 		--build-arg BASE_IMAGE=$(GO_RUNNER_IMAGE) \
 		--build-arg VERSION=$(IMAGE_TAG) \
 		-t $(PAUSE_IMAGE) \
+		-t $(IMAGE_REPO)/$(IMAGE_REPO_PREFIX)/$(PAUSE_IMAGE_NAME):3.2 \
 		-f ./docker/pause/Dockerfile ./_output/pause/
 
 .PHONY: docker-push
 docker-push:
 	docker push $(PAUSE_IMAGE)
+	docker push $(IMAGE_REPO)/$(IMAGE_REPO_PREFIX)/$(PAUSE_IMAGE_NAME):3.2
 
 .PHONY: checksums
 checksums: tarballs local-images


### PR DESCRIPTION
This change fixes kubeadm which has 3.2 hard coded as the version of pause to deploy.

https://github.com/kubernetes/kubernetes/blob/release-1.18/cmd/kubeadm/app/constants/constants_unix.go#L26
