### PR TITLE
Add local image target to k8s make file

### DIFF
--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -114,7 +114,7 @@ checksums:
 build: test pause tarballs clean-repo local-images checksums
 
 .PHONY: release
-release: binaries pause tarballs clean-repo images checksums
+release: binaries pause tarballs clean-repo local-images images checksums
 	$(BASE_DIRECTORY)/release/copy_artifacts.sh $(COMPONENT) $(RELEASE_BRANCH) $(RELEASE)
 	$(BASE_DIRECTORY)/release/s3_sync.sh $(RELEASE_BRANCH) $(RELEASE) $(ARTIFACT_BUCKET) $(REPO)
 	echo "Done $(COMPONENT)"


### PR DESCRIPTION
We need the tar balls and other associated files for release, so call the local images target for release.