### PR TITLE
fix kubernetes patches to enable make test in builds

### DIFF
--- a/build/update-kubernetes-version/Dockerfile
+++ b/build/update-kubernetes-version/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:e35d4971088ca37db784caf525373f7342126bf3 as build
+FROM 316434458148.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:afa151c76fdefe7248c1a75bb1a764c7e28fb334 as build
 ARG RELEASE_BRANCH 
 ARG KUBERNETES_ROOT
 

--- a/projects/kubernetes/kubernetes/1-18/patches/0001-EKS-PATCH-Added-allowlist-CIDR-flag-use-klog.patch
+++ b/projects/kubernetes/kubernetes/1-18/patches/0001-EKS-PATCH-Added-allowlist-CIDR-flag-use-klog.patch
@@ -22,6 +22,7 @@ Signed-off-by: Jackson West <jgw@amazon.com>
  cmd/kube-apiserver/app/dialer.go             | 46 ++++++++++
  cmd/kube-apiserver/app/options/BUILD         |  1 +
  cmd/kube-apiserver/app/options/options.go    |  9 ++
+ .../app/options/options_test.go               |     1 +
  cmd/kube-apiserver/app/options/validation.go | 15 ++++
  cmd/kube-apiserver/app/options/allowlist.go  |  9 ++
  cmd/kube-apiserver/app/server.go             |  6 ++
@@ -31,7 +32,7 @@ Signed-off-by: Jackson West <jgw@amazon.com>
  pkg/kubeapiserver/options/options.go         |  1 +
  pkg/registry/core/node/BUILD                 |  1 +
  pkg/registry/core/node/strategy.go           | 14 +++
- 13 files changed, 235 insertions(+)
+ 14 files changed, 236 insertions(+)
  create mode 100644 cmd/kube-apiserver/app/dialer.go
  create mode 100644 cmd/kube-apiserver/app/options/allowlist.go
  create mode 100644 pkg/kubeapiserver/options/ipnetslice.go
@@ -147,6 +148,18 @@ index e64604758db..0fc452410d3 100644
  	fs.Var(&s.ServiceNodePortRange, "service-node-port-range", ""+
  		"A port range to reserve for services with NodePort visibility. "+
  		"Example: '30000-32767'. Inclusive at both ends of the range.")
+diff --git a/cmd/kube-apiserver/app/options/options_test.go b/cmd/kube-apiserver/app/options/options_test.go
+index 9afed6eb875..77d2b3a68ab 100644
+--- a/cmd/kube-apiserver/app/options/options_test.go
++++ b/cmd/kube-apiserver/app/options/options_test.go
+@@ -126,6 +126,7 @@ func TestAddFlags(t *testing.T) {
+ 		MasterCount:            5,
+ 		EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),
+ 		AllowPrivileged:        false,
++		ProxyCIDRAllowlist:     kubeoptions.NewIPNetSlice("0.0.0.0/0"),
+ 		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
+ 			AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+ 			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 diff --git a/cmd/kube-apiserver/app/options/validation.go b/cmd/kube-apiserver/app/options/validation.go
 index 4f94e438d00..5926205e201 100644
 --- a/cmd/kube-apiserver/app/options/validation.go

--- a/projects/kubernetes/kubernetes/1-18/patches/0010-EKS-PATCH-refine-aws-loadbalancer-worker-node-SG-rul.patch
+++ b/projects/kubernetes/kubernetes/1-18/patches/0010-EKS-PATCH-refine-aws-loadbalancer-worker-node-SG-rul.patch
@@ -117,64 +117,10 @@ diff --git a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go b/staging
 index b4549a80527..720de76d58e 100644
 --- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
 +++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
-@@ -2024,3 +2024,116 @@ func TestConstructStsEndpoint(t *testing.T) {
+@@ -2024,3 +2024,62 @@ func TestConstructStsEndpoint(t *testing.T) {
  		require.NoError(t, err)
  	})
  }
-+
-+func TestNodeAddressesForFargate(t *testing.T) {
-+	awsServices := newMockedFakeAWSServices(TestClusterID)
-+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
-+	c.cfg.Global.IPAddress = "1.2.3.4"
-+	c.cfg.Global.PrivateDNSName = "ip-1-2-3-4.compute.amazon.com"
-+
-+	nodeAddresses, _ := c.NodeAddresses(context.TODO(), "fargate-ip-1-2-3-4.compute.amazon.com")
-+	verifyNodeAddressesForFargate(t, nodeAddresses)
-+}
-+
-+func TestBuildFargateTaskFromDescribeNetworkInterfaces(t *testing.T) {
-+	awsServices := newMockedFakeAWSServices(TestClusterID)
-+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
-+	c.cfg.Global.ProviderIDPrefix = "fargateTest"
-+
-+	awsInstance, _ := c.buildAWSInstanceForFargateNode("fargate-ip-1-2-3-4.compute.amazon.com")
-+	assert.Equal(t, "vpc-123456", awsInstance.vpcID)
-+	assert.Equal(t, "subnet-123456", awsInstance.subnetID)
-+	assert.Equal(t, "1.2.3.4", awsInstance.addresses[0].Address)
-+	assert.Equal(t, "us-west-2b", awsInstance.availabilityZone)
-+	assert.Equal(t, "fargateTest/fargate-ip-1-2-3-4.compute.amazon.com", awsInstance.awsID)
-+}
-+
-+func TestNodeAddressesByProviderIDForFargate(t *testing.T) {
-+	awsServices := newMockedFakeAWSServices(TestClusterID)
-+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
-+	c.cfg.Global.IPAddress = "1.2.3.4"
-+	c.cfg.Global.PrivateDNSName = "ip-1-2-3-4.compute.amazon.com"
-+
-+	nodeAddresses, _ := c.NodeAddressesByProviderID(context.TODO(), "fargateTest/fargate-ip-1-2-3-4.compute.amazon.com")
-+	verifyNodeAddressesForFargate(t, nodeAddresses)
-+}
-+
-+func verifyNodeAddressesForFargate(t *testing.T, nodeAddresses []v1.NodeAddress) {
-+	assert.Equal(t, 2, len(nodeAddresses))
-+	assert.Equal(t, "1.2.3.4", nodeAddresses[0].Address)
-+	assert.Equal(t, v1.NodeInternalIP, nodeAddresses[0].Type)
-+	assert.Equal(t, "ip-1-2-3-4.compute.amazon.com", nodeAddresses[1].Address)
-+	assert.Equal(t, v1.NodeInternalDNS, nodeAddresses[1].Type)
-+}
-+
-+func TestBuildFargateTaskUsingPrivateIpFromDescribeNetworkInterfaces(t *testing.T) {
-+	awsServices := newMockedFakeAWSServices(TestClusterID)
-+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
-+	c.cfg.Global.ProviderIDPrefix = "fargateTest"
-+	nodeName := "fargate-1.2.3.4"
-+
-+	awsInstance, _ := c.buildAWSInstanceForFargateNode(nodeName)
-+	assert.Equal(t, "1.2.3.4", awsInstance.addresses[0].Address)
-+	assert.Equal(t, string(awsInstance.nodeName), nodeName)
-+	assert.Equal(t, "fargateTest/fargate-1.2.3.4", awsInstance.awsID)
-+	assert.Equal(t, 1, len(awsInstance.addresses))
-+}
 +
 +func TestCloud_sortELBSecurityGroupList(t *testing.T) {
 +	type args struct {

--- a/projects/kubernetes/kubernetes/1-19/patches/0001-EKS-PATCH-Added-allowlist-CIDR-flag-use-klog.patch
+++ b/projects/kubernetes/kubernetes/1-19/patches/0001-EKS-PATCH-Added-allowlist-CIDR-flag-use-klog.patch
@@ -171,7 +171,7 @@ index 2149c0bed25..c618539dd05 100644
  		MasterCount:            5,
  		EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),
  		AllowPrivileged:        false,
-+		ProxyCIDRAllowlist:     kubeoptions.NewIPNetSlice(),
++		ProxyCIDRAllowlist:     kubeoptions.NewIPNetSlice("0.0.0.0/0"),
  		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
  			AdvertiseAddress:            net.ParseIP("192.168.10.10"),
  			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -104,7 +104,7 @@ checksums: tarballs
 	build/create_release_checksums.sh $(RELEASE_BRANCH)
 
 .PHONY: build
-build: checksums
+build: tarballs test checksums
 
 .PHONY: release
 release: images checksums

--- a/projects/kubernetes/kubernetes/build/run_tests.sh
+++ b/projects/kubernetes/kubernetes/build/run_tests.sh
@@ -20,20 +20,30 @@ set -o nounset
 set -o pipefail
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "${MAKE_ROOT}/build/lib/init.sh"
+source "${MAKE_ROOT}/../../../build/lib/common.sh"
 
 export ARTIFACTS=${ARTIFACTS:-"./_artifacts"}
 export KUBE_JUNIT_REPORT_DIR="${ARTIFACTS}"
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export LOG_LEVEL=4
+export KUBE_TIMEOUT=${KUBE_TIMEOUT:-"--timeout=600s"}
+
+build::binaries::use_go_version_k8s "$RELEASE_BRANCH"
+
+go get gotest.tools/gotestsum
 
 cd $MAKE_ROOT/kubernetes
 
 # Install etcd for tests
 ./hack/install-etcd.sh
 
-# Install gotestsum which is used to get the junit output
-# TODO: fails through athens proxy on the same dep as external-snapshotter
-GOPROXY=direct go get gotest.tools/gotestsum
-
-# Add gopath and etcd bin paths for use by unit test  
-PATH="${GOPATH}/bin:${MAKE_ROOT}/kubernetes/third_party/etcd:${PATH}" make test KUBE_TIMEOUT=--timeout=600s
+MAX_RETRIES=3
+# There are flakes in upstream tests, the process also caches passing results
+# so on rerun it only runs the tests which failed
+for i in $(seq 1 $MAX_RETRIES); 
+do 
+  [ $i -gt 1 ] && sleep 5
+  PATH="${GOPATH}/bin:${MAKE_ROOT}/kubernetes/third_party/etcd:${PATH}" make test && ret=0 && break || ret=$?; 
+done
+exit $ret


### PR DESCRIPTION
This adds kubernetes `make test` to the presubmit builds.  Does not currently add it to the release/postsubmit build.

make test is the upstream kubernetes make test target.  It runs more than just "unit tests", some of the tests are spinning up the api server, utilizing etcd, etc.  I say this because there are Flakes 😱   Upstream does a great job tracking and tackling, see their approach [here](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/flaky-tests.md). [Here](http://storage.googleapis.com/k8s-metrics/flakes-latest.json) is their latest top flakes report, the `ci-kubernetes-cached-make-test` job is equivalent to what we are running here.

To avoid bogging us down with failed builds due to upstream flakes, this PR adds basic retry "logic".  Upstream already caches successfully test runs so when running `make test` over and over, it only runs the previously failed tests.  After running the tests in prow a number of times, up to 3 retries seems to be enough to get everything passing, but I think something we should watch for and potentially increase if necessary.  Funny enough, 1.19 actually seems flakier than 1.18 and the worst offenders match upstreams worst offenders.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
