### PR TITLE
use postsubmit bucket artifacts when creating kops cluster

### DIFF
--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -19,6 +19,11 @@ export RELEASE_BRANCH=${RELEASE_BRANCH:-"${DEFAULT_RELEASE_BRANCH}"}
 RELEASE_ENVIRONMENT=${RELEASE_ENVIRONMENT:-development}
 export DEFAULT_RELEASE=$(cat ${BASE_DIRECTORY}/release/${RELEASE_BRANCH}/${RELEASE_ENVIRONMENT}/RELEASE)
 export RELEASE=${RELEASE:-${DEFAULT_RELEASE}}
+export ARTIFACT_BASE_URL="https://distro.eks.amazonaws.com"
+
+if [ -n "$ARTIFACT_BUCKET" ]; then
+    export ARTIFACT_BASE_URL="https://$ARTIFACT_BUCKET.s3.amazonaws.com"
+fi
 
 if [ "${PREFLIGHT_CHECK_PASSED:-false}" != "true" ]
 then
@@ -65,7 +70,7 @@ export PREFLIGHT_CHECK_PASSED
 
 export KUBERNETES_VERSION=$(cat ../../projects/kubernetes/kubernetes/${RELEASE_BRANCH}/GIT_TAG)
 export IMAGE_REPO=${IMAGE_REPO:-public.ecr.aws/eks-distro}
-export ARTIFACT_URL=${ARTIFACT_URL:-https://distro.eks.amazonaws.com/kubernetes-${RELEASE_BRANCH}/releases/${RELEASE}/artifacts}
+export ARTIFACT_URL=${ARTIFACT_URL:-$ARTIFACT_BASE_URL/kubernetes-${RELEASE_BRANCH}/releases/${RELEASE}/artifacts}
 export CNI_VERSION=$(cat ../../projects/containernetworking/plugins/GIT_TAG)
 export CNI_VERSION_URL=${ARTIFACT_URL}/plugins/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tar.gz
 export CNI_ASSET_HASH_STRING=${CNI_ASSET_HASH_STRING:-sha256:$(curl -s ${CNI_VERSION_URL}.sha256 | cut -f1 -d' ')}


### PR DESCRIPTION
When going through the embargo process @abhinavmpandey08 and I noticed that the kops cluster being created is using the artifacts from the prod cloudfront distro.  I believe that it should be using the artifacts that were just built and pushed to the artifact bucket instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
