### PR TITLE
fix retry logic for kubernetes unit tests

### DIFF
--- a/projects/kubernetes/kubernetes/build/run_tests.sh
+++ b/projects/kubernetes/kubernetes/build/run_tests.sh
@@ -48,10 +48,10 @@ done
 if [ $ret -ne 0 ]; then
   echo "Tests failed after $MAX_RETRIES runs, checking if failures are known flakes"
 
-  latest_log=$(ls -td _artifacts/*.stdout | head -1)
-  gotestsum --jsonfile _artifacts/out.json --raw-command cat "$latest_log"
-  jq -r 'select(.Action=="fail" and .Test) | [.Package, .Test]  | join("/")' _artifacts/out.json > _artifacts/failed_tests
-  non_flakes=$(grep -Fxv -f $MAKE_ROOT/top_flakes _artifacts/failed_tests || true)
+  latest_log=$(ls -td $ARTIFACTS/junit*.stdout | head -1)
+  gotestsum --jsonfile $ARTIFACTS/out.json --raw-command cat "$latest_log"
+  jq -r 'select(.Action=="fail" and .Test) | [.Package, .Test]  | join("/")' $ARTIFACTS/out.json > $ARTIFACTS/failed_tests
+  non_flakes=$(grep -Fxv -f $MAKE_ROOT/top_flakes $ARTIFACTS/failed_tests || true)
 
   if [ ! "$non_flakes" ]
   then


### PR DESCRIPTION
When the kubernetes unit tests would fail 5 times, if the only failures are known flakes it is supposed to still pass.  There was a bug in the way it checked for failures in that in prow the ARTIFACTS env var is set to /logs/artifacts but the script was assuming ./_artifacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

