### PR TITLE
kubernetes/release: fix uses of git_tag for kubernetes/release

### DIFF
--- a/development/pull-all.sh
+++ b/development/pull-all.sh
@@ -25,7 +25,7 @@ RELEASE_TAG="eks-${RELEASE_BRANCH}-${RELEASE}"
 RELEASE_CRD="https://distro.eks.amazonaws.com/kubernetes-${RELEASE_BRANCH}/kubernetes-${RELEASE_BRANCH}-eks-${RELEASE}.yaml"
 ECR_BASE="public.ecr.aws/eks-distro"
 
-RELEASE_GIT_TAG=$(cat "${BASE_DIRECTORY}"/projects/kubernetes/release/GIT_TAG)
+RELEASE_GIT_TAG=$(cat "${BASE_DIRECTORY}"/projects/kubernetes/release/${RELEASE_BRANCH}/GIT_TAG)
 
 while read -r image_uri; do
   docker pull "$image_uri"

--- a/release/prow-release.sh
+++ b/release/prow-release.sh
@@ -28,8 +28,8 @@ cd ${BASE_DIRECTORY}
 RELEASE_ENVIRONMENT=${RELEASE_ENVIRONMENT:-development}
 
 export RELEASE=$(cat ${BASE_DIRECTORY}/release/${RELEASE_BRANCH}/${RELEASE_ENVIRONMENT}/RELEASE)
-export KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
-export PRESUBMIT_KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
+export KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/${RELEASE_BRANCH}/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
+export PRESUBMIT_KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/${RELEASE_BRANCH}/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 export BASE_REPO=${BASE_REPO:-${IMAGE_REPO}}
 export BASE_IMAGE=${BASE_IMAGE:-public.ecr.aws/eks-distro-build-tooling/eks-distro-base:$(cat ${BASE_DIRECTORY}/EKS_DISTRO_BASE_TAG_FILE)}
 

--- a/release/prow.sh
+++ b/release/prow.sh
@@ -22,8 +22,8 @@ cd ${BASE_DIRECTORY}
 RELEASE_ENVIRONMENT=${RELEASE_ENVIRONMENT:-development}
 
 export RELEASE=$(cat ${BASE_DIRECTORY}/release/${RELEASE_BRANCH}/${RELEASE_ENVIRONMENT}/RELEASE)
-export KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
-export PRESUBMIT_KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
+export KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/${RELEASE_BRANCH}/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
+export PRESUBMIT_KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/${RELEASE_BRANCH}/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 export BASE_REPO=${BASE_REPO:-${IMAGE_REPO}}
 export BASE_IMAGE=${BASE_IMAGE:-public.ecr.aws/eks-distro-build-tooling/eks-distro-base:$(cat ${BASE_DIRECTORY}/EKS_DISTRO_BASE_TAG_FILE)}
 


### PR DESCRIPTION
Fix other spots we are pulling the git_tag for kubernetes/release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
