### PR TITLE
Give S3 artifacts public read access by default

### DIFF
--- a/release/s3_sync.sh
+++ b/release/s3_sync.sh
@@ -20,14 +20,9 @@ RELEASE="${2?Second required argument is release for example 1}"
 ARTIFACT_BUCKET="${3?Third required argument is artifact bucket name}"
 REPO="${4:-""}"
 BASE_DIRECTORY=$(git rev-parse --show-toplevel)
-RELEASE_ENVIRONMENT=${RELEASE_ENVIRONMENT:-development}
 
-if [ "$RELEASE_ENVIRONMENT" == "production" ]
-then
-  PUBLIC_READ='--acl public-read'
-else
-  PUBLIC_READ=''
-fi
+PUBLIC_READ='--acl public-read'
+
 cd ${BASE_DIRECTORY}
 PREFIX_DIR=kubernetes-${RELEASE_BRANCH}
 DEST_DIR=${PREFIX_DIR}/releases/${RELEASE}/artifacts


### PR DESCRIPTION
Giving public read access to the objects uploaded to the S3 bucket in postsubmits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
