### PR TITLE
kubernetes do not call local-images in release target

### DIFF
--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -31,10 +31,11 @@ PRESUBMIT_GO_RUNNER_IMAGE?=$(KUBE_BASE_REPO)/$(GO_RUNNER_IMAGE_NAME):$(PRESUBMIT
 PRESUBMIT_KUBE_PROXY_BASE_IMAGE?=$(KUBE_BASE_REPO)/$(KUBE_PROXY_BASE_IMAGE_NAME):$(PRESUBMIT_KUBE_BASE_TAG)
 
 PAUSE_SRC_DIR?=kubernetes/build/pause
-PAUSE_DST_DIR?=_output/pause
+PAUSE_DST_DIR?=_output/$(RELEASE_BRANCH)/pause
 PAUSE_IMAGE_NAME?=pause
 PAUSE_IMAGE_TAG?=$(IMAGE_TAG)
 PAUSE_IMAGE?=$(IMAGE_REPO)/$(IMAGE_REPO_PREFIX)/$(PAUSE_IMAGE_NAME):$(PAUSE_IMAGE_TAG)
+PAUSE_IMAGE_3_2="$(IMAGE_REPO)/$(IMAGE_REPO_PREFIX)/$(PAUSE_IMAGE_NAME):3.2"
 
 .PHONY: update-version
 update-version: binaries
@@ -60,30 +61,21 @@ pause: $(PAUSE_DST_DIR)/pause.c
 
 .PHONY: local-images
 local-images:
-	build/create_images.sh $(RELEASE_BRANCH) $(PRESUBMIT_GO_RUNNER_IMAGE) $(PRESUBMIT_KUBE_PROXY_BASE_IMAGE) $(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false
-	buildctl \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--local dockerfile=./docker/pause/ \
-		--local context=./_output/pause \
-		--opt build-arg:BASE_IMAGE=$(PRESUBMIT_GO_RUNNER_IMAGE) \
-		--opt build-arg:VERSION=$(IMAGE_TAG) \
-		--output type=oci,oci-mediatypes=true,name=$(PAUSE_IMAGE),dest=_output/$(RELEASE_BRANCH)/bin/linux/amd64/pause.tar
+	build/create_images.sh \
+		$(RELEASE_BRANCH) $(PRESUBMIT_GO_RUNNER_IMAGE) $(PRESUBMIT_KUBE_PROXY_BASE_IMAGE) \
+		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) "$(PAUSE_IMAGE),$(PAUSE_IMAGE_3_2)" false
 
 .PHONY: images
 images:
-	build/create_images.sh $(RELEASE_BRANCH) $(GO_RUNNER_IMAGE) $(KUBE_PROXY_BASE_IMAGE) $(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) true
-	buildctl \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64,linux/arm64  \
-		--local dockerfile=./docker/pause/ \
-		--local context=./_output/pause \
-		--opt build-arg:BASE_IMAGE=$(GO_RUNNER_IMAGE) \
-		--opt build-arg:VERSION=$(IMAGE_TAG) \
-		--output type=image,oci-mediatypes=true,\"name=$(PAUSE_IMAGE),$(IMAGE_REPO)/$(IMAGE_REPO_PREFIX)/$(PAUSE_IMAGE_NAME):3.2\",push=true
-
+	# we publish oci tarballs in release mode in addition to pushing images for use by kops and other installer tools
+	build/create_images.sh \
+		$(RELEASE_BRANCH) $(GO_RUNNER_IMAGE) $(KUBE_PROXY_BASE_IMAGE) \
+		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) "$(PAUSE_IMAGE),$(PAUSE_IMAGE_3_2)" false
+	
+	build/create_images.sh \
+		$(RELEASE_BRANCH) $(GO_RUNNER_IMAGE) $(KUBE_PROXY_BASE_IMAGE) \
+		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) "$(PAUSE_IMAGE),$(PAUSE_IMAGE_3_2)" true
+		
 .PHONY: docker
 docker: binaries pause
 	build/create_docker_images.sh $(RELEASE_BRANCH) $(GO_RUNNER_IMAGE) $(KUBE_PROXY_BASE_IMAGE) $(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG)
@@ -92,14 +84,14 @@ docker: binaries pause
 		--build-arg BASE_IMAGE=$(GO_RUNNER_IMAGE) \
 		--build-arg VERSION=$(IMAGE_TAG) \
 		-t $(PAUSE_IMAGE) \
-		-t $(IMAGE_REPO)/$(IMAGE_REPO_PREFIX)/$(PAUSE_IMAGE_NAME):3.2 \
-		-f ./docker/pause/Dockerfile ./_output/pause/
+		-t $(PAUSE_IMAGE_3_2) \
+		-f ./docker/pause/Dockerfile $(PAUSE_DST_DIR)
 
 .PHONY: docker-push
 docker-push:
 	build/docker_push.sh $(RELEASE_BRANCH) $(GO_RUNNER_IMAGE) $(KUBE_PROXY_BASE_IMAGE) $(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG)
 	docker push $(PAUSE_IMAGE)
-	docker push $(IMAGE_REPO)/$(IMAGE_REPO_PREFIX)/$(PAUSE_IMAGE_NAME):3.2
+	docker push $(PAUSE_IMAGE_3_2)
 
 .PHONY: checksums
 checksums:
@@ -109,7 +101,7 @@ checksums:
 build: binaries pause tarballs clean-repo local-images checksums
 
 .PHONY: release
-release: binaries pause tarballs clean-repo local-images images checksums
+release: binaries pause tarballs clean-repo images checksums
 	$(BASE_DIRECTORY)/release/copy_artifacts.sh $(COMPONENT) $(RELEASE_BRANCH) $(RELEASE)
 	$(BASE_DIRECTORY)/release/s3_sync.sh $(RELEASE_BRANCH) $(RELEASE) $(ARTIFACT_BUCKET) $(REPO)
 	echo "Done $(COMPONENT)"

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -63,7 +63,7 @@ pause: $(PAUSE_DST_DIR)/pause.c
 local-images:
 	build/create_images.sh \
 		$(RELEASE_BRANCH) $(PRESUBMIT_GO_RUNNER_IMAGE) $(PRESUBMIT_KUBE_PROXY_BASE_IMAGE) \
-		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) "$(PAUSE_IMAGE),$(PAUSE_IMAGE_3_2)" false
+		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) "$(PAUSE_IMAGE),$(PAUSE_IMAGE_3_2)" false true
 
 .PHONY: images
 images:

--- a/projects/kubernetes/kubernetes/build/create_images.sh
+++ b/projects/kubernetes/kubernetes/build/create_images.sh
@@ -27,6 +27,7 @@ REPO_PREFIX="$5"
 IMAGE_TAG="$6"
 PAUSE_IMAGE="$7"
 PUSH="$8"
+SKIP_ARM=${9-false}
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
@@ -40,7 +41,7 @@ BIN_DIR=${OUTPUT_DIR}/${RELEASE_BRANCH}/bin
 if [ "$PUSH" != "true" ]; then
     echo "Placing images under in $BIN_DIR"
     build::images::release_image_tar $RELEASE_BRANCH $GO_RUNNER_IMAGE $KUBE_PROXY_BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $BIN_DIR
-    build::images::pause_tar $GO_RUNNER_IMAGE $IMAGE_TAG $PAUSE_IMAGE ${OUTPUT_DIR}/${RELEASE_BRANCH}/pause $BIN_DIR
+    build::images::pause_tar $GO_RUNNER_IMAGE $IMAGE_TAG $PAUSE_IMAGE ${OUTPUT_DIR}/${RELEASE_BRANCH}/pause $BIN_DIR $SKIP_ARM
 
 else
     build::images::push $RELEASE_BRANCH $GO_RUNNER_IMAGE $KUBE_PROXY_BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $BIN_DIR

--- a/projects/kubernetes/kubernetes/build/create_images.sh
+++ b/projects/kubernetes/kubernetes/build/create_images.sh
@@ -25,7 +25,8 @@ KUBE_PROXY_BASE_IMAGE="$3"
 REPOSITORY_BASE="$4"
 REPO_PREFIX="$5"
 IMAGE_TAG="$6"
-PUSH="$7"
+PAUSE_IMAGE="$7"
+PUSH="$8"
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
@@ -39,6 +40,10 @@ BIN_DIR=${OUTPUT_DIR}/${RELEASE_BRANCH}/bin
 if [ "$PUSH" != "true" ]; then
     echo "Placing images under in $BIN_DIR"
     build::images::release_image_tar $RELEASE_BRANCH $GO_RUNNER_IMAGE $KUBE_PROXY_BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $BIN_DIR
+    build::images::pause_tar $GO_RUNNER_IMAGE $IMAGE_TAG $PAUSE_IMAGE ${OUTPUT_DIR}/${RELEASE_BRANCH}/pause $BIN_DIR
+
 else
     build::images::push $RELEASE_BRANCH $GO_RUNNER_IMAGE $KUBE_PROXY_BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $BIN_DIR
+    build::images::pause_push $GO_RUNNER_IMAGE $IMAGE_TAG $PAUSE_IMAGE ${OUTPUT_DIR}/${RELEASE_BRANCH}/pause 
 fi
+

--- a/projects/kubernetes/kubernetes/build/lib/images.sh
+++ b/projects/kubernetes/kubernetes/build/lib/images.sh
@@ -141,8 +141,12 @@ function build::images::pause_tar(){
     local -r image_tag="$3"
     local -r context_dir="$4"
     local -r bin_dir="$5"
+    local -r skip_arm="$6"
 
     for platform in "${KUBE_LINUX_IMAGE_PLATFORMS[@]}"; do
+        if [ "$platform" == "arm64" ] && [ $skip_arm == true ]; then
+            continue
+        fi
         buildctl \
             build \
             --frontend dockerfile.v0 \

--- a/projects/kubernetes/kubernetes/build/lib/images.sh
+++ b/projects/kubernetes/kubernetes/build/lib/images.sh
@@ -133,3 +133,44 @@ function build::images::docker::push(){
         docker push ${repository}/${repo_prefix}/${binary}:${image_tag}
     done
 }
+
+# Create platform-specific OCI image tars
+function build::images::pause_tar(){
+    local -r go_runner_image="$1"
+    local -r version="$2"
+    local -r image_tag="$3"
+    local -r context_dir="$4"
+    local -r bin_dir="$5"
+
+    for platform in "${KUBE_LINUX_IMAGE_PLATFORMS[@]}"; do
+        buildctl \
+            build \
+            --frontend dockerfile.v0 \
+            --opt platform=linux/${platform} \
+            --local dockerfile=./docker/pause/ \
+            --local context=${context_dir} \
+            --opt build-arg:BASE_IMAGE=${go_runner_image} \
+            --opt build-arg:VERSION=${version} \
+            --output type=oci,oci-mediatypes=true,\"name=${image_tag}\",dest=${bin_dir}/linux/${platform}/pause.tar
+    done
+}
+
+# Create platform-specific OCI image tars
+function build::images::pause_push(){
+    local -r go_runner_image="$1"
+    local -r version="$2"
+    local -r image_tag="$3"
+    local -r context_dir="$4"
+
+    for platform in "${KUBE_LINUX_IMAGE_PLATFORMS[@]}"; do
+        buildctl \
+            build \
+            --frontend dockerfile.v0 \
+            --opt platform=linux/${platform} \
+            --local dockerfile=./docker/pause/ \
+            --local context=${context_dir} \
+            --opt build-arg:BASE_IMAGE=${go_runner_image} \
+            --opt build-arg:VERSION=${version} \
+            --output type=image,oci-mediatypes=true,\"name=${image_tag}\",push=true
+    done
+}


### PR DESCRIPTION
We added the local-images call to the release target to support the kops testing because the oci tarballs are needed.  However, due to the fact that the local-images is intended to be used only by the build target and not the release target, a hardcoded "hack" was added to make local-images work when adding new versions of kubernetes.  This means that our oci images produced by the release targets are not 100% correct since they are using the hardcoded go-runner tag.  This also makes spinning up new dev stacks/envs difficult because we assume that hardcoded go-runner image exist (I am going to look at this in a future pr).

This PR changes the kubernetes makefile to instead of calling the local-images target, the images target calls the helper create-images script two times, one of local oci tarballs and one for pushing to the registry.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
