### PR TITLE
Exit PR creation script gracefully if no files were changed

### DIFF
--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -44,6 +44,10 @@ git checkout -b $PR_BRANCH
 for FILE in $(find . -type f \( -name ATTRIBUTION.txt ! -path "*/_output/*" \)); do    
     git add $FILE
 done
+FILES_ADDED=$(git diff --staged --name-only)
+if [ "$FILES_CHANGED" = "" ]; then
+    exit 0
+fi
 
 git commit -m "$COMMIT_MESSAGE" || true
 


### PR DESCRIPTION
We don't want the script to invoke `git commit` and fail if no files were modified, i.e., thus no files were added by `git add`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
