### PR TITLE
use same version of kops for all release branches

### DIFF
--- a/development/kops/cluster_wait.sh
+++ b/development/kops/cluster_wait.sh
@@ -23,7 +23,7 @@ $PREFLIGHT_CHECK_PASSED || exit 1
 # Add IAM configmap
 COUNT=0
 echo 'Waiting for cluster to come up...'
-while ! kubectl apply -f ./${KOPS_CLUSTER_NAME}/aws-iam-authenticator.yaml
+while ! kubectl --context $KOPS_CLUSTER_NAME apply -f ./${KOPS_CLUSTER_NAME}/aws-iam-authenticator.yaml
 do
     sleep 5
     COUNT=$(expr $COUNT + 1)

--- a/development/kops/create_cluster.sh
+++ b/development/kops/create_cluster.sh
@@ -19,9 +19,4 @@ BASEDIR=$(dirname "$0")
 source ${BASEDIR}/set_environment.sh
 $PREFLIGHT_CHECK_PASSED || exit 1
 
-if  [[ $RELEASE_BRANCH == "1-18" ]]
-then
-    ${KOPS} update cluster --name ${KOPS_CLUSTER_NAME} --yes
-else
-    ${KOPS} update cluster --admin --name ${KOPS_CLUSTER_NAME} --yes
-fi
+${KOPS} update cluster --admin --name ${KOPS_CLUSTER_NAME} --yes

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -63,7 +63,6 @@ spec:
     image: {{ .kube_scheduler.repository }}:{{ .kube_scheduler.tag }}
   kubeProxy:
     image: {{ .kube_proxy.repository }}:{{ .kube_proxy.tag }}
-  # Metrics Server will be supported with kops 1.19
   metricsServer:
     enabled: true
     insecure: true
@@ -74,30 +73,14 @@ spec:
   kubeDNS:
     provider: CoreDNS
     coreDNSImage: {{ .coredns.repository }}:{{ .coredns.tag }}
-    externalCoreFile: |
-      .:53 {
-          errors
-          health {
-            lameduck 5s
-          }
-          kubernetes cluster.local. in-addr.arpa ip6.arpa {
-            pods insecure
-            #upstream
-            fallthrough in-addr.arpa ip6.arpa
-          }
-          prometheus :9153
-          forward . /etc/resolv.conf
-          loop
-          cache 30
-          loadbalance
-          reload
-      }
   masterKubelet:
     podInfraContainerImage: {{ .pause.repository }}:{{ .pause.tag }}
-  # kubelet might already be defined, append the following config
   kubelet:
     podInfraContainerImage: {{ .pause.repository }}:{{ .pause.tag }}
     anonymousAuth: false
+    # for 1.19 and above webhook auth is the default mode
+    authorizationMode: Webhook
+    authenticationTokenWebhook: true
 
 ---
 

--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -31,18 +31,7 @@ fi
 if [ ! -x ${KOPS} ]
 then
     echo "Determine kops version"
-    if [ "${RELEASE_BRANCH}" == "1-18" ]
-    then
-        KOPS_VERSION="v1.18.3"
-    else
-        if [ "${RELEASE_BRANCH}" == "1-20" ]
-        then
-            KOPS_VERSION="v1.20.0-beta.2"
-        else
-            KOPS_VERSION="v1.19.0-beta.3"
-        fi
-    fi
-
+    KOPS_VERSION="v1.20.0-beta.2"
     echo "Download kops"
     KOPS_URL="https://github.com/kubernetes/kops/releases/download/${KOPS_VERSION}/kops-${OS}-${ARCH}"
     set -x

--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -68,6 +68,6 @@ export ARTIFACT_URL=${ARTIFACT_URL:-https://distro.eks.amazonaws.com/kubernetes-
 export CNI_VERSION=$(cat ../../projects/containernetworking/plugins/GIT_TAG)
 export CNI_VERSION_URL=${ARTIFACT_URL}/plugins/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tar.gz
 export CNI_ASSET_HASH_STRING=${CNI_ASSET_HASH_STRING:-sha256:$(curl -s ${CNI_VERSION_URL}.sha256 | cut -f1 -d' ')}
-export KOPS=bin/kops-${RELEASE_BRANCH}
+export KOPS=bin/kops
 mkdir -p bin
 export PATH=`pwd`/bin:${PATH}


### PR DESCRIPTION
Looking at the kops release compat [page](https://kops.sigs.k8s.io/welcome/releases/) I wonder if we should just use the latest kops version for all k8s versions?  When updating to a new k8s version, we would then just bump the kops version to the respective version for that new k8s version.  Based on the historical release schedule, this may mean we end up typically using beta releases of kops, but that is what we have been using so far.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

