### PR TITLE
Added SSM agent install to kops

### DIFF
--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -24,6 +24,13 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: events
+  externalPolicies:
+    node:
+    - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    master:
+    - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    bastion:
+    - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
   iam:
     allowContainerRegistry: true
     legacy: false
@@ -104,6 +111,13 @@ spec:
   role: Master
   subnets:
   - {{.awsRegion}}a
+  additionalUserData:
+  - name: ssm-install.sh
+    type: text/x-shellscript
+    content: |
+      #!/bin/sh
+      sudo snap install amazon-ssm-agent --classic
+      sudo snap start amazon-ssm-agent
 
 ---
 
@@ -129,3 +143,10 @@ spec:
   - {{.awsRegion}}a
   - {{.awsRegion}}b
   - {{.awsRegion}}c
+  additionalUserData:
+  - name: ssm-install.sh
+    type: text/x-shellscript
+    content: |
+      #!/bin/sh
+      sudo snap install amazon-ssm-agent --classic
+      sudo snap start amazon-ssm-agent


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Added SSM agent installation to the kops template. Amazon SSM is not required for EKS-D, but it is leveraged for installing internal agents in our CI processes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
