### PR TITLE
Generate attribution file in presubmits as dry-run

### DIFF
--- a/projects/containernetworking/plugins/Makefile
+++ b/projects/containernetworking/plugins/Makefile
@@ -19,7 +19,7 @@ tarballs:  binaries
 	build/create_tarballs.sh $(REPO) $(GIT_TAG)
 
 .PHONY: build
-build: tarballs
+build: tarballs attribution
 	echo "Done $(COMPONENT)"
 
 .PHONY: release

--- a/projects/containernetworking/plugins/build/create_tarballs.sh
+++ b/projects/containernetworking/plugins/build/create_tarballs.sh
@@ -45,8 +45,6 @@ function build::plugins::tarball() {
     cp ATTRIBUTION.txt $BIN_ROOT/$REPO/${OS}-${ARCH}/ 
     build::common::create_tarball ${TAR_PATH}/${TAR_FILE} $BIN_ROOT/$REPO/${OS}-${ARCH} .
   done
-  rm -rf $BIN_ROOT
-  rm -rf $LICENSES_PATH
 }
 
 build::plugins::tarball

--- a/projects/coredns/coredns/Makefile
+++ b/projects/coredns/coredns/Makefile
@@ -69,7 +69,7 @@ docker-push:
 	docker push $(IMAGE)
 
 .PHONY: build
-build: local-images
+build: local-images attribution
 
 .PHONY: release
 release: images

--- a/projects/etcd-io/etcd/Makefile
+++ b/projects/etcd-io/etcd/Makefile
@@ -72,7 +72,7 @@ tarballs:
 	build/create_tarballs.sh $(REPO) $(GIT_TAG) $(RELEASE_BRANCH)
 
 .PHONY: build
-build: local-images tarballs
+build: local-images tarballs attribution
 
 .PHONY: release
 release: images tarballs

--- a/projects/etcd-io/etcd/build/create_tarballs.sh
+++ b/projects/etcd-io/etcd/build/create_tarballs.sh
@@ -46,8 +46,6 @@ function build::etcd::tarball() {
     cp "$RELEASE_BRANCH"/ATTRIBUTION.txt $BIN_ROOT/$REPO/${OS}-${ARCH}/
     build::common::create_tarball  "${TAR_PATH}/${TAR_FILE}" "${BIN_ROOT}/${REPO}" "$OS"-"$ARCH"
   done
-  rm -rf "$BIN_ROOT"
-  rm -rf "$LICENSES_PATH"
 }
 
 build::etcd::tarball

--- a/projects/kubernetes-csi/external-attacher/Makefile
+++ b/projects/kubernetes-csi/external-attacher/Makefile
@@ -65,7 +65,7 @@ docker-push:
 	docker push $(IMAGE)
 
 .PHONY: build
-build: local-images
+build: local-images attribution
 	
 .PHONY: release
 release: images

--- a/projects/kubernetes-csi/external-provisioner/Makefile
+++ b/projects/kubernetes-csi/external-provisioner/Makefile
@@ -67,7 +67,7 @@ docker-push:
 	docker push $(IMAGE)
 
 .PHONY: build
-build: local-images
+build: local-images attribution
 
 .PHONY: release
 release: images

--- a/projects/kubernetes-csi/external-resizer/Makefile
+++ b/projects/kubernetes-csi/external-resizer/Makefile
@@ -65,7 +65,7 @@ docker-push:
 	docker push $(IMAGE)
 
 .PHONY: build
-build: local-images
+build: local-images attribution
 
 .PHONY: release
 release: images

--- a/projects/kubernetes-csi/external-snapshotter/Makefile
+++ b/projects/kubernetes-csi/external-snapshotter/Makefile
@@ -116,7 +116,7 @@ docker-push:
 	docker push $(SNAPSHOT_VALIDATION_WEBHOOK_IMAGE)
 
 .PHONY: build
-build: local-images
+build: local-images attribution
 
 .PHONY: release
 release: images

--- a/projects/kubernetes-csi/livenessprobe/Makefile
+++ b/projects/kubernetes-csi/livenessprobe/Makefile
@@ -65,7 +65,7 @@ docker-push:
 	docker push $(IMAGE)
 
 .PHONY: build
-build: local-images
+build: local-images attribution
 
 .PHONY: release
 release: images

--- a/projects/kubernetes-csi/node-driver-registrar/Makefile
+++ b/projects/kubernetes-csi/node-driver-registrar/Makefile
@@ -65,7 +65,7 @@ docker-push:
 	docker push $(IMAGE)
 
 .PHONY: build
-build: local-images
+build: local-images attribution
 
 .PHONY: release
 release: images

--- a/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
@@ -72,7 +72,7 @@ tarballs:
 	build/create_tarballs.sh $(REPO) $(GIT_TAG) $(RELEASE_BRANCH)
 
 .PHONY: build
-build: local-images tarballs
+build: local-images tarballs attribution
 
 .PHONY: release
 release: images local-images tarballs

--- a/projects/kubernetes-sigs/aws-iam-authenticator/build/create_tarballs.sh
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/build/create_tarballs.sh
@@ -46,8 +46,6 @@ function build::aws-iam-authenticator::tarball() {
     cp $RELEASE_BRANCH/ATTRIBUTION.txt $BIN_ROOT/$REPO/${OS}-${ARCH}/ 
     build::common::create_tarball  ${TAR_PATH}/${TAR_FILE} ${BIN_ROOT}/${REPO} ${OS}-${ARCH}
   done
-  rm -rf $LICENSES_DIR
-  rm -rf $BIN_ROOT
 }
 
 build::aws-iam-authenticator::tarball

--- a/projects/kubernetes-sigs/metrics-server/Makefile
+++ b/projects/kubernetes-sigs/metrics-server/Makefile
@@ -75,7 +75,7 @@ tarballs:
 	# empty target
 
 .PHONY: build
-build: local-images tarballs
+build: local-images tarballs attribution
 
 .PHONY: release
 release: images tarballs

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -95,7 +95,7 @@ checksums:
 	build/create_release_checksums.sh $(RELEASE_BRANCH)
 
 .PHONY: build
-build: binaries pause tarballs clean-repo local-images checksums
+build: binaries pause tarballs clean-repo local-images checksums attribution
 
 .PHONY: release
 release: binaries pause tarballs clean-repo images checksums

--- a/projects/kubernetes/release/Makefile
+++ b/projects/kubernetes/release/Makefile
@@ -106,7 +106,7 @@ clean:
 	rm -rf ./_output ./release
 
 .PHONY: build
-build: local-images
+build: local-images attribution
 
 .PHONY: release
 release: images


### PR DESCRIPTION
Perform attribution-generation during presubmit to ensure that there are no errors while generating the ATTRIBUTION.txt file. This dry-run will ensure that the changes pushed into main don't affect the attribution-generation PR automation workflow in the periodic.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
