### PR TITLE
Fix variable name in PR creation script

### DIFF
--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -45,7 +45,7 @@ for FILE in $(find . -type f \( -name ATTRIBUTION.txt ! -path "*/_output/*" \));
     git add $FILE
 done
 FILES_ADDED=$(git diff --staged --name-only)
-if [ "$FILES_CHANGED" = "" ]; then
+if [ "$FILES_ADDED" = "" ]; then
     exit 0
 fi
 


### PR DESCRIPTION
Fixed the variable name in the PR creation script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
