### PR TITLE
Remove yum updates from Dockerfile since the base image has already run it

### DIFF
--- a/projects/kubernetes/release/docker/kube-proxy-base/Dockerfile
+++ b/projects/kubernetes/release/docker/kube-proxy-base/Dockerfile
@@ -18,7 +18,6 @@ FROM $BASE_IMAGE
 ARG TARGETARCH
 ARG TARGETOS
 
-RUN yum update -y
 # Installing dependencies listed in upstream here: https://github.com/kubernetes/release/blob/master/images/build/debian-iptables/buster/Dockerfile
 # Since we rely on AL2, necessary files from netbase are already included, and we aren't making the same optimizations as of now.
 RUN yum install -y \


### PR DESCRIPTION
Removing `yum update` from kube-proxy-base Dockerfile since it uses eks-distro-base as he base image and that already has been `yum update`d

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
