### PR TITLE
overwrite clusterrole for coredns to have endpointslices perms

### DIFF
--- a/development/kops/cluster_wait.sh
+++ b/development/kops/cluster_wait.sh
@@ -35,5 +35,23 @@ do
     echo 'Waiting for cluster to come up...'
 done
 
+# In 1-20 since we are using coredns 1.8.3 which now watches endpointslices
+# instead of endpoints, we need to add additional permissions that kops
+# does not currently add since it still supports coredns 1.7.x
+if [ "${RELEASE_BRANCH}" == "1-20" ]; then
+while ! kubectl --context $KOPS_CLUSTER_NAME apply -f ./core_dns_cluster_role.yaml
+do
+    sleep 5
+    COUNT=$(expr $COUNT + 1)
+    if [ $COUNT -gt 120 ]
+    then
+        echo "Failed to configure coredns clusterrole"
+        exit 1
+    fi
+    echo 'Waiting for cluster to come up...'
+done
+fi
+
+
 set -x
 ${KOPS} validate cluster --wait 15m

--- a/development/kops/core_dns_cluster_role.yaml
+++ b/development/kops/core_dns_cluster_role.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:coredns
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    - services
+    - pods
+    - namespaces
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs:
+    - list
+    - watch
+---


### PR DESCRIPTION
If we do want to ship 1.8.3 this should fix the conformance test runs.

I got this from the PR in the codedns repo https://github.com/coredns/deployment/pull/246

Interestingly, upstream kubernetes only add 1.8.0 in the 1.21 branch and when they added it they did not seem to update the clusterrole, not sure if this is something they havent tested yet? https://github.com/kubernetes/kubernetes/pull/99752/files

I want to make sure 1.8.3 is what the EKS team wants us to include in the 1.20 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
