### PR TITLE
fix ecr-public login to check for running docker vs if it is installed

### DIFF
--- a/development/ecr/ecr-command.sh
+++ b/development/ecr/ecr-command.sh
@@ -49,7 +49,7 @@ function login_ecr_public {
         --query 'authorizationData.authorizationToken')
 
     DOCKER_CONFIG=${DOCKER_CONFIG:-"~/.docker"}
-    if [ "$(which docker)" != "" ]; then
+    if command -v docker &> /dev/null && docker info > /dev/null 2>&1; then
         echo $TOKEN | \
             base64 --decode | \
             cut -d: -f2 | \


### PR DESCRIPTION
We added docker to the builder-base image so now the wrong block is being run.  Changed condition to check for docker and make sure its running.

We might be able to remove a lot of this logic since the ecr-helper now supports ecr-pubic, but we can look into that a future date.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


