### PR TITLE
Fetch k8s release git tag using release-branch in release command

### DIFF
--- a/cmd/release/docs/internal/component_table.go
+++ b/cmd/release/docs/internal/component_table.go
@@ -60,7 +60,7 @@ func GetComponentVersionsTable(release *Release) (string, error) {
 		tableRows = append(tableRows, tableRow)
 	}
 
-	otherAssetsVersion, _ := GetKubernetesReleaseGitTag()
+	otherAssetsVersion, _ := GetKubernetesReleaseGitTag(release.branch)
 	for _, asset := range assetsNotInReleaseManifest {
 		uri := fmt.Sprintf("%s/kubernetes/%s:%s-%s", ecrBase, asset, otherAssetsVersion, release.EKSBranchNumber)
 		tableRow := fmt.Sprintf("| %s | %s | %s |", asset, otherAssetsVersion[1:], uri) // [1:] removes 'v'

--- a/cmd/release/internal/directories.go
+++ b/cmd/release/internal/directories.go
@@ -25,8 +25,8 @@ func GetGitRootDirectory() string {
 }
 
 // GetKubernetesReleaseGitTag returns the trimmed value of Kubernetes release GIT_TAG
-func GetKubernetesReleaseGitTag() (string, error) {
-	fileOutput, err := ioutil.ReadFile(gitRootDirectory + "/projects/kubernetes/release/GIT_TAG")
+func GetKubernetesReleaseGitTag(releaseBranch string) (string, error) {
+	fileOutput, err := ioutil.ReadFile(fmt.Sprintf("%s/projects/kubernetes/release/%s/GIT_TAG", gitRootDirectory, releaseBranch))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixing file path to obtain git tag for `kubernetes/release` project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
