### PR TITLE
Fixed bug in pull-all.sh

### DIFF
--- a/development/pull-all.sh
+++ b/development/pull-all.sh
@@ -25,12 +25,12 @@ RELEASE_TAG="eks-${RELEASE_BRANCH}-${RELEASE}"
 RELEASE_CRD="https://distro.eks.amazonaws.com/kubernetes-${RELEASE_BRANCH}/kubernetes-${RELEASE_BRANCH}-eks-${RELEASE}.yaml"
 ECR_BASE="public.ecr.aws/eks-distro"
 
-KUBERNETES_GIT_TAG=$(cat "${BASE_DIRECTORY}"/projects/kubernetes/kubernetes/"${RELEASE_BRANCH}"/GIT_TAG)
-GO_RUNNER_GIT_TAG=$(cat "${BASE_DIRECTORY}"/projects/kubernetes/release/GIT_TAG)
+RELEASE_GIT_TAG=$(cat "${BASE_DIRECTORY}"/projects/kubernetes/release/GIT_TAG)
 
 while read -r image_uri; do
   docker pull "$image_uri"
 done < <(curl "${RELEASE_CRD}" | sed -n -e "s|^.*uri: \\($ECR_BASE\\)|\1|p")
 
-docker pull "${ECR_BASE}/kubernetes/kube-proxy:${KUBERNETES_GIT_TAG}-${RELEASE_TAG}"
-docker pull "${ECR_BASE}/kubernetes/go-runner:${GO_RUNNER_GIT_TAG}-${RELEASE_TAG}"
+# These are not in the CRD
+docker pull "${ECR_BASE}/kubernetes/kube-proxy-base:${RELEASE_GIT_TAG}-${RELEASE_TAG}"
+docker pull "${ECR_BASE}/kubernetes/go-runner:${RELEASE_GIT_TAG}-${RELEASE_TAG}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* The [original version of the script](https://github.com/aws/eks-distro/blob/1a7eb816266ec840905f68da46c29206fac03411/development/pull-all.sh#L12) included kube-proxy-base, but this revised versions does not. It is not in the CRD, so it is not included in the curl loop.
* kube-proxy is already being pulled as part of the curl process. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
