### PR TITLE
WIP: add step to produce KIND images for EKS-D

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,5 @@ makes:
 	$(call presubmit-cleanup, $(TARGET), "projects/kubernetes-csi/external-snapshotter")
 	make -C projects/kubernetes-csi/external-provisioner $(TARGET)
 	$(call presubmit-cleanup, $(TARGET), "projects/kubernetes-csi/external-provisioner")
+	make -C projects/kind-images $(TARGET)
+	$(call presubmit-cleanup, $(TARGET), "projects/kind-images")

--- a/projects/kind-images/Dockerfile.amd64
+++ b/projects/kind-images/Dockerfile.amd64
@@ -1,0 +1,8 @@
+FROM kindest/node:v1.18.8
+
+ARG K8S_VERSION=v1.18.9-eks-1-18-1
+
+COPY amd64/* /usr/bin/
+
+RUN echo ${K8S_VERSION} > /kind/version
+RUN chmod +x /usr/bin/kubectl /usr/bin/kubeadm /usr/bin/kubelet


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds a sub-project to produce KIND-based images for EKS-D, by 
  [ ] copying binaries from the previous build steps (kubernetes/_output) into the sub-project directory
  [ ] changing the version of KIND image to match with the version-build of EKS-D.
  [ ] build the image, and push to the target repository

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.