### PR TITLE
new patches from upstream for 1.18 1.19 and 1.20

### DIFF
--- a/projects/kubernetes/kubernetes/1-18/patches/0019-2021-25735_1_18.patch
+++ b/projects/kubernetes/kubernetes/1-18/patches/0019-2021-25735_1_18.patch
@@ -1,0 +1,1343 @@
+From a8d0a02ef8150de1cf465cd87202215b782aec31 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Fri, 29 Jan 2021 13:28:44 -0500
+Subject: update fuzzer to create random, but valid nodes
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/fuzzer/fuzzer.go                | 52 ++++++++++++++++++-
+ .../pkg/apis/meta/fuzzer/fuzzer.go            | 24 ++++++++-
+ 2 files changed, 73 insertions(+), 3 deletions(-)
+
+diff --git a/pkg/apis/core/fuzzer/fuzzer.go b/pkg/apis/core/fuzzer/fuzzer.go
+index 44517298295..df747a9c073 100644
+--- a/pkg/apis/core/fuzzer/fuzzer.go
++++ b/pkg/apis/core/fuzzer/fuzzer.go
+@@ -21,10 +21,12 @@ import (
+ 	"strconv"
+ 	"time"
+ 
+-	fuzz "github.com/google/gofuzz"
++	"k8s.io/apimachinery/pkg/util/uuid"
+ 
++	fuzz "github.com/google/gofuzz"
+ 	corev1 "k8s.io/api/core/v1"
+ 	"k8s.io/apimachinery/pkg/api/resource"
++	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/runtime"
+ 	"k8s.io/apimachinery/pkg/runtime/schema"
+@@ -293,6 +295,40 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
+ 			ct.TerminationMessagePath = "/" + ct.TerminationMessagePath // Must be non-empty
+ 			ct.TerminationMessagePolicy = "File"
+ 		},
++		func(p *core.Taint, c fuzz.Continue) {
++			c.FuzzNoCustom(p) // fuzz self without calling this function again
++			if p == nil {
++				return
++			}
++
++			p.Key = metafuzzer.RandomDNSLabel(c)
++			switch c.Rand.Int31n(3) {
++			case 0:
++				p.Effect = core.TaintEffectNoSchedule
++			case 1:
++				p.Effect = core.TaintEffectNoExecute
++			case 2:
++				p.Effect = core.TaintEffectPreferNoSchedule
++			}
++			p.Value = metafuzzer.RandomDNSLabel(c)
++		},
++		func(p *core.ConfigMapNodeConfigSource, c fuzz.Continue) {
++			c.FuzzNoCustom(p) // fuzz self without calling this function again
++			if p == nil {
++				return
++			}
++
++			p.UID = ""
++			p.ResourceVersion = ""
++			p.Name = metafuzzer.RandomDNSLabel(c)
++			p.Namespace = metafuzzer.RandomDNSLabel(c)
++			p.KubeletConfigKey = metafuzzer.RandomDNSLabel(c)
++		},
++		func(ep *core.EphemeralContainer, c fuzz.Continue) {
++			c.FuzzNoCustom(ep)                                                                   // fuzz self without calling this function again
++			ep.EphemeralContainerCommon.TerminationMessagePath = "/" + ep.TerminationMessagePath // Must be non-empty
++			ep.EphemeralContainerCommon.TerminationMessagePolicy = "File"
++		},
+ 		func(p *core.Probe, c fuzz.Continue) {
+ 			c.FuzzNoCustom(p)
+ 			// These fields have default values.
+@@ -498,7 +534,21 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
+ 		},
+ 		func(s *core.NodeStatus, c fuzz.Continue) {
+ 			c.FuzzNoCustom(s)
++
+ 			s.Allocatable = s.Capacity
++
++			if s.Config != nil && s.Config.LastKnownGood != nil && s.Config.LastKnownGood.ConfigMap != nil {
++				s.Config.LastKnownGood.ConfigMap.UID = uuid.NewUUID()
++				s.Config.LastKnownGood.ConfigMap.ResourceVersion = c.RandString()
++			}
++			if s.Config != nil && s.Config.Assigned != nil && s.Config.Assigned.ConfigMap != nil {
++				s.Config.Assigned.ConfigMap.UID = uuid.NewUUID()
++				s.Config.Assigned.ConfigMap.ResourceVersion = c.RandString()
++			}
++			if s.Config != nil && s.Config.Active != nil && s.Config.Active.ConfigMap != nil {
++				s.Config.Active.ConfigMap.UID = uuid.NewUUID()
++				s.Config.Active.ConfigMap.ResourceVersion = c.RandString()
++			}
+ 		},
+ 		func(e *core.Event, c fuzz.Continue) {
+ 			c.FuzzNoCustom(e)
+diff --git a/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go b/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
+index 68cf673b764..49fe6735849 100644
+--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
++++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
+@@ -137,7 +137,7 @@ func randomLabelPart(c fuzz.Continue, canBeEmpty bool) string {
+ 	return string(runes)
+ }
+ 
+-func randomDNSLabel(c fuzz.Continue) string {
++func RandomDNSLabel(c fuzz.Continue) string {
+ 	validStartEnd := []charRange{{'0', '9'}, {'a', 'z'}}
+ 	validMiddle := []charRange{{'0', '9'}, {'a', 'z'}, {'-', '-'}}
+ 
+@@ -163,7 +163,7 @@ func randomLabelKey(c fuzz.Continue) string {
+ 		prefixPartsLen := c.Rand.Intn(2) + 1
+ 		prefixParts := make([]string, prefixPartsLen)
+ 		for i := range prefixParts {
+-			prefixParts[i] = randomDNSLabel(c)
++			prefixParts[i] = RandomDNSLabel(c)
+ 		}
+ 		prefixPart = strings.Join(prefixParts, ".") + "/"
+ 	}
+@@ -203,17 +203,37 @@ func v1FuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
+ 			} else {
+ 				delete(j.Labels, "")
+ 			}
++			for k := range j.Labels {
++				j.Labels[RandomDNSLabel(c)] = randomLabelPart(c, true)
++				delete(j.Labels, k)
++			}
++
+ 			if len(j.Annotations) == 0 {
+ 				j.Annotations = nil
+ 			} else {
+ 				delete(j.Annotations, "")
+ 			}
++			for k := range j.Annotations {
++				j.Annotations[RandomDNSLabel(c)] = randomLabelPart(c, true)
++				delete(j.Annotations, k)
++			}
++
+ 			if len(j.OwnerReferences) == 0 {
+ 				j.OwnerReferences = nil
+ 			}
+ 			if len(j.Finalizers) == 0 {
+ 				j.Finalizers = nil
+ 			}
++			for i := 0; i < len(j.Finalizers); i++ {
++				j.Finalizers[i] = RandomDNSLabel(c) + "/" + RandomDNSLabel(c)
++			}
++		},
++		func(j *metav1.OwnerReference, c fuzz.Continue) {
++			c.FuzzNoCustom(j)
++
++			if len(j.APIVersion) == 0 {
++				j.APIVersion = RandomDNSLabel(c)
++			}
+ 		},
+ 		func(j *metav1.ListMeta, c fuzz.Continue) {
+ 			j.ResourceVersion = strconv.FormatUint(c.RandUint64(), 10)
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From f7cf1346e26d95532e4b9f6f52b544bd422d951f Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Fri, 29 Jan 2021 13:29:04 -0500
+Subject: add test for validation mutation of nodes
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/fuzzer/BUILD                    |   2 +
+ pkg/apis/core/validation/BUILD                |   8 +
+ pkg/apis/core/validation/mutation_test.go     | 172 ++++++++++++++++++
+ .../apimachinery/pkg/api/apitesting/BUILD     |   1 +
+ .../api/apitesting/validationtesting/BUILD    |  30 +++
+ .../validationtesting/validation.go           | 153 ++++++++++++++++
+ .../apitesting/validationtesting/wrapper.go   | 132 ++++++++++++++
+ 7 files changed, 498 insertions(+)
+ create mode 100644 pkg/apis/core/validation/mutation_test.go
+ create mode 100644 staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD
+ create mode 100644 staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go
+ create mode 100644 staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go
+
+diff --git a/pkg/apis/core/fuzzer/BUILD b/pkg/apis/core/fuzzer/BUILD
+index c30003bbdd7..963c2fbe312 100644
+--- a/pkg/apis/core/fuzzer/BUILD
++++ b/pkg/apis/core/fuzzer/BUILD
+@@ -13,11 +13,13 @@ go_library(
+         "//pkg/apis/core:go_default_library",
+         "//staging/src/k8s.io/api/core/v1:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+         "//vendor/github.com/google/gofuzz:go_default_library",
+     ],
+ )
+diff --git a/pkg/apis/core/validation/BUILD b/pkg/apis/core/validation/BUILD
+index 30f0bdcc3c2..1196e301510 100644
+--- a/pkg/apis/core/validation/BUILD
++++ b/pkg/apis/core/validation/BUILD
+@@ -49,19 +49,27 @@ go_test(
+     srcs = [
+         "conditional_validation_test.go",
+         "events_test.go",
++        "mutation_test.go",
+         "validation_test.go",
+     ],
+     embed = [":go_default_library"],
+     deps = [
++        "//pkg/api/legacyscheme:go_default_library",
+         "//pkg/apis/core:go_default_library",
++        "//pkg/apis/core/fuzzer:go_default_library",
+         "//pkg/capabilities:go_default_library",
+         "//pkg/features:go_default_library",
+         "//pkg/security/apparmor:go_default_library",
+         "//staging/src/k8s.io/api/core/v1:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/fuzzer:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+diff --git a/pkg/apis/core/validation/mutation_test.go b/pkg/apis/core/validation/mutation_test.go
+new file mode 100644
+index 00000000000..3d89a3107d0
+--- /dev/null
++++ b/pkg/apis/core/validation/mutation_test.go
+@@ -0,0 +1,172 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package validation
++
++import (
++	"math/rand"
++	"reflect"
++	"testing"
++	"time"
++
++	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
++	"k8s.io/apimachinery/pkg/api/apitesting/validationtesting"
++	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/runtime"
++	"k8s.io/apimachinery/pkg/util/diff"
++	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
++	"k8s.io/apimachinery/pkg/util/validation/field"
++	"k8s.io/kubernetes/pkg/api/legacyscheme"
++	"k8s.io/kubernetes/pkg/apis/core"
++	coreapi "k8s.io/kubernetes/pkg/apis/core"
++	corefuzzer "k8s.io/kubernetes/pkg/apis/core/fuzzer"
++)
++
++func getScheme() *runtime.Scheme {
++	scheme := &runtime.Scheme{}
++	utilruntime.Must(coreapi.AddToScheme(scheme))
++	return scheme
++}
++
++func wrapNodeValidation(node *core.Node) field.ErrorList {
++	return ValidateNode(node, NodeValidationOptions{})
++}
++func wrapNodeUpdateValidation(one, two *core.Node) field.ErrorList {
++	return ValidateNodeUpdate(one, two, NodeValidationOptions{})
++}
++
++func getValidators() *validationtesting.RuntimeObjectsValidator {
++	validator := validationtesting.NewRuntimeObjectsValidator()
++
++	validator.MustRegister(&coreapi.Node{}, false, wrapNodeValidation, wrapNodeUpdateValidation)
++	return validator
++}
++
++type validateUpdateCheck struct {
++	obj    runtime.Object
++	oldObj runtime.Object
++}
++
++func newClusterScopedObjectMeta(name string) metav1.ObjectMeta {
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(metafuzzer.Funcs, rand.NewSource(seed), legacyscheme.Codecs)
++
++	objMeta := metav1.ObjectMeta{}
++	fuzzer.Fuzz(&objMeta)
++	objMeta.Name = name
++	objMeta.Namespace = ""
++	// we don't validate these in this method
++	objMeta.ManagedFields = nil
++
++	return objMeta
++}
++
++func newClusterScopedObjectMetaUpdate(oldObjMeta metav1.ObjectMeta) metav1.ObjectMeta {
++	oldObjMetaCopy := oldObjMeta.DeepCopy()
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(metafuzzer.Funcs, rand.NewSource(seed), legacyscheme.Codecs)
++
++	objMeta := metav1.ObjectMeta{}
++	fuzzer.Fuzz(&objMeta)
++
++	// many fields are immutable
++	objMeta.Name = oldObjMetaCopy.Name
++	objMeta.Namespace = oldObjMetaCopy.Namespace
++	objMeta.UID = oldObjMetaCopy.UID
++	objMeta.CreationTimestamp = oldObjMetaCopy.CreationTimestamp
++	objMeta.DeletionTimestamp = oldObjMetaCopy.DeletionTimestamp
++	objMeta.DeletionGracePeriodSeconds = oldObjMetaCopy.DeletionGracePeriodSeconds
++	objMeta.ClusterName = oldObjMetaCopy.ClusterName
++	objMeta.Generation = oldObjMetaCopy.Generation
++	objMeta.ManagedFields = oldObjMetaCopy.ManagedFields
++
++	return objMeta
++}
++
++func newNode(name string) *coreapi.Node {
++	ret := &coreapi.Node{}
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(
++		fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, corefuzzer.Funcs),
++		rand.NewSource(seed), legacyscheme.Codecs)
++	fuzzer.Fuzz(ret)
++
++	ret.ObjectMeta = newClusterScopedObjectMeta(name)
++
++	return ret
++}
++
++func newNodeUpdate(node *coreapi.Node) *coreapi.Node {
++	ret := &coreapi.Node{}
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(
++		fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, corefuzzer.Funcs),
++		rand.NewSource(seed), legacyscheme.Codecs)
++	fuzzer.Fuzz(ret)
++
++	nodeCopy := node.DeepCopy()
++	ret.ObjectMeta = newClusterScopedObjectMetaUpdate(nodeCopy.ObjectMeta)
++	ret.Spec.ProviderID = nodeCopy.Spec.ProviderID
++	ret.Spec.PodCIDRs = nodeCopy.Spec.PodCIDRs
++	ret.Spec.ConfigSource = nodeCopy.Spec.ConfigSource
++	ret.Spec.DoNotUseExternalID = nodeCopy.Spec.DoNotUseExternalID
++
++	return ret
++}
++
++func newNodeValidationUpdateCheck() validateUpdateCheck {
++	old := newNode("the-node")
++	return validateUpdateCheck{
++		obj:    newNodeUpdate(old),
++		oldObj: old,
++	}
++}
++
++// this test checks to see if validateUpdate mutates its arguments
++func TestMutationValidateUpdate(t *testing.T) {
++	validators := getValidators()
++
++	// only test node now, but this is a proof of concept for overall enforcement
++	mutationObjects := []validateUpdateCheck{
++		newNodeValidationUpdateCheck(),
++	}
++
++	for _, tt := range mutationObjects {
++		typeName := reflect.TypeOf(tt.obj)
++		for i := 0; i < 20; i++ {
++			t.Run(typeName.Name(), func(t *testing.T) {
++				validator, exists := validators.GetInfo(tt.obj)
++				if !exists {
++					t.Fatal("missing validation func")
++				}
++
++				originalObj := tt.obj.DeepCopyObject()
++				originalOldObj := tt.oldObj.DeepCopyObject()
++				errors := validator.Validator.ValidateUpdate(tt.obj, tt.oldObj)
++				if len(errors) > 0 {
++					t.Fatal(errors)
++				}
++				if !reflect.DeepEqual(tt.oldObj, originalOldObj) {
++					t.Errorf("mutation of oldObject:\n%v", diff.ObjectGoPrintDiff(originalOldObj, tt.oldObj))
++				}
++				if !reflect.DeepEqual(tt.obj, originalObj) {
++					t.Errorf("mutation of oldObject:\n%v", diff.ObjectGoPrintDiff(originalObj, tt.obj))
++				}
++			})
++		}
++	}
++}
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD
+index 6144d9be6e4..8abac47d9d1 100644
+--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD
+@@ -32,6 +32,7 @@ filegroup(
+         "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/fuzzer:all-srcs",
+         "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/naming:all-srcs",
+         "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip:all-srcs",
++        "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting:all-srcs",
+     ],
+     tags = ["automanaged"],
+ )
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD
+new file mode 100644
+index 00000000000..0570f81a3f6
+--- /dev/null
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD
+@@ -0,0 +1,30 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "validation.go",
++        "wrapper.go",
++    ],
++    importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/apitesting/validationtesting",
++    importpath = "k8s.io/apimachinery/pkg/api/apitesting/validationtesting",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
++    ],
++)
++
++filegroup(
++    name = "package-srcs",
++    srcs = glob(["**"]),
++    tags = ["automanaged"],
++    visibility = ["//visibility:private"],
++)
++
++filegroup(
++    name = "all-srcs",
++    srcs = [":package-srcs"],
++    tags = ["automanaged"],
++    visibility = ["//visibility:public"],
++)
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go
+new file mode 100644
+index 00000000000..6f751b04cf3
+--- /dev/null
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go
+@@ -0,0 +1,153 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package validationtesting
++
++import (
++	"fmt"
++	"reflect"
++
++	"k8s.io/apimachinery/pkg/runtime"
++	"k8s.io/apimachinery/pkg/util/validation/field"
++)
++
++type RuntimeObjectValidator interface {
++	Validate(obj runtime.Object) field.ErrorList
++	ValidateUpdate(obj, old runtime.Object) field.ErrorList
++}
++
++type RuntimeObjectsValidator struct {
++	typeToValidator map[reflect.Type]RuntimeObjectValidatorInfo
++}
++
++func NewRuntimeObjectsValidator() *RuntimeObjectsValidator {
++	return &RuntimeObjectsValidator{map[reflect.Type]RuntimeObjectValidatorInfo{}}
++}
++
++type RuntimeObjectValidatorInfo struct {
++	Validator     RuntimeObjectValidator
++	IsNamespaced  bool
++	HasObjectMeta bool
++	UpdateAllowed bool
++}
++
++func (v *RuntimeObjectsValidator) GetInfoForType(apiType reflect.Type) (RuntimeObjectValidatorInfo, bool) {
++	ptrType := reflect.PtrTo(apiType)
++
++	ret, ok := v.typeToValidator[ptrType]
++	return ret, ok
++}
++
++func (v *RuntimeObjectsValidator) GetInfo(obj runtime.Object) (RuntimeObjectValidatorInfo, bool) {
++	ret, ok := v.typeToValidator[reflect.TypeOf(obj)]
++	return ret, ok
++}
++
++func (v *RuntimeObjectsValidator) MustRegister(obj runtime.Object, namespaceScoped bool, validateFunction interface{}, validateUpdateFunction interface{}) {
++	if err := v.Register(obj, namespaceScoped, validateFunction, validateUpdateFunction); err != nil {
++		panic(err)
++	}
++}
++
++func (v *RuntimeObjectsValidator) Register(obj runtime.Object, namespaceScoped bool, validateFunction interface{}, validateUpdateFunction interface{}) error {
++	objType := reflect.TypeOf(obj)
++	if oldValidator, exists := v.typeToValidator[objType]; exists {
++		panic(fmt.Sprintf("%v is already registered with %v", objType, oldValidator))
++	}
++
++	validator, err := NewValidationWrapper(validateFunction, validateUpdateFunction)
++	if err != nil {
++		return err
++	}
++
++	updateAllowed := validateUpdateFunction != nil
++
++	v.typeToValidator[objType] = RuntimeObjectValidatorInfo{validator, namespaceScoped, HasObjectMeta(obj), updateAllowed}
++
++	return nil
++}
++
++func (v *RuntimeObjectsValidator) Validate(obj runtime.Object) field.ErrorList {
++	if obj == nil {
++		return field.ErrorList{}
++	}
++
++	allErrs := field.ErrorList{}
++
++	specificValidationInfo, err := v.getSpecificValidationInfo(obj)
++	if err != nil {
++		allErrs = append(allErrs, field.InternalError(nil, err))
++		return allErrs
++	}
++
++	allErrs = append(allErrs, specificValidationInfo.Validator.Validate(obj)...)
++	return allErrs
++}
++
++func (v *RuntimeObjectsValidator) ValidateUpdate(obj, old runtime.Object) field.ErrorList {
++	if obj == nil && old == nil {
++		return field.ErrorList{}
++	}
++	if newType, oldType := reflect.TypeOf(obj), reflect.TypeOf(old); newType != oldType {
++		return field.ErrorList{field.Invalid(field.NewPath("kind"), newType.Kind(), fmt.Sprintf("expected type %s, for field %s, got %s", oldType.Kind().String(), "kind", newType.Kind().String()))}
++	}
++
++	allErrs := field.ErrorList{}
++
++	specificValidationInfo, err := v.getSpecificValidationInfo(obj)
++	if err != nil {
++		if fieldErr, ok := err.(*field.Error); ok {
++			allErrs = append(allErrs, fieldErr)
++		} else {
++			allErrs = append(allErrs, field.InternalError(nil, err))
++		}
++		return allErrs
++	}
++
++	allErrs = append(allErrs, specificValidationInfo.Validator.ValidateUpdate(obj, old)...)
++
++	// no errors so far, make sure that the new object is actually valid against the original validator
++	if len(allErrs) == 0 {
++		allErrs = append(allErrs, specificValidationInfo.Validator.Validate(obj)...)
++	}
++
++	return allErrs
++}
++
++func (v *RuntimeObjectsValidator) getSpecificValidationInfo(obj runtime.Object) (RuntimeObjectValidatorInfo, error) {
++	objType := reflect.TypeOf(obj)
++	specificValidationInfo, exists := v.typeToValidator[objType]
++	if !exists {
++		return RuntimeObjectValidatorInfo{}, fmt.Errorf("no validator registered for %v", objType)
++	}
++
++	return specificValidationInfo, nil
++}
++
++func (v *RuntimeObjectsValidator) GetRequiresNamespace(obj runtime.Object) (bool, error) {
++	objType := reflect.TypeOf(obj)
++	specificValidationInfo, exists := v.typeToValidator[objType]
++	if !exists {
++		return false, fmt.Errorf("no validator registered for %v", objType)
++	}
++
++	return specificValidationInfo.IsNamespaced, nil
++}
++
++func HasObjectMeta(obj runtime.Object) bool {
++	objValue := reflect.ValueOf(obj).Elem()
++	return objValue.FieldByName("ObjectMeta").IsValid()
++}
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go
+new file mode 100644
+index 00000000000..e7b1d48b7e6
+--- /dev/null
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go
+@@ -0,0 +1,132 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package validationtesting
++
++import (
++	"fmt"
++	"reflect"
++
++	"k8s.io/apimachinery/pkg/runtime"
++	"k8s.io/apimachinery/pkg/util/validation/field"
++)
++
++type WrappingValidator struct {
++	validate       *reflect.Value
++	validateUpdate *reflect.Value
++}
++
++func (v *WrappingValidator) Validate(obj runtime.Object) field.ErrorList {
++	return callValidate(reflect.ValueOf(obj), *v.validate)
++}
++
++func (v *WrappingValidator) ValidateUpdate(obj, old runtime.Object) field.ErrorList {
++	if v.validateUpdate == nil {
++		// if there is no update validation, fail.
++		return field.ErrorList{field.Forbidden(field.NewPath("obj"), fmt.Sprintf("%v", obj))}
++	}
++
++	return callValidateUpdate(reflect.ValueOf(obj), reflect.ValueOf(old), *v.validateUpdate)
++}
++
++func NewValidationWrapper(validateFunction interface{}, validateUpdateFunction interface{}) (*WrappingValidator, error) {
++	validateFunctionValue := reflect.ValueOf(validateFunction)
++	validateType := validateFunctionValue.Type()
++	if err := verifyValidateFunctionSignature(validateType); err != nil {
++		return nil, err
++	}
++
++	var validateUpdateFunctionValue *reflect.Value
++	if validateUpdateFunction != nil {
++		functionValue := reflect.ValueOf(validateUpdateFunction)
++		validateUpdateType := functionValue.Type()
++		if err := verifyValidateUpdateFunctionSignature(validateUpdateType); err != nil {
++			return nil, err
++		}
++
++		validateUpdateFunctionValue = &functionValue
++	}
++
++	return &WrappingValidator{&validateFunctionValue, validateUpdateFunctionValue}, nil
++}
++
++func verifyValidateFunctionSignature(ft reflect.Type) error {
++	if ft.Kind() != reflect.Func {
++		return fmt.Errorf("expected func, got: %v", ft)
++	}
++	if ft.NumIn() != 1 {
++		return fmt.Errorf("expected one 'in' param, got: %v", ft)
++	}
++	if ft.NumOut() != 1 {
++		return fmt.Errorf("expected one 'out' param, got: %v", ft)
++	}
++	if ft.In(0).Kind() != reflect.Ptr {
++		return fmt.Errorf("expected pointer arg for 'in' param 0, got: %v", ft)
++	}
++	errorType := reflect.TypeOf(&field.ErrorList{}).Elem()
++	if ft.Out(0) != errorType {
++		return fmt.Errorf("expected field.ErrorList return, got: %v", ft)
++	}
++	return nil
++}
++
++func verifyValidateUpdateFunctionSignature(ft reflect.Type) error {
++	if ft.Kind() != reflect.Func {
++		return fmt.Errorf("expected func, got: %v", ft)
++	}
++	if ft.NumIn() != 2 {
++		return fmt.Errorf("expected two 'in' params, got: %v", ft)
++	}
++	if ft.NumOut() != 1 {
++		return fmt.Errorf("expected one 'out' param, got: %v", ft)
++	}
++	if ft.In(0).Kind() != reflect.Ptr {
++		return fmt.Errorf("expected pointer arg for 'in' param 0, got: %v", ft)
++	}
++	if ft.In(1).Kind() != reflect.Ptr {
++		return fmt.Errorf("expected pointer arg for 'in' param 1, got: %v", ft)
++	}
++	errorType := reflect.TypeOf(&field.ErrorList{}).Elem()
++	if ft.Out(0) != errorType {
++		return fmt.Errorf("expected field.ErrorList return, got: %v", ft)
++	}
++	return nil
++}
++
++// callCustom calls 'custom' with sv & dv. custom must be a conversion function.
++func callValidate(obj, validateMethod reflect.Value) field.ErrorList {
++	args := []reflect.Value{obj}
++	ret := validateMethod.Call(args)[0].Interface()
++
++	// This convolution is necessary because nil interfaces won't convert
++	// to errors.
++	if ret == nil {
++		return nil
++	}
++	return ret.(field.ErrorList)
++}
++
++func callValidateUpdate(obj, old, validateMethod reflect.Value) field.ErrorList {
++	args := []reflect.Value{obj, old}
++	ret := validateMethod.Call(args)[0].Interface()
++
++	// This convolution is necessary because nil interfaces won't convert
++	// to errors.
++	if ret == nil {
++		return nil
++	}
++	return ret.(field.ErrorList)
++}
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From fb1b62ff1479707f8420295c7037180bbc9930b5 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Fri, 29 Jan 2021 13:47:31 -0500
+Subject: tweak validation to avoid mutation
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 46 +++++++++-----------------
+ 1 file changed, 15 insertions(+), 31 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index 3daeb139d59..068c8decf4d 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -29,8 +29,6 @@ import (
+ 	"unicode"
+ 	"unicode/utf8"
+ 
+-	"k8s.io/klog"
+-
+ 	v1 "k8s.io/api/core/v1"
+ 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+ 	"k8s.io/apimachinery/pkg/api/resource"
+@@ -4611,11 +4609,8 @@ func ValidateNodeUpdate(node, oldNode *core.Node, opts NodeValidationOptions) fi
+ 		addresses[address] = true
+ 	}
+ 
+-	if len(oldNode.Spec.PodCIDRs) == 0 {
+-		// Allow the controller manager to assign a CIDR to a node if it doesn't have one.
+-		//this is a no op for a string slice.
+-		oldNode.Spec.PodCIDRs = node.Spec.PodCIDRs
+-	} else {
++	// Allow the controller manager to assign a CIDR to a node if it doesn't have one.
++	if len(oldNode.Spec.PodCIDRs) > 0 {
+ 		// compare the entire slice
+ 		if len(oldNode.Spec.PodCIDRs) != len(node.Spec.PodCIDRs) {
+ 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "podCIDRs"), "node updates may not change podCIDR except from \"\" to valid"))
+@@ -4629,46 +4624,35 @@ func ValidateNodeUpdate(node, oldNode *core.Node, opts NodeValidationOptions) fi
+ 	}
+ 
+ 	// Allow controller manager updating provider ID when not set
+-	if len(oldNode.Spec.ProviderID) == 0 {
+-		oldNode.Spec.ProviderID = node.Spec.ProviderID
+-	} else {
+-		if oldNode.Spec.ProviderID != node.Spec.ProviderID {
+-			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "providerID"), "node updates may not change providerID except from \"\" to valid"))
+-		}
++	if len(oldNode.Spec.ProviderID) > 0 && oldNode.Spec.ProviderID != node.Spec.ProviderID {
++		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "providerID"), "node updates may not change providerID except from \"\" to valid"))
+ 	}
+ 
+ 	if node.Spec.ConfigSource != nil {
+ 		allErrs = append(allErrs, validateNodeConfigSourceSpec(node.Spec.ConfigSource, field.NewPath("spec", "configSource"))...)
+ 	}
+-	oldNode.Spec.ConfigSource = node.Spec.ConfigSource
+ 	if node.Status.Config != nil {
+ 		allErrs = append(allErrs, validateNodeConfigStatus(node.Status.Config, field.NewPath("status", "config"))...)
+ 	}
+-	oldNode.Status.Config = node.Status.Config
+-
+-	// TODO: move reset function to its own location
+-	// Ignore metadata changes now that they have been tested
+-	oldNode.ObjectMeta = node.ObjectMeta
+-	// Allow users to update capacity
+-	oldNode.Status.Capacity = node.Status.Capacity
+-	// Allow users to unschedule node
+-	oldNode.Spec.Unschedulable = node.Spec.Unschedulable
+-	// Clear status
+-	oldNode.Status = node.Status
+ 
+ 	// update taints
+ 	if len(node.Spec.Taints) > 0 {
+ 		allErrs = append(allErrs, validateNodeTaints(node.Spec.Taints, fldPath.Child("taints"))...)
+ 	}
+-	oldNode.Spec.Taints = node.Spec.Taints
+ 
+-	// We made allowed changes to oldNode, and now we compare oldNode to node. Any remaining differences indicate changes to protected fields.
+-	// TODO: Add a 'real' error type for this error and provide print actual diffs.
+-	if !apiequality.Semantic.DeepEqual(oldNode, node) {
+-		klog.V(4).Infof("Update failed validation %#v vs %#v", oldNode, node)
+-		allErrs = append(allErrs, field.Forbidden(field.NewPath(""), "node updates may only change labels, taints, or capacity (or configSource, if the DynamicKubeletConfig feature gate is enabled)"))
++	if node.Spec.DoNotUseExternalID != oldNode.Spec.DoNotUseExternalID {
++		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "externalID"), "may not be updated"))
+ 	}
+ 
++	// status and metadata are allowed change (barring restrictions above), so separately test spec field.
++	// spec only has a few fields, so check the ones we don't allow changing
++	//  1. PodCIDRs - immutable after first set - checked above
++	//  2. ProviderID - immutable after first set - checked above
++	//  3. Unschedulable - allowed to change
++	//  4. Taints - allowed to change
++	//  5. ConfigSource - allowed to change (and checked above)
++	//  6. DoNotUseExternalID - immutable - checked above
++
+ 	return allErrs
+ }
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 81c39ef52a45b5ac49903f03cf948de2f1ead208 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 16:21:42 -0500
+Subject: remove unnecessary mutations in validation
+
+These mutations are already done in the strategy
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 22 ++--------------------
+ 1 file changed, 2 insertions(+), 20 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index 068c8decf4d..e51e45f3907 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -1868,13 +1868,11 @@ func ValidatePersistentVolumeUpdate(newPv, oldPv *core.PersistentVolume) field.E
+ }
+ 
+ // ValidatePersistentVolumeStatusUpdate tests to see if the status update is legal for an end user to make.
+-// newPv is updated with fields that cannot be changed.
+ func ValidatePersistentVolumeStatusUpdate(newPv, oldPv *core.PersistentVolume) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newPv.ObjectMeta, &oldPv.ObjectMeta, field.NewPath("metadata"))
+ 	if len(newPv.ResourceVersion) == 0 {
+ 		allErrs = append(allErrs, field.Required(field.NewPath("resourceVersion"), ""))
+ 	}
+-	newPv.Spec = oldPv.Spec
+ 	return allErrs
+ }
+ 
+@@ -2018,7 +2016,6 @@ func ValidatePersistentVolumeClaimStatusUpdate(newPvc, oldPvc *core.PersistentVo
+ 	for r, qty := range newPvc.Status.Capacity {
+ 		allErrs = append(allErrs, validateBasicResource(qty, capPath.Key(string(r)))...)
+ 	}
+-	newPvc.Spec = oldPvc.Spec
+ 	return allErrs
+ }
+ 
+@@ -3821,8 +3818,7 @@ func ValidateContainerStateTransition(newStatuses, oldStatuses []core.ContainerS
+ 	return allErrs
+ }
+ 
+-// ValidatePodStatusUpdate tests to see if the update is legal for an end user to make. newPod is updated with fields
+-// that cannot be changed.
++// ValidatePodStatusUpdate tests to see if the update is legal for an end user to make.
+ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod) field.ErrorList {
+ 	fldPath := field.NewPath("metadata")
+ 	allErrs := ValidateObjectMetaUpdate(&newPod.ObjectMeta, &oldPod.ObjectMeta, fldPath)
+@@ -3845,9 +3841,6 @@ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod) field.ErrorList {
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.ContainerStatuses, oldPod.Status.ContainerStatuses, fldPath.Child("containerStatuses"), oldPod.Spec.RestartPolicy)...)
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), oldPod.Spec.RestartPolicy)...)
+ 
+-	// For status update we ignore changes to pod spec.
+-	newPod.Spec = oldPod.Spec
+-
+ 	return allErrs
+ }
+ 
+@@ -5368,7 +5361,6 @@ func ValidateResourceQuantityValue(resource string, value resource.Quantity, fld
+ }
+ 
+ // ValidateResourceQuotaUpdate tests to see if the update is legal for an end user to make.
+-// newResourceQuota is updated with fields that cannot be changed.
+ func ValidateResourceQuotaUpdate(newResourceQuota, oldResourceQuota *core.ResourceQuota) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newResourceQuota.ObjectMeta, &oldResourceQuota.ObjectMeta, field.NewPath("metadata"))
+ 	allErrs = append(allErrs, ValidateResourceQuotaSpec(&newResourceQuota.Spec, field.NewPath("spec"))...)
+@@ -5387,12 +5379,10 @@ func ValidateResourceQuotaUpdate(newResourceQuota, oldResourceQuota *core.Resour
+ 		allErrs = append(allErrs, field.Invalid(fldPath, newResourceQuota.Spec.Scopes, fieldImmutableErrorMsg))
+ 	}
+ 
+-	newResourceQuota.Status = oldResourceQuota.Status
+ 	return allErrs
+ }
+ 
+ // ValidateResourceQuotaStatusUpdate tests to see if the status update is legal for an end user to make.
+-// newResourceQuota is updated with fields that cannot be changed.
+ func ValidateResourceQuotaStatusUpdate(newResourceQuota, oldResourceQuota *core.ResourceQuota) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newResourceQuota.ObjectMeta, &oldResourceQuota.ObjectMeta, field.NewPath("metadata"))
+ 	if len(newResourceQuota.ResourceVersion) == 0 {
+@@ -5410,7 +5400,6 @@ func ValidateResourceQuotaStatusUpdate(newResourceQuota, oldResourceQuota *core.
+ 		allErrs = append(allErrs, ValidateResourceQuotaResourceName(string(k), resPath)...)
+ 		allErrs = append(allErrs, ValidateResourceQuantityValue(string(k), v, resPath)...)
+ 	}
+-	newResourceQuota.Spec = oldResourceQuota.Spec
+ 	return allErrs
+ }
+ 
+@@ -5443,19 +5432,14 @@ func validateKubeFinalizerName(stringValue string, fldPath *field.Path) field.Er
+ }
+ 
+ // ValidateNamespaceUpdate tests to make sure a namespace update can be applied.
+-// newNamespace is updated with fields that cannot be changed
+ func ValidateNamespaceUpdate(newNamespace *core.Namespace, oldNamespace *core.Namespace) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+-	newNamespace.Spec.Finalizers = oldNamespace.Spec.Finalizers
+-	newNamespace.Status = oldNamespace.Status
+ 	return allErrs
+ }
+ 
+-// ValidateNamespaceStatusUpdate tests to see if the update is legal for an end user to make. newNamespace is updated with fields
+-// that cannot be changed.
++// ValidateNamespaceStatusUpdate tests to see if the update is legal for an end user to make.
+ func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *core.Namespace) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+-	newNamespace.Spec = oldNamespace.Spec
+ 	if newNamespace.DeletionTimestamp.IsZero() {
+ 		if newNamespace.Status.Phase != core.NamespaceActive {
+ 			allErrs = append(allErrs, field.Invalid(field.NewPath("status", "Phase"), newNamespace.Status.Phase, "may only be 'Active' if `deletionTimestamp` is empty"))
+@@ -5469,7 +5453,6 @@ func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *core.Namespace) f
+ }
+ 
+ // ValidateNamespaceFinalizeUpdate tests to see if the update is legal for an end user to make.
+-// newNamespace is updated with fields that cannot be changed.
+ func ValidateNamespaceFinalizeUpdate(newNamespace, oldNamespace *core.Namespace) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+ 
+@@ -5478,7 +5461,6 @@ func ValidateNamespaceFinalizeUpdate(newNamespace, oldNamespace *core.Namespace)
+ 		idxPath := fldPath.Index(i)
+ 		allErrs = append(allErrs, validateFinalizerName(string(newNamespace.Spec.Finalizers[i]), idxPath)...)
+ 	}
+-	newNamespace.Status = oldNamespace.Status
+ 	return allErrs
+ }
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 9e9b903754ab1e60cbb32608749f8640e429fdfa Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 16:55:41 -0500
+Subject: move secret mutation from validation to prepareforupdate
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 4 ----
+ pkg/registry/core/secret/strategy.go   | 6 ++++++
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index e51e45f3907..2ebda1bfc4d 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -5058,10 +5058,6 @@ func ValidateSecret(secret *core.Secret) field.ErrorList {
+ func ValidateSecretUpdate(newSecret, oldSecret *core.Secret) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newSecret.ObjectMeta, &oldSecret.ObjectMeta, field.NewPath("metadata"))
+ 
+-	if len(newSecret.Type) == 0 {
+-		newSecret.Type = oldSecret.Type
+-	}
+-
+ 	allErrs = append(allErrs, ValidateImmutableField(newSecret.Type, oldSecret.Type, field.NewPath("type"))...)
+ 	if oldSecret.Immutable != nil && *oldSecret.Immutable {
+ 		if newSecret.Immutable == nil || !*newSecret.Immutable {
+diff --git a/pkg/registry/core/secret/strategy.go b/pkg/registry/core/secret/strategy.go
+index 0d5908d8975..aad00387ac1 100644
+--- a/pkg/registry/core/secret/strategy.go
++++ b/pkg/registry/core/secret/strategy.go
+@@ -73,6 +73,12 @@ func (strategy) AllowCreateOnUpdate() bool {
+ func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+ 	newSecret := obj.(*api.Secret)
+ 	oldSecret := old.(*api.Secret)
++
++	// this is weird, but consistent with what the validatedUpdate function used to do.
++	if len(newSecret.Type) == 0 {
++		newSecret.Type = oldSecret.Type
++	}
++
+ 	dropDisabledFields(newSecret, oldSecret)
+ }
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 1897e85073610673a3e952780c0853646705a80e Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 17:18:11 -0500
+Subject: add markers for inspected validation mutation hits
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go                 | 10 +++++-----
+ .../pkg/apis/apiextensions/validation/validation.go    |  2 +-
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index 2ebda1bfc4d..239135ba6ab 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -1945,7 +1945,7 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
+ 	// Claims are immutable in order to enforce quota, range limits, etc. without gaming the system.
+ 	if len(oldPvc.Spec.VolumeName) == 0 {
+ 		// volumeName changes are allowed once.
+-		oldPvcClone.Spec.VolumeName = newPvcClone.Spec.VolumeName
++		oldPvcClone.Spec.VolumeName = newPvcClone.Spec.VolumeName // +k8s:verify-mutation:reason=clone
+ 	}
+ 
+ 	if validateStorageClassUpgrade(oldPvcClone.Annotations, newPvcClone.Annotations,
+@@ -1961,7 +1961,7 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
+ 	if utilfeature.DefaultFeatureGate.Enabled(features.ExpandPersistentVolumes) {
+ 		// lets make sure storage values are same.
+ 		if newPvc.Status.Phase == core.ClaimBound && newPvcClone.Spec.Resources.Requests != nil {
+-			newPvcClone.Spec.Resources.Requests["storage"] = oldPvc.Spec.Resources.Requests["storage"]
++			newPvcClone.Spec.Resources.Requests["storage"] = oldPvc.Spec.Resources.Requests["storage"] // +k8s:verify-mutation:reason=clone
+ 		}
+ 
+ 		oldSize := oldPvc.Spec.Resources.Requests["storage"]
+@@ -2309,13 +2309,13 @@ func GetVolumeMountMap(mounts []core.VolumeMount) map[string]string {
+ }
+ 
+ func GetVolumeDeviceMap(devices []core.VolumeDevice) map[string]string {
+-	voldevices := make(map[string]string)
++	volDevices := make(map[string]string)
+ 
+ 	for _, dev := range devices {
+-		voldevices[dev.Name] = dev.DevicePath
++		volDevices[dev.Name] = dev.DevicePath
+ 	}
+ 
+-	return voldevices
++	return volDevices
+ }
+ 
+ func ValidateVolumeMounts(mounts []core.VolumeMount, voldevices map[string]string, volumes map[string]core.VolumeSource, container *core.Container, fldPath *field.Path) field.ErrorList {
+diff --git a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+index 82e4e9d15dd..00d6cbd3f75 100644
+--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
++++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+@@ -1366,7 +1366,7 @@ func validateAPIApproval(newCRD, oldCRD *apiextensions.CustomResourceDefinition,
+ 	var oldApprovalState *apihelpers.APIApprovalState
+ 	if oldCRD != nil {
+ 		t, _ := apihelpers.GetAPIApprovalState(oldCRD.Annotations)
+-		oldApprovalState = &t
++		oldApprovalState = &t // +k8s:verify-mutation:reason=clone
+ 	}
+ 	newApprovalState, reason := apihelpers.GetAPIApprovalState(newCRD.Annotations)
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From f94db721fe89135e3d995b0189885141190ef7ab Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 17:33:34 -0500
+Subject: remove pod toleration toleration seconds mutation
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index 239135ba6ab..6830060434c 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -2969,10 +2969,11 @@ func validateOnlyAddedTolerations(newTolerations []core.Toleration, oldToleratio
+ 	allErrs := field.ErrorList{}
+ 	for _, old := range oldTolerations {
+ 		found := false
+-		old.TolerationSeconds = nil
+-		for _, new := range newTolerations {
+-			new.TolerationSeconds = nil
+-			if reflect.DeepEqual(old, new) {
++		oldTolerationClone := old.DeepCopy()
++		for _, newToleration := range newTolerations {
++			// assign to our clone before doing a deep equal so we can allow tolerationseconds to change.
++			oldTolerationClone.TolerationSeconds = newToleration.TolerationSeconds // +k8s:verify-mutation:reason=clone
++			if reflect.DeepEqual(*oldTolerationClone, newToleration) {
+ 				found = true
+ 				break
+ 			}
+@@ -3756,6 +3757,9 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
+ 		allErrs = append(allErrs, field.Invalid(specPath.Child("activeDeadlineSeconds"), newPod.Spec.ActiveDeadlineSeconds, "must not update from a positive integer to nil value"))
+ 	}
+ 
++	// Allow only additions to tolerations updates.
++	allErrs = append(allErrs, validateOnlyAddedTolerations(newPod.Spec.Tolerations, oldPod.Spec.Tolerations, specPath.Child("tolerations"))...)
++
+ 	// handle updateable fields by munging those fields prior to deep equal comparison.
+ 	mungedPod := *newPod
+ 	// munge spec.containers[*].image
+@@ -3779,10 +3783,6 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
+ 		mungedPod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
+ 	}
+ 
+-	// Allow only additions to tolerations updates.
+-	mungedPod.Spec.Tolerations = oldPod.Spec.Tolerations
+-	allErrs = append(allErrs, validateOnlyAddedTolerations(newPod.Spec.Tolerations, oldPod.Spec.Tolerations, specPath.Child("tolerations"))...)
+-
+ 	if !apiequality.Semantic.DeepEqual(mungedPod.Spec, oldPod.Spec) {
+ 		// This diff isn't perfect, but it's a helluva lot better an "I'm not going to tell you what the difference is".
+ 		//TODO: Pinpoint the specific field that causes the invalid error after we have strategic merge diff
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 0a7faaa1781710e8e36faa91e649be71239f11b8 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 17:43:57 -0500
+Subject: full deepcopy on munged pod spec
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 30 ++++++++++++++++----------
+ 1 file changed, 19 insertions(+), 11 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index 6830060434c..95a3d015651 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -3760,33 +3760,41 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
+ 	// Allow only additions to tolerations updates.
+ 	allErrs = append(allErrs, validateOnlyAddedTolerations(newPod.Spec.Tolerations, oldPod.Spec.Tolerations, specPath.Child("tolerations"))...)
+ 
++	// the last thing to check is pod spec equality.  If the pod specs are equal, then we can simply return the errors we have
++	// so far and save the cost of a deep copy.
++	if apiequality.Semantic.DeepEqual(newPod.Spec, oldPod.Spec) {
++		return allErrs
++	}
++
+ 	// handle updateable fields by munging those fields prior to deep equal comparison.
+-	mungedPod := *newPod
++	mungedPodSpec := *newPod.Spec.DeepCopy()
+ 	// munge spec.containers[*].image
+ 	var newContainers []core.Container
+-	for ix, container := range mungedPod.Spec.Containers {
+-		container.Image = oldPod.Spec.Containers[ix].Image
++	for ix, container := range mungedPodSpec.Containers {
++		container.Image = oldPod.Spec.Containers[ix].Image // +k8s:verify-mutation:reason=clone
+ 		newContainers = append(newContainers, container)
+ 	}
+-	mungedPod.Spec.Containers = newContainers
++	mungedPodSpec.Containers = newContainers
+ 	// munge spec.initContainers[*].image
+ 	var newInitContainers []core.Container
+-	for ix, container := range mungedPod.Spec.InitContainers {
+-		container.Image = oldPod.Spec.InitContainers[ix].Image
++	for ix, container := range mungedPodSpec.InitContainers {
++		container.Image = oldPod.Spec.InitContainers[ix].Image // +k8s:verify-mutation:reason=clone
+ 		newInitContainers = append(newInitContainers, container)
+ 	}
+-	mungedPod.Spec.InitContainers = newInitContainers
++	mungedPodSpec.InitContainers = newInitContainers
+ 	// munge spec.activeDeadlineSeconds
+-	mungedPod.Spec.ActiveDeadlineSeconds = nil
++	mungedPodSpec.ActiveDeadlineSeconds = nil
+ 	if oldPod.Spec.ActiveDeadlineSeconds != nil {
+ 		activeDeadlineSeconds := *oldPod.Spec.ActiveDeadlineSeconds
+-		mungedPod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
++		mungedPodSpec.ActiveDeadlineSeconds = &activeDeadlineSeconds
+ 	}
++	// tolerations are checked before the deep copy, so munge those too
++	mungedPodSpec.Tolerations = oldPod.Spec.Tolerations // +k8s:verify-mutation:reason=clone
+ 
+-	if !apiequality.Semantic.DeepEqual(mungedPod.Spec, oldPod.Spec) {
++	if !apiequality.Semantic.DeepEqual(mungedPodSpec, oldPod.Spec) {
+ 		// This diff isn't perfect, but it's a helluva lot better an "I'm not going to tell you what the difference is".
+ 		//TODO: Pinpoint the specific field that causes the invalid error after we have strategic merge diff
+-		specDiff := diff.ObjectDiff(mungedPod.Spec, oldPod.Spec)
++		specDiff := diff.ObjectDiff(mungedPodSpec, oldPod.Spec)
+ 		allErrs = append(allErrs, field.Forbidden(specPath, fmt.Sprintf("pod updates may not change fields other than `spec.containers[*].image`, `spec.initContainers[*].image`, `spec.activeDeadlineSeconds` or `spec.tolerations` (only additions to existing tolerations)\n%v", specDiff)))
+ 	}
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From a390477d00f0d7cd0d8aeea38efa2c8597f38ffd Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Wed, 17 Feb 2021 10:51:38 -0500
+Subject: deepcopy statefulsets
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/apps/validation/validation.go | 20 +++++++-------------
+ 1 file changed, 7 insertions(+), 13 deletions(-)
+
+diff --git a/pkg/apis/apps/validation/validation.go b/pkg/apis/apps/validation/validation.go
+index 6ac73cb6b7e..03e0d2024dd 100644
+--- a/pkg/apis/apps/validation/validation.go
++++ b/pkg/apis/apps/validation/validation.go
+@@ -144,21 +144,15 @@ func ValidateStatefulSet(statefulSet *apps.StatefulSet) field.ErrorList {
+ func ValidateStatefulSetUpdate(statefulSet, oldStatefulSet *apps.StatefulSet) field.ErrorList {
+ 	allErrs := apivalidation.ValidateObjectMetaUpdate(&statefulSet.ObjectMeta, &oldStatefulSet.ObjectMeta, field.NewPath("metadata"))
+ 
+-	restoreReplicas := statefulSet.Spec.Replicas
+-	statefulSet.Spec.Replicas = oldStatefulSet.Spec.Replicas
+-
+-	restoreTemplate := statefulSet.Spec.Template
+-	statefulSet.Spec.Template = oldStatefulSet.Spec.Template
+-
+-	restoreStrategy := statefulSet.Spec.UpdateStrategy
+-	statefulSet.Spec.UpdateStrategy = oldStatefulSet.Spec.UpdateStrategy
+-
+-	if !apiequality.Semantic.DeepEqual(statefulSet.Spec, oldStatefulSet.Spec) {
++	// statefulset updates aren't super common and general updates are likely to be touching spec, so we'll do this
++	// deep copy right away.  This avoids mutating our inputs
++	newStatefulSetClone := statefulSet.DeepCopy()
++	newStatefulSetClone.Spec.Replicas = oldStatefulSet.Spec.Replicas             // +k8s:verify-mutation:reason=clone
++	newStatefulSetClone.Spec.Template = oldStatefulSet.Spec.Template             // +k8s:verify-mutation:reason=clone
++	newStatefulSetClone.Spec.UpdateStrategy = oldStatefulSet.Spec.UpdateStrategy // +k8s:verify-mutation:reason=clone
++	if !apiequality.Semantic.DeepEqual(newStatefulSetClone.Spec, oldStatefulSet.Spec) {
+ 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden"))
+ 	}
+-	statefulSet.Spec.Replicas = restoreReplicas
+-	statefulSet.Spec.Template = restoreTemplate
+-	statefulSet.Spec.UpdateStrategy = restoreStrategy
+ 
+ 	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(statefulSet.Spec.Replicas), field.NewPath("spec", "replicas"))...)
+ 	return allErrs
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 41b9c222fc7f7b8cebcf839ac7119e62b7439fb3 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Wed, 17 Feb 2021 11:17:18 -0500
+Subject: add verify script to catch most validation mutations
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ hack/make-rules/verify.sh              |  1 +
+ hack/verify-non-mutating-validation.sh | 41 ++++++++++++++++++++++++++
+ 2 files changed, 42 insertions(+)
+ create mode 100755 hack/verify-non-mutating-validation.sh
+
+diff --git a/hack/make-rules/verify.sh b/hack/make-rules/verify.sh
+index 1ceb531a065..75a85e41bf2 100755
+--- a/hack/make-rules/verify.sh
++++ b/hack/make-rules/verify.sh
+@@ -70,6 +70,7 @@ QUICK_PATTERNS+=(
+   "verify-vendor-licenses.sh"
+   "verify-gofmt.sh"
+   "verify-imports.sh"
++  "verify-non-mutating-validation.sh"
+   "verify-pkg-names.sh"
+   "verify-readonly-packages.sh"
+   "verify-spelling.sh"
+diff --git a/hack/verify-non-mutating-validation.sh b/hack/verify-non-mutating-validation.sh
+new file mode 100755
+index 00000000000..5fe3bed2146
+--- /dev/null
++++ b/hack/verify-non-mutating-validation.sh
+@@ -0,0 +1,41 @@
++#!/usr/bin/env bash
++
++# Copyright 2020 The Kubernetes Authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++# This script checks that validation files do not mutate their inputs.
++# Usage: `hack/verify-non-mutating-validation.sh`.
++
++set -o errexit
++set -o nounset
++set -o pipefail
++
++KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
++source "${KUBE_ROOT}/hack/lib/init.sh"
++
++mutationOutput=$(find . -name validation.go | xargs egrep -n ' = old' | grep -v '// +k8s:verify-mutation:reason=clone' || true)
++foundMutation=$(echo "${mutationOutput}" | wc -c)
++# when there's no match, there is a newline
++if [ "$foundMutation" -gt "1" ]; then
++  echo "${mutationOutput}"
++  exit 1
++fi
++
++mutationOutput=$(! find . -name validation.go | xargs egrep -n 'old.* = ' | grep -v '// +k8s:verify-mutation:reason=clone' || true)
++foundMutation=$(echo "${mutationOutput}" | wc -l)
++# when there's no match, there is a newline
++if [ "$foundMutation" -gt "1" ]; then
++  echo "${mutationOutput}"
++  exit 1
++fi
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+

--- a/projects/kubernetes/kubernetes/1-19/patches/0015-2021-25735_1_19.patch
+++ b/projects/kubernetes/kubernetes/1-19/patches/0015-2021-25735_1_19.patch
@@ -1,0 +1,1340 @@
+From d760b17d02164237bd7fde77027518f47fc62be2 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Fri, 29 Jan 2021 13:28:44 -0500
+Subject: update fuzzer to create random, but valid nodes
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/fuzzer/fuzzer.go                | 52 ++++++++++++++++++-
+ .../pkg/apis/meta/fuzzer/fuzzer.go            | 24 ++++++++-
+ 2 files changed, 73 insertions(+), 3 deletions(-)
+
+diff --git a/pkg/apis/core/fuzzer/fuzzer.go b/pkg/apis/core/fuzzer/fuzzer.go
+index 2d33f44d88f..f025eda3698 100644
+--- a/pkg/apis/core/fuzzer/fuzzer.go
++++ b/pkg/apis/core/fuzzer/fuzzer.go
+@@ -21,10 +21,12 @@ import (
+ 	"strconv"
+ 	"time"
+ 
+-	fuzz "github.com/google/gofuzz"
++	"k8s.io/apimachinery/pkg/util/uuid"
+ 
++	fuzz "github.com/google/gofuzz"
+ 	corev1 "k8s.io/api/core/v1"
+ 	"k8s.io/apimachinery/pkg/api/resource"
++	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/runtime"
+ 	"k8s.io/apimachinery/pkg/runtime/schema"
+@@ -301,6 +303,40 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
+ 			ct.TerminationMessagePath = "/" + ct.TerminationMessagePath // Must be non-empty
+ 			ct.TerminationMessagePolicy = "File"
+ 		},
++		func(p *core.Taint, c fuzz.Continue) {
++			c.FuzzNoCustom(p) // fuzz self without calling this function again
++			if p == nil {
++				return
++			}
++
++			p.Key = metafuzzer.RandomDNSLabel(c)
++			switch c.Rand.Int31n(3) {
++			case 0:
++				p.Effect = core.TaintEffectNoSchedule
++			case 1:
++				p.Effect = core.TaintEffectNoExecute
++			case 2:
++				p.Effect = core.TaintEffectPreferNoSchedule
++			}
++			p.Value = metafuzzer.RandomDNSLabel(c)
++		},
++		func(p *core.ConfigMapNodeConfigSource, c fuzz.Continue) {
++			c.FuzzNoCustom(p) // fuzz self without calling this function again
++			if p == nil {
++				return
++			}
++
++			p.UID = ""
++			p.ResourceVersion = ""
++			p.Name = metafuzzer.RandomDNSLabel(c)
++			p.Namespace = metafuzzer.RandomDNSLabel(c)
++			p.KubeletConfigKey = metafuzzer.RandomDNSLabel(c)
++		},
++		func(ep *core.EphemeralContainer, c fuzz.Continue) {
++			c.FuzzNoCustom(ep)                                                                   // fuzz self without calling this function again
++			ep.EphemeralContainerCommon.TerminationMessagePath = "/" + ep.TerminationMessagePath // Must be non-empty
++			ep.EphemeralContainerCommon.TerminationMessagePolicy = "File"
++		},
+ 		func(p *core.Probe, c fuzz.Continue) {
+ 			c.FuzzNoCustom(p)
+ 			// These fields have default values.
+@@ -506,7 +542,21 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
+ 		},
+ 		func(s *core.NodeStatus, c fuzz.Continue) {
+ 			c.FuzzNoCustom(s)
++
+ 			s.Allocatable = s.Capacity
++
++			if s.Config != nil && s.Config.LastKnownGood != nil && s.Config.LastKnownGood.ConfigMap != nil {
++				s.Config.LastKnownGood.ConfigMap.UID = uuid.NewUUID()
++				s.Config.LastKnownGood.ConfigMap.ResourceVersion = c.RandString()
++			}
++			if s.Config != nil && s.Config.Assigned != nil && s.Config.Assigned.ConfigMap != nil {
++				s.Config.Assigned.ConfigMap.UID = uuid.NewUUID()
++				s.Config.Assigned.ConfigMap.ResourceVersion = c.RandString()
++			}
++			if s.Config != nil && s.Config.Active != nil && s.Config.Active.ConfigMap != nil {
++				s.Config.Active.ConfigMap.UID = uuid.NewUUID()
++				s.Config.Active.ConfigMap.ResourceVersion = c.RandString()
++			}
+ 		},
+ 		func(e *core.Event, c fuzz.Continue) {
+ 			c.FuzzNoCustom(e)
+diff --git a/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go b/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
+index bb5e8a2712d..5b2d1453526 100644
+--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
++++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
+@@ -137,7 +137,7 @@ func randomLabelPart(c fuzz.Continue, canBeEmpty bool) string {
+ 	return string(runes)
+ }
+ 
+-func randomDNSLabel(c fuzz.Continue) string {
++func RandomDNSLabel(c fuzz.Continue) string {
+ 	validStartEnd := []charRange{{'0', '9'}, {'a', 'z'}}
+ 	validMiddle := []charRange{{'0', '9'}, {'a', 'z'}, {'-', '-'}}
+ 
+@@ -163,7 +163,7 @@ func randomLabelKey(c fuzz.Continue) string {
+ 		prefixPartsLen := c.Rand.Intn(2) + 1
+ 		prefixParts := make([]string, prefixPartsLen)
+ 		for i := range prefixParts {
+-			prefixParts[i] = randomDNSLabel(c)
++			prefixParts[i] = RandomDNSLabel(c)
+ 		}
+ 		prefixPart = strings.Join(prefixParts, ".") + "/"
+ 	}
+@@ -203,22 +203,42 @@ func v1FuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
+ 			} else {
+ 				delete(j.Labels, "")
+ 			}
++			for k := range j.Labels {
++				j.Labels[RandomDNSLabel(c)] = randomLabelPart(c, true)
++				delete(j.Labels, k)
++			}
++
+ 			if len(j.Annotations) == 0 {
+ 				j.Annotations = nil
+ 			} else {
+ 				delete(j.Annotations, "")
+ 			}
++			for k := range j.Annotations {
++				j.Annotations[RandomDNSLabel(c)] = randomLabelPart(c, true)
++				delete(j.Annotations, k)
++			}
++
+ 			if len(j.OwnerReferences) == 0 {
+ 				j.OwnerReferences = nil
+ 			}
+ 			if len(j.Finalizers) == 0 {
+ 				j.Finalizers = nil
+ 			}
++			for i := 0; i < len(j.Finalizers); i++ {
++				j.Finalizers[i] = RandomDNSLabel(c) + "/" + RandomDNSLabel(c)
++			}
+ 		},
+ 		func(j *metav1.ResourceVersionMatch, c fuzz.Continue) {
+ 			matches := []metav1.ResourceVersionMatch{"", metav1.ResourceVersionMatchExact, metav1.ResourceVersionMatchNotOlderThan}
+ 			*j = matches[c.Rand.Intn(len(matches))]
+ 		},
++		func(j *metav1.OwnerReference, c fuzz.Continue) {
++			c.FuzzNoCustom(j)
++
++			if len(j.APIVersion) == 0 {
++				j.APIVersion = RandomDNSLabel(c)
++			}
++		},
+ 		func(j *metav1.ListMeta, c fuzz.Continue) {
+ 			j.ResourceVersion = strconv.FormatUint(c.RandUint64(), 10)
+ 			j.SelfLink = c.RandString()
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 97ce8e61a83122a7a3b44c5dbacdfd9df2ff8e26 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Fri, 29 Jan 2021 13:29:04 -0500
+Subject: add test for validation mutation of nodes
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/fuzzer/BUILD                    |   2 +
+ pkg/apis/core/validation/BUILD                |   8 +
+ pkg/apis/core/validation/mutation_test.go     | 163 ++++++++++++++++++
+ .../apimachinery/pkg/api/apitesting/BUILD     |   1 +
+ .../api/apitesting/validationtesting/BUILD    |  30 ++++
+ .../validationtesting/validation.go           | 153 ++++++++++++++++
+ .../apitesting/validationtesting/wrapper.go   | 132 ++++++++++++++
+ 7 files changed, 489 insertions(+)
+ create mode 100644 pkg/apis/core/validation/mutation_test.go
+ create mode 100644 staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD
+ create mode 100644 staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go
+ create mode 100644 staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go
+
+diff --git a/pkg/apis/core/fuzzer/BUILD b/pkg/apis/core/fuzzer/BUILD
+index c30003bbdd7..963c2fbe312 100644
+--- a/pkg/apis/core/fuzzer/BUILD
++++ b/pkg/apis/core/fuzzer/BUILD
+@@ -13,11 +13,13 @@ go_library(
+         "//pkg/apis/core:go_default_library",
+         "//staging/src/k8s.io/api/core/v1:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+         "//vendor/github.com/google/gofuzz:go_default_library",
+     ],
+ )
+diff --git a/pkg/apis/core/validation/BUILD b/pkg/apis/core/validation/BUILD
+index 8fb48c2400b..a07fe6612c5 100644
+--- a/pkg/apis/core/validation/BUILD
++++ b/pkg/apis/core/validation/BUILD
+@@ -51,20 +51,28 @@ go_test(
+     srcs = [
+         "conditional_validation_test.go",
+         "events_test.go",
++        "mutation_test.go",
+         "validation_test.go",
+     ],
+     embed = [":go_default_library"],
+     deps = [
++        "//pkg/api/legacyscheme:go_default_library",
+         "//pkg/apis/core:go_default_library",
++        "//pkg/apis/core/fuzzer:go_default_library",
+         "//pkg/capabilities:go_default_library",
+         "//pkg/features:go_default_library",
+         "//staging/src/k8s.io/api/core/v1:go_default_library",
+         "//staging/src/k8s.io/api/events/v1:go_default_library",
+         "//staging/src/k8s.io/api/events/v1beta1:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/fuzzer:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+diff --git a/pkg/apis/core/validation/mutation_test.go b/pkg/apis/core/validation/mutation_test.go
+new file mode 100644
+index 00000000000..2a3dcc66cce
+--- /dev/null
++++ b/pkg/apis/core/validation/mutation_test.go
+@@ -0,0 +1,163 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package validation
++
++import (
++	"math/rand"
++	"reflect"
++	"testing"
++	"time"
++
++	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
++	"k8s.io/apimachinery/pkg/api/apitesting/validationtesting"
++	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/runtime"
++	"k8s.io/apimachinery/pkg/util/diff"
++	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
++	"k8s.io/kubernetes/pkg/api/legacyscheme"
++	coreapi "k8s.io/kubernetes/pkg/apis/core"
++	corefuzzer "k8s.io/kubernetes/pkg/apis/core/fuzzer"
++)
++
++func getScheme() *runtime.Scheme {
++	scheme := &runtime.Scheme{}
++	utilruntime.Must(coreapi.AddToScheme(scheme))
++	return scheme
++}
++
++func getValidators() *validationtesting.RuntimeObjectsValidator {
++	validator := validationtesting.NewRuntimeObjectsValidator()
++
++	validator.MustRegister(&coreapi.Node{}, false, ValidateNode, ValidateNodeUpdate)
++	return validator
++}
++
++type validateUpdateCheck struct {
++	obj    runtime.Object
++	oldObj runtime.Object
++}
++
++func newClusterScopedObjectMeta(name string) metav1.ObjectMeta {
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(metafuzzer.Funcs, rand.NewSource(seed), legacyscheme.Codecs)
++
++	objMeta := metav1.ObjectMeta{}
++	fuzzer.Fuzz(&objMeta)
++	objMeta.Name = name
++	objMeta.Namespace = ""
++	// we don't validate these in this method
++	objMeta.ManagedFields = nil
++
++	return objMeta
++}
++
++func newClusterScopedObjectMetaUpdate(oldObjMeta metav1.ObjectMeta) metav1.ObjectMeta {
++	oldObjMetaCopy := oldObjMeta.DeepCopy()
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(metafuzzer.Funcs, rand.NewSource(seed), legacyscheme.Codecs)
++
++	objMeta := metav1.ObjectMeta{}
++	fuzzer.Fuzz(&objMeta)
++
++	// many fields are immutable
++	objMeta.Name = oldObjMetaCopy.Name
++	objMeta.Namespace = oldObjMetaCopy.Namespace
++	objMeta.UID = oldObjMetaCopy.UID
++	objMeta.CreationTimestamp = oldObjMetaCopy.CreationTimestamp
++	objMeta.DeletionTimestamp = oldObjMetaCopy.DeletionTimestamp
++	objMeta.DeletionGracePeriodSeconds = oldObjMetaCopy.DeletionGracePeriodSeconds
++	objMeta.ClusterName = oldObjMetaCopy.ClusterName
++	objMeta.Generation = oldObjMetaCopy.Generation
++	objMeta.ManagedFields = oldObjMetaCopy.ManagedFields
++
++	return objMeta
++}
++
++func newNode(name string) *coreapi.Node {
++	ret := &coreapi.Node{}
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(
++		fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, corefuzzer.Funcs),
++		rand.NewSource(seed), legacyscheme.Codecs)
++	fuzzer.Fuzz(ret)
++
++	ret.ObjectMeta = newClusterScopedObjectMeta(name)
++
++	return ret
++}
++
++func newNodeUpdate(node *coreapi.Node) *coreapi.Node {
++	ret := &coreapi.Node{}
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(
++		fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, corefuzzer.Funcs),
++		rand.NewSource(seed), legacyscheme.Codecs)
++	fuzzer.Fuzz(ret)
++
++	nodeCopy := node.DeepCopy()
++	ret.ObjectMeta = newClusterScopedObjectMetaUpdate(nodeCopy.ObjectMeta)
++	ret.Spec.ProviderID = nodeCopy.Spec.ProviderID
++	ret.Spec.PodCIDRs = nodeCopy.Spec.PodCIDRs
++	ret.Spec.ConfigSource = nodeCopy.Spec.ConfigSource
++	ret.Spec.DoNotUseExternalID = nodeCopy.Spec.DoNotUseExternalID
++
++	return ret
++}
++
++func newNodeValidationUpdateCheck() validateUpdateCheck {
++	old := newNode("the-node")
++	return validateUpdateCheck{
++		obj:    newNodeUpdate(old),
++		oldObj: old,
++	}
++}
++
++// this test checks to see if validateUpdate mutates its arguments
++func TestMutationValidateUpdate(t *testing.T) {
++	validators := getValidators()
++
++	// only test node now, but this is a proof of concept for overall enforcement
++	mutationObjects := []validateUpdateCheck{
++		newNodeValidationUpdateCheck(),
++	}
++
++	for _, tt := range mutationObjects {
++		typeName := reflect.TypeOf(tt.obj)
++		for i := 0; i < 20; i++ {
++			t.Run(typeName.Name(), func(t *testing.T) {
++				validator, exists := validators.GetInfo(tt.obj)
++				if !exists {
++					t.Fatal("missing validation func")
++				}
++
++				originalObj := tt.obj.DeepCopyObject()
++				originalOldObj := tt.oldObj.DeepCopyObject()
++				errors := validator.Validator.ValidateUpdate(tt.obj, tt.oldObj)
++				if len(errors) > 0 {
++					t.Fatal(errors)
++				}
++				if !reflect.DeepEqual(tt.oldObj, originalOldObj) {
++					t.Errorf("mutation of oldObject:\n%v", diff.ObjectGoPrintDiff(originalOldObj, tt.oldObj))
++				}
++				if !reflect.DeepEqual(tt.obj, originalObj) {
++					t.Errorf("mutation of oldObject:\n%v", diff.ObjectGoPrintDiff(originalObj, tt.obj))
++				}
++			})
++		}
++	}
++}
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD
+index 6144d9be6e4..8abac47d9d1 100644
+--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD
+@@ -32,6 +32,7 @@ filegroup(
+         "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/fuzzer:all-srcs",
+         "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/naming:all-srcs",
+         "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip:all-srcs",
++        "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting:all-srcs",
+     ],
+     tags = ["automanaged"],
+ )
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD
+new file mode 100644
+index 00000000000..0570f81a3f6
+--- /dev/null
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD
+@@ -0,0 +1,30 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "validation.go",
++        "wrapper.go",
++    ],
++    importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/apitesting/validationtesting",
++    importpath = "k8s.io/apimachinery/pkg/api/apitesting/validationtesting",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
++    ],
++)
++
++filegroup(
++    name = "package-srcs",
++    srcs = glob(["**"]),
++    tags = ["automanaged"],
++    visibility = ["//visibility:private"],
++)
++
++filegroup(
++    name = "all-srcs",
++    srcs = [":package-srcs"],
++    tags = ["automanaged"],
++    visibility = ["//visibility:public"],
++)
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go
+new file mode 100644
+index 00000000000..6f751b04cf3
+--- /dev/null
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go
+@@ -0,0 +1,153 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package validationtesting
++
++import (
++	"fmt"
++	"reflect"
++
++	"k8s.io/apimachinery/pkg/runtime"
++	"k8s.io/apimachinery/pkg/util/validation/field"
++)
++
++type RuntimeObjectValidator interface {
++	Validate(obj runtime.Object) field.ErrorList
++	ValidateUpdate(obj, old runtime.Object) field.ErrorList
++}
++
++type RuntimeObjectsValidator struct {
++	typeToValidator map[reflect.Type]RuntimeObjectValidatorInfo
++}
++
++func NewRuntimeObjectsValidator() *RuntimeObjectsValidator {
++	return &RuntimeObjectsValidator{map[reflect.Type]RuntimeObjectValidatorInfo{}}
++}
++
++type RuntimeObjectValidatorInfo struct {
++	Validator     RuntimeObjectValidator
++	IsNamespaced  bool
++	HasObjectMeta bool
++	UpdateAllowed bool
++}
++
++func (v *RuntimeObjectsValidator) GetInfoForType(apiType reflect.Type) (RuntimeObjectValidatorInfo, bool) {
++	ptrType := reflect.PtrTo(apiType)
++
++	ret, ok := v.typeToValidator[ptrType]
++	return ret, ok
++}
++
++func (v *RuntimeObjectsValidator) GetInfo(obj runtime.Object) (RuntimeObjectValidatorInfo, bool) {
++	ret, ok := v.typeToValidator[reflect.TypeOf(obj)]
++	return ret, ok
++}
++
++func (v *RuntimeObjectsValidator) MustRegister(obj runtime.Object, namespaceScoped bool, validateFunction interface{}, validateUpdateFunction interface{}) {
++	if err := v.Register(obj, namespaceScoped, validateFunction, validateUpdateFunction); err != nil {
++		panic(err)
++	}
++}
++
++func (v *RuntimeObjectsValidator) Register(obj runtime.Object, namespaceScoped bool, validateFunction interface{}, validateUpdateFunction interface{}) error {
++	objType := reflect.TypeOf(obj)
++	if oldValidator, exists := v.typeToValidator[objType]; exists {
++		panic(fmt.Sprintf("%v is already registered with %v", objType, oldValidator))
++	}
++
++	validator, err := NewValidationWrapper(validateFunction, validateUpdateFunction)
++	if err != nil {
++		return err
++	}
++
++	updateAllowed := validateUpdateFunction != nil
++
++	v.typeToValidator[objType] = RuntimeObjectValidatorInfo{validator, namespaceScoped, HasObjectMeta(obj), updateAllowed}
++
++	return nil
++}
++
++func (v *RuntimeObjectsValidator) Validate(obj runtime.Object) field.ErrorList {
++	if obj == nil {
++		return field.ErrorList{}
++	}
++
++	allErrs := field.ErrorList{}
++
++	specificValidationInfo, err := v.getSpecificValidationInfo(obj)
++	if err != nil {
++		allErrs = append(allErrs, field.InternalError(nil, err))
++		return allErrs
++	}
++
++	allErrs = append(allErrs, specificValidationInfo.Validator.Validate(obj)...)
++	return allErrs
++}
++
++func (v *RuntimeObjectsValidator) ValidateUpdate(obj, old runtime.Object) field.ErrorList {
++	if obj == nil && old == nil {
++		return field.ErrorList{}
++	}
++	if newType, oldType := reflect.TypeOf(obj), reflect.TypeOf(old); newType != oldType {
++		return field.ErrorList{field.Invalid(field.NewPath("kind"), newType.Kind(), fmt.Sprintf("expected type %s, for field %s, got %s", oldType.Kind().String(), "kind", newType.Kind().String()))}
++	}
++
++	allErrs := field.ErrorList{}
++
++	specificValidationInfo, err := v.getSpecificValidationInfo(obj)
++	if err != nil {
++		if fieldErr, ok := err.(*field.Error); ok {
++			allErrs = append(allErrs, fieldErr)
++		} else {
++			allErrs = append(allErrs, field.InternalError(nil, err))
++		}
++		return allErrs
++	}
++
++	allErrs = append(allErrs, specificValidationInfo.Validator.ValidateUpdate(obj, old)...)
++
++	// no errors so far, make sure that the new object is actually valid against the original validator
++	if len(allErrs) == 0 {
++		allErrs = append(allErrs, specificValidationInfo.Validator.Validate(obj)...)
++	}
++
++	return allErrs
++}
++
++func (v *RuntimeObjectsValidator) getSpecificValidationInfo(obj runtime.Object) (RuntimeObjectValidatorInfo, error) {
++	objType := reflect.TypeOf(obj)
++	specificValidationInfo, exists := v.typeToValidator[objType]
++	if !exists {
++		return RuntimeObjectValidatorInfo{}, fmt.Errorf("no validator registered for %v", objType)
++	}
++
++	return specificValidationInfo, nil
++}
++
++func (v *RuntimeObjectsValidator) GetRequiresNamespace(obj runtime.Object) (bool, error) {
++	objType := reflect.TypeOf(obj)
++	specificValidationInfo, exists := v.typeToValidator[objType]
++	if !exists {
++		return false, fmt.Errorf("no validator registered for %v", objType)
++	}
++
++	return specificValidationInfo.IsNamespaced, nil
++}
++
++func HasObjectMeta(obj runtime.Object) bool {
++	objValue := reflect.ValueOf(obj).Elem()
++	return objValue.FieldByName("ObjectMeta").IsValid()
++}
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go
+new file mode 100644
+index 00000000000..e7b1d48b7e6
+--- /dev/null
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go
+@@ -0,0 +1,132 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package validationtesting
++
++import (
++	"fmt"
++	"reflect"
++
++	"k8s.io/apimachinery/pkg/runtime"
++	"k8s.io/apimachinery/pkg/util/validation/field"
++)
++
++type WrappingValidator struct {
++	validate       *reflect.Value
++	validateUpdate *reflect.Value
++}
++
++func (v *WrappingValidator) Validate(obj runtime.Object) field.ErrorList {
++	return callValidate(reflect.ValueOf(obj), *v.validate)
++}
++
++func (v *WrappingValidator) ValidateUpdate(obj, old runtime.Object) field.ErrorList {
++	if v.validateUpdate == nil {
++		// if there is no update validation, fail.
++		return field.ErrorList{field.Forbidden(field.NewPath("obj"), fmt.Sprintf("%v", obj))}
++	}
++
++	return callValidateUpdate(reflect.ValueOf(obj), reflect.ValueOf(old), *v.validateUpdate)
++}
++
++func NewValidationWrapper(validateFunction interface{}, validateUpdateFunction interface{}) (*WrappingValidator, error) {
++	validateFunctionValue := reflect.ValueOf(validateFunction)
++	validateType := validateFunctionValue.Type()
++	if err := verifyValidateFunctionSignature(validateType); err != nil {
++		return nil, err
++	}
++
++	var validateUpdateFunctionValue *reflect.Value
++	if validateUpdateFunction != nil {
++		functionValue := reflect.ValueOf(validateUpdateFunction)
++		validateUpdateType := functionValue.Type()
++		if err := verifyValidateUpdateFunctionSignature(validateUpdateType); err != nil {
++			return nil, err
++		}
++
++		validateUpdateFunctionValue = &functionValue
++	}
++
++	return &WrappingValidator{&validateFunctionValue, validateUpdateFunctionValue}, nil
++}
++
++func verifyValidateFunctionSignature(ft reflect.Type) error {
++	if ft.Kind() != reflect.Func {
++		return fmt.Errorf("expected func, got: %v", ft)
++	}
++	if ft.NumIn() != 1 {
++		return fmt.Errorf("expected one 'in' param, got: %v", ft)
++	}
++	if ft.NumOut() != 1 {
++		return fmt.Errorf("expected one 'out' param, got: %v", ft)
++	}
++	if ft.In(0).Kind() != reflect.Ptr {
++		return fmt.Errorf("expected pointer arg for 'in' param 0, got: %v", ft)
++	}
++	errorType := reflect.TypeOf(&field.ErrorList{}).Elem()
++	if ft.Out(0) != errorType {
++		return fmt.Errorf("expected field.ErrorList return, got: %v", ft)
++	}
++	return nil
++}
++
++func verifyValidateUpdateFunctionSignature(ft reflect.Type) error {
++	if ft.Kind() != reflect.Func {
++		return fmt.Errorf("expected func, got: %v", ft)
++	}
++	if ft.NumIn() != 2 {
++		return fmt.Errorf("expected two 'in' params, got: %v", ft)
++	}
++	if ft.NumOut() != 1 {
++		return fmt.Errorf("expected one 'out' param, got: %v", ft)
++	}
++	if ft.In(0).Kind() != reflect.Ptr {
++		return fmt.Errorf("expected pointer arg for 'in' param 0, got: %v", ft)
++	}
++	if ft.In(1).Kind() != reflect.Ptr {
++		return fmt.Errorf("expected pointer arg for 'in' param 1, got: %v", ft)
++	}
++	errorType := reflect.TypeOf(&field.ErrorList{}).Elem()
++	if ft.Out(0) != errorType {
++		return fmt.Errorf("expected field.ErrorList return, got: %v", ft)
++	}
++	return nil
++}
++
++// callCustom calls 'custom' with sv & dv. custom must be a conversion function.
++func callValidate(obj, validateMethod reflect.Value) field.ErrorList {
++	args := []reflect.Value{obj}
++	ret := validateMethod.Call(args)[0].Interface()
++
++	// This convolution is necessary because nil interfaces won't convert
++	// to errors.
++	if ret == nil {
++		return nil
++	}
++	return ret.(field.ErrorList)
++}
++
++func callValidateUpdate(obj, old, validateMethod reflect.Value) field.ErrorList {
++	args := []reflect.Value{obj, old}
++	ret := validateMethod.Call(args)[0].Interface()
++
++	// This convolution is necessary because nil interfaces won't convert
++	// to errors.
++	if ret == nil {
++		return nil
++	}
++	return ret.(field.ErrorList)
++}
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 7685d43b5c03f7e958f62e069f41455eff283014 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Fri, 29 Jan 2021 13:47:31 -0500
+Subject: tweak validation to avoid mutation
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 46 +++++++++-----------------
+ 1 file changed, 15 insertions(+), 31 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index 87e946293df..4abb9d951df 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -29,8 +29,6 @@ import (
+ 	"unicode"
+ 	"unicode/utf8"
+ 
+-	"k8s.io/klog/v2"
+-
+ 	v1 "k8s.io/api/core/v1"
+ 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+ 	"k8s.io/apimachinery/pkg/api/resource"
+@@ -4756,11 +4754,8 @@ func ValidateNodeUpdate(node, oldNode *core.Node) field.ErrorList {
+ 		addresses[address] = true
+ 	}
+ 
+-	if len(oldNode.Spec.PodCIDRs) == 0 {
+-		// Allow the controller manager to assign a CIDR to a node if it doesn't have one.
+-		//this is a no op for a string slice.
+-		oldNode.Spec.PodCIDRs = node.Spec.PodCIDRs
+-	} else {
++	// Allow the controller manager to assign a CIDR to a node if it doesn't have one.
++	if len(oldNode.Spec.PodCIDRs) > 0 {
+ 		// compare the entire slice
+ 		if len(oldNode.Spec.PodCIDRs) != len(node.Spec.PodCIDRs) {
+ 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "podCIDRs"), "node updates may not change podCIDR except from \"\" to valid"))
+@@ -4774,46 +4769,35 @@ func ValidateNodeUpdate(node, oldNode *core.Node) field.ErrorList {
+ 	}
+ 
+ 	// Allow controller manager updating provider ID when not set
+-	if len(oldNode.Spec.ProviderID) == 0 {
+-		oldNode.Spec.ProviderID = node.Spec.ProviderID
+-	} else {
+-		if oldNode.Spec.ProviderID != node.Spec.ProviderID {
+-			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "providerID"), "node updates may not change providerID except from \"\" to valid"))
+-		}
++	if len(oldNode.Spec.ProviderID) > 0 && oldNode.Spec.ProviderID != node.Spec.ProviderID {
++		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "providerID"), "node updates may not change providerID except from \"\" to valid"))
+ 	}
+ 
+ 	if node.Spec.ConfigSource != nil {
+ 		allErrs = append(allErrs, validateNodeConfigSourceSpec(node.Spec.ConfigSource, field.NewPath("spec", "configSource"))...)
+ 	}
+-	oldNode.Spec.ConfigSource = node.Spec.ConfigSource
+ 	if node.Status.Config != nil {
+ 		allErrs = append(allErrs, validateNodeConfigStatus(node.Status.Config, field.NewPath("status", "config"))...)
+ 	}
+-	oldNode.Status.Config = node.Status.Config
+-
+-	// TODO: move reset function to its own location
+-	// Ignore metadata changes now that they have been tested
+-	oldNode.ObjectMeta = node.ObjectMeta
+-	// Allow users to update capacity
+-	oldNode.Status.Capacity = node.Status.Capacity
+-	// Allow users to unschedule node
+-	oldNode.Spec.Unschedulable = node.Spec.Unschedulable
+-	// Clear status
+-	oldNode.Status = node.Status
+ 
+ 	// update taints
+ 	if len(node.Spec.Taints) > 0 {
+ 		allErrs = append(allErrs, validateNodeTaints(node.Spec.Taints, fldPath.Child("taints"))...)
+ 	}
+-	oldNode.Spec.Taints = node.Spec.Taints
+ 
+-	// We made allowed changes to oldNode, and now we compare oldNode to node. Any remaining differences indicate changes to protected fields.
+-	// TODO: Add a 'real' error type for this error and provide print actual diffs.
+-	if !apiequality.Semantic.DeepEqual(oldNode, node) {
+-		klog.V(4).Infof("Update failed validation %#v vs %#v", oldNode, node)
+-		allErrs = append(allErrs, field.Forbidden(field.NewPath(""), "node updates may only change labels, taints, or capacity (or configSource, if the DynamicKubeletConfig feature gate is enabled)"))
++	if node.Spec.DoNotUseExternalID != oldNode.Spec.DoNotUseExternalID {
++		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "externalID"), "may not be updated"))
+ 	}
+ 
++	// status and metadata are allowed change (barring restrictions above), so separately test spec field.
++	// spec only has a few fields, so check the ones we don't allow changing
++	//  1. PodCIDRs - immutable after first set - checked above
++	//  2. ProviderID - immutable after first set - checked above
++	//  3. Unschedulable - allowed to change
++	//  4. Taints - allowed to change
++	//  5. ConfigSource - allowed to change (and checked above)
++	//  6. DoNotUseExternalID - immutable - checked above
++
+ 	return allErrs
+ }
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 8476212dddc881a817c0a807bcbf9c07fcab1b81 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 16:21:42 -0500
+Subject: remove unnecessary mutations in validation
+
+These mutations are already done in the strategy
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 22 ++--------------------
+ 1 file changed, 2 insertions(+), 20 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index 4abb9d951df..6503e66869d 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -1939,13 +1939,11 @@ func ValidatePersistentVolumeUpdate(newPv, oldPv *core.PersistentVolume) field.E
+ }
+ 
+ // ValidatePersistentVolumeStatusUpdate tests to see if the status update is legal for an end user to make.
+-// newPv is updated with fields that cannot be changed.
+ func ValidatePersistentVolumeStatusUpdate(newPv, oldPv *core.PersistentVolume) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newPv.ObjectMeta, &oldPv.ObjectMeta, field.NewPath("metadata"))
+ 	if len(newPv.ResourceVersion) == 0 {
+ 		allErrs = append(allErrs, field.Required(field.NewPath("resourceVersion"), ""))
+ 	}
+-	newPv.Spec = oldPv.Spec
+ 	return allErrs
+ }
+ 
+@@ -2091,7 +2089,6 @@ func ValidatePersistentVolumeClaimStatusUpdate(newPvc, oldPvc *core.PersistentVo
+ 	for r, qty := range newPvc.Status.Capacity {
+ 		allErrs = append(allErrs, validateBasicResource(qty, capPath.Key(string(r)))...)
+ 	}
+-	newPvc.Spec = oldPvc.Spec
+ 	return allErrs
+ }
+ 
+@@ -4020,8 +4017,7 @@ func ValidateContainerStateTransition(newStatuses, oldStatuses []core.ContainerS
+ 	return allErrs
+ }
+ 
+-// ValidatePodStatusUpdate tests to see if the update is legal for an end user to make. newPod is updated with fields
+-// that cannot be changed.
++// ValidatePodStatusUpdate tests to see if the update is legal for an end user to make.
+ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod) field.ErrorList {
+ 	fldPath := field.NewPath("metadata")
+ 	allErrs := ValidateObjectMetaUpdate(&newPod.ObjectMeta, &oldPod.ObjectMeta, fldPath)
+@@ -4052,9 +4048,6 @@ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod) field.ErrorList {
+ 		}
+ 	}
+ 
+-	// For status update we ignore changes to pod spec.
+-	newPod.Spec = oldPod.Spec
+-
+ 	return allErrs
+ }
+ 
+@@ -5513,7 +5506,6 @@ func ValidateResourceQuantityValue(resource string, value resource.Quantity, fld
+ }
+ 
+ // ValidateResourceQuotaUpdate tests to see if the update is legal for an end user to make.
+-// newResourceQuota is updated with fields that cannot be changed.
+ func ValidateResourceQuotaUpdate(newResourceQuota, oldResourceQuota *core.ResourceQuota) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newResourceQuota.ObjectMeta, &oldResourceQuota.ObjectMeta, field.NewPath("metadata"))
+ 	allErrs = append(allErrs, ValidateResourceQuotaSpec(&newResourceQuota.Spec, field.NewPath("spec"))...)
+@@ -5532,12 +5524,10 @@ func ValidateResourceQuotaUpdate(newResourceQuota, oldResourceQuota *core.Resour
+ 		allErrs = append(allErrs, field.Invalid(fldPath, newResourceQuota.Spec.Scopes, fieldImmutableErrorMsg))
+ 	}
+ 
+-	newResourceQuota.Status = oldResourceQuota.Status
+ 	return allErrs
+ }
+ 
+ // ValidateResourceQuotaStatusUpdate tests to see if the status update is legal for an end user to make.
+-// newResourceQuota is updated with fields that cannot be changed.
+ func ValidateResourceQuotaStatusUpdate(newResourceQuota, oldResourceQuota *core.ResourceQuota) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newResourceQuota.ObjectMeta, &oldResourceQuota.ObjectMeta, field.NewPath("metadata"))
+ 	if len(newResourceQuota.ResourceVersion) == 0 {
+@@ -5555,7 +5545,6 @@ func ValidateResourceQuotaStatusUpdate(newResourceQuota, oldResourceQuota *core.
+ 		allErrs = append(allErrs, ValidateResourceQuotaResourceName(string(k), resPath)...)
+ 		allErrs = append(allErrs, ValidateResourceQuantityValue(string(k), v, resPath)...)
+ 	}
+-	newResourceQuota.Spec = oldResourceQuota.Spec
+ 	return allErrs
+ }
+ 
+@@ -5588,19 +5577,14 @@ func validateKubeFinalizerName(stringValue string, fldPath *field.Path) field.Er
+ }
+ 
+ // ValidateNamespaceUpdate tests to make sure a namespace update can be applied.
+-// newNamespace is updated with fields that cannot be changed
+ func ValidateNamespaceUpdate(newNamespace *core.Namespace, oldNamespace *core.Namespace) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+-	newNamespace.Spec.Finalizers = oldNamespace.Spec.Finalizers
+-	newNamespace.Status = oldNamespace.Status
+ 	return allErrs
+ }
+ 
+-// ValidateNamespaceStatusUpdate tests to see if the update is legal for an end user to make. newNamespace is updated with fields
+-// that cannot be changed.
++// ValidateNamespaceStatusUpdate tests to see if the update is legal for an end user to make.
+ func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *core.Namespace) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+-	newNamespace.Spec = oldNamespace.Spec
+ 	if newNamespace.DeletionTimestamp.IsZero() {
+ 		if newNamespace.Status.Phase != core.NamespaceActive {
+ 			allErrs = append(allErrs, field.Invalid(field.NewPath("status", "Phase"), newNamespace.Status.Phase, "may only be 'Active' if `deletionTimestamp` is empty"))
+@@ -5614,7 +5598,6 @@ func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *core.Namespace) f
+ }
+ 
+ // ValidateNamespaceFinalizeUpdate tests to see if the update is legal for an end user to make.
+-// newNamespace is updated with fields that cannot be changed.
+ func ValidateNamespaceFinalizeUpdate(newNamespace, oldNamespace *core.Namespace) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+ 
+@@ -5623,7 +5606,6 @@ func ValidateNamespaceFinalizeUpdate(newNamespace, oldNamespace *core.Namespace)
+ 		idxPath := fldPath.Index(i)
+ 		allErrs = append(allErrs, validateFinalizerName(string(newNamespace.Spec.Finalizers[i]), idxPath)...)
+ 	}
+-	newNamespace.Status = oldNamespace.Status
+ 	return allErrs
+ }
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From d00d12f2dd9ca1dc9b3b5b9a550c8329ee0f6e56 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 16:55:41 -0500
+Subject: move secret mutation from validation to prepareforupdate
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 4 ----
+ pkg/registry/core/secret/strategy.go   | 6 ++++++
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index 6503e66869d..a1f6c8a999b 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -5203,10 +5203,6 @@ func ValidateSecret(secret *core.Secret) field.ErrorList {
+ func ValidateSecretUpdate(newSecret, oldSecret *core.Secret) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newSecret.ObjectMeta, &oldSecret.ObjectMeta, field.NewPath("metadata"))
+ 
+-	if len(newSecret.Type) == 0 {
+-		newSecret.Type = oldSecret.Type
+-	}
+-
+ 	allErrs = append(allErrs, ValidateImmutableField(newSecret.Type, oldSecret.Type, field.NewPath("type"))...)
+ 	if oldSecret.Immutable != nil && *oldSecret.Immutable {
+ 		if newSecret.Immutable == nil || !*newSecret.Immutable {
+diff --git a/pkg/registry/core/secret/strategy.go b/pkg/registry/core/secret/strategy.go
+index 0d5908d8975..aad00387ac1 100644
+--- a/pkg/registry/core/secret/strategy.go
++++ b/pkg/registry/core/secret/strategy.go
+@@ -73,6 +73,12 @@ func (strategy) AllowCreateOnUpdate() bool {
+ func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+ 	newSecret := obj.(*api.Secret)
+ 	oldSecret := old.(*api.Secret)
++
++	// this is weird, but consistent with what the validatedUpdate function used to do.
++	if len(newSecret.Type) == 0 {
++		newSecret.Type = oldSecret.Type
++	}
++
+ 	dropDisabledFields(newSecret, oldSecret)
+ }
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 6e85e1a0d2682e3d3be0129f2c92e29690752a5e Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 17:18:11 -0500
+Subject: add markers for inspected validation mutation hits
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go                 | 10 +++++-----
+ .../pkg/apis/apiextensions/validation/validation.go    |  2 +-
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index a1f6c8a999b..c131b7e0263 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -2016,7 +2016,7 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
+ 	// Claims are immutable in order to enforce quota, range limits, etc. without gaming the system.
+ 	if len(oldPvc.Spec.VolumeName) == 0 {
+ 		// volumeName changes are allowed once.
+-		oldPvcClone.Spec.VolumeName = newPvcClone.Spec.VolumeName
++		oldPvcClone.Spec.VolumeName = newPvcClone.Spec.VolumeName // +k8s:verify-mutation:reason=clone
+ 	}
+ 
+ 	if validateStorageClassUpgrade(oldPvcClone.Annotations, newPvcClone.Annotations,
+@@ -2032,7 +2032,7 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
+ 	if utilfeature.DefaultFeatureGate.Enabled(features.ExpandPersistentVolumes) {
+ 		// lets make sure storage values are same.
+ 		if newPvc.Status.Phase == core.ClaimBound && newPvcClone.Spec.Resources.Requests != nil {
+-			newPvcClone.Spec.Resources.Requests["storage"] = oldPvc.Spec.Resources.Requests["storage"]
++			newPvcClone.Spec.Resources.Requests["storage"] = oldPvc.Spec.Resources.Requests["storage"] // +k8s:verify-mutation:reason=clone
+ 		}
+ 
+ 		oldSize := oldPvc.Spec.Resources.Requests["storage"]
+@@ -2382,13 +2382,13 @@ func GetVolumeMountMap(mounts []core.VolumeMount) map[string]string {
+ }
+ 
+ func GetVolumeDeviceMap(devices []core.VolumeDevice) map[string]string {
+-	voldevices := make(map[string]string)
++	volDevices := make(map[string]string)
+ 
+ 	for _, dev := range devices {
+-		voldevices[dev.Name] = dev.DevicePath
++		volDevices[dev.Name] = dev.DevicePath
+ 	}
+ 
+-	return voldevices
++	return volDevices
+ }
+ 
+ func ValidateVolumeMounts(mounts []core.VolumeMount, voldevices map[string]string, volumes map[string]core.VolumeSource, container *core.Container, fldPath *field.Path) field.ErrorList {
+diff --git a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+index e25dd1e7a72..32ae5e99436 100644
+--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
++++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+@@ -1409,7 +1409,7 @@ func validateAPIApproval(newCRD, oldCRD *apiextensions.CustomResourceDefinition,
+ 	var oldApprovalState *apihelpers.APIApprovalState
+ 	if oldCRD != nil {
+ 		t, _ := apihelpers.GetAPIApprovalState(oldCRD.Annotations)
+-		oldApprovalState = &t
++		oldApprovalState = &t // +k8s:verify-mutation:reason=clone
+ 	}
+ 	newApprovalState, reason := apihelpers.GetAPIApprovalState(newCRD.Annotations)
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 023cbc81fec462be6085e3347c8f06912266c38c Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 17:33:34 -0500
+Subject: remove pod toleration toleration seconds mutation
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index c131b7e0263..bf726d34f00 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -3052,10 +3052,11 @@ func validateOnlyAddedTolerations(newTolerations []core.Toleration, oldToleratio
+ 	allErrs := field.ErrorList{}
+ 	for _, old := range oldTolerations {
+ 		found := false
+-		old.TolerationSeconds = nil
+-		for _, new := range newTolerations {
+-			new.TolerationSeconds = nil
+-			if reflect.DeepEqual(old, new) {
++		oldTolerationClone := old.DeepCopy()
++		for _, newToleration := range newTolerations {
++			// assign to our clone before doing a deep equal so we can allow tolerationseconds to change.
++			oldTolerationClone.TolerationSeconds = newToleration.TolerationSeconds // +k8s:verify-mutation:reason=clone
++			if reflect.DeepEqual(*oldTolerationClone, newToleration) {
+ 				found = true
+ 				break
+ 			}
+@@ -3955,6 +3956,9 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
+ 		allErrs = append(allErrs, field.Invalid(specPath.Child("activeDeadlineSeconds"), newPod.Spec.ActiveDeadlineSeconds, "must not update from a positive integer to nil value"))
+ 	}
+ 
++	// Allow only additions to tolerations updates.
++	allErrs = append(allErrs, validateOnlyAddedTolerations(newPod.Spec.Tolerations, oldPod.Spec.Tolerations, specPath.Child("tolerations"))...)
++
+ 	// handle updateable fields by munging those fields prior to deep equal comparison.
+ 	mungedPod := *newPod
+ 	// munge spec.containers[*].image
+@@ -3978,10 +3982,6 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
+ 		mungedPod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
+ 	}
+ 
+-	// Allow only additions to tolerations updates.
+-	mungedPod.Spec.Tolerations = oldPod.Spec.Tolerations
+-	allErrs = append(allErrs, validateOnlyAddedTolerations(newPod.Spec.Tolerations, oldPod.Spec.Tolerations, specPath.Child("tolerations"))...)
+-
+ 	if !apiequality.Semantic.DeepEqual(mungedPod.Spec, oldPod.Spec) {
+ 		// This diff isn't perfect, but it's a helluva lot better an "I'm not going to tell you what the difference is".
+ 		//TODO: Pinpoint the specific field that causes the invalid error after we have strategic merge diff
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 9f5106c6c039f6bf7be4deb96253ec6a41e4406e Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 17:43:57 -0500
+Subject: full deepcopy on munged pod spec
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 30 ++++++++++++++++----------
+ 1 file changed, 19 insertions(+), 11 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index bf726d34f00..2e6a1b317aa 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -3959,33 +3959,41 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
+ 	// Allow only additions to tolerations updates.
+ 	allErrs = append(allErrs, validateOnlyAddedTolerations(newPod.Spec.Tolerations, oldPod.Spec.Tolerations, specPath.Child("tolerations"))...)
+ 
++	// the last thing to check is pod spec equality.  If the pod specs are equal, then we can simply return the errors we have
++	// so far and save the cost of a deep copy.
++	if apiequality.Semantic.DeepEqual(newPod.Spec, oldPod.Spec) {
++		return allErrs
++	}
++
+ 	// handle updateable fields by munging those fields prior to deep equal comparison.
+-	mungedPod := *newPod
++	mungedPodSpec := *newPod.Spec.DeepCopy()
+ 	// munge spec.containers[*].image
+ 	var newContainers []core.Container
+-	for ix, container := range mungedPod.Spec.Containers {
+-		container.Image = oldPod.Spec.Containers[ix].Image
++	for ix, container := range mungedPodSpec.Containers {
++		container.Image = oldPod.Spec.Containers[ix].Image // +k8s:verify-mutation:reason=clone
+ 		newContainers = append(newContainers, container)
+ 	}
+-	mungedPod.Spec.Containers = newContainers
++	mungedPodSpec.Containers = newContainers
+ 	// munge spec.initContainers[*].image
+ 	var newInitContainers []core.Container
+-	for ix, container := range mungedPod.Spec.InitContainers {
+-		container.Image = oldPod.Spec.InitContainers[ix].Image
++	for ix, container := range mungedPodSpec.InitContainers {
++		container.Image = oldPod.Spec.InitContainers[ix].Image // +k8s:verify-mutation:reason=clone
+ 		newInitContainers = append(newInitContainers, container)
+ 	}
+-	mungedPod.Spec.InitContainers = newInitContainers
++	mungedPodSpec.InitContainers = newInitContainers
+ 	// munge spec.activeDeadlineSeconds
+-	mungedPod.Spec.ActiveDeadlineSeconds = nil
++	mungedPodSpec.ActiveDeadlineSeconds = nil
+ 	if oldPod.Spec.ActiveDeadlineSeconds != nil {
+ 		activeDeadlineSeconds := *oldPod.Spec.ActiveDeadlineSeconds
+-		mungedPod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
++		mungedPodSpec.ActiveDeadlineSeconds = &activeDeadlineSeconds
+ 	}
++	// tolerations are checked before the deep copy, so munge those too
++	mungedPodSpec.Tolerations = oldPod.Spec.Tolerations // +k8s:verify-mutation:reason=clone
+ 
+-	if !apiequality.Semantic.DeepEqual(mungedPod.Spec, oldPod.Spec) {
++	if !apiequality.Semantic.DeepEqual(mungedPodSpec, oldPod.Spec) {
+ 		// This diff isn't perfect, but it's a helluva lot better an "I'm not going to tell you what the difference is".
+ 		//TODO: Pinpoint the specific field that causes the invalid error after we have strategic merge diff
+-		specDiff := diff.ObjectDiff(mungedPod.Spec, oldPod.Spec)
++		specDiff := diff.ObjectDiff(mungedPodSpec, oldPod.Spec)
+ 		allErrs = append(allErrs, field.Forbidden(specPath, fmt.Sprintf("pod updates may not change fields other than `spec.containers[*].image`, `spec.initContainers[*].image`, `spec.activeDeadlineSeconds` or `spec.tolerations` (only additions to existing tolerations)\n%v", specDiff)))
+ 	}
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 5997de4079a6122151697bd95196f9c773af202c Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Wed, 17 Feb 2021 10:51:38 -0500
+Subject: deepcopy statefulsets
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/apps/validation/validation.go | 20 +++++++-------------
+ 1 file changed, 7 insertions(+), 13 deletions(-)
+
+diff --git a/pkg/apis/apps/validation/validation.go b/pkg/apis/apps/validation/validation.go
+index 6ac73cb6b7e..03e0d2024dd 100644
+--- a/pkg/apis/apps/validation/validation.go
++++ b/pkg/apis/apps/validation/validation.go
+@@ -144,21 +144,15 @@ func ValidateStatefulSet(statefulSet *apps.StatefulSet) field.ErrorList {
+ func ValidateStatefulSetUpdate(statefulSet, oldStatefulSet *apps.StatefulSet) field.ErrorList {
+ 	allErrs := apivalidation.ValidateObjectMetaUpdate(&statefulSet.ObjectMeta, &oldStatefulSet.ObjectMeta, field.NewPath("metadata"))
+ 
+-	restoreReplicas := statefulSet.Spec.Replicas
+-	statefulSet.Spec.Replicas = oldStatefulSet.Spec.Replicas
+-
+-	restoreTemplate := statefulSet.Spec.Template
+-	statefulSet.Spec.Template = oldStatefulSet.Spec.Template
+-
+-	restoreStrategy := statefulSet.Spec.UpdateStrategy
+-	statefulSet.Spec.UpdateStrategy = oldStatefulSet.Spec.UpdateStrategy
+-
+-	if !apiequality.Semantic.DeepEqual(statefulSet.Spec, oldStatefulSet.Spec) {
++	// statefulset updates aren't super common and general updates are likely to be touching spec, so we'll do this
++	// deep copy right away.  This avoids mutating our inputs
++	newStatefulSetClone := statefulSet.DeepCopy()
++	newStatefulSetClone.Spec.Replicas = oldStatefulSet.Spec.Replicas             // +k8s:verify-mutation:reason=clone
++	newStatefulSetClone.Spec.Template = oldStatefulSet.Spec.Template             // +k8s:verify-mutation:reason=clone
++	newStatefulSetClone.Spec.UpdateStrategy = oldStatefulSet.Spec.UpdateStrategy // +k8s:verify-mutation:reason=clone
++	if !apiequality.Semantic.DeepEqual(newStatefulSetClone.Spec, oldStatefulSet.Spec) {
+ 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden"))
+ 	}
+-	statefulSet.Spec.Replicas = restoreReplicas
+-	statefulSet.Spec.Template = restoreTemplate
+-	statefulSet.Spec.UpdateStrategy = restoreStrategy
+ 
+ 	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(statefulSet.Spec.Replicas), field.NewPath("spec", "replicas"))...)
+ 	return allErrs
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 0646f64553ac36fa2ac6b8460ba448da1b1e03da Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Wed, 17 Feb 2021 11:17:18 -0500
+Subject: add verify script to catch most validation mutations
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ hack/make-rules/verify.sh              |  1 +
+ hack/verify-non-mutating-validation.sh | 41 ++++++++++++++++++++++++++
+ 2 files changed, 42 insertions(+)
+ create mode 100755 hack/verify-non-mutating-validation.sh
+
+diff --git a/hack/make-rules/verify.sh b/hack/make-rules/verify.sh
+index b91244cb8fd..a4551ed04f6 100755
+--- a/hack/make-rules/verify.sh
++++ b/hack/make-rules/verify.sh
+@@ -81,6 +81,7 @@ QUICK_PATTERNS+=(
+   "verify-vendor-licenses.sh"
+   "verify-gofmt.sh"
+   "verify-imports.sh"
++  "verify-non-mutating-validation.sh"
+   "verify-pkg-names.sh"
+   "verify-readonly-packages.sh"
+   "verify-spelling.sh"
+diff --git a/hack/verify-non-mutating-validation.sh b/hack/verify-non-mutating-validation.sh
+new file mode 100755
+index 00000000000..5fe3bed2146
+--- /dev/null
++++ b/hack/verify-non-mutating-validation.sh
+@@ -0,0 +1,41 @@
++#!/usr/bin/env bash
++
++# Copyright 2020 The Kubernetes Authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++# This script checks that validation files do not mutate their inputs.
++# Usage: `hack/verify-non-mutating-validation.sh`.
++
++set -o errexit
++set -o nounset
++set -o pipefail
++
++KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
++source "${KUBE_ROOT}/hack/lib/init.sh"
++
++mutationOutput=$(find . -name validation.go | xargs egrep -n ' = old' | grep -v '// +k8s:verify-mutation:reason=clone' || true)
++foundMutation=$(echo "${mutationOutput}" | wc -c)
++# when there's no match, there is a newline
++if [ "$foundMutation" -gt "1" ]; then
++  echo "${mutationOutput}"
++  exit 1
++fi
++
++mutationOutput=$(! find . -name validation.go | xargs egrep -n 'old.* = ' | grep -v '// +k8s:verify-mutation:reason=clone' || true)
++foundMutation=$(echo "${mutationOutput}" | wc -l)
++# when there's no match, there is a newline
++if [ "$foundMutation" -gt "1" ]; then
++  echo "${mutationOutput}"
++  exit 1
++fi
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+

--- a/projects/kubernetes/kubernetes/1-20/patches/0011-2021-25735_1_20.patch
+++ b/projects/kubernetes/kubernetes/1-20/patches/0011-2021-25735_1_20.patch
@@ -1,0 +1,1335 @@
+From b32a57d6ab20d306c3a0831a55bafd5657596efc Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Fri, 29 Jan 2021 13:28:44 -0500
+Subject: update fuzzer to create random, but valid nodes
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/fuzzer/fuzzer.go                | 47 ++++++++++++++++++-
+ .../pkg/apis/meta/fuzzer/fuzzer.go            | 24 +++++++++-
+ 2 files changed, 68 insertions(+), 3 deletions(-)
+
+diff --git a/pkg/apis/core/fuzzer/fuzzer.go b/pkg/apis/core/fuzzer/fuzzer.go
+index 43c4943474f..f025eda3698 100644
+--- a/pkg/apis/core/fuzzer/fuzzer.go
++++ b/pkg/apis/core/fuzzer/fuzzer.go
+@@ -21,10 +21,12 @@ import (
+ 	"strconv"
+ 	"time"
+ 
+-	fuzz "github.com/google/gofuzz"
++	"k8s.io/apimachinery/pkg/util/uuid"
+ 
++	fuzz "github.com/google/gofuzz"
+ 	corev1 "k8s.io/api/core/v1"
+ 	"k8s.io/apimachinery/pkg/api/resource"
++	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/runtime"
+ 	"k8s.io/apimachinery/pkg/runtime/schema"
+@@ -301,6 +303,35 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
+ 			ct.TerminationMessagePath = "/" + ct.TerminationMessagePath // Must be non-empty
+ 			ct.TerminationMessagePolicy = "File"
+ 		},
++		func(p *core.Taint, c fuzz.Continue) {
++			c.FuzzNoCustom(p) // fuzz self without calling this function again
++			if p == nil {
++				return
++			}
++
++			p.Key = metafuzzer.RandomDNSLabel(c)
++			switch c.Rand.Int31n(3) {
++			case 0:
++				p.Effect = core.TaintEffectNoSchedule
++			case 1:
++				p.Effect = core.TaintEffectNoExecute
++			case 2:
++				p.Effect = core.TaintEffectPreferNoSchedule
++			}
++			p.Value = metafuzzer.RandomDNSLabel(c)
++		},
++		func(p *core.ConfigMapNodeConfigSource, c fuzz.Continue) {
++			c.FuzzNoCustom(p) // fuzz self without calling this function again
++			if p == nil {
++				return
++			}
++
++			p.UID = ""
++			p.ResourceVersion = ""
++			p.Name = metafuzzer.RandomDNSLabel(c)
++			p.Namespace = metafuzzer.RandomDNSLabel(c)
++			p.KubeletConfigKey = metafuzzer.RandomDNSLabel(c)
++		},
+ 		func(ep *core.EphemeralContainer, c fuzz.Continue) {
+ 			c.FuzzNoCustom(ep)                                                                   // fuzz self without calling this function again
+ 			ep.EphemeralContainerCommon.TerminationMessagePath = "/" + ep.TerminationMessagePath // Must be non-empty
+@@ -511,7 +542,21 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
+ 		},
+ 		func(s *core.NodeStatus, c fuzz.Continue) {
+ 			c.FuzzNoCustom(s)
++
+ 			s.Allocatable = s.Capacity
++
++			if s.Config != nil && s.Config.LastKnownGood != nil && s.Config.LastKnownGood.ConfigMap != nil {
++				s.Config.LastKnownGood.ConfigMap.UID = uuid.NewUUID()
++				s.Config.LastKnownGood.ConfigMap.ResourceVersion = c.RandString()
++			}
++			if s.Config != nil && s.Config.Assigned != nil && s.Config.Assigned.ConfigMap != nil {
++				s.Config.Assigned.ConfigMap.UID = uuid.NewUUID()
++				s.Config.Assigned.ConfigMap.ResourceVersion = c.RandString()
++			}
++			if s.Config != nil && s.Config.Active != nil && s.Config.Active.ConfigMap != nil {
++				s.Config.Active.ConfigMap.UID = uuid.NewUUID()
++				s.Config.Active.ConfigMap.ResourceVersion = c.RandString()
++			}
+ 		},
+ 		func(e *core.Event, c fuzz.Continue) {
+ 			c.FuzzNoCustom(e)
+diff --git a/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go b/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
+index bb5e8a2712d..5b2d1453526 100644
+--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
++++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
+@@ -137,7 +137,7 @@ func randomLabelPart(c fuzz.Continue, canBeEmpty bool) string {
+ 	return string(runes)
+ }
+ 
+-func randomDNSLabel(c fuzz.Continue) string {
++func RandomDNSLabel(c fuzz.Continue) string {
+ 	validStartEnd := []charRange{{'0', '9'}, {'a', 'z'}}
+ 	validMiddle := []charRange{{'0', '9'}, {'a', 'z'}, {'-', '-'}}
+ 
+@@ -163,7 +163,7 @@ func randomLabelKey(c fuzz.Continue) string {
+ 		prefixPartsLen := c.Rand.Intn(2) + 1
+ 		prefixParts := make([]string, prefixPartsLen)
+ 		for i := range prefixParts {
+-			prefixParts[i] = randomDNSLabel(c)
++			prefixParts[i] = RandomDNSLabel(c)
+ 		}
+ 		prefixPart = strings.Join(prefixParts, ".") + "/"
+ 	}
+@@ -203,22 +203,42 @@ func v1FuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
+ 			} else {
+ 				delete(j.Labels, "")
+ 			}
++			for k := range j.Labels {
++				j.Labels[RandomDNSLabel(c)] = randomLabelPart(c, true)
++				delete(j.Labels, k)
++			}
++
+ 			if len(j.Annotations) == 0 {
+ 				j.Annotations = nil
+ 			} else {
+ 				delete(j.Annotations, "")
+ 			}
++			for k := range j.Annotations {
++				j.Annotations[RandomDNSLabel(c)] = randomLabelPart(c, true)
++				delete(j.Annotations, k)
++			}
++
+ 			if len(j.OwnerReferences) == 0 {
+ 				j.OwnerReferences = nil
+ 			}
+ 			if len(j.Finalizers) == 0 {
+ 				j.Finalizers = nil
+ 			}
++			for i := 0; i < len(j.Finalizers); i++ {
++				j.Finalizers[i] = RandomDNSLabel(c) + "/" + RandomDNSLabel(c)
++			}
+ 		},
+ 		func(j *metav1.ResourceVersionMatch, c fuzz.Continue) {
+ 			matches := []metav1.ResourceVersionMatch{"", metav1.ResourceVersionMatchExact, metav1.ResourceVersionMatchNotOlderThan}
+ 			*j = matches[c.Rand.Intn(len(matches))]
+ 		},
++		func(j *metav1.OwnerReference, c fuzz.Continue) {
++			c.FuzzNoCustom(j)
++
++			if len(j.APIVersion) == 0 {
++				j.APIVersion = RandomDNSLabel(c)
++			}
++		},
+ 		func(j *metav1.ListMeta, c fuzz.Continue) {
+ 			j.ResourceVersion = strconv.FormatUint(c.RandUint64(), 10)
+ 			j.SelfLink = c.RandString()
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From e4498dd7f31b861137531ba44db1e724c99cfa31 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Fri, 29 Jan 2021 13:29:04 -0500
+Subject: add test for validation mutation of nodes
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/fuzzer/BUILD                    |   2 +
+ pkg/apis/core/validation/BUILD                |   9 +
+ pkg/apis/core/validation/mutation_test.go     | 163 ++++++++++++++++++
+ .../apimachinery/pkg/api/apitesting/BUILD     |   1 +
+ .../api/apitesting/validationtesting/BUILD    |  30 ++++
+ .../validationtesting/validation.go           | 153 ++++++++++++++++
+ .../apitesting/validationtesting/wrapper.go   | 132 ++++++++++++++
+ 7 files changed, 490 insertions(+)
+ create mode 100644 pkg/apis/core/validation/mutation_test.go
+ create mode 100644 staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD
+ create mode 100644 staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go
+ create mode 100644 staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go
+
+diff --git a/pkg/apis/core/fuzzer/BUILD b/pkg/apis/core/fuzzer/BUILD
+index c30003bbdd7..963c2fbe312 100644
+--- a/pkg/apis/core/fuzzer/BUILD
++++ b/pkg/apis/core/fuzzer/BUILD
+@@ -13,11 +13,13 @@ go_library(
+         "//pkg/apis/core:go_default_library",
+         "//staging/src/k8s.io/api/core/v1:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+         "//vendor/github.com/google/gofuzz:go_default_library",
+     ],
+ )
+diff --git a/pkg/apis/core/validation/BUILD b/pkg/apis/core/validation/BUILD
+index 70d2bd71733..2b626ffaf08 100644
+--- a/pkg/apis/core/validation/BUILD
++++ b/pkg/apis/core/validation/BUILD
+@@ -51,19 +51,28 @@ go_test(
+     srcs = [
+         "conditional_validation_test.go",
+         "events_test.go",
++        "mutation_test.go",
+         "validation_test.go",
+     ],
+     embed = [":go_default_library"],
+     deps = [
++        "//pkg/api/legacyscheme:go_default_library",
+         "//pkg/apis/core:go_default_library",
++        "//pkg/apis/core/fuzzer:go_default_library",
+         "//pkg/capabilities:go_default_library",
+         "//pkg/features:go_default_library",
+         "//staging/src/k8s.io/api/core/v1:go_default_library",
+         "//staging/src/k8s.io/api/events/v1:go_default_library",
+         "//staging/src/k8s.io/api/events/v1beta1:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/fuzzer:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
+         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+diff --git a/pkg/apis/core/validation/mutation_test.go b/pkg/apis/core/validation/mutation_test.go
+new file mode 100644
+index 00000000000..2a3dcc66cce
+--- /dev/null
++++ b/pkg/apis/core/validation/mutation_test.go
+@@ -0,0 +1,163 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package validation
++
++import (
++	"math/rand"
++	"reflect"
++	"testing"
++	"time"
++
++	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
++	"k8s.io/apimachinery/pkg/api/apitesting/validationtesting"
++	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/runtime"
++	"k8s.io/apimachinery/pkg/util/diff"
++	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
++	"k8s.io/kubernetes/pkg/api/legacyscheme"
++	coreapi "k8s.io/kubernetes/pkg/apis/core"
++	corefuzzer "k8s.io/kubernetes/pkg/apis/core/fuzzer"
++)
++
++func getScheme() *runtime.Scheme {
++	scheme := &runtime.Scheme{}
++	utilruntime.Must(coreapi.AddToScheme(scheme))
++	return scheme
++}
++
++func getValidators() *validationtesting.RuntimeObjectsValidator {
++	validator := validationtesting.NewRuntimeObjectsValidator()
++
++	validator.MustRegister(&coreapi.Node{}, false, ValidateNode, ValidateNodeUpdate)
++	return validator
++}
++
++type validateUpdateCheck struct {
++	obj    runtime.Object
++	oldObj runtime.Object
++}
++
++func newClusterScopedObjectMeta(name string) metav1.ObjectMeta {
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(metafuzzer.Funcs, rand.NewSource(seed), legacyscheme.Codecs)
++
++	objMeta := metav1.ObjectMeta{}
++	fuzzer.Fuzz(&objMeta)
++	objMeta.Name = name
++	objMeta.Namespace = ""
++	// we don't validate these in this method
++	objMeta.ManagedFields = nil
++
++	return objMeta
++}
++
++func newClusterScopedObjectMetaUpdate(oldObjMeta metav1.ObjectMeta) metav1.ObjectMeta {
++	oldObjMetaCopy := oldObjMeta.DeepCopy()
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(metafuzzer.Funcs, rand.NewSource(seed), legacyscheme.Codecs)
++
++	objMeta := metav1.ObjectMeta{}
++	fuzzer.Fuzz(&objMeta)
++
++	// many fields are immutable
++	objMeta.Name = oldObjMetaCopy.Name
++	objMeta.Namespace = oldObjMetaCopy.Namespace
++	objMeta.UID = oldObjMetaCopy.UID
++	objMeta.CreationTimestamp = oldObjMetaCopy.CreationTimestamp
++	objMeta.DeletionTimestamp = oldObjMetaCopy.DeletionTimestamp
++	objMeta.DeletionGracePeriodSeconds = oldObjMetaCopy.DeletionGracePeriodSeconds
++	objMeta.ClusterName = oldObjMetaCopy.ClusterName
++	objMeta.Generation = oldObjMetaCopy.Generation
++	objMeta.ManagedFields = oldObjMetaCopy.ManagedFields
++
++	return objMeta
++}
++
++func newNode(name string) *coreapi.Node {
++	ret := &coreapi.Node{}
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(
++		fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, corefuzzer.Funcs),
++		rand.NewSource(seed), legacyscheme.Codecs)
++	fuzzer.Fuzz(ret)
++
++	ret.ObjectMeta = newClusterScopedObjectMeta(name)
++
++	return ret
++}
++
++func newNodeUpdate(node *coreapi.Node) *coreapi.Node {
++	ret := &coreapi.Node{}
++	seed := time.Now().UnixNano()
++	fuzzer := fuzzer.FuzzerFor(
++		fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, corefuzzer.Funcs),
++		rand.NewSource(seed), legacyscheme.Codecs)
++	fuzzer.Fuzz(ret)
++
++	nodeCopy := node.DeepCopy()
++	ret.ObjectMeta = newClusterScopedObjectMetaUpdate(nodeCopy.ObjectMeta)
++	ret.Spec.ProviderID = nodeCopy.Spec.ProviderID
++	ret.Spec.PodCIDRs = nodeCopy.Spec.PodCIDRs
++	ret.Spec.ConfigSource = nodeCopy.Spec.ConfigSource
++	ret.Spec.DoNotUseExternalID = nodeCopy.Spec.DoNotUseExternalID
++
++	return ret
++}
++
++func newNodeValidationUpdateCheck() validateUpdateCheck {
++	old := newNode("the-node")
++	return validateUpdateCheck{
++		obj:    newNodeUpdate(old),
++		oldObj: old,
++	}
++}
++
++// this test checks to see if validateUpdate mutates its arguments
++func TestMutationValidateUpdate(t *testing.T) {
++	validators := getValidators()
++
++	// only test node now, but this is a proof of concept for overall enforcement
++	mutationObjects := []validateUpdateCheck{
++		newNodeValidationUpdateCheck(),
++	}
++
++	for _, tt := range mutationObjects {
++		typeName := reflect.TypeOf(tt.obj)
++		for i := 0; i < 20; i++ {
++			t.Run(typeName.Name(), func(t *testing.T) {
++				validator, exists := validators.GetInfo(tt.obj)
++				if !exists {
++					t.Fatal("missing validation func")
++				}
++
++				originalObj := tt.obj.DeepCopyObject()
++				originalOldObj := tt.oldObj.DeepCopyObject()
++				errors := validator.Validator.ValidateUpdate(tt.obj, tt.oldObj)
++				if len(errors) > 0 {
++					t.Fatal(errors)
++				}
++				if !reflect.DeepEqual(tt.oldObj, originalOldObj) {
++					t.Errorf("mutation of oldObject:\n%v", diff.ObjectGoPrintDiff(originalOldObj, tt.oldObj))
++				}
++				if !reflect.DeepEqual(tt.obj, originalObj) {
++					t.Errorf("mutation of oldObject:\n%v", diff.ObjectGoPrintDiff(originalObj, tt.obj))
++				}
++			})
++		}
++	}
++}
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD
+index 6144d9be6e4..8abac47d9d1 100644
+--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/BUILD
+@@ -32,6 +32,7 @@ filegroup(
+         "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/fuzzer:all-srcs",
+         "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/naming:all-srcs",
+         "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip:all-srcs",
++        "//staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting:all-srcs",
+     ],
+     tags = ["automanaged"],
+ )
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD
+new file mode 100644
+index 00000000000..0570f81a3f6
+--- /dev/null
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/BUILD
+@@ -0,0 +1,30 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "go_default_library",
++    srcs = [
++        "validation.go",
++        "wrapper.go",
++    ],
++    importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/apitesting/validationtesting",
++    importpath = "k8s.io/apimachinery/pkg/api/apitesting/validationtesting",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
++        "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
++    ],
++)
++
++filegroup(
++    name = "package-srcs",
++    srcs = glob(["**"]),
++    tags = ["automanaged"],
++    visibility = ["//visibility:private"],
++)
++
++filegroup(
++    name = "all-srcs",
++    srcs = [":package-srcs"],
++    tags = ["automanaged"],
++    visibility = ["//visibility:public"],
++)
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go
+new file mode 100644
+index 00000000000..6f751b04cf3
+--- /dev/null
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/validation.go
+@@ -0,0 +1,153 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package validationtesting
++
++import (
++	"fmt"
++	"reflect"
++
++	"k8s.io/apimachinery/pkg/runtime"
++	"k8s.io/apimachinery/pkg/util/validation/field"
++)
++
++type RuntimeObjectValidator interface {
++	Validate(obj runtime.Object) field.ErrorList
++	ValidateUpdate(obj, old runtime.Object) field.ErrorList
++}
++
++type RuntimeObjectsValidator struct {
++	typeToValidator map[reflect.Type]RuntimeObjectValidatorInfo
++}
++
++func NewRuntimeObjectsValidator() *RuntimeObjectsValidator {
++	return &RuntimeObjectsValidator{map[reflect.Type]RuntimeObjectValidatorInfo{}}
++}
++
++type RuntimeObjectValidatorInfo struct {
++	Validator     RuntimeObjectValidator
++	IsNamespaced  bool
++	HasObjectMeta bool
++	UpdateAllowed bool
++}
++
++func (v *RuntimeObjectsValidator) GetInfoForType(apiType reflect.Type) (RuntimeObjectValidatorInfo, bool) {
++	ptrType := reflect.PtrTo(apiType)
++
++	ret, ok := v.typeToValidator[ptrType]
++	return ret, ok
++}
++
++func (v *RuntimeObjectsValidator) GetInfo(obj runtime.Object) (RuntimeObjectValidatorInfo, bool) {
++	ret, ok := v.typeToValidator[reflect.TypeOf(obj)]
++	return ret, ok
++}
++
++func (v *RuntimeObjectsValidator) MustRegister(obj runtime.Object, namespaceScoped bool, validateFunction interface{}, validateUpdateFunction interface{}) {
++	if err := v.Register(obj, namespaceScoped, validateFunction, validateUpdateFunction); err != nil {
++		panic(err)
++	}
++}
++
++func (v *RuntimeObjectsValidator) Register(obj runtime.Object, namespaceScoped bool, validateFunction interface{}, validateUpdateFunction interface{}) error {
++	objType := reflect.TypeOf(obj)
++	if oldValidator, exists := v.typeToValidator[objType]; exists {
++		panic(fmt.Sprintf("%v is already registered with %v", objType, oldValidator))
++	}
++
++	validator, err := NewValidationWrapper(validateFunction, validateUpdateFunction)
++	if err != nil {
++		return err
++	}
++
++	updateAllowed := validateUpdateFunction != nil
++
++	v.typeToValidator[objType] = RuntimeObjectValidatorInfo{validator, namespaceScoped, HasObjectMeta(obj), updateAllowed}
++
++	return nil
++}
++
++func (v *RuntimeObjectsValidator) Validate(obj runtime.Object) field.ErrorList {
++	if obj == nil {
++		return field.ErrorList{}
++	}
++
++	allErrs := field.ErrorList{}
++
++	specificValidationInfo, err := v.getSpecificValidationInfo(obj)
++	if err != nil {
++		allErrs = append(allErrs, field.InternalError(nil, err))
++		return allErrs
++	}
++
++	allErrs = append(allErrs, specificValidationInfo.Validator.Validate(obj)...)
++	return allErrs
++}
++
++func (v *RuntimeObjectsValidator) ValidateUpdate(obj, old runtime.Object) field.ErrorList {
++	if obj == nil && old == nil {
++		return field.ErrorList{}
++	}
++	if newType, oldType := reflect.TypeOf(obj), reflect.TypeOf(old); newType != oldType {
++		return field.ErrorList{field.Invalid(field.NewPath("kind"), newType.Kind(), fmt.Sprintf("expected type %s, for field %s, got %s", oldType.Kind().String(), "kind", newType.Kind().String()))}
++	}
++
++	allErrs := field.ErrorList{}
++
++	specificValidationInfo, err := v.getSpecificValidationInfo(obj)
++	if err != nil {
++		if fieldErr, ok := err.(*field.Error); ok {
++			allErrs = append(allErrs, fieldErr)
++		} else {
++			allErrs = append(allErrs, field.InternalError(nil, err))
++		}
++		return allErrs
++	}
++
++	allErrs = append(allErrs, specificValidationInfo.Validator.ValidateUpdate(obj, old)...)
++
++	// no errors so far, make sure that the new object is actually valid against the original validator
++	if len(allErrs) == 0 {
++		allErrs = append(allErrs, specificValidationInfo.Validator.Validate(obj)...)
++	}
++
++	return allErrs
++}
++
++func (v *RuntimeObjectsValidator) getSpecificValidationInfo(obj runtime.Object) (RuntimeObjectValidatorInfo, error) {
++	objType := reflect.TypeOf(obj)
++	specificValidationInfo, exists := v.typeToValidator[objType]
++	if !exists {
++		return RuntimeObjectValidatorInfo{}, fmt.Errorf("no validator registered for %v", objType)
++	}
++
++	return specificValidationInfo, nil
++}
++
++func (v *RuntimeObjectsValidator) GetRequiresNamespace(obj runtime.Object) (bool, error) {
++	objType := reflect.TypeOf(obj)
++	specificValidationInfo, exists := v.typeToValidator[objType]
++	if !exists {
++		return false, fmt.Errorf("no validator registered for %v", objType)
++	}
++
++	return specificValidationInfo.IsNamespaced, nil
++}
++
++func HasObjectMeta(obj runtime.Object) bool {
++	objValue := reflect.ValueOf(obj).Elem()
++	return objValue.FieldByName("ObjectMeta").IsValid()
++}
+diff --git a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go
+new file mode 100644
+index 00000000000..e7b1d48b7e6
+--- /dev/null
++++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/validationtesting/wrapper.go
+@@ -0,0 +1,132 @@
++/*
++Copyright 2021 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package validationtesting
++
++import (
++	"fmt"
++	"reflect"
++
++	"k8s.io/apimachinery/pkg/runtime"
++	"k8s.io/apimachinery/pkg/util/validation/field"
++)
++
++type WrappingValidator struct {
++	validate       *reflect.Value
++	validateUpdate *reflect.Value
++}
++
++func (v *WrappingValidator) Validate(obj runtime.Object) field.ErrorList {
++	return callValidate(reflect.ValueOf(obj), *v.validate)
++}
++
++func (v *WrappingValidator) ValidateUpdate(obj, old runtime.Object) field.ErrorList {
++	if v.validateUpdate == nil {
++		// if there is no update validation, fail.
++		return field.ErrorList{field.Forbidden(field.NewPath("obj"), fmt.Sprintf("%v", obj))}
++	}
++
++	return callValidateUpdate(reflect.ValueOf(obj), reflect.ValueOf(old), *v.validateUpdate)
++}
++
++func NewValidationWrapper(validateFunction interface{}, validateUpdateFunction interface{}) (*WrappingValidator, error) {
++	validateFunctionValue := reflect.ValueOf(validateFunction)
++	validateType := validateFunctionValue.Type()
++	if err := verifyValidateFunctionSignature(validateType); err != nil {
++		return nil, err
++	}
++
++	var validateUpdateFunctionValue *reflect.Value
++	if validateUpdateFunction != nil {
++		functionValue := reflect.ValueOf(validateUpdateFunction)
++		validateUpdateType := functionValue.Type()
++		if err := verifyValidateUpdateFunctionSignature(validateUpdateType); err != nil {
++			return nil, err
++		}
++
++		validateUpdateFunctionValue = &functionValue
++	}
++
++	return &WrappingValidator{&validateFunctionValue, validateUpdateFunctionValue}, nil
++}
++
++func verifyValidateFunctionSignature(ft reflect.Type) error {
++	if ft.Kind() != reflect.Func {
++		return fmt.Errorf("expected func, got: %v", ft)
++	}
++	if ft.NumIn() != 1 {
++		return fmt.Errorf("expected one 'in' param, got: %v", ft)
++	}
++	if ft.NumOut() != 1 {
++		return fmt.Errorf("expected one 'out' param, got: %v", ft)
++	}
++	if ft.In(0).Kind() != reflect.Ptr {
++		return fmt.Errorf("expected pointer arg for 'in' param 0, got: %v", ft)
++	}
++	errorType := reflect.TypeOf(&field.ErrorList{}).Elem()
++	if ft.Out(0) != errorType {
++		return fmt.Errorf("expected field.ErrorList return, got: %v", ft)
++	}
++	return nil
++}
++
++func verifyValidateUpdateFunctionSignature(ft reflect.Type) error {
++	if ft.Kind() != reflect.Func {
++		return fmt.Errorf("expected func, got: %v", ft)
++	}
++	if ft.NumIn() != 2 {
++		return fmt.Errorf("expected two 'in' params, got: %v", ft)
++	}
++	if ft.NumOut() != 1 {
++		return fmt.Errorf("expected one 'out' param, got: %v", ft)
++	}
++	if ft.In(0).Kind() != reflect.Ptr {
++		return fmt.Errorf("expected pointer arg for 'in' param 0, got: %v", ft)
++	}
++	if ft.In(1).Kind() != reflect.Ptr {
++		return fmt.Errorf("expected pointer arg for 'in' param 1, got: %v", ft)
++	}
++	errorType := reflect.TypeOf(&field.ErrorList{}).Elem()
++	if ft.Out(0) != errorType {
++		return fmt.Errorf("expected field.ErrorList return, got: %v", ft)
++	}
++	return nil
++}
++
++// callCustom calls 'custom' with sv & dv. custom must be a conversion function.
++func callValidate(obj, validateMethod reflect.Value) field.ErrorList {
++	args := []reflect.Value{obj}
++	ret := validateMethod.Call(args)[0].Interface()
++
++	// This convolution is necessary because nil interfaces won't convert
++	// to errors.
++	if ret == nil {
++		return nil
++	}
++	return ret.(field.ErrorList)
++}
++
++func callValidateUpdate(obj, old, validateMethod reflect.Value) field.ErrorList {
++	args := []reflect.Value{obj, old}
++	ret := validateMethod.Call(args)[0].Interface()
++
++	// This convolution is necessary because nil interfaces won't convert
++	// to errors.
++	if ret == nil {
++		return nil
++	}
++	return ret.(field.ErrorList)
++}
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 8f2344f4b0143be485b1846b49f92a736689604e Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Fri, 29 Jan 2021 13:47:31 -0500
+Subject: tweak validation to avoid mutation
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 46 +++++++++-----------------
+ 1 file changed, 15 insertions(+), 31 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index fd3477176a4..d4a16bbc0f0 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -29,8 +29,6 @@ import (
+ 	"unicode"
+ 	"unicode/utf8"
+ 
+-	"k8s.io/klog/v2"
+-
+ 	v1 "k8s.io/api/core/v1"
+ 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+ 	"k8s.io/apimachinery/pkg/api/resource"
+@@ -4754,11 +4752,8 @@ func ValidateNodeUpdate(node, oldNode *core.Node) field.ErrorList {
+ 		addresses[address] = true
+ 	}
+ 
+-	if len(oldNode.Spec.PodCIDRs) == 0 {
+-		// Allow the controller manager to assign a CIDR to a node if it doesn't have one.
+-		//this is a no op for a string slice.
+-		oldNode.Spec.PodCIDRs = node.Spec.PodCIDRs
+-	} else {
++	// Allow the controller manager to assign a CIDR to a node if it doesn't have one.
++	if len(oldNode.Spec.PodCIDRs) > 0 {
+ 		// compare the entire slice
+ 		if len(oldNode.Spec.PodCIDRs) != len(node.Spec.PodCIDRs) {
+ 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "podCIDRs"), "node updates may not change podCIDR except from \"\" to valid"))
+@@ -4772,46 +4767,35 @@ func ValidateNodeUpdate(node, oldNode *core.Node) field.ErrorList {
+ 	}
+ 
+ 	// Allow controller manager updating provider ID when not set
+-	if len(oldNode.Spec.ProviderID) == 0 {
+-		oldNode.Spec.ProviderID = node.Spec.ProviderID
+-	} else {
+-		if oldNode.Spec.ProviderID != node.Spec.ProviderID {
+-			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "providerID"), "node updates may not change providerID except from \"\" to valid"))
+-		}
++	if len(oldNode.Spec.ProviderID) > 0 && oldNode.Spec.ProviderID != node.Spec.ProviderID {
++		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "providerID"), "node updates may not change providerID except from \"\" to valid"))
+ 	}
+ 
+ 	if node.Spec.ConfigSource != nil {
+ 		allErrs = append(allErrs, validateNodeConfigSourceSpec(node.Spec.ConfigSource, field.NewPath("spec", "configSource"))...)
+ 	}
+-	oldNode.Spec.ConfigSource = node.Spec.ConfigSource
+ 	if node.Status.Config != nil {
+ 		allErrs = append(allErrs, validateNodeConfigStatus(node.Status.Config, field.NewPath("status", "config"))...)
+ 	}
+-	oldNode.Status.Config = node.Status.Config
+-
+-	// TODO: move reset function to its own location
+-	// Ignore metadata changes now that they have been tested
+-	oldNode.ObjectMeta = node.ObjectMeta
+-	// Allow users to update capacity
+-	oldNode.Status.Capacity = node.Status.Capacity
+-	// Allow users to unschedule node
+-	oldNode.Spec.Unschedulable = node.Spec.Unschedulable
+-	// Clear status
+-	oldNode.Status = node.Status
+ 
+ 	// update taints
+ 	if len(node.Spec.Taints) > 0 {
+ 		allErrs = append(allErrs, validateNodeTaints(node.Spec.Taints, fldPath.Child("taints"))...)
+ 	}
+-	oldNode.Spec.Taints = node.Spec.Taints
+ 
+-	// We made allowed changes to oldNode, and now we compare oldNode to node. Any remaining differences indicate changes to protected fields.
+-	// TODO: Add a 'real' error type for this error and provide print actual diffs.
+-	if !apiequality.Semantic.DeepEqual(oldNode, node) {
+-		klog.V(4).Infof("Update failed validation %#v vs %#v", oldNode, node)
+-		allErrs = append(allErrs, field.Forbidden(field.NewPath(""), "node updates may only change labels, taints, or capacity (or configSource, if the DynamicKubeletConfig feature gate is enabled)"))
++	if node.Spec.DoNotUseExternalID != oldNode.Spec.DoNotUseExternalID {
++		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "externalID"), "may not be updated"))
+ 	}
+ 
++	// status and metadata are allowed change (barring restrictions above), so separately test spec field.
++	// spec only has a few fields, so check the ones we don't allow changing
++	//  1. PodCIDRs - immutable after first set - checked above
++	//  2. ProviderID - immutable after first set - checked above
++	//  3. Unschedulable - allowed to change
++	//  4. Taints - allowed to change
++	//  5. ConfigSource - allowed to change (and checked above)
++	//  6. DoNotUseExternalID - immutable - checked above
++
+ 	return allErrs
+ }
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 83abb704429fd8c974b4897dc0ad9ff345bfd2c8 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 16:21:42 -0500
+Subject: remove unnecessary mutations in validation
+
+These mutations are already done in the strategy
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 22 ++--------------------
+ 1 file changed, 2 insertions(+), 20 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index d4a16bbc0f0..772f0f64bbe 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -1942,13 +1942,11 @@ func ValidatePersistentVolumeUpdate(newPv, oldPv *core.PersistentVolume) field.E
+ }
+ 
+ // ValidatePersistentVolumeStatusUpdate tests to see if the status update is legal for an end user to make.
+-// newPv is updated with fields that cannot be changed.
+ func ValidatePersistentVolumeStatusUpdate(newPv, oldPv *core.PersistentVolume) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newPv.ObjectMeta, &oldPv.ObjectMeta, field.NewPath("metadata"))
+ 	if len(newPv.ResourceVersion) == 0 {
+ 		allErrs = append(allErrs, field.Required(field.NewPath("resourceVersion"), ""))
+ 	}
+-	newPv.Spec = oldPv.Spec
+ 	return allErrs
+ }
+ 
+@@ -2094,7 +2092,6 @@ func ValidatePersistentVolumeClaimStatusUpdate(newPvc, oldPvc *core.PersistentVo
+ 	for r, qty := range newPvc.Status.Capacity {
+ 		allErrs = append(allErrs, validateBasicResource(qty, capPath.Key(string(r)))...)
+ 	}
+-	newPvc.Spec = oldPvc.Spec
+ 	return allErrs
+ }
+ 
+@@ -4030,8 +4027,7 @@ func ValidateContainerStateTransition(newStatuses, oldStatuses []core.ContainerS
+ 	return allErrs
+ }
+ 
+-// ValidatePodStatusUpdate tests to see if the update is legal for an end user to make. newPod is updated with fields
+-// that cannot be changed.
++// ValidatePodStatusUpdate tests to see if the update is legal for an end user to make.
+ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod) field.ErrorList {
+ 	fldPath := field.NewPath("metadata")
+ 	allErrs := ValidateObjectMetaUpdate(&newPod.ObjectMeta, &oldPod.ObjectMeta, fldPath)
+@@ -4062,9 +4058,6 @@ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod) field.ErrorList {
+ 		}
+ 	}
+ 
+-	// For status update we ignore changes to pod spec.
+-	newPod.Spec = oldPod.Spec
+-
+ 	return allErrs
+ }
+ 
+@@ -5511,7 +5504,6 @@ func ValidateResourceQuantityValue(resource string, value resource.Quantity, fld
+ }
+ 
+ // ValidateResourceQuotaUpdate tests to see if the update is legal for an end user to make.
+-// newResourceQuota is updated with fields that cannot be changed.
+ func ValidateResourceQuotaUpdate(newResourceQuota, oldResourceQuota *core.ResourceQuota) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newResourceQuota.ObjectMeta, &oldResourceQuota.ObjectMeta, field.NewPath("metadata"))
+ 	allErrs = append(allErrs, ValidateResourceQuotaSpec(&newResourceQuota.Spec, field.NewPath("spec"))...)
+@@ -5530,12 +5522,10 @@ func ValidateResourceQuotaUpdate(newResourceQuota, oldResourceQuota *core.Resour
+ 		allErrs = append(allErrs, field.Invalid(fldPath, newResourceQuota.Spec.Scopes, fieldImmutableErrorMsg))
+ 	}
+ 
+-	newResourceQuota.Status = oldResourceQuota.Status
+ 	return allErrs
+ }
+ 
+ // ValidateResourceQuotaStatusUpdate tests to see if the status update is legal for an end user to make.
+-// newResourceQuota is updated with fields that cannot be changed.
+ func ValidateResourceQuotaStatusUpdate(newResourceQuota, oldResourceQuota *core.ResourceQuota) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newResourceQuota.ObjectMeta, &oldResourceQuota.ObjectMeta, field.NewPath("metadata"))
+ 	if len(newResourceQuota.ResourceVersion) == 0 {
+@@ -5553,7 +5543,6 @@ func ValidateResourceQuotaStatusUpdate(newResourceQuota, oldResourceQuota *core.
+ 		allErrs = append(allErrs, ValidateResourceQuotaResourceName(string(k), resPath)...)
+ 		allErrs = append(allErrs, ValidateResourceQuantityValue(string(k), v, resPath)...)
+ 	}
+-	newResourceQuota.Spec = oldResourceQuota.Spec
+ 	return allErrs
+ }
+ 
+@@ -5586,19 +5575,14 @@ func validateKubeFinalizerName(stringValue string, fldPath *field.Path) field.Er
+ }
+ 
+ // ValidateNamespaceUpdate tests to make sure a namespace update can be applied.
+-// newNamespace is updated with fields that cannot be changed
+ func ValidateNamespaceUpdate(newNamespace *core.Namespace, oldNamespace *core.Namespace) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+-	newNamespace.Spec.Finalizers = oldNamespace.Spec.Finalizers
+-	newNamespace.Status = oldNamespace.Status
+ 	return allErrs
+ }
+ 
+-// ValidateNamespaceStatusUpdate tests to see if the update is legal for an end user to make. newNamespace is updated with fields
+-// that cannot be changed.
++// ValidateNamespaceStatusUpdate tests to see if the update is legal for an end user to make.
+ func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *core.Namespace) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+-	newNamespace.Spec = oldNamespace.Spec
+ 	if newNamespace.DeletionTimestamp.IsZero() {
+ 		if newNamespace.Status.Phase != core.NamespaceActive {
+ 			allErrs = append(allErrs, field.Invalid(field.NewPath("status", "Phase"), newNamespace.Status.Phase, "may only be 'Active' if `deletionTimestamp` is empty"))
+@@ -5612,7 +5596,6 @@ func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *core.Namespace) f
+ }
+ 
+ // ValidateNamespaceFinalizeUpdate tests to see if the update is legal for an end user to make.
+-// newNamespace is updated with fields that cannot be changed.
+ func ValidateNamespaceFinalizeUpdate(newNamespace, oldNamespace *core.Namespace) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+ 
+@@ -5621,7 +5604,6 @@ func ValidateNamespaceFinalizeUpdate(newNamespace, oldNamespace *core.Namespace)
+ 		idxPath := fldPath.Index(i)
+ 		allErrs = append(allErrs, validateFinalizerName(string(newNamespace.Spec.Finalizers[i]), idxPath)...)
+ 	}
+-	newNamespace.Status = oldNamespace.Status
+ 	return allErrs
+ }
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 110383abf3563a360749ef48d0cb89a7e32fd67a Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 16:55:41 -0500
+Subject: move secret mutation from validation to prepareforupdate
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 4 ----
+ pkg/registry/core/secret/strategy.go   | 6 ++++++
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index 772f0f64bbe..9d0c4ed0568 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -5201,10 +5201,6 @@ func ValidateSecret(secret *core.Secret) field.ErrorList {
+ func ValidateSecretUpdate(newSecret, oldSecret *core.Secret) field.ErrorList {
+ 	allErrs := ValidateObjectMetaUpdate(&newSecret.ObjectMeta, &oldSecret.ObjectMeta, field.NewPath("metadata"))
+ 
+-	if len(newSecret.Type) == 0 {
+-		newSecret.Type = oldSecret.Type
+-	}
+-
+ 	allErrs = append(allErrs, ValidateImmutableField(newSecret.Type, oldSecret.Type, field.NewPath("type"))...)
+ 	if oldSecret.Immutable != nil && *oldSecret.Immutable {
+ 		if newSecret.Immutable == nil || !*newSecret.Immutable {
+diff --git a/pkg/registry/core/secret/strategy.go b/pkg/registry/core/secret/strategy.go
+index 0d5908d8975..aad00387ac1 100644
+--- a/pkg/registry/core/secret/strategy.go
++++ b/pkg/registry/core/secret/strategy.go
+@@ -73,6 +73,12 @@ func (strategy) AllowCreateOnUpdate() bool {
+ func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+ 	newSecret := obj.(*api.Secret)
+ 	oldSecret := old.(*api.Secret)
++
++	// this is weird, but consistent with what the validatedUpdate function used to do.
++	if len(newSecret.Type) == 0 {
++		newSecret.Type = oldSecret.Type
++	}
++
+ 	dropDisabledFields(newSecret, oldSecret)
+ }
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 120798d93abf6f74186bfee35bb6260c900fc38d Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 17:18:11 -0500
+Subject: add markers for inspected validation mutation hits
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go                 | 10 +++++-----
+ .../pkg/apis/apiextensions/validation/validation.go    |  2 +-
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index 9d0c4ed0568..a09091daef8 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -2019,7 +2019,7 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
+ 	// Claims are immutable in order to enforce quota, range limits, etc. without gaming the system.
+ 	if len(oldPvc.Spec.VolumeName) == 0 {
+ 		// volumeName changes are allowed once.
+-		oldPvcClone.Spec.VolumeName = newPvcClone.Spec.VolumeName
++		oldPvcClone.Spec.VolumeName = newPvcClone.Spec.VolumeName // +k8s:verify-mutation:reason=clone
+ 	}
+ 
+ 	if validateStorageClassUpgrade(oldPvcClone.Annotations, newPvcClone.Annotations,
+@@ -2035,7 +2035,7 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
+ 	if utilfeature.DefaultFeatureGate.Enabled(features.ExpandPersistentVolumes) {
+ 		// lets make sure storage values are same.
+ 		if newPvc.Status.Phase == core.ClaimBound && newPvcClone.Spec.Resources.Requests != nil {
+-			newPvcClone.Spec.Resources.Requests["storage"] = oldPvc.Spec.Resources.Requests["storage"]
++			newPvcClone.Spec.Resources.Requests["storage"] = oldPvc.Spec.Resources.Requests["storage"] // +k8s:verify-mutation:reason=clone
+ 		}
+ 
+ 		oldSize := oldPvc.Spec.Resources.Requests["storage"]
+@@ -2414,13 +2414,13 @@ func GetVolumeMountMap(mounts []core.VolumeMount) map[string]string {
+ }
+ 
+ func GetVolumeDeviceMap(devices []core.VolumeDevice) map[string]string {
+-	voldevices := make(map[string]string)
++	volDevices := make(map[string]string)
+ 
+ 	for _, dev := range devices {
+-		voldevices[dev.Name] = dev.DevicePath
++		volDevices[dev.Name] = dev.DevicePath
+ 	}
+ 
+-	return voldevices
++	return volDevices
+ }
+ 
+ func ValidateVolumeMounts(mounts []core.VolumeMount, voldevices map[string]string, volumes map[string]core.VolumeSource, container *core.Container, fldPath *field.Path) field.ErrorList {
+diff --git a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+index e25dd1e7a72..32ae5e99436 100644
+--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
++++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+@@ -1409,7 +1409,7 @@ func validateAPIApproval(newCRD, oldCRD *apiextensions.CustomResourceDefinition,
+ 	var oldApprovalState *apihelpers.APIApprovalState
+ 	if oldCRD != nil {
+ 		t, _ := apihelpers.GetAPIApprovalState(oldCRD.Annotations)
+-		oldApprovalState = &t
++		oldApprovalState = &t // +k8s:verify-mutation:reason=clone
+ 	}
+ 	newApprovalState, reason := apihelpers.GetAPIApprovalState(newCRD.Annotations)
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 0743eb081bfe09db213144176c20df85ac31dfe2 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 17:33:34 -0500
+Subject: remove pod toleration toleration seconds mutation
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index a09091daef8..bc25ff4e9eb 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -3084,10 +3084,11 @@ func validateOnlyAddedTolerations(newTolerations []core.Toleration, oldToleratio
+ 	allErrs := field.ErrorList{}
+ 	for _, old := range oldTolerations {
+ 		found := false
+-		old.TolerationSeconds = nil
+-		for _, new := range newTolerations {
+-			new.TolerationSeconds = nil
+-			if reflect.DeepEqual(old, new) {
++		oldTolerationClone := old.DeepCopy()
++		for _, newToleration := range newTolerations {
++			// assign to our clone before doing a deep equal so we can allow tolerationseconds to change.
++			oldTolerationClone.TolerationSeconds = newToleration.TolerationSeconds // +k8s:verify-mutation:reason=clone
++			if reflect.DeepEqual(*oldTolerationClone, newToleration) {
+ 				found = true
+ 				break
+ 			}
+@@ -3965,6 +3966,9 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
+ 		allErrs = append(allErrs, field.Invalid(specPath.Child("activeDeadlineSeconds"), newPod.Spec.ActiveDeadlineSeconds, "must not update from a positive integer to nil value"))
+ 	}
+ 
++	// Allow only additions to tolerations updates.
++	allErrs = append(allErrs, validateOnlyAddedTolerations(newPod.Spec.Tolerations, oldPod.Spec.Tolerations, specPath.Child("tolerations"))...)
++
+ 	// handle updateable fields by munging those fields prior to deep equal comparison.
+ 	mungedPod := *newPod
+ 	// munge spec.containers[*].image
+@@ -3988,10 +3992,6 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
+ 		mungedPod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
+ 	}
+ 
+-	// Allow only additions to tolerations updates.
+-	mungedPod.Spec.Tolerations = oldPod.Spec.Tolerations
+-	allErrs = append(allErrs, validateOnlyAddedTolerations(newPod.Spec.Tolerations, oldPod.Spec.Tolerations, specPath.Child("tolerations"))...)
+-
+ 	if !apiequality.Semantic.DeepEqual(mungedPod.Spec, oldPod.Spec) {
+ 		// This diff isn't perfect, but it's a helluva lot better an "I'm not going to tell you what the difference is".
+ 		//TODO: Pinpoint the specific field that causes the invalid error after we have strategic merge diff
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 1dd8cc0bb1260ce122757debeb85c6566e9302a4 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Mon, 15 Feb 2021 17:43:57 -0500
+Subject: full deepcopy on munged pod spec
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/core/validation/validation.go | 30 ++++++++++++++++----------
+ 1 file changed, 19 insertions(+), 11 deletions(-)
+
+diff --git a/pkg/apis/core/validation/validation.go b/pkg/apis/core/validation/validation.go
+index bc25ff4e9eb..af58e0ef243 100644
+--- a/pkg/apis/core/validation/validation.go
++++ b/pkg/apis/core/validation/validation.go
+@@ -3969,33 +3969,41 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
+ 	// Allow only additions to tolerations updates.
+ 	allErrs = append(allErrs, validateOnlyAddedTolerations(newPod.Spec.Tolerations, oldPod.Spec.Tolerations, specPath.Child("tolerations"))...)
+ 
++	// the last thing to check is pod spec equality.  If the pod specs are equal, then we can simply return the errors we have
++	// so far and save the cost of a deep copy.
++	if apiequality.Semantic.DeepEqual(newPod.Spec, oldPod.Spec) {
++		return allErrs
++	}
++
+ 	// handle updateable fields by munging those fields prior to deep equal comparison.
+-	mungedPod := *newPod
++	mungedPodSpec := *newPod.Spec.DeepCopy()
+ 	// munge spec.containers[*].image
+ 	var newContainers []core.Container
+-	for ix, container := range mungedPod.Spec.Containers {
+-		container.Image = oldPod.Spec.Containers[ix].Image
++	for ix, container := range mungedPodSpec.Containers {
++		container.Image = oldPod.Spec.Containers[ix].Image // +k8s:verify-mutation:reason=clone
+ 		newContainers = append(newContainers, container)
+ 	}
+-	mungedPod.Spec.Containers = newContainers
++	mungedPodSpec.Containers = newContainers
+ 	// munge spec.initContainers[*].image
+ 	var newInitContainers []core.Container
+-	for ix, container := range mungedPod.Spec.InitContainers {
+-		container.Image = oldPod.Spec.InitContainers[ix].Image
++	for ix, container := range mungedPodSpec.InitContainers {
++		container.Image = oldPod.Spec.InitContainers[ix].Image // +k8s:verify-mutation:reason=clone
+ 		newInitContainers = append(newInitContainers, container)
+ 	}
+-	mungedPod.Spec.InitContainers = newInitContainers
++	mungedPodSpec.InitContainers = newInitContainers
+ 	// munge spec.activeDeadlineSeconds
+-	mungedPod.Spec.ActiveDeadlineSeconds = nil
++	mungedPodSpec.ActiveDeadlineSeconds = nil
+ 	if oldPod.Spec.ActiveDeadlineSeconds != nil {
+ 		activeDeadlineSeconds := *oldPod.Spec.ActiveDeadlineSeconds
+-		mungedPod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
++		mungedPodSpec.ActiveDeadlineSeconds = &activeDeadlineSeconds
+ 	}
++	// tolerations are checked before the deep copy, so munge those too
++	mungedPodSpec.Tolerations = oldPod.Spec.Tolerations // +k8s:verify-mutation:reason=clone
+ 
+-	if !apiequality.Semantic.DeepEqual(mungedPod.Spec, oldPod.Spec) {
++	if !apiequality.Semantic.DeepEqual(mungedPodSpec, oldPod.Spec) {
+ 		// This diff isn't perfect, but it's a helluva lot better an "I'm not going to tell you what the difference is".
+ 		//TODO: Pinpoint the specific field that causes the invalid error after we have strategic merge diff
+-		specDiff := diff.ObjectDiff(mungedPod.Spec, oldPod.Spec)
++		specDiff := diff.ObjectDiff(mungedPodSpec, oldPod.Spec)
+ 		allErrs = append(allErrs, field.Forbidden(specPath, fmt.Sprintf("pod updates may not change fields other than `spec.containers[*].image`, `spec.initContainers[*].image`, `spec.activeDeadlineSeconds` or `spec.tolerations` (only additions to existing tolerations)\n%v", specDiff)))
+ 	}
+ 
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From 9a331b8c5ea1a4802571b489c477b81c7fb55bdc Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Wed, 17 Feb 2021 10:51:38 -0500
+Subject: deepcopy statefulsets
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ pkg/apis/apps/validation/validation.go | 20 +++++++-------------
+ 1 file changed, 7 insertions(+), 13 deletions(-)
+
+diff --git a/pkg/apis/apps/validation/validation.go b/pkg/apis/apps/validation/validation.go
+index e297c8a75b9..ef784d6be04 100644
+--- a/pkg/apis/apps/validation/validation.go
++++ b/pkg/apis/apps/validation/validation.go
+@@ -144,21 +144,15 @@ func ValidateStatefulSet(statefulSet *apps.StatefulSet) field.ErrorList {
+ func ValidateStatefulSetUpdate(statefulSet, oldStatefulSet *apps.StatefulSet) field.ErrorList {
+ 	allErrs := apivalidation.ValidateObjectMetaUpdate(&statefulSet.ObjectMeta, &oldStatefulSet.ObjectMeta, field.NewPath("metadata"))
+ 
+-	restoreReplicas := statefulSet.Spec.Replicas
+-	statefulSet.Spec.Replicas = oldStatefulSet.Spec.Replicas
+-
+-	restoreTemplate := statefulSet.Spec.Template
+-	statefulSet.Spec.Template = oldStatefulSet.Spec.Template
+-
+-	restoreStrategy := statefulSet.Spec.UpdateStrategy
+-	statefulSet.Spec.UpdateStrategy = oldStatefulSet.Spec.UpdateStrategy
+-
+-	if !apiequality.Semantic.DeepEqual(statefulSet.Spec, oldStatefulSet.Spec) {
++	// statefulset updates aren't super common and general updates are likely to be touching spec, so we'll do this
++	// deep copy right away.  This avoids mutating our inputs
++	newStatefulSetClone := statefulSet.DeepCopy()
++	newStatefulSetClone.Spec.Replicas = oldStatefulSet.Spec.Replicas             // +k8s:verify-mutation:reason=clone
++	newStatefulSetClone.Spec.Template = oldStatefulSet.Spec.Template             // +k8s:verify-mutation:reason=clone
++	newStatefulSetClone.Spec.UpdateStrategy = oldStatefulSet.Spec.UpdateStrategy // +k8s:verify-mutation:reason=clone
++	if !apiequality.Semantic.DeepEqual(newStatefulSetClone.Spec, oldStatefulSet.Spec) {
+ 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden"))
+ 	}
+-	statefulSet.Spec.Replicas = restoreReplicas
+-	statefulSet.Spec.Template = restoreTemplate
+-	statefulSet.Spec.UpdateStrategy = restoreStrategy
+ 
+ 	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(statefulSet.Spec.Replicas), field.NewPath("spec", "replicas"))...)
+ 	return allErrs
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+
+
+From b72917a9127d403a6791aef7afa151c89a5deff7 Mon Sep 17 00:00:00 2001
+From: David Eads <deads@redhat.com>
+Date: Wed, 17 Feb 2021 11:17:18 -0500
+Subject: add verify script to catch most validation mutations
+
+Signed-off-by: CJ Cullen <cjcullen@google.com>
+---
+ hack/make-rules/verify.sh              |  1 +
+ hack/verify-non-mutating-validation.sh | 41 ++++++++++++++++++++++++++
+ 2 files changed, 42 insertions(+)
+ create mode 100755 hack/verify-non-mutating-validation.sh
+
+diff --git a/hack/make-rules/verify.sh b/hack/make-rules/verify.sh
+index 12fb78d5b98..0dce9a50ad5 100755
+--- a/hack/make-rules/verify.sh
++++ b/hack/make-rules/verify.sh
+@@ -82,6 +82,7 @@ QUICK_PATTERNS+=(
+   "verify-vendor-licenses.sh"
+   "verify-gofmt.sh"
+   "verify-imports.sh"
++  "verify-non-mutating-validation.sh"
+   "verify-pkg-names.sh"
+   "verify-readonly-packages.sh"
+   "verify-spelling.sh"
+diff --git a/hack/verify-non-mutating-validation.sh b/hack/verify-non-mutating-validation.sh
+new file mode 100755
+index 00000000000..5fe3bed2146
+--- /dev/null
++++ b/hack/verify-non-mutating-validation.sh
+@@ -0,0 +1,41 @@
++#!/usr/bin/env bash
++
++# Copyright 2020 The Kubernetes Authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++# This script checks that validation files do not mutate their inputs.
++# Usage: `hack/verify-non-mutating-validation.sh`.
++
++set -o errexit
++set -o nounset
++set -o pipefail
++
++KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
++source "${KUBE_ROOT}/hack/lib/init.sh"
++
++mutationOutput=$(find . -name validation.go | xargs egrep -n ' = old' | grep -v '// +k8s:verify-mutation:reason=clone' || true)
++foundMutation=$(echo "${mutationOutput}" | wc -c)
++# when there's no match, there is a newline
++if [ "$foundMutation" -gt "1" ]; then
++  echo "${mutationOutput}"
++  exit 1
++fi
++
++mutationOutput=$(! find . -name validation.go | xargs egrep -n 'old.* = ' | grep -v '// +k8s:verify-mutation:reason=clone' || true)
++foundMutation=$(echo "${mutationOutput}" | wc -l)
++# when there's no match, there is a newline
++if [ "$foundMutation" -gt "1" ]; then
++  echo "${mutationOutput}"
++  exit 1
++fi
+-- 
+2.30.1.766.gb4fecdf3b7-goog
+


### PR DESCRIPTION
New patches from upstream.  I expect the unit tests to fail here and will probably force merge.  I am waiting for the final changes upstream to see what else they had to change to fix some of the generated files unit tests and will do so when they do.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
