### PR TITLE
fix: adjust old install steps for new documentation architecture.

### DIFF
--- a/docs/contents/users/install/index.md
+++ b/docs/contents/users/install/index.md
@@ -5,5 +5,6 @@ These instructions are provided by the community and if there are any issues
 with them, please submit a pull request. These installation methods may not
 be tested.
 
-* [kOps](kops.md) we use kOps for EKS-D automated tests
-* [kubeadm](kubeadm.md) this has been tested on a cluster of Raspberry Pis
+* [kOps](kops.md) we use kOps for EKS-D automated tests.
+* [kubeadm](kubeadm.md) this has been tested on a cluster of Raspberry Pis.
+* [kubeinit](kubeinit.md) deploys EKS-D using Ansible on top of Libvirt hosts.

--- a/docs/contents/users/install/kubeinit.md
+++ b/docs/contents/users/install/kubeinit.md
@@ -1,6 +1,13 @@
-# Installation
+# EKS Distro deployment using Kubeinit on top of Libvirt
 
-## Libvirt
+Follow these instructions to create an EKS-D Kubernetes cluster using
+Kubeinit.
+
+[KubeInit](https://github.com/kubeinit/kubeinit)
+is an Ansible collection to ease the deployment
+of multiple upstream Kubernetes distributions.
+The following sections will describe a 3 controllers,
+1 compute deployment on a Libvirt host.
 
 Libvirt deployments are based in multiple guests VMs
 deployed on a common hypervisor host.
@@ -8,17 +15,7 @@ There are multiple use cases that can fit this scenario
 for instance continuous integration deployments or
 development environments.
 
-### KubeInit
-
-[KubeInit](https://github.com/kubeinit/kubeinit)
-is an Ansible collection to ease the deployment
-of multiple upstream Kubernetes distributions.
-The following sections will describe a 3 controllers,
-1 compute deployment on a Libvirt host using Kubeinit as
-the Ansible automation to configure the requirements
-to have a functional cluster.
-
-#### Components
+### Components
 
 Here is a list of the components that are currently deployed:
 
@@ -39,7 +36,7 @@ Here is a list of the components that are currently deployed:
 * Controller nodes: 3
 * Worker nodes: 1
 
-#### Deploying
+### Deploying
 
 The deployment procedure is the same as it is for the other
 Kubernetes distributions that can be deployed with KubeInit.
@@ -66,7 +63,8 @@ ansible-playbook \
     ./playbooks/$distro.yml
 ```
 
-This will deploy by default a 3 controllers 1 compute cluster.
+This will deploy by default a 3 controllers 1 compute cluster
+in a single hypervisor.
 
 The deployment time was fairly quick (around 15 minutes):
 
@@ -96,7 +94,7 @@ user	1m24.846s
 sys	0m24.366s
 ```
 
-Let's run some commands in the cluster.
+Now the deployment can be verified by executing a few checks.
 
 ```bash
 [root@eks-service-01 ~]: curl --user registryusername:registrypassword \


### PR DESCRIPTION
*Description of changes:*

This PR adjust a recent PR merge that includes install steps
for EKS-D on top of a Libvirt host.

Now the installation is aligned with the kops and kubeadm procedures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
