### PR TITLE
add additional wait for dns resolution for kops clusters

### DIFF
--- a/development/kops/run_all.sh
+++ b/development/kops/run_all.sh
@@ -45,6 +45,7 @@ trap cleanup SIGINT SIGTERM ERR
 ./create_cluster.sh
 ./set_nodeport_access.sh
 ./cluster_wait.sh
+./validate_dns.sh
 ./validate_eks.sh
 ./run_sonobuoy.sh
 ./delete_cluster.sh || true

--- a/development/kops/validate_dns.sh
+++ b/development/kops/validate_dns.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# In prow we have occasional dns issues after a cluster has been created
+# Wait for 60 seconds giving both dns pods a chance to get the latest
+# ip for the api server.  Printing out the results to potentially
+# make debugging easier
+
+set -eo pipefail
+BASEDIR=$(dirname "$0")
+echo "This script will create a cluster"
+cd "$BASEDIR"
+source ./set_environment.sh
+$PREFLIGHT_CHECK_PASSED || exit 1
+
+APISERVER="api.$KOPS_CLUSTER_NAME"
+for i in {1..12}
+do
+  echo "$APISERVER resolves to $(dig +short $APISERVER)"
+  sleep 5s
+done


### PR DESCRIPTION
There are a number of failures in prow due to dns resolution.  Attempt to solve this by waiting for the TTL to expire on the api server domain.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

