### PR TITLE
Updated generate_crd to use dynamtic latestRelease

### DIFF
--- a/release/generate_crd.sh
+++ b/release/generate_crd.sh
@@ -34,7 +34,7 @@ DESTINATION="./kubernetes-${RELEASE_BRANCH}/kubernetes-${RELEASE_BRANCH}-eks-${R
     --release-number ${RELEASE} | tee ${DESTINATION}
 mkdir -p releasechannels
 grep -v '^#.*' eks-distro-build-tooling/release/config/${RELEASE_BRANCH}/${RELEASE_BRANCH}.yaml \
-    | sed "s/\latestRelease: .*/latestRelease: ${RELEASE}/" >releasechannels/${RELEASE_BRANCH}.yaml
+    | sed "s/latestRelease: .*/latestRelease: ${RELEASE}/" >releasechannels/${RELEASE_BRANCH}.yaml
 mkdir -p crds
 grep -v '^#.*' eks-distro-build-tooling/release/config/crds/releasechannels.distro.eks.amazonaws.com-v1alpha1.yaml \
     >crds/releasechannels.distro.eks.amazonaws.com-v1alpha1.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Replaces `latestRelease` value from `eks-distro-build-tooling/release/config/${RELEASE_BRANCH}/${RELEASE_BRANCH}.yaml` with `RELEASE` when generating releasechannel 
* Tested locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
