### PR TITLE
fix pause push and update kops version

### DIFF
--- a/development/kops/gather_logs.sh
+++ b/development/kops/gather_logs.sh
@@ -19,11 +19,11 @@ BASEDIR=$(dirname "$0")
 source ${BASEDIR}/set_environment.sh
 $PREFLIGHT_CHECK_PASSED || exit 1
 
-export LOG_DUMP_SAVE_SERVICES="kops-configuration"
+export LOG_DUMP_SAVE_SERVICES="kops-configuration containerd protokube"
 export KUBERNETES_PROVIDER="none" # the script from upstream doesnt seem to handle aws exactly right
 export LOG_DUMP_SSH_KEY="~/.ssh/id_rsa"
 export LOG_DUMP_SSH_USER="ubuntu"
-export LOG_DUMP_EXTRA_FILES="cloud-init-output.log cloud-init.log containers/*"
+export LOG_DUMP_EXTRA_FILES="cloud-init-output.log cloud-init.log kube-proxy.log containers/*"
 export LOG_DUMP_SYSTEMD_JOURNAL=true
 ARTIFACTS=${ARTIFACTS:-"./_artifacts"}
 

--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -31,7 +31,7 @@ fi
 if [ ! -x ${KOPS} ]
 then
     echo "Determine kops version"
-    KOPS_VERSION="v1.20.0-beta.2"
+    KOPS_VERSION="v1.20.0"
     echo "Download kops"
     KOPS_URL="https://github.com/kubernetes/kops/releases/download/${KOPS_VERSION}/kops-${OS}-${ARCH}"
     set -x

--- a/projects/kubernetes/kubernetes/build/lib/images.sh
+++ b/projects/kubernetes/kubernetes/build/lib/images.sh
@@ -166,15 +166,13 @@ function build::images::pause_push(){
     local -r image_tag="$3"
     local -r context_dir="$4"
 
-    for platform in "${KUBE_LINUX_IMAGE_PLATFORMS[@]}"; do
-        buildctl \
-            build \
-            --frontend dockerfile.v0 \
-            --opt platform=linux/${platform} \
-            --local dockerfile=./docker/pause/ \
-            --local context=${context_dir} \
-            --opt build-arg:BASE_IMAGE=${go_runner_image} \
-            --opt build-arg:VERSION=${version} \
-            --output type=image,oci-mediatypes=true,\"name=${image_tag}\",push=true
-    done
+    buildctl \
+        build \
+        --frontend dockerfile.v0 \
+        --opt platform=linux/amd64,linux/arm64 \
+        --local dockerfile=./docker/pause/ \
+        --local context=${context_dir} \
+        --opt build-arg:BASE_IMAGE=${go_runner_image} \
+        --opt build-arg:VERSION=${version} \
+        --output type=image,oci-mediatypes=true,\"name=${image_tag}\",push=true
 }


### PR DESCRIPTION
When refactoring the pause image handling yesterday, I missed changing the push block to push both platforms in the same call.  Also updated to stable release of kops and added additional logs to collector script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


