### PR TITLE
Get rid of DEVELOPMENT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
 ARTIFACT_BUCKET?=my-s3-bucket
 
-DEVELOPMENT?=false
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
@@ -33,7 +32,6 @@ build:
 		--target=build \
 		--release-branch=${RELEASE_BRANCH} \
 		--release=${RELEASE} \
-		--development=${DEVELOPMENT} \
 		--region=${AWS_REGION} \
 		--account-id=${AWS_ACCOUNT_ID} \
 		--image-repo=${IMAGE_REPO} \
@@ -47,7 +45,6 @@ postsubmit-build: setup
 		--target=release \
 		--release-branch=${RELEASE_BRANCH} \
 		--release=${RELEASE} \
-		--development=${DEVELOPMENT} \
 		--region=${AWS_REGION} \
 		--account-id=${AWS_ACCOUNT_ID} \
 		--image-repo=${IMAGE_REPO} \

--- a/cmd/main_postsubmit.go
+++ b/cmd/main_postsubmit.go
@@ -54,7 +54,6 @@ func main() {
 	target := flag.String("target", "release", "Make target")
 	releaseBranch := flag.String("release-branch", "1-19", "Release branch to test")
 	release := flag.String("release", "1", "Release to test")
-	development := flag.Bool("development", false, "Build as a development build")
 	region := flag.String("region", "us-west-2", "AWS region to use")
 	accountId := flag.String("account-id", "", "AWS Account ID to use")
 	imageRepo := flag.String("image-repo", "", "Container image repository")
@@ -83,7 +82,6 @@ func main() {
 	c.makeArgs = []string{
 		fmt.Sprintf("RELEASE_BRANCH=%s", c.releaseBranch),
 		fmt.Sprintf("RELEASE=%s", c.release),
-		fmt.Sprintf("DEVELOPMENT=%t", *development),
 		fmt.Sprintf("AWS_REGION=%s", *region),
 		fmt.Sprintf("AWS_ACCOUNT_ID=%s", *accountId),
 		fmt.Sprintf("IMAGE_REPO=%s", *imageRepo),

--- a/projects/coredns/coredns/Makefile
+++ b/projects/coredns/coredns/Makefile
@@ -10,7 +10,6 @@ REPO=coredns
 COMPONENT=coredns/$(REPO)
 CLONE_URL=https://github.com/$(COMPONENT).git
 
-DEVELOPMENT?=true
 AWS_REGION?=us-west-2
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 
@@ -26,9 +25,6 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=${GIT_TAG}-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 .PHONY: binaries
 binaries:

--- a/projects/etcd-io/etcd/Makefile
+++ b/projects/etcd-io/etcd/Makefile
@@ -10,7 +10,6 @@ REPO=etcd
 COMPONENT=etcd-io/$(REPO)
 CLONE_URL=https://github.com/$(COMPONENT).git
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
@@ -25,9 +24,6 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 .PHONY: binaries
 binaries:

--- a/projects/kubernetes-csi/external-attacher/Makefile
+++ b/projects/kubernetes-csi/external-attacher/Makefile
@@ -10,7 +10,6 @@ REPO=external-attacher
 COMPONENT=kubernetes-csi/$(REPO)
 CLONE_URL=https://github.com/$(COMPONENT).git
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
@@ -25,9 +24,6 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 .PHONY: binaries
 binaries:

--- a/projects/kubernetes-csi/external-provisioner/Makefile
+++ b/projects/kubernetes-csi/external-provisioner/Makefile
@@ -10,7 +10,6 @@ REPO=external-provisioner
 COMPONENT=kubernetes-csi/$(REPO)
 CLONE_URL=https://github.com/$(COMPONENT).git
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
@@ -26,10 +25,6 @@ IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 GOPROXY_DNS?=direct
 export GOPROXY=$(GOPROXY_DNS)
-
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 
 .PHONY: binaries

--- a/projects/kubernetes-csi/external-resizer/Makefile
+++ b/projects/kubernetes-csi/external-resizer/Makefile
@@ -10,7 +10,6 @@ REPO=external-resizer
 COMPONENT=kubernetes-csi/$(REPO)
 CLONE_URL=https://github.com/$(COMPONENT).git
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
@@ -25,9 +24,6 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 .PHONY: binaries
 binaries:

--- a/projects/kubernetes-csi/external-snapshotter/Makefile
+++ b/projects/kubernetes-csi/external-snapshotter/Makefile
@@ -10,7 +10,6 @@ REPO=external-snapshotter
 COMPONENT=kubernetes-csi/$(REPO)
 CLONE_URL=https://github.com/$(COMPONENT).git
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
@@ -30,9 +29,6 @@ SNAPSHOT_VALIDATION_WEBHOOK_IMAGE?=$(IMAGE_REPO)/kubernetes-csi/external-snapsho
 GOPROXY_DNS?=direct
 export GOPROXY=$(GOPROXY_DNS)
 
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 .PHONY: binaries
 binaries:

--- a/projects/kubernetes-csi/livenessprobe/Makefile
+++ b/projects/kubernetes-csi/livenessprobe/Makefile
@@ -10,7 +10,6 @@ REPO=livenessprobe
 COMPONENT=kubernetes-csi/$(REPO)
 CLONE_URL=https://github.com/$(COMPONENT).git
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
@@ -25,9 +24,6 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 .PHONY: binaries
 binaries:

--- a/projects/kubernetes-csi/node-driver-registrar/Makefile
+++ b/projects/kubernetes-csi/node-driver-registrar/Makefile
@@ -10,7 +10,6 @@ REPO=node-driver-registrar
 COMPONENT=kubernetes-csi/$(REPO)
 CLONE_URL=https://github.com/$(COMPONENT).git
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
@@ -25,9 +24,6 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 .PHONY: binaries
 binaries:

--- a/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
@@ -10,7 +10,6 @@ REPO=aws-iam-authenticator
 COMPONENT=kubernetes-sigs/$(REPO)
 CLONE_URL=https://github.com/$(COMPONENT).git
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
@@ -25,9 +24,6 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 .PHONY: binaries
 binaries:

--- a/projects/kubernetes-sigs/metrics-server/Makefile
+++ b/projects/kubernetes-sigs/metrics-server/Makefile
@@ -10,7 +10,6 @@ REPO=metrics-server
 COMPONENT=kubernetes-sigs/$(REPO)
 CLONE_URL=https://github.com/$(COMPONENT).git
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
@@ -25,9 +24,6 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 #Make sure GOPATH is set
 .PHONY: binaries

--- a/projects/kubernetes/release/Makefile
+++ b/projects/kubernetes/release/Makefile
@@ -10,7 +10,6 @@ REPO=release
 COMPONENT=kubernetes/$(REPO)
 CLONE_URL=https://github.com/$(COMPONENT).git
 
-DEVELOPMENT?=true
 AWS_REGION?=us-west-2
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 
@@ -30,9 +29,6 @@ KUBE_PROXY_BASE_IMAGE_NAME?=kubernetes/kube-proxy-base
 KUBE_PROXY_BASE_IMAGE_TAG?=${GIT_TAG}-eks-${RELEASE_BRANCH}-${RELEASE}
 KUBE_PROXY_BASE_IMAGE?=$(IMAGE_REPO)/$(KUBE_PROXY_BASE_IMAGE_NAME):$(KUBE_PROXY_BASE_IMAGE_TAG)
 
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 .PHONY: binaries
 binaries:

--- a/release/s3_sync.sh
+++ b/release/s3_sync.sh
@@ -20,9 +20,9 @@ RELEASE="${2?Second required argument is release for example 1}"
 ARTIFACT_BUCKET="${3?Third required argument is artifact bucket name}"
 REPO="${4:-""}"
 BASE_DIRECTORY=$(git rev-parse --show-toplevel)
-DEVELOPMENT=${DEVELOPMENT:-false}
+RELEASE_ENVIRONMENT=${RELEASE_ENVIRONMENT:-development}
 
-if [ "$DEVELOPMENT" == "false" ]
+if [ "$RELEASE_ENVIRONMENT" == "production" ]
 then
   PUBLIC_READ='--acl public-read'
 else


### PR DESCRIPTION
This DEVELOPMENT variable was used in a strange way and we should just stick with the new RELEASE_ENVIRONMENT. This changes the development build so you use the real base image consistent with how prow does it. Our instructions already say to use the base image.