### PR TITLE
fix gather logs for bash 4.3 in builder base

### DIFF
--- a/development/kops/cluster_wait.sh
+++ b/development/kops/cluster_wait.sh
@@ -36,4 +36,4 @@ do
 done
 
 set -x
-${KOPS} validate cluster --wait 15m --count 5
+${KOPS} validate cluster --wait 15m

--- a/development/kops/log-dump/Readme.md
+++ b/development/kops/log-dump/Readme.md
@@ -15,3 +15,7 @@ of sync-ing from upstream, please document them here. The script is unmodified e
    * Note: there are two inconsequential changes made by the above sed commands that actually should not be changed.
      A comment with a github url in it and a file name, which is not create by kops and therefore 
      does not affect the intent of how we are using the script.
+* the version of bash (4.3) we use in our builds does not support using ${arr[@]} when the array is empty.  There is one
+  spot in the script that tries to do this for windows node, which we are not using.
+   * sed -i 's/all_selected_nodes+=( "${windows_node_names\[@\]}" )//' log-dump.sh
+   * Note: https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u

--- a/development/kops/log-dump/log-dump.sh
+++ b/development/kops/log-dump/log-dump.sh
@@ -608,7 +608,7 @@ function dump_nodes() {
     linux_nodes_selected_for_logs=( "${node_names[@]}" )
   fi
   all_selected_nodes=( "${linux_nodes_selected_for_logs[@]}" )
-  all_selected_nodes+=( "${windows_node_names[@]}" )
+  
 
   proc=${max_dump_processes}
   start="$(date +%s)"

--- a/development/kops/run_all.sh
+++ b/development/kops/run_all.sh
@@ -20,7 +20,7 @@ cd ${BASEDIR}
 function cleanup()
 {
   echo 'Deleting...'
-  ./gather_logs.sh
+  ./gather_logs.sh || true
   ./delete_cluster.sh || true
   ./delete_store.sh
   exit 255;
@@ -49,6 +49,6 @@ trap cleanup SIGINT SIGTERM ERR
 ./validate_dns.sh
 ./validate_eks.sh
 ./run_sonobuoy.sh
-./gather_logs.sh
+./gather_logs.sh || true
 ./delete_cluster.sh || true
 ./delete_store.sh


### PR DESCRIPTION
From [postsubmit](https://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm.s3.us-west-2.amazonaws.com/logs/build-1-18-postsubmit/1379462774362476544/build-container-build-log.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAUTLHWUYSKQA5MCGD%2F20210406%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210406T165535Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjENn%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJIMEYCIQD4KzqhPdleZdpzCX8rSPY3VhYz8Siq3OrnLu8%2FQQ7lxQIhAO8WqlvP6VQ0YU3jcvvdQtHUBDlHq7fRD9RE8SSToTolKvAECDIQABoMMzE2NDM0NDU4MTQ4Igwj5o86hehNhLV%2FoOkqzQTKWNi06a6l2E%2F7MwMVSbAdcf5ONd0tpr52wIHCxaOB14hMt1kll8RJ1bx1OYj0FkTI5RFCDCDJKNftKeQC0myGxSayuR0cPoktO8eRIGfAWi2oJsJpn5Z0jVVjWERRnbcnaj1EBS05QDzNxC1xX9MTal956TegfEfyHK2704nlS%2F9lYPFJD0glo9FYCx7F%2B0kO4bYfe%2F1%2BhFa83sSIUMpBkKENl32ce9Ses%2F0iVZysYeZtPHshD%2Fxwiwc63wJnJen3nmfVaBQafPitEvILowdBF9pf%2F8r4ZZUPiUUMqXpoQT9bkZ2Xw%2FKvYdTh0dJ6MRxhYT04qXRXzTSFVjkunnS%2FwQRkV1%2ByC%2BicfSEL3rOjGhWXONg2xjzhg143QsgDyXgOE9j2M4ofNdyDUHyAvsKo5eL9QhaExQ%2BINYu%2FCImdcvbX%2FkQ%2FCOssEMznCPXCc2D3bfsz0RoDZt20p1h72CruHbBFfdW%2FANSBHcBOwXAjrlVkkGOvI9wJ3SPwFld%2FLE3kwUQPwgd%2BgJZjlZnvvVK6NtcKBvbe9XBdlbthb3FBxZQVEJzA9ZGGAi0ouX6u3%2FNucGV2vGYw%2BAs2mA8fG4Wsp8WGFHCqK%2B5IdpGpnW3ya%2Bcw43X4CGs%2B%2FSoK3OPKLmxGqCgPKksa16V9AdYzUWOHAnGRN5g4W6FxTudiEGvxp2DkIRVcCOA7dwkV4S3N%2F%2FTqmLRndly9Z3z3k9m3x6e%2FInk7BaLa%2B83ysrFnT3NryrA8jzoKTastrEespAyfymJ1LYGVg3DxED2oZsvnMMKisoMGOpkByI%2B0ItgP%2Bt8jGGzrN%2BmtU5G8loWZkh5bYvV7un7jVgKf45jSODVf8YkwExuHIzm6dQIjfv5jLCFc6Jwuv353drpRftrWbCSbonyS0Oma69G5UFWy0ai6ZdOzc9l38y3NqzSIvcYGoJHmNcepwXOl2o%2B3AiuMqCrXqWbJkUWEnVDg8NdxSSdr8MGVzI9RgThR%2BpTBaLWW0S3O&X-Amz-SignedHeaders=host&X-Amz-Signature=723dfb2b13bb127dc6b9899a33cd00cc0355fa8f4c115657aee017ec9e83b2e3) the new log-dump script from the upstream test-infra repo does not work correctly on bash 4.3, which we use in the builder base.

There was also an issue in this run where the kops cluster did not validate.  We had added a --count flag to that call to try and stabilize random dns issues.  Looking at the kops [code](https://github.com/kubernetes/kops/blob/v1.20.0-beta.2/cmd/kops/validate_cluster.go#L225) further if using --count, kops will fail as soon as a failure happens after a previous success.  This is really not what we want so removing this flag for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
