### PR TITLE
WIP - Add OCI image tarballs for etcd and coredns

### DIFF
--- a/projects/coredns/coredns/Makefile
+++ b/projects/coredns/coredns/Makefile
@@ -34,6 +34,10 @@ endif
 binaries:
 	build/create_binaries.sh $(CLONE_URL) $(REPO) $(GIT_TAG) $(GOLANG_VERSION)
 
+.PHONY: image-tars
+image-tars:
+	build/create_image_tars.sh $(BASE_IMAGE) $(RELEASE_BRANCH) $(IMAGE)
+
 .PHONY: local-images
 local-images: binaries
 	buildctl \
@@ -44,7 +48,7 @@ local-images: binaries
 		--opt build-arg:RELEASE_BRANCH=$(RELEASE_BRANCH) \
 		--local dockerfile=./docker/linux \
 		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=/tmp/coredns.tar
+		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=$(MAKE_ROOT)/_output/bin/coredns/linux-amd64/coredns.tar
 		
 .PHONY: images
 images: binaries
@@ -73,10 +77,10 @@ docker-push:
 	docker push $(IMAGE)
 
 .PHONY: build
-build: local-images
+build: local-images image-tars
 
 .PHONY: release
-release: images
+release: images image-tars
 	echo "Done $(COMPONENT)"
 
 .PHONY: all

--- a/projects/coredns/coredns/build/create_image_tars.sh
+++ b/projects/coredns/coredns/build/create_image_tars.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+BASE_IMAGE="$1"
+RELEASE_BRANCH="$2"
+IMAGE="$3"
+
+readonly SUPPORTED_PLATFORMS=(
+  linux/amd64
+  linux/arm64
+)
+
+MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "${MAKE_ROOT}/../../../build/lib/common.sh"
+
+function build::coredns::image_tars(){
+  for platform in "${SUPPORTED_PLATFORMS[@]}";
+  do
+      OS="$(cut -d '/' -f1 <<< ${platform})"
+      ARCH="$(cut -d '/' -f2 <<< ${platform})"
+      buildctl \
+		      build \
+		      --frontend dockerfile.v0 \
+		      --opt platform=${platform} \
+		      --opt build-arg:BASE_IMAGE=${BASE_IMAGE} \
+          --opt build-arg:RELEASE_BRANCH=${RELEASE_BRANCH} \
+		      --local dockerfile=./docker/linux \
+		      --local context=. \
+		      --output type=oci,oci-mediatypes=true,name=${IMAGE},dest=${MAKE_ROOT}/_output/bin/coredns/${OS}-${ARCH}/coredns.tar
+  done
+}
+
+build::coredns::image_tars

--- a/projects/etcd-io/etcd/Makefile
+++ b/projects/etcd-io/etcd/Makefile
@@ -33,6 +33,10 @@ endif
 binaries:
 	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_TAG) $(GOLANG_VERSION)
 
+.PHONY: image-tars
+image-tars:
+	build/create_image_tars.sh $(BASE_IMAGE) $(IMAGE)
+
 .PHONY: local-images
 local-images: binaries
 	buildctl \
@@ -42,7 +46,7 @@ local-images: binaries
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
 		--local dockerfile=./docker/linux \
 		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=/tmp/etcd.tar
+		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=$(MAKE_ROOT)/_output/bin/etcd/linux-amd64/etcd.tar
 
 .PHONY: images
 images: binaries
@@ -73,10 +77,10 @@ tarballs:
 	build/create_tarballs.sh $(REPO) $(GIT_TAG)
 
 .PHONY: build
-build: local-images tarballs
+build: local-images image-tars tarballs
 
 .PHONY: release
-release: images tarballs
+release: images image-tars tarballs
 	$(BASE_DIRECTORY)/release/copy_artifacts.sh $(COMPONENT) $(RELEASE_BRANCH) $(RELEASE)
 	$(BASE_DIRECTORY)/release/s3_sync.sh $(RELEASE_BRANCH) $(RELEASE) $(ARTIFACT_BUCKET) $(REPO)
 	echo "Done $(COMPONENT)"

--- a/projects/etcd-io/etcd/build/create_image_tars.sh
+++ b/projects/etcd-io/etcd/build/create_image_tars.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+BASE_IMAGE="$1"
+IMAGE="$2"
+
+readonly SUPPORTED_PLATFORMS=(
+  linux/amd64
+  linux/arm64
+)
+
+MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "${MAKE_ROOT}/../../../build/lib/common.sh"
+
+function build::etcd::image_tars(){
+  for platform in "${SUPPORTED_PLATFORMS[@]}";
+  do
+      OS="$(cut -d '/' -f1 <<< ${platform})"
+      ARCH="$(cut -d '/' -f2 <<< ${platform})"
+      buildctl \
+		      build \
+		      --frontend dockerfile.v0 \
+		      --opt platform=${platform} \
+		      --opt build-arg:BASE_IMAGE=${BASE_IMAGE} \
+		      --local dockerfile=./docker/linux \
+		      --local context=. \
+		      --output type=oci,oci-mediatypes=true,name=${IMAGE},dest=${MAKE_ROOT}/_output/bin/etcd/${OS}-${ARCH}/etcd.tar
+  done
+}
+
+build::etcd::image_tars


### PR DESCRIPTION
We need OCI image tarballs of etcd and coredns projects for building AMI's with EKS-D artifacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
