### PR TITLE
make versions in kops values.yaml configurable

### DIFF
--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -26,31 +26,33 @@ if [ -f "./${KOPS_CLUSTER_NAME}/values.yaml" ]; then
     exit 1
 fi
 
-
 function get_container_latest_tag() {
     REPOSITORY_NAME="${1}"
-    DEFAULT_TAG="${2}"
+    VERSION="${2}"
     RELEASE="${3}"
+    DEFAULT_TAG="${VERSION}-eks-${RELEASE}"
+
     if [ "${REPOSITORY_URI}" == "${DEFAULT_REPOSITORY_URI}" ]
     then
-        echo "${DEFAULT_TAG}-${RELEASE}"
+        echo "${DEFAULT_TAG}"
         return
     fi
-    QUERY='[.imageDetails[] | select(.imageTags != null)] | sort_by(.imagePushedAt)|reverse|first|.imageTags[0]'
-    if [[ "${REPOSITORY_URI}" != "public.ecr.aws/*" ]] # Public
+    if [[ "${REPOSITORY_URI}" == "public.ecr.aws/*" ]] # Public
     then
-        if aws --region us-east-1 ecr-public describe-images --repository-name "${REPOSITORY_NAME}" --image-ids=imageTag=${DEFAULT_TAG}-${RELEASE} 2>/dev/null >/dev/null
+        if aws --region us-east-1 ecr-public describe-images --repository-name "${REPOSITORY_NAME}" --image-ids=imageTag=${DEFAULT_TAG} 2>/dev/null >/dev/null
         then
-            TAG=${DEFAULT_TAG}-${RELEASE}
+            TAG=${DEFAULT_TAG}
         else
-            TAG=${DEFAULT_TAG}-${DEFAULT_RELEASE}
+            TAG=${VERSION}-eks-${DEFAULT_RELEASE}
         fi
     else # Private
         if aws ecr describe-images --repository-name "${REPOSITORY_NAME}" --image-ids=imageTag=${DEFAULT_TAG}-${RELEASE} 2>/dev/null >/dev/null
         then
             TAG=${DEFAULT_TAG}-${RELEASE}
         else
-            TAG=${DEFAULT_TAG}-1
+            # Get the latest tagged imaged for the given version
+            QUERY="imageDetails[?starts_with(imageTags[0],\`${VERSION}-\`)]|reverse(sort_by(@,&imagePushedAt))[0].imageTags[0]"
+            TAG=$(aws ecr describe-images --filter tagStatus=TAGGED --repository-name "${REPOSITORY_NAME}" --query "${QUERY}")
         fi
     fi
     echo "${TAG:-${DEFAULT_TAG}}"
@@ -58,9 +60,24 @@ function get_container_latest_tag() {
 
 function get_container_yaml() {
     REPOSITORY_NAME="${1}"
+    RELEASE="${2}"
+    VERSION="$(get_project_version $REPOSITORY_NAME)"
     echo "    repository: ${REPOSITORY_URI}/${REPOSITORY_NAME}
-    tag: $(get_container_latest_tag $*)"
+    tag: $(get_container_latest_tag $REPOSITORY_NAME $VERSION $RELEASE)"
 }
+
+function get_project_version(){
+    REPOSITORY_NAME="${1}"
+    if  [[ $REPOSITORY_NAME == kubernetes/* ]] 
+    then
+        VERSION=$(cat ${BASEDIR}/../../projects/kubernetes/kubernetes/${RELEASE_BRANCH}/GIT_TAG)
+    else
+        VERSION=$(cat ${BASEDIR}/../../projects/${REPOSITORY_NAME}/GIT_TAG)
+    fi
+    
+    echo $VERSION
+}
+
 
 echo "Creating ./${KOPS_CLUSTER_NAME}/values.yaml"
 cat << EOF > ./${KOPS_CLUSTER_NAME}/values.yaml
@@ -69,19 +86,19 @@ clusterName: $KOPS_CLUSTER_NAME
 configBase: $KOPS_STATE_STORE/$KOPS_CLUSTER_NAME
 awsRegion: $AWS_DEFAULT_REGION
 pause:
-$(get_container_yaml kubernetes/pause v1.18.9-eks-1-18 $RELEASE)
+$(get_container_yaml kubernetes/pause $RELEASE)
 kube_apiserver:
-$(get_container_yaml kubernetes/kube-apiserver v1.18.9-eks-1-18 $RELEASE)
+$(get_container_yaml kubernetes/kube-apiserver $RELEASE)
 kube_controller_manager:
-$(get_container_yaml kubernetes/kube-controller-manager v1.18.9-eks-1-18 $RELEASE)
+$(get_container_yaml kubernetes/kube-controller-manager $RELEASE)
 kube_scheduler:
-$(get_container_yaml kubernetes/kube-scheduler v1.18.9-eks-1-18 $RELEASE)
+$(get_container_yaml kubernetes/kube-scheduler $RELEASE)
 kube_proxy:
-$(get_container_yaml kubernetes/kube-proxy v1.18.9-eks-1-18 $RELEASE)
+$(get_container_yaml kubernetes/kube-proxy $RELEASE)
 metrics_server:
-$(get_container_yaml kubernetes-sigs/metrics-server v0.4.0-eks-1-18 $RELEASE)
+$(get_container_yaml kubernetes-sigs/metrics-server $RELEASE)
 awsiamauth:
-$(get_container_yaml kubernetes-sigs/aws-iam-authenticator v0.5.2-eks-1-18 $RELEASE)
+$(get_container_yaml kubernetes-sigs/aws-iam-authenticator $RELEASE)
 coredns:
-$(get_container_yaml coredns/coredns v1.7.0-eks-1-18 $RELEASE)
+$(get_container_yaml coredns/coredns $RELEASE)
 EOF


### PR DESCRIPTION
This makes 2 main changes:

- instead of hardcoding v1.18.9, it pulls the git_tag from each project and considers RELEASE_BRANCH=1-19|1-18
- based on the tag it finds the latest tag in the ecr repo

Since our images in an non-public ecr repo, running this kops script will work for us, but not our customers.  We could look into use ecr-public for these prerelease builds in the future.  

Since we all have access to the build account which owns these images, we can run the following:

```
export KOPS_CLUSTER_NAME=cluster2.jgw.people.aws.dev
export AWS_DEFAULT_PROFILE=mr-build-prod-pdx-ro 
export REPOSITORY_URI=316434458148.dkr.ecr.us-west-2.amazonaws.com
export KOPS_STATE_STORE=s3://kops-state-store-cluster2

RELEASE_BRANCH=1-19 ./create_values_yaml.sh 
```

Which creates

```
kubernetesVersion: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/1/artifacts/kubernetes/v1.19.6
clusterName: cluster1.jgw.people.aws.dev
configBase: s3://kops-state-store-cluster2/cluster1.jgw.people.aws.dev
awsRegion: us-west-2
pause:
    repository: 316434458148.dkr.ecr.us-west-2.amazonaws.com/kubernetes/pause
    tag: "v1.19.6-1ad80444c6f04d5fac5d57b2b33213d707ffd5d6"
kube_apiserver:
    repository: 316434458148.dkr.ecr.us-west-2.amazonaws.com/kubernetes/kube-apiserver
    tag: "v1.19.6-1ad80444c6f04d5fac5d57b2b33213d707ffd5d6"
kube_controller_manager:
    repository: 316434458148.dkr.ecr.us-west-2.amazonaws.com/kubernetes/kube-controller-manager
    tag: "v1.19.6-1ad80444c6f04d5fac5d57b2b33213d707ffd5d6"
kube_scheduler:
    repository: 316434458148.dkr.ecr.us-west-2.amazonaws.com/kubernetes/kube-scheduler
    tag: "v1.19.6-1ad80444c6f04d5fac5d57b2b33213d707ffd5d6"
kube_proxy:
    repository: 316434458148.dkr.ecr.us-west-2.amazonaws.com/kubernetes/kube-proxy
    tag: "v1.19.6-1ad80444c6f04d5fac5d57b2b33213d707ffd5d6"
metrics_server:
    repository: 316434458148.dkr.ecr.us-west-2.amazonaws.com/kubernetes-sigs/metrics-server
    tag: "v0.4.0-1ad80444c6f04d5fac5d57b2b33213d707ffd5d6"
awsiamauth:
    repository: 316434458148.dkr.ecr.us-west-2.amazonaws.com/kubernetes-sigs/aws-iam-authenticator
    tag: "v0.5.2-1ad80444c6f04d5fac5d57b2b33213d707ffd5d6"
coredns:
    repository: 316434458148.dkr.ecr.us-west-2.amazonaws.com/coredns/coredns
    tag: "v1.7.0-1ad80444c6f04d5fac5d57b2b33213d707ffd5d6"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

