### PR TITLE
do not run kubernetes test when running build

### DIFF
--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -104,7 +104,7 @@ checksums:
 	build/create_release_checksums.sh $(RELEASE_BRANCH)
 
 .PHONY: build
-build: pause tarballs clean-repo local-images checksums
+build: binaries pause tarballs clean-repo local-images checksums
 
 .PHONY: release
 release: binaries pause tarballs clean-repo local-images images checksums

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -104,7 +104,7 @@ checksums:
 	build/create_release_checksums.sh $(RELEASE_BRANCH)
 
 .PHONY: build
-build: test pause tarballs clean-repo local-images checksums
+build: pause tarballs clean-repo local-images checksums
 
 .PHONY: release
 release: binaries pause tarballs clean-repo local-images images checksums


### PR DESCRIPTION
To go along with https://github.com/aws/eks-distro-prow-jobs/pull/143 instead of running unit tests for kubernetes in every post submit, only run them when patches or version changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

