### PR TITLE
We should link to all the community installs and let the customer decide

### DIFF
--- a/docs/contents/users/index.md
+++ b/docs/contents/users/index.md
@@ -2,8 +2,9 @@
 
 The best way to try out EKS Distro (EKS-D) is to use one of the
 [Partners](../users/install/partners.md) procedures to install and start an EKS-D cluster.
-Community procedures (such as [Starting EKS-D with kubeadm](../users/install/kubeadm-onsite.md))
-are also available.
+You may also find a community supported installation method useful. Community
+supported installation methods are found on our
+[community supported installation page](../users/install/index.md).
 If you want to build EKS-D from source code, follow the instructions
 in [Build Prerequisites](build-prerequisites.md) and [Build EKS-D](build.md).
 


### PR DESCRIPTION
For some reason the link to the community installation page was removed and replaced with one method. This brings it back. Installing with `kubeadm` should probably be a last resort instead of our go to method
