### PR TITLE
attribution: additional checks to ensure prohibited licenses are flagged

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ update-kubernetes-version:
 .PHONY: clean
 clean: makes
 	@echo 'Done' $(TARGET)
+	rm -rf _output
 
 .PHONY: makes
 makes:
@@ -134,6 +135,8 @@ attribution-files:
 	build/update-attribution-files/make_attribution.sh projects/kubernetes-csi/external-provisioner
 	build/update-attribution-files/make_attribution.sh projects/kubernetes/release
 	build/update-attribution-files/make_attribution.sh projects/kubernetes/kubernetes
+
+	cat _output/total_summary.txt
 
 .PHONY: update-attribution-files
 update-attribution-files: attribution-files

--- a/build/update-attribution-files/make_attribution.sh
+++ b/build/update-attribution-files/make_attribution.sh
@@ -17,11 +17,15 @@ set -x
 set -o errexit
 set -o nounset
 set -o pipefail
+shopt -s globstar
 
 PROJECT="$1"
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 PROJECT_ROOT=$MAKE_ROOT/$PROJECT
+
+mkdir -p _output
+touch _output/total_summary.txt
 
 function build::attribution::generate(){
     if [ $# -ge 1 ]; then
@@ -29,6 +33,11 @@ function build::attribution::generate(){
     fi
     make -C $PROJECT_ROOT binaries
     make -C $PROJECT_ROOT attribution
+    for summary in $PROJECT_ROOT/_output/**/summary.txt; do
+        sed -i "s/+.*=/ =/g" $summary
+        awk -F" =\> " '{ count[$1]+=$2} END { for (item in count) printf("%s => %d\n", item, count[item]) }' \
+            $summary _output/total_summary.txt | sort > _output/total_summary.tmp && mv _output/total_summary.tmp _output/total_summary.txt
+    done    
     make -C $PROJECT_ROOT clean
 }
 


### PR DESCRIPTION
Improve handling of attribution file generation to ensure prohibited licenses are not allowed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
