### PR TITLE
Fix checksum path

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -60,8 +60,9 @@ function build::common::generate_shasum() {
 
   cd $tarpath
   for file in $(find . -name '*.tar.gz'); do
-    sha256sum "$file" > "$file.sha256"
-    sha512sum "$file" > "$file.sha512"
+    filepath=$(basename $file)
+    sha256sum "$filepath" > "$file.sha256"
+    sha512sum "$filepath" > "$file.sha512"
   done
   cd -
 }


### PR DESCRIPTION
This isn't terribly important, but we generate our sha sum files with `./` in the file names and this change gets rid of that. The kubernetes shasums do not have this, this covers etcd, cni, and coredns.