### PR TITLE
Fix edit uri for docs on EKS Distro site

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,6 +4,7 @@ site_author: 'The EKS-D contributors'
 site_url: 'https://distro.eks.amazonaws.com'
 repo_name: 'aws/eks-distro'
 repo_url: 'https://github.com/aws/eks-distro'
+edit_uri: 'edit/main/docs/contents'
 copyright: 'Copyright &copy; 2020 Amazon'
 docs_dir: 'contents'
 nav:


### PR DESCRIPTION
Override default docs edit link on the [EKS-D website](https://distro.eks.amazonaws.com)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
