### PR TITLE
retry sonobuoy run and validate kops cluster additional times

### DIFF
--- a/development/kops/cluster_wait.sh
+++ b/development/kops/cluster_wait.sh
@@ -36,4 +36,4 @@ do
 done
 
 set -x
-${KOPS} validate cluster --wait 15m
+${KOPS} validate cluster --wait 15m --count 5

--- a/development/kops/run_sonobuoy.sh
+++ b/development/kops/run_sonobuoy.sh
@@ -29,8 +29,8 @@ fi
 CONFORMANCE_IMAGE=k8s.gcr.io/conformance:${KUBERNETES_VERSION}
 wget -qO- ${SONOBUOY} |tar -xz sonobuoy
 chmod 755 sonobuoy
-echo "Making sure cluster ${KOPS_CLUSTER_NAME} is ready to run sonobuoy"
-while ! ./sonobuoy --context ${KOPS_CLUSTER_NAME} run --mode=certified-conformance --wait --mode quick --kube-conformance-image ${CONFORMANCE_IMAGE}
+echo "Testing cluster ${KOPS_CLUSTER_NAME}"
+while ! ./sonobuoy --context ${KOPS_CLUSTER_NAME} run --mode=certified-conformance --wait --kube-conformance-image ${CONFORMANCE_IMAGE}
 do
   ./sonobuoy --context ${KOPS_CLUSTER_NAME} delete --all --wait||true
   sleep 5
@@ -42,9 +42,7 @@ do
   fi
   echo 'Waiting for the cluster to be ready...'
 done
-./sonobuoy --context ${KOPS_CLUSTER_NAME} delete --all --wait||true
-echo "Testing cluster ${KOPS_CLUSTER_NAME}"
-./sonobuoy --context ${KOPS_CLUSTER_NAME} run --mode=certified-conformance --wait --kube-conformance-image ${CONFORMANCE_IMAGE}
+
 results=$(./sonobuoy --context ${KOPS_CLUSTER_NAME} retrieve)
 mv $results "./${KOPS_CLUSTER_NAME}/$results"
 results="./${KOPS_CLUSTER_NAME}/$results"


### PR DESCRIPTION
kops validate accepts and --count perm to run the validation multiple times.  Setting this to 5 just to see if maybe that would limit some of the random dns flakes we see. 

Also, instead of running the quick conformance tests, which was an attempt to make sure the cluster and dns was all up, now run the real tests and just retry until it works.... Looking through the sonobuoy code im pretty sure that it only returns an error code != 0 when it fails to get started, once its running even if the tests fail, it still returns a 0.  So I do not think this will create an infinite loop of runs when a test does actually fail, but we should watch for that case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
