### PR TITLE
Use BUILD_ID instead of sha1 so CRD can be generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 
 DEVELOPMENT?=false

--- a/projects/containernetworking/plugins/Makefile
+++ b/projects/containernetworking/plugins/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 

--- a/projects/coredns/coredns/Makefile
+++ b/projects/coredns/coredns/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 

--- a/projects/etcd-io/etcd/Makefile
+++ b/projects/etcd-io/etcd/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 

--- a/projects/kubernetes-csi/external-attacher/Makefile
+++ b/projects/kubernetes-csi/external-attacher/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 

--- a/projects/kubernetes-csi/external-provisioner/Makefile
+++ b/projects/kubernetes-csi/external-provisioner/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 

--- a/projects/kubernetes-csi/external-resizer/Makefile
+++ b/projects/kubernetes-csi/external-resizer/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 

--- a/projects/kubernetes-csi/external-snapshotter/Makefile
+++ b/projects/kubernetes-csi/external-snapshotter/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 

--- a/projects/kubernetes-csi/livenessprobe/Makefile
+++ b/projects/kubernetes-csi/livenessprobe/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 

--- a/projects/kubernetes-csi/node-driver-registrar/Makefile
+++ b/projects/kubernetes-csi/node-driver-registrar/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 

--- a/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 

--- a/projects/kubernetes-sigs/metrics-server/Makefile
+++ b/projects/kubernetes-sigs/metrics-server/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat ./$(RELEASE_BRANCH)/GIT_TAG)
 

--- a/projects/kubernetes/release/Makefile
+++ b/projects/kubernetes/release/Makefile
@@ -1,11 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 RELEASE_BRANCH?=1-18
 DEFAULT_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/RELEASE)
-ifneq ("$(PULL_BASE_SHA)","")
-	RELEASE?=$(PULL_BASE_SHA)
-else
-	RELEASE?=$(DEFAULT_RELEASE)
-endif
+RELEASE?=$(or $(BUILD_ID),$(DEFAULT_RELEASE))
 ARTIFACT_BUCKET?=my-s3-bucket
 GIT_TAG?=$(shell cat GIT_TAG)
 


### PR DESCRIPTION
The CRD generation insists on a number rather than a string for release, so use BUILD_ID instead of SHA1 for development builds.