### PR TITLE
Add community supporte installation page

### DIFF
--- a/docs/contents/users/index.md
+++ b/docs/contents/users/index.md
@@ -1,8 +1,18 @@
-## Starting a Cluster
+## Create an EKS Distro Cluster
 
-Before you start your cluster, you need to get several container images.
-Container images can be accessed either from the public ECR registry or
-built from scratch.
+The best way to create an EKS Distro cluster may be using one of our
+[Partners](../community/partners.md). There are links and instructions on that
+page for third party methods to install EKS-D.
+
+You may also find a community supported installation method useful. Community
+supported installation methods are found on our
+[community supported installation page](install/index.md).
+
+## Getting Container Images
+
+If your cluster deploment does not automatically pull container images, you may
+need to get them manually.  Container images can be accessed either from the
+public ECR registry or built from scratch.
 
 ### EKS Distro Container Images
 
@@ -12,12 +22,7 @@ script](https://github.com/aws/eks-distro/blob/main/development/pull-all.sh) is
 provided to demonstrate how to do this. You can also browse the [EKS Distro
 Container Repository](https://gallery.ecr.aws/?searchTerm=eks-distro&verified=verified)
 
+
 ### Building Your Own Container Images
 See the [Build Guide](build.md) for more information about building your own
 container images.
-
-## Create cluster scripts
-
-You can deploy EKS Distro any way you like, but we use kOps for testing. You
-may like to use the testing scripts which are documented in this
-[README](https://github.com/aws/eks-distro/blob/main/development/kops/README.md).

--- a/docs/contents/users/install/index.md
+++ b/docs/contents/users/install/index.md
@@ -6,4 +6,4 @@ with them, please submit a pull request. These installation methods may not
 be tested.
 
 * [kOps](kops.md) we use kOps for EKS-D automated tests
-* [kubeadm](kops.md) this has been tested on a cluster of Raspberry Pis
+* [kubeadm](kubeadm.md) this has been tested on a cluster of Raspberry Pis

--- a/docs/contents/users/install/index.md
+++ b/docs/contents/users/install/index.md
@@ -1,0 +1,9 @@
+# EKS Distro Installation 
+
+This page covers our community supported EKS Distro installation methods.
+These instructions are provided by the community and if there are any issues
+with them, please submit a pull request. These installation methods may not
+be tested.
+
+* [kOps](kops.md) we use kOps for EKS-D automated tests
+* [kubeadm](kops.md) this has been tested on a cluster of Raspberry Pis

--- a/docs/contents/users/install/kops.md
+++ b/docs/contents/users/install/kops.md
@@ -1,0 +1,58 @@
+# EKS Distro kOps Cluster
+
+Follow these instructions to create an EKS-D Kubernetes cluster using
+kOps.  Refer to the [kops documentation](https://kops.sigs.k8s.io/getting_started/aws/)
+for full instructions.  Most of these commands require that you have
+`KOPS_STATE_STORE` and `KOPS_CLUSTER_NAME` set and exported.
+
+## kOps Cluster Create
+
+### 1. Clone the eks-distro Repository
+The easiest way to access our sample kOps scripts would be to clone the
+repository and cd to the `kops` directory:
+```bash
+git clone https://github.com/aws/eks-distro.git
+cd eks-distro/development/kops 
+```
+
+### 2. Create the Cluster Configuration
+You will need to set and export `KOPS_STATE_STORE` to the s3 bucket to use for
+your kOps state and `KOPS_CLUSTER_NAME` to a valid subdomain controlled by Route53.
+If your kOps state store does not exist, this script will create it. It will
+also generate the cluster configuration:
+```bash
+export KOPS_STATE_STORE=s3://kops-state-store
+export KOPS_CLUSTER_NAME=clustername.example.com
+./create_configuration.sh 
+```
+
+### 3. Create the Cluster
+Once the cluster configuration has been created succcessfully, create the
+EKS-D cluster:
+```bash
+./create_cluster.sh 
+```
+
+### 4. Wait for the Cluster
+It may take a while for the cluster. You can use the `cluster_wait.sh`
+script to wait for the cluster to be ready. Once the cluster is ready this
+script will add the AWS IAM authenticator.
+```bash
+./cluster_wait.sh
+```
+When the script completes, your cluster is ready to use.
+
+## Verify Your Cluster is Running EKS-D
+
+You can verify the pods in your cluster are using the EKS Distro images by running
+the following command:
+```bash
+kubectl get po --all-namespaces -o json | jq -r '.items[].spec.containers[].image' | sort -u
+```
+
+## kOps Cluster Delete
+
+To tear down the cluster, run:
+```bash
+./delete_cluster.sh
+```

--- a/docs/contents/users/install/kubeadm.md
+++ b/docs/contents/users/install/kubeadm.md
@@ -1,0 +1,138 @@
+# EKS Distro kubeadm Cluster
+
+Follow these instructions to create an EKS-D Kubernetes cluster using
+`kubeadm`.  You will need a version of `kubeadm` that matches the
+version of EKS-D you are using. For example if you are using EKS-D
+1.18, use a 1.18 version of [kubeadm](https://v1-18.docs.kubernetes.io/docs/reference/setup-tools/kubeadm/).
+Start with the following configuration example and modify it to your
+needs. You will need to provide the values for variables surrounded
+by `{{` and `}}`
+
+```
+apiVersion: kubeadm.k8s.io/v1beta2
+bootstrapTokens:
+- groups:
+  - system:bootstrappers:kubeadm:default-node-token
+  token: {{ bootstrap_token }}
+  ttl: 24h0m0s
+  usages:
+  - signing
+  - authentication
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: {{ primary_ip }}
+  bindPort: 6443
+nodeRegistration:
+  criSocket: /var/run/dockershim.sock
+  name: {{ primary_hostname }}
+  taints:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+---
+apiServer:
+  timeoutForControlPlane: 4m0s
+apiVersion: kubeadm.k8s.io/v1beta2
+certificatesDir: /etc/kubernetes/pki
+clusterName: kubernetes
+controllerManager: {}
+dns:
+  type: CoreDNS
+  imageRepository: public.ecr.aws/eks-distro/coredns
+  imageTag: v1.7.0-eks-1-18-1
+etcd:
+  local:
+    dataDir: /var/lib/etcd
+    imageRepository: public.ecr.aws/eks-distro/etcd-io
+    imageTag: v3.4.14-eks-1-18-1 
+imageRepository: public.ecr.aws/eks-distro/kubernetes
+kind: ClusterConfiguration
+kubernetesVersion: v1.18.9-eks-1-18-1
+networking:
+  dnsDomain: cluster.local
+  serviceSubnet: 10.96.0.0/12
+  podSubnet: 10.244.0.0/16
+scheduler: {}
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+bindAddress: 0.0.0.0
+clientConnection:
+  acceptContentTypes: ""
+  burst: 0
+  contentType: ""
+  kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+  qps: 0
+clusterCIDR: ""
+configSyncPeriod: 0s
+conntrack:
+  maxPerCore: null
+  min: null
+  tcpCloseWaitTimeout: null
+  tcpEstablishedTimeout: null
+detectLocalMode: ""
+enableProfiling: false
+healthzBindAddress: ""
+hostnameOverride: ""
+iptables:
+  masqueradeAll: false
+  masqueradeBit: null
+  minSyncPeriod: 0s
+  syncPeriod: 0s
+ipvs:
+  excludeCIDRs: null
+  minSyncPeriod: 0s
+  scheduler: ""
+  strictARP: false
+  syncPeriod: 0s
+  tcpFinTimeout: 0s
+  tcpTimeout: 0s
+  udpTimeout: 0s
+kind: KubeProxyConfiguration
+metricsBindAddress: ""
+mode: ""
+nodePortAddresses: null
+oomScoreAdj: null
+portRange: ""
+showHiddenMetricsForVersion: ""
+udpIdleTimeout: 0s
+winkernel:
+  enableDSR: false
+  networkName: ""
+  sourceVip: ""
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  anonymous:
+    enabled: false
+  webhook:
+    cacheTTL: 0s
+    enabled: true
+  x509:
+    clientCAFile: /etc/kubernetes/pki/ca.crt
+authorization:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: 0s
+    cacheUnauthorizedTTL: 0s
+clusterDNS:
+- 10.96.0.10
+clusterDomain: cluster.local
+cpuManagerReconcilePeriod: 0s
+evictionPressureTransitionPeriod: 0s
+fileCheckFrequency: 0s
+healthzBindAddress: 127.0.0.1
+healthzPort: 10248
+httpCheckFrequency: 0s
+imageMinimumGCAge: 0s
+kind: KubeletConfiguration
+nodeStatusReportFrequency: 0s
+nodeStatusUpdateFrequency: 0s
+rotateCertificates: true
+runtimeRequestTimeout: 0s
+staticPodPath: /etc/kubernetes/manifests
+streamingConnectionIdleTimeout: 0s
+syncFrequency: 0s
+volumeStatsAggPeriod: 0s
+```
+
+Use the configuration file with the `kubeadm init --config kube.yaml` command.
+Use the same configuration file with your join commands.


### PR DESCRIPTION
Document clean up of the installation page. Create a community supported installation page and add `kubeadm` support.

Closes: https://github.com/aws/eks-distro/issues/110
