### PR TITLE
Reorganize make target dependencies in Kubernetes due to failed jobs

### DIFF
--- a/cmd/main_postsubmit.go
+++ b/cmd/main_postsubmit.go
@@ -57,11 +57,7 @@ func main() {
 	development := flag.Bool("development", false, "Build as a development build")
 	region := flag.String("region", "us-west-2", "AWS region to use")
 	accountId := flag.String("account-id", "", "AWS Account ID to use")
-	baseImage := flag.String("base-image", "", "Base container image")
 	imageRepo := flag.String("image-repo", "", "Container image repository")
-	goRunnerImage := flag.String("go-runner-image", "", "go-runner image")
-	kubeProxyBase := flag.String("kube-proxy-base", "", "kube-proxy base image")
-	imageTag := flag.String("image-tag", "", "tag for build images")
 	artifactBucket := flag.String("artifact-bucket", "", "S3 bucket for artifacts")
 	gitRoot := flag.String("git-root", "", "Git root directory")
 	dryRun := flag.Bool("dry-run", false, "Echo out commands, but don't run them")
@@ -90,11 +86,7 @@ func main() {
 		fmt.Sprintf("DEVELOPMENT=%t", *development),
 		fmt.Sprintf("AWS_REGION=%s", *region),
 		fmt.Sprintf("AWS_ACCOUNT_ID=%s", *accountId),
-		fmt.Sprintf("BASE_IMAGE=%s", *baseImage),
 		fmt.Sprintf("IMAGE_REPO=%s", *imageRepo),
-		fmt.Sprintf("GO_RUNNER_IMAGE=%s", *goRunnerImage),
-		fmt.Sprintf("KUBE_PROXY_BASE_IMAGE=%s", *kubeProxyBase),
-		fmt.Sprintf("IMAGE_TAG=%s", *imageTag),
 	}
 
 	cmd := exec.Command("git", "-C", *gitRoot, "diff", "--name-only", "HEAD^", "HEAD")

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -24,6 +24,13 @@ KUBE_BASE_TAG?=${KUBE_BASE_GIT_TAG}-eks-${RELEASE_BRANCH}-${RELEASE}
 GO_RUNNER_IMAGE?=$(BASE_REPO)/$(GO_RUNNER_IMAGE_NAME):$(KUBE_BASE_TAG)
 KUBE_PROXY_BASE_IMAGE?=$(BASE_REPO)/$(KUBE_PROXY_BASE_IMAGE_NAME):$(KUBE_BASE_TAG)
 
+# Since the image won't be available for the local-images target,
+# need to override based on an image that is already available.
+# We want to a better way than this to avoid having to change often.
+PRESUBMIT_KUBE_BASE_TAG?=v0.4.2-ea45689a0da457711b15fa1245338cd0b636ad4b
+PRESUBMIT_GO_RUNNER_IMAGE?=$(BASE_REPO)/$(GO_RUNNER_IMAGE_NAME):$(PRESUBMIT_KUBE_BASE_TAG)
+PRESUBMIT_KUBE_PROXY_BASE_IMAGE?=$(BASE_REPO)/$(KUBE_PROXY_BASE_IMAGE_NAME):$(PRESUBMIT_KUBE_BASE_TAG)
+
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 IMAGE_REPO_PREFIX=kubernetes
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -57,7 +57,7 @@ $(PAUSE_DST_DIR)/pause.c:
 pause: $(PAUSE_DST_DIR)/pause.c
 
 .PHONY: local-images
-local-images: pause
+local-images:
 	build/create_images.sh $(RELEASE_BRANCH) $(GO_RUNNER_IMAGE) $(KUBE_PROXY_BASE_IMAGE) $(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false
 	buildctl \
 		build \
@@ -70,7 +70,7 @@ local-images: pause
 		--output type=oci,oci-mediatypes=true,name=$(PAUSE_IMAGE),dest=_output/$(RELEASE_BRANCH)/bin/linux/amd64/pause.tar
 
 .PHONY: images
-images: binaries pause
+images:
 	build/create_images.sh $(RELEASE_BRANCH) $(GO_RUNNER_IMAGE) $(KUBE_PROXY_BASE_IMAGE) $(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) true
 	buildctl \
 		build \
@@ -104,12 +104,10 @@ checksums:
 	build/create_release_checksums.sh $(RELEASE_BRANCH)
 
 .PHONY: build
-build: test local_images tarballs checksums
-	rm -rf ./kubernetes
+build: test pause clean-repo local_images tarballs checksums
 
 .PHONY: release
-release: images tarballs checksums
-	rm -rf ./kubernetes
+release: binaries pause clean-repo images tarballs checksums
 	$(BASE_DIRECTORY)/release/copy_artifacts.sh $(COMPONENT) $(RELEASE_BRANCH) $(RELEASE)
 	$(BASE_DIRECTORY)/release/s3_sync.sh $(RELEASE_BRANCH) $(RELEASE) $(ARTIFACT_BUCKET) $(REPO)
 	echo "Done $(COMPONENT)"
@@ -121,6 +119,10 @@ all: release
 test: binaries
 	build/run_tests.sh $(RELEASE_BRANCH)
 
+.PHONY: clean-repo
+clean-repo:
+	rm -rf ./kubernetes
+
 .PHONY: clean
-clean:
-	rm -rf ./kubernetes ./_output
+clean: clean-repo
+	rm -rf ./_output

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -111,7 +111,7 @@ checksums:
 	build/create_release_checksums.sh $(RELEASE_BRANCH)
 
 .PHONY: build
-build: test pause clean-repo local_images tarballs checksums
+build: test pause clean-repo local-images tarballs checksums
 
 .PHONY: release
 release: binaries pause clean-repo images tarballs checksums

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -65,14 +65,14 @@ pause: $(PAUSE_DST_DIR)/pause.c
 
 .PHONY: local-images
 local-images:
-	build/create_images.sh $(RELEASE_BRANCH) $(GO_RUNNER_IMAGE) $(KUBE_PROXY_BASE_IMAGE) $(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false
+	build/create_images.sh $(RELEASE_BRANCH) $(PRESUBMIT_GO_RUNNER_IMAGE) $(PRESUBMIT_KUBE_PROXY_BASE_IMAGE) $(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false
 	buildctl \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
 		--local dockerfile=./docker/pause/ \
 		--local context=./_output/pause \
-		--opt build-arg:BASE_IMAGE=$(GO_RUNNER_IMAGE) \
+		--opt build-arg:BASE_IMAGE=$(PRESUBMIT_GO_RUNNER_IMAGE) \
 		--opt build-arg:VERSION=$(IMAGE_TAG) \
 		--output type=oci,oci-mediatypes=true,name=$(PAUSE_IMAGE),dest=_output/$(RELEASE_BRANCH)/bin/linux/amd64/pause.tar
 

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -47,7 +47,7 @@ binaries:
 	build/create_binaries.sh $(CLONE_URL) $(RELEASE_BRANCH) $(GIT_TAG)
 
 .PHONY: tarballs
-tarballs: binaries
+tarballs:
 	build/create_tarballs.sh $(RELEASE_BRANCH)
 
 $(PAUSE_DST_DIR)/pause.c:
@@ -55,10 +55,9 @@ $(PAUSE_DST_DIR)/pause.c:
 	cp $(PAUSE_SRC_DIR)/linux/pause.c $(PAUSE_DST_DIR) || cp $(PAUSE_SRC_DIR)/pause.c $(PAUSE_DST_DIR)
 
 pause: $(PAUSE_DST_DIR)/pause.c
-	rm -rf ./kubernetes
 
 .PHONY: local-images
-local-images: binaries pause
+local-images: pause
 	build/create_images.sh $(RELEASE_BRANCH) $(GO_RUNNER_IMAGE) $(KUBE_PROXY_BASE_IMAGE) $(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false
 	buildctl \
 		build \
@@ -101,14 +100,16 @@ docker-push:
 	docker push $(IMAGE_REPO)/$(IMAGE_REPO_PREFIX)/$(PAUSE_IMAGE_NAME):3.2
 
 .PHONY: checksums
-checksums: tarballs
+checksums:
 	build/create_release_checksums.sh $(RELEASE_BRANCH)
 
 .PHONY: build
-build: tarballs test checksums
+build: test local_images tarballs checksums
+	rm -rf ./kubernetes
 
 .PHONY: release
-release: images checksums
+release: images tarballs checksums
+	rm -rf ./kubernetes
 	$(BASE_DIRECTORY)/release/copy_artifacts.sh $(COMPONENT) $(RELEASE_BRANCH) $(RELEASE)
 	$(BASE_DIRECTORY)/release/s3_sync.sh $(RELEASE_BRANCH) $(RELEASE) $(ARTIFACT_BUCKET) $(REPO)
 	echo "Done $(COMPONENT)"

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -111,10 +111,10 @@ checksums:
 	build/create_release_checksums.sh $(RELEASE_BRANCH)
 
 .PHONY: build
-build: test pause clean-repo local-images tarballs checksums
+build: test pause tarballs clean-repo local-images checksums
 
 .PHONY: release
-release: binaries pause clean-repo images tarballs checksums
+release: binaries pause tarballs clean-repo images checksums
 	$(BASE_DIRECTORY)/release/copy_artifacts.sh $(COMPONENT) $(RELEASE_BRANCH) $(RELEASE)
 	$(BASE_DIRECTORY)/release/s3_sync.sh $(RELEASE_BRANCH) $(RELEASE) $(ARTIFACT_BUCKET) $(REPO)
 	echo "Done $(COMPONENT)"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Builds in prow are failing due to being unable to find the kubernetes/kubernetes/kubernetes folder. Reorganizing the target dependencies to ensure that we have a streamlined structure for both our presubmits and postsubmits.

Removing other unnecessary environment variables as our Makefile will construct those values based on the RELEASE. My assumption before was that if they were empty anyways, they would be set in the Makefile but that wasn't the case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
