### PR TITLE
do not ignore delete cluster failure

### DIFF
--- a/development/kops/run_all.sh
+++ b/development/kops/run_all.sh
@@ -50,5 +50,5 @@ trap cleanup SIGINT SIGTERM ERR
 ./validate_eks.sh
 ./run_sonobuoy.sh
 ./gather_logs.sh || true
-./delete_cluster.sh || true
+./delete_cluster.sh
 ./delete_store.sh


### PR DESCRIPTION
If delete fails we were still deleting the store which makes cleanup harder.  I think its probably ok to fail if delete fails?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
