### PR TITLE
Remove create store name from run all

### DIFF
--- a/development/kops/create_store_name.sh
+++ b/development/kops/create_store_name.sh
@@ -14,5 +14,5 @@
 # limitations under the License.
 
 # Create a unique s3 bucket name
-export KOPS_STATE_STORE="s3://kops-state-store-$(cat /dev/urandom | LC_ALL=C tr -dc "[:alpha:]" | tr '[:upper:]' '[:lower:]' | head -c 32)"
+export KOPS_STATE_STORE=${KOPS_STATE_STORE:-s3://kops-state-store-$(cat /dev/urandom | LC_ALL=C tr -dc "[:alpha:]" | tr '[:upper:]' '[:lower:]' | head -c 32)}
 echo export KOPS_STATE_STORE="${KOPS_STATE_STORE}"

--- a/development/kops/run_all.sh
+++ b/development/kops/run_all.sh
@@ -25,7 +25,6 @@ set -exo pipefail
 BASEDIR=$(dirname "$0")
 echo "This script will create a cluster, run tests and tear it down"
 cd "$BASEDIR"
-source ./create_store_name.sh
 source ./set_environment.sh
 $PREFLIGHT_CHECK_PASSED || exit 1
 ./install_requirements.sh


### PR DESCRIPTION
The `run_all.sh` script is primarily for out automated tests and we will reuse the same old bucket for that. I've left it around for people to use to generate a name and fixed the problem where it would override the name of the bucket you set in the env.
