### PR TITLE
Use specific go version binaries in each project

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -76,3 +76,28 @@ function build::gather_licenses() {
      -o -name 'NOTICE' -o -name 'COPYING' -o -name 'NOTICE.txt' \
      -o -name 'LICENSE.code' -o -name 'LICENCE.md' \) | while IFS= read -r NAME; do mkdir -p "${outputdir}/$(dirname $NAME)" && cp  "$NAME" "${outputdir}/${NAME}"; done
 }
+
+function build::common::use_go_version() {
+  local -r version=$1
+  local gobinaryversion=""
+
+  if [[ $version == "1.13"* ]]; then
+    gobinaryversion="1.13"
+  fi
+  if [[ $version == "1.14"* ]]; then
+    gobinaryversion="1.14"
+  fi
+  if [[ $version == "1.15"* ]]; then
+    gobinaryversion="1.15"
+  fi
+
+  if [[ "$gobinaryversion" == "" ]]; then
+    return
+  fi
+
+  # This is the path where the specific go binary versions reside in our builder-base image
+  local -r gobinarypath=/go/go${gobinaryversion}/bin
+  echo "Adding $gobinarypath to PATH"
+  # Adding to the beginning of PATH to allow for builds on specific version if it exists
+  export PATH=${gobinarypath}:$PATH
+}

--- a/projects/containernetworking/plugins/build/create_binaries.sh
+++ b/projects/containernetworking/plugins/build/create_binaries.sh
@@ -25,6 +25,8 @@ TAG="$3"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
+GOLANG_VERSION="1.14"
+
 readonly SUPPORTED_PLATFORMS=(
   linux/amd64
   linux/arm64
@@ -38,6 +40,7 @@ function build::plugins::binaries(){
   git clone "$CLONE_URL" "$REPO"
   cd "$REPO"
   git checkout "$TAG"
+  build::common::use_go_version $GOLANG_VERSION
   for platform in "${SUPPORTED_PLATFORMS[@]}"; do
     OS="$(cut -d '/' -f1 <<< ${platform})"
     ARCH="$(cut -d '/' -f2 <<< ${platform})"

--- a/projects/coredns/coredns/Makefile
+++ b/projects/coredns/coredns/Makefile
@@ -32,7 +32,6 @@ IMAGE_NAME?=coredns/coredns
 IMAGE_TAG?=${GIT_TAG}-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-
 ifeq ($(DEVELOPMENT),true)
 	BASE_IMAGE=amazonlinux:2
 endif

--- a/projects/coredns/coredns/build/create_binaries.sh
+++ b/projects/coredns/coredns/build/create_binaries.sh
@@ -25,6 +25,8 @@ TAG="$3"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
+GOLANG_VERSION="1.13"
+
 readonly SUPPORTED_PLATFORMS=(
   linux/amd64
   linux/arm64
@@ -38,6 +40,7 @@ function build::coredns::binaries(){
   git clone $CLONE_URL $REPO
   cd "$REPO"
   git checkout $TAG
+  build::common::use_go_version $GOLANG_VERSION
   go mod vendor
   for platform in "${SUPPORTED_PLATFORMS[@]}";
   do

--- a/projects/etcd-io/etcd/build/create_binaries.sh
+++ b/projects/etcd-io/etcd/build/create_binaries.sh
@@ -25,6 +25,8 @@ TAG="$3"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
+GOLANG_VERSION="1.14"
+
 readonly SUPPORTED_PLATFORMS=(
   linux/amd64
   linux/arm64
@@ -38,6 +40,7 @@ function build::etcd::binaries(){
   git clone $CLONE_URL $REPO
   cd $REPO
   git checkout $TAG
+  build::common::use_go_version $GOLANG_VERSION
   go mod vendor
   for platform in "${SUPPORTED_PLATFORMS[@]}";
   do

--- a/projects/kubernetes-csi/external-attacher/build/create_binaries.sh
+++ b/projects/kubernetes-csi/external-attacher/build/create_binaries.sh
@@ -25,6 +25,8 @@ TAG="$3"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
+GOLANG_VERSION="1.15"
+
 readonly SUPPORTED_PLATFORMS=(
   linux/amd64
   linux/arm64
@@ -38,6 +40,7 @@ function build::external-attacher::binaries(){
   git clone $CLONE_URL $REPO
   cd $REPO
   git checkout $TAG
+  build::common::use_go_version $GOLANG_VERSION
   for platform in "${SUPPORTED_PLATFORMS[@]}";
   do
     OS="$(cut -d '/' -f1 <<< ${platform})"

--- a/projects/kubernetes-csi/external-provisioner/build/create_binaries.sh
+++ b/projects/kubernetes-csi/external-provisioner/build/create_binaries.sh
@@ -25,6 +25,8 @@ TAG="$3"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
+GOLANG_VERSION="1.15"
+
 readonly SUPPORTED_PLATFORMS=(
   linux/amd64
   linux/arm64
@@ -38,6 +40,7 @@ function build::external-provisioner::binaries(){
   git clone $CLONE_URL $REPO
   cd $REPO
   git checkout $TAG
+  build::common::use_go_version $GOLANG_VERSION
   for platform in "${SUPPORTED_PLATFORMS[@]}";
   do
     OS="$(cut -d '/' -f1 <<< ${platform})"

--- a/projects/kubernetes-csi/external-resizer/build/create_binaries.sh
+++ b/projects/kubernetes-csi/external-resizer/build/create_binaries.sh
@@ -25,6 +25,8 @@ TAG="$3"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
+GOLANG_VERSION="1.15"
+
 readonly SUPPORTED_PLATFORMS=(
   linux/amd64
   linux/arm64
@@ -38,6 +40,7 @@ function build::external-resizer::binaries(){
   git clone $CLONE_URL $REPO
   cd $REPO
   git checkout $TAG
+  build::common::use_go_version $GOLANG_VERSION
   for platform in "${SUPPORTED_PLATFORMS[@]}";
   do
     OS="$(cut -d '/' -f1 <<< ${platform})"

--- a/projects/kubernetes-csi/external-snapshotter/build/create_binaries.sh
+++ b/projects/kubernetes-csi/external-snapshotter/build/create_binaries.sh
@@ -25,6 +25,8 @@ TAG="$3"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
+GOLANG_VERSION="1.15"
+
 readonly SUPPORTED_PLATFORMS=(
   linux/amd64
   linux/arm64
@@ -38,6 +40,7 @@ function build::external-snapshotter::binaries(){
   git clone $CLONE_URL $REPO
   cd $REPO
   git checkout $TAG
+  build::common::use_go_version $GOLANG_VERSION
   for platform in "${SUPPORTED_PLATFORMS[@]}";
   do
     OS="$(cut -d '/' -f1 <<< ${platform})"

--- a/projects/kubernetes-csi/livenessprobe/build/create_binaries.sh
+++ b/projects/kubernetes-csi/livenessprobe/build/create_binaries.sh
@@ -25,6 +25,8 @@ TAG="$3"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
+GOLANG_VERSION="1.15"
+
 readonly SUPPORTED_PLATFORMS=(
   linux/amd64
   linux/arm64
@@ -38,6 +40,7 @@ function build::livenessprobe::binaries(){
   git clone $CLONE_URL $REPO
   cd $REPO
   git checkout $TAG
+  build::common::use_go_version $GOLANG_VERSION
   for platform in "${SUPPORTED_PLATFORMS[@]}";
   do
     OS="$(cut -d '/' -f1 <<< ${platform})"

--- a/projects/kubernetes-csi/node-driver-registrar/build/create_binaries.sh
+++ b/projects/kubernetes-csi/node-driver-registrar/build/create_binaries.sh
@@ -25,6 +25,8 @@ TAG="$3"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
+GOLANG_VERSION="1.15"
+
 readonly SUPPORTED_PLATFORMS=(
   linux/amd64
   linux/arm64
@@ -38,6 +40,7 @@ function build::node-driver-registrar::binaries(){
   git clone $CLONE_URL $REPO
   cd $REPO
   git checkout $TAG
+  build::common::use_go_version $GOLANG_VERSION
   for platform in "${SUPPORTED_PLATFORMS[@]}";
   do
     OS="$(cut -d '/' -f1 <<< ${platform})"

--- a/projects/kubernetes-sigs/aws-iam-authenticator/build/create_binaries.sh
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/build/create_binaries.sh
@@ -25,6 +25,8 @@ TAG="$3"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
+GOLANG_VERSION="1.13"
+
 readonly SUPPORTED_PLATFORMS=(
   linux/amd64
   linux/arm64
@@ -41,6 +43,7 @@ function build::aws-iam-authenticator::binaries(){
   git clone "$CLONE_URL" "$REPO"
   cd "$REPO"
   git checkout "$TAG"
+  build::common::use_go_version $GOLANG_VERSION
   for platform in "${SUPPORTED_PLATFORMS[@]}";
   do
     OS="$(cut -d '/' -f1 <<< ${platform})"

--- a/projects/kubernetes-sigs/metrics-server/build/create_binaries.sh
+++ b/projects/kubernetes-sigs/metrics-server/build/create_binaries.sh
@@ -25,6 +25,8 @@ TAG="$3"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
+GOLANG_VERSION="1.14"
+
 readonly SUPPORTED_PLATFORMS=(
   linux/amd64
   linux/arm64
@@ -43,6 +45,7 @@ function build::metrics-server::binaries(){
   local -r build_date=$(git -C $REPO show -s --format=format:%ct HEAD)
   local -r goldflags="-X ${pkg}/version.gitVersion=$TAG -X ${pkg}/version.gitCommit=$git_commit -X ${pkg}/version.buildDate=$build_date"
   git -C $REPO checkout "$TAG"
+  build::common::use_go_version $GOLANG_VERSION
   for platform in "${SUPPORTED_PLATFORMS[@]}";
   do
     OS="$(cut -d '/' -f1 <<< ${platform})"

--- a/projects/kubernetes/kubernetes/build/create_binaries.sh
+++ b/projects/kubernetes/kubernetes/build/create_binaries.sh
@@ -35,6 +35,7 @@ if [ -d ${OUTPUT_DIR}/${RELEASE_BRANCH}/bin ]; then
 fi
 build::git::clone "$CLONE_URL" "$SOURCE_DIR"
 build::git::patch "$SOURCE_DIR" "$GIT_TAG" "$PATCH_DIR"
+build::binaries::use_go_version_k8s "$RELEASE_BRANCH"
 build::binaries::kube_bins "$SOURCE_DIR"
 
 mkdir -p ${OUTPUT_DIR}/${RELEASE_BRANCH}/bin

--- a/projects/kubernetes/kubernetes/build/lib/binaries.sh
+++ b/projects/kubernetes/kubernetes/build/lib/binaries.sh
@@ -13,6 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+function build::binaries::use_go_version_k8s() {
+    local -r releasebranch="$1"
+
+    if [[ "$releasebranch" == "1-18" ]]; then
+        build::common::use_go_version "1.13"
+    fi
+}
 
 function build::binaries::kube_bins() {
     local -r repository="$1"

--- a/projects/kubernetes/release/build/create_binaries.sh
+++ b/projects/kubernetes/release/build/create_binaries.sh
@@ -22,6 +22,8 @@ CLONE_URL=$1
 REPOSITORY=$2
 TAG=$3
 
+GOLANG_VERSION="1.15"
+
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 OUTPUT_DIR="${OUTPUT_DIR:-${MAKE_ROOT}/_output}"
 
@@ -31,6 +33,7 @@ source "${MAKE_ROOT}/../../../build/lib/common.sh"
 
 mkdir -p $OUTPUT_DIR
 build::clone::release $CLONE_URL $REPOSITORY $TAG
+build::common::use_go_version $GOLANG_VERSION
 build::binaries::bins $MAKE_ROOT/$REPOSITORY $OUTPUT_DIR
 
 build::gather_licenses $MAKE_ROOT/$REPOSITORY $MAKE_ROOT/LICENSES


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding ability to specify the version of go we want for each project. This PR will only use the different version of go once the following PR is merged: https://github.com/aws/eks-distro-prow-jobs/pull/69

For most projects, there is a variable we set in the create_binaries script that will look for the appropriate version of go. Note that we don't have to specify the 3rd number in the list of numbers as we set that in the common script, allowing us to not have to change the version for every single project if we are just doing a go upgrade.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
