### PR TITLE
update kops for 1.21 support

### DIFF
--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -31,7 +31,7 @@ fi
 if [ ! -x ${KOPS} ]
 then
     echo "Determine kops version"
-    KOPS_VERSION="v1.20.0"
+    KOPS_VERSION="v1.21.0-beta.3"
     echo "Download kops"
     KOPS_URL="https://github.com/kubernetes/kops/releases/download/${KOPS_VERSION}/kops-${OS}-${ARCH}"
     set -x


### PR DESCRIPTION
We need to update to the 1.21 for kubernetes 1.21 support.  We typically end up using beta releases so that part is not a concern.  I have not tested this, but will watch the postsubmit test runs to make sure the previous versions still work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
