### PR TITLE
Make kops domain name configurable

### DIFF
--- a/development/kops/prow.sh
+++ b/development/kops/prow.sh
@@ -40,7 +40,9 @@ EOF
 export AWS_CONFIG_FILE=$(pwd)/config
 export AWS_PROFILE=conformance-test
 unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE
-export KOPS_CLUSTER_NAME=${RELEASE_BRANCH}-$(git rev-parse --short HEAD).prod-build-pdx.kops-ci.model-rocket.aws.dev
+DEFAULT_KOPS_ZONE_NAME="prod-build-pdx.kops-ci.model-rocket.aws.dev"
+KOPS_ZONE_NAME=${KOPS_ZONE_NAME:-"${DEFAULT_KOPS_ZONE_NAME}"}
+export KOPS_CLUSTER_NAME=${RELEASE_BRANCH}-$(git rev-parse --short HEAD).${KOPS_ZONE_NAME}
 if  [[ $RELEASE_BRANCH == "1-20" ]]
 then
   # Hack to make sure we create kops clusters for both kubernetes 1-18 and 1-19


### PR DESCRIPTION
kops domain name is currently set to a static value `prod-build-pdx.kops-ci.model-rocket.aws.dev`
This PR parameterizes that kops domain so a custom one can be passed in without having to modify the `prow.sh` script. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
