### PR TITLE
Changed table generation to use prev release

### DIFF
--- a/cmd/release/docs/internal/component_table.go
+++ b/cmd/release/docs/internal/component_table.go
@@ -3,10 +3,8 @@ package internal
 import (
 	. "../../internal"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"regexp"
 	"sort"
@@ -14,21 +12,47 @@ import (
 )
 
 const (
-	ecrBase                = "public.ecr.aws/eks-distro"
-	tableRowStart          = "| "
-	tableRowEnd            = " |"
-	tableHeader            = tableRowStart + "Name | Version | URI" + tableRowEnd
-	tableHeaderBodyDivider = "|------|---------|-----|"
+	ecrBase = "public.ecr.aws/eks-distro"
 )
 
 var (
 	assetsNotInReleaseManifest = []string{"go-runner", "kube-proxy-base"}
-	linebreakString            = string(linebreak)
 )
+
+type componentTableInput struct {
+	releaseManifestURL          string
+	branch                      string
+	eksBranchNumber             []byte
+	isConvertFromPreviousNumber bool
+	eksBranchPreviousNumber     []byte
+}
 
 // GetComponentVersionsTable returns Markdown table of component versions for the release. Release manifest must exist.
 func GetComponentVersionsTable(release *Release) (string, error) {
-	resp, err := http.Get(release.ManifestURL)
+	input := componentTableInput{
+		releaseManifestURL:          release.ManifestURL,
+		branch:                      release.Branch(),
+		eksBranchNumber:             []byte(release.EKSBranchNumber),
+		isConvertFromPreviousNumber: false,
+	}
+	return getComponentVersionsTable(input)
+}
+
+// GetComponentVersionsTableIfNoReleaseManifest returns Markdown table of component versions for the release. Previous
+// release manifest must exist.
+func GetComponentVersionsTableIfNoReleaseManifest(release *Release) (string, error) {
+	input := componentTableInput{
+		releaseManifestURL:          release.PreviousManifestURL,
+		branch:                      release.Branch(),
+		eksBranchNumber:             []byte(release.EKSBranchNumber),
+		isConvertFromPreviousNumber: true,
+		eksBranchPreviousNumber:     []byte(release.EKSBranchPreviousNumber),
+	}
+	return getComponentVersionsTable(input)
+}
+
+func getComponentVersionsTable(input componentTableInput) (string, error) {
+	resp, err := http.Get(input.releaseManifestURL)
 	if err != nil {
 		return "", fmt.Errorf("error getting release manifest: %v", err)
 	}
@@ -41,110 +65,48 @@ func GetComponentVersionsTable(release *Release) (string, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("error reading response to release manifest call: %v", err)
+		return "", fmt.Errorf("error reading release manifest: %v", err)
 	}
 
-	uriSuffix := getURISuffix(release)
+	re := regexp.MustCompile(fmt.Sprintf(`uri: (%s.*)`, ecrBase))
+	foundMatches := re.FindAllSubmatch(body, -1)
 
-	// Assumes format for desired lines is "uri: <ecrBase>[...]", and everything from ecrBase to end should be captured.
-	captureRegexForLine := regexp.MustCompile(fmt.Sprintf(`uri: (%s.*)`, ecrBase))
-	foundMatches := captureRegexForLine.FindAllSubmatch(body, -1)
-
-	// Assumes uri format is "<ecrBase>/[some_stuff]/<NAME>:v<VERSION>-<uriSuffix>", where NAME and VERSION are targeted.
-	// Example: "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.15-eks-1-20-2" -> NAME is "etcd" and VERSION is "3.4.15"
+	// 	Assumes uri format is "public.ecr.aws/eks-distro/[some_stuff]/<NAME>:v<VERSION>-eks-[branch]-[number]",
+	//	where NAME and VERSION are the values needed.
 	captureRegexForName := regexp.MustCompile(`.*/(.*):v`)
-	captureRegexForVersion := regexp.MustCompile(fmt.Sprintf(`:v(.*)-%s`, uriSuffix))
+	captureRegexForVersion := regexp.MustCompile(`:v(.*)-eks`)
 
 	var tableRows []string
 
-	// Example uri value and what it creates from this:
-	//		input uri from match:	public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.15-eks-1-20-2
-	//		output table row:		| etcd | 3.4.15 | public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.15-eks-1-20-2 |
+	//	Example uri value and what it creates from this:
+	//		uri: public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14-eks-1-18-5
+	//		output: | etcd | 3.4.14 | public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14-eks-1-18-5 |
 	for _, matchPair := range foundMatches {
 		uri := matchPair[1]
-		name := string(captureRegexForName.FindSubmatch(uri)[1])
-		version := string(captureRegexForVersion.FindSubmatch(uri)[1])
-		tableRows = append(tableRows, formatComponentRow(name, version, string(uri)))
+		if input.isConvertFromPreviousNumber {
+			if !bytes.HasSuffix(uri, input.eksBranchPreviousNumber) {
+				return "", fmt.Errorf("failed to find expected release number in uri %q", uri)
+			}
+			uri = append(bytes.TrimSuffix(uri, input.eksBranchPreviousNumber), input.eksBranchNumber...)
+		}
+		name := captureRegexForName.FindSubmatch(uri)[1]
+		version := captureRegexForVersion.FindSubmatch(uri)[1]
+
+		tableRow := fmt.Sprintf("| %s | %s | %s |", name, version, uri)
+		tableRows = append(tableRows, tableRow)
 	}
 
-	assetsVersion, _ := GetKubernetesReleaseGitTag(release.Branch())
-	for _, assetName := range assetsNotInReleaseManifest {
-		uri := fmt.Sprintf("%s/kubernetes/%s:%s-%s", ecrBase, assetName, assetsVersion, uriSuffix)
-		tableRows = append(tableRows, formatComponentRow(assetName, strings.TrimPrefix(assetsVersion, "v"), uri))
+	otherAssetsVersion, _ := GetKubernetesReleaseGitTag(input.branch)
+	for _, asset := range assetsNotInReleaseManifest {
+		uri := fmt.Sprintf("%s/kubernetes/%s:%s-%s", ecrBase, asset, otherAssetsVersion, input.eksBranchNumber)
+		tableRow := fmt.Sprintf("| %s | %s | %s |", asset, otherAssetsVersion[1:], uri) // [1:] removes 'v'
+
+		tableRows = append(tableRows, tableRow)
 	}
 
 	sort.Strings(tableRows)
 
-	tableRows = append([]string{tableHeader, tableHeaderBodyDivider}, tableRows...)
+	tableRows = append([]string{"| Name | Version | URI |", "|------|---------|-----|"}, tableRows...)
 
-	return strings.Join(tableRows, linebreakString), nil
-}
-
-// GetComponentVersionsTableWithSameComponentVersionsAsPrevRelease returns Markdown table of presumed component versions
-// for the release.
-// The previous patch release's component version table must exist in the expected file and in the expected table format.
-// Returned table uses the same components and their versions as the previous patch release. The returned table is not
-// checked for accuracy or compared with the release manifest. References to the EKS-D release number are updated.
-func GetComponentVersionsTableWithSameComponentVersionsAsPrevRelease(release *Release) (string, error) {
-	prevTable, err := getPreviousReleaseComponentTable(release)
-	if err != nil {
-		return "", fmt.Errorf("failed to get previous release component table: %v", err)
-	}
-	// The first two rows presumably are tableHeader and tableHeaderBodyDivider, so any table with less than 3 row is
-	// considered invalid, as it either lacks tableHeader and/or tableHeaderBodyDivider or has no components
-	if len(prevTable) < 3 {
-		return "", fmt.Errorf("prev component table is invalid, as it is too short (length %d)", len(prevTable))
-	}
-
-	currTable := []string{string(prevTable[0]), string(prevTable[1])}
-
-	prevRowSuffix := []byte(getURISuffixForPreviousRelease(release) + tableRowEnd)
-	currRowSuffix := []byte(getURISuffix(release) + tableRowEnd)
-
-	// The first two rows presumably are tableHeader and tableHeaderBodyDivider, so they are skipped.
-	for _, prevRow := range prevTable[2:] {
-		if !bytes.HasSuffix(prevRow, prevRowSuffix) {
-			return "", fmt.Errorf("suffix %q not found in table row %q", prevRowSuffix, prevRow)
-		}
-		currTable = append(currTable, string(append(bytes.TrimSuffix(prevRow, prevRowSuffix), currRowSuffix...)))
-	}
-
-	return strings.Join(currTable, linebreakString), nil
-}
-
-func getURISuffix(release *Release) string {
-	return release.EKSBranchNumber
-}
-
-func getURISuffixForPreviousRelease(release *Release) string {
-	return release.EKSBranchPreviousNumber
-}
-
-func formatComponentRow(name, version, uri string) string {
-	return fmt.Sprintf("%s%s | %s | %s%s", tableRowStart, name, version, uri, tableRowEnd)
-}
-
-func getPreviousReleaseComponentTable(release *Release) ([][]byte, error) {
-	fileOutput, err := ioutil.ReadFile(GetPreviousReleaseIndexFilePath(release.Branch(), release.PreviousNumber()))
-	if err != nil {
-		return [][]byte{}, fmt.Errorf("error reading file with previous release component table: %v", err)
-	}
-
-	splitData := bytes.Split(fileOutput, linebreak)
-	header, headerBodyDivider := []byte(tableHeader), []byte(tableHeaderBodyDivider)
-
-	for i := 0; i < len(splitData)-1; i++ {
-		if bytes.Equal(header, splitData[i]) && bytes.Equal(headerBodyDivider, splitData[i+1]) {
-			lineStart := []byte(tableRowStart)
-			// j starts at i + 2 because the first two rows presumably are tableHeader and tableHeaderBodyDivider
-			for j := i + 2; j <= len(splitData); j++ {
-				if j != len(splitData) && bytes.HasPrefix(splitData[j], lineStart) {
-					continue
-				}
-				return splitData[i:j], nil
-			}
-		}
-
-	}
-	return [][]byte{}, errors.New("unable to find previous release component table in file")
+	return strings.Join(tableRows, "\n"), nil
 }

--- a/cmd/release/docs/internal/component_table.go
+++ b/cmd/release/docs/internal/component_table.go
@@ -2,31 +2,37 @@ package internal
 
 import (
 	. "../../internal"
-	"sort"
-
+	"bytes"
+	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 )
 
 const (
-	ecrBase = "public.ecr.aws/eks-distro"
+	ecrBase                = "public.ecr.aws/eks-distro"
+	tableRowStart          = "| "
+	tableRowEnd            = " |"
+	tableHeader            = tableRowStart + "Name | Version | URI" + tableRowEnd
+	tableHeaderBodyDivider = "|------|---------|-----|"
 )
 
 var (
 	assetsNotInReleaseManifest = []string{"go-runner", "kube-proxy-base"}
+	linebreakString            = string(linebreak)
 )
 
 // GetComponentVersionsTable returns Markdown table of component versions for the release. Release manifest must exist.
-// TODO: ensure no race conditions
 func GetComponentVersionsTable(release *Release) (string, error) {
 	resp, err := http.Get(release.ManifestURL)
 	if err != nil {
 		return "", fmt.Errorf("error getting release manifest: %v", err)
 	}
-	
+
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
@@ -38,39 +44,107 @@ func GetComponentVersionsTable(release *Release) (string, error) {
 		return "", fmt.Errorf("error reading response to release manifest call: %v", err)
 	}
 
-	re := regexp.MustCompile(fmt.Sprintf(`uri: (%s.*)`, ecrBase))
-	foundMatches := re.FindAllSubmatch(body, -1)
+	uriSuffix := getURISuffix(release)
 
-	// 	Assumes uri format is "public.ecr.aws/eks-distro/[some_stuff]/<NAME>:v<VERSION>-eks-[branch]-[number]",
-	//	where NAME and VERSION are the values needed.
+	// Assumes format for desired lines is "uri: <ecrBase>[...]", and everything from ecrBase to end should be captured.
+	captureRegexForLine := regexp.MustCompile(fmt.Sprintf(`uri: (%s.*)`, ecrBase))
+	foundMatches := captureRegexForLine.FindAllSubmatch(body, -1)
+
+	// Assumes uri format is "<ecrBase>/[some_stuff]/<NAME>:v<VERSION>-<uriSuffix>", where NAME and VERSION are targeted.
+	// Example: "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.15-eks-1-20-2" -> NAME is "etcd" and VERSION is "3.4.15"
 	captureRegexForName := regexp.MustCompile(`.*/(.*):v`)
-	captureRegexForVersion := regexp.MustCompile(`:v(.*)-eks`)
+	captureRegexForVersion := regexp.MustCompile(fmt.Sprintf(`:v(.*)-%s`, uriSuffix))
 
 	var tableRows []string
 
-	//	Example uri value and what it creates from this:
-	//		uri: public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14-eks-1-18-5
-	//		output: | etcd | 3.4.14 | public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14-eks-1-18-5 |
+	// Example uri value and what it creates from this:
+	//		input uri from match:	public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.15-eks-1-20-2
+	//		output table row:		| etcd | 3.4.15 | public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.15-eks-1-20-2 |
 	for _, matchPair := range foundMatches {
 		uri := matchPair[1]
-		name := captureRegexForName.FindSubmatch(uri)[1]
-		version := captureRegexForVersion.FindSubmatch(uri)[1]
-
-		tableRow := fmt.Sprintf("| %s | %s | %s |", name, version, uri)
-		tableRows = append(tableRows, tableRow)
+		name := string(captureRegexForName.FindSubmatch(uri)[1])
+		version := string(captureRegexForVersion.FindSubmatch(uri)[1])
+		tableRows = append(tableRows, formatComponentRow(name, version, string(uri)))
 	}
 
-	otherAssetsVersion, _ := GetKubernetesReleaseGitTag(release.Branch())
-	for _, asset := range assetsNotInReleaseManifest {
-		uri := fmt.Sprintf("%s/kubernetes/%s:%s-%s", ecrBase, asset, otherAssetsVersion, release.EKSBranchNumber)
-		tableRow := fmt.Sprintf("| %s | %s | %s |", asset, otherAssetsVersion[1:], uri) // [1:] removes 'v'
-
-		tableRows = append(tableRows, tableRow)
+	assetsVersion, _ := GetKubernetesReleaseGitTag(release.Branch())
+	for _, assetName := range assetsNotInReleaseManifest {
+		uri := fmt.Sprintf("%s/kubernetes/%s:%s-%s", ecrBase, assetName, assetsVersion, uriSuffix)
+		tableRows = append(tableRows, formatComponentRow(assetName, strings.TrimPrefix(assetsVersion, "v"), uri))
 	}
 
 	sort.Strings(tableRows)
 
-	tableRows = append([]string{"| Name | Version | URI |", "|------|---------|-----|"}, tableRows...)
+	tableRows = append([]string{tableHeader, tableHeaderBodyDivider}, tableRows...)
 
-	return strings.Join(tableRows, "\n"), nil
+	return strings.Join(tableRows, linebreakString), nil
+}
+
+// GetComponentVersionsTableWithSameComponentVersionsAsPrevRelease returns Markdown table of presumed component versions
+// for the release.
+// The previous patch release's component version table must exist in the expected file and in the expected table format.
+// Returned table uses the same components and their versions as the previous patch release. The returned table is not
+// checked for accuracy or compared with the release manifest. References to the EKS-D release number are updated.
+func GetComponentVersionsTableWithSameComponentVersionsAsPrevRelease(release *Release) (string, error) {
+	prevTable, err := getPreviousReleaseComponentTable(release)
+	if err != nil {
+		return "", fmt.Errorf("failed to get previous release component table: %v", err)
+	}
+	// The first two rows presumably are tableHeader and tableHeaderBodyDivider, so any table with less than 3 row is
+	// considered invalid, as it either lacks tableHeader and/or tableHeaderBodyDivider or has no components
+	if len(prevTable) < 3 {
+		return "", fmt.Errorf("prev component table is invalid, as it is too short (length %d)", len(prevTable))
+	}
+
+	currTable := []string{string(prevTable[0]), string(prevTable[1])}
+
+	prevRowSuffix := []byte(getURISuffixForPreviousRelease(release) + tableRowEnd)
+	currRowSuffix := []byte(getURISuffix(release) + tableRowEnd)
+
+	// The first two rows presumably are tableHeader and tableHeaderBodyDivider, so they are skipped.
+	for _, prevRow := range prevTable[2:] {
+		if !bytes.HasSuffix(prevRow, prevRowSuffix) {
+			return "", fmt.Errorf("suffix %q not found in table row %q", prevRowSuffix, prevRow)
+		}
+		currTable = append(currTable, string(append(bytes.TrimSuffix(prevRow, prevRowSuffix), currRowSuffix...)))
+	}
+
+	return strings.Join(currTable, linebreakString), nil
+}
+
+func getURISuffix(release *Release) string {
+	return release.EKSBranchNumber
+}
+
+func getURISuffixForPreviousRelease(release *Release) string {
+	return release.EKSBranchPreviousNumber
+}
+
+func formatComponentRow(name, version, uri string) string {
+	return fmt.Sprintf("%s%s | %s | %s%s", tableRowStart, name, version, uri, tableRowEnd)
+}
+
+func getPreviousReleaseComponentTable(release *Release) ([][]byte, error) {
+	fileOutput, err := ioutil.ReadFile(GetPreviousReleaseIndexFilePath(release.Branch(), release.PreviousNumber()))
+	if err != nil {
+		return [][]byte{}, fmt.Errorf("error reading file with previous release component table: %v", err)
+	}
+
+	splitData := bytes.Split(fileOutput, linebreak)
+	header, headerBodyDivider := []byte(tableHeader), []byte(tableHeaderBodyDivider)
+
+	for i := 0; i < len(splitData)-1; i++ {
+		if bytes.Equal(header, splitData[i]) && bytes.Equal(headerBodyDivider, splitData[i+1]) {
+			lineStart := []byte(tableRowStart)
+			// j starts at i + 2 because the first two rows presumably are tableHeader and tableHeaderBodyDivider
+			for j := i + 2; j <= len(splitData); j++ {
+				if j != len(splitData) && bytes.HasPrefix(splitData[j], lineStart) {
+					continue
+				}
+				return splitData[i:j], nil
+			}
+		}
+
+	}
+	return [][]byte{}, errors.New("unable to find previous release component table in file")
 }

--- a/cmd/release/docs/main.go
+++ b/cmd/release/docs/main.go
@@ -91,7 +91,7 @@ func createGeneratedDocsInfo(includeGenerated *includeGenerated, formattedReleas
 	var indexAppendToEndFunc func(*utils.Release) (string, error)
 	if includeGenerated.indexAppendedText {
 		// Use 'GetComponentVersionsTable' to generate the table using the release manifest, which must exist.
-		indexAppendToEndFunc = GetComponentVersionsTableWithSameComponentVersionsAsPrevRelease
+		indexAppendToEndFunc = GetComponentVersionsTableIfNoReleaseManifest
 	}
 	return []GeneratedDoc{
 		{

--- a/cmd/release/docs/main.go
+++ b/cmd/release/docs/main.go
@@ -21,7 +21,7 @@ func main() {
 	// Generate new files
 	includeChangelog := *flag.Bool("includeChangelog", true, "If changelog should be generated")
 	includeIndex := *flag.Bool("includeIndex", true, "If index in branch dir should be generated")
-	includeIndexAppendedText := *flag.Bool("includeIndexAppendedText", false, "If Markdown table should be generated")
+	includeIndexAppendedText := *flag.Bool("includeIndexAppendedText", true, "If Markdown table should be generated")
 	includeAnnouncement := *flag.Bool("includeAnnouncement", true, "If release announcement should be generated")
 
 	// Update existing files
@@ -90,7 +90,8 @@ type includeGenerated struct {
 func createGeneratedDocsInfo(includeGenerated *includeGenerated, formattedReleaseVersion string) []GeneratedDoc {
 	var indexAppendToEndFunc func(*utils.Release) (string, error)
 	if includeGenerated.indexAppendedText {
-		indexAppendToEndFunc = GetComponentVersionsTable
+		// Use 'GetComponentVersionsTable' to generate the table using the release manifest, which must exist.
+		indexAppendToEndFunc = GetComponentVersionsTableWithSameComponentVersionsAsPrevRelease
 	}
 	return []GeneratedDoc{
 		{

--- a/cmd/release/internal/directories.go
+++ b/cmd/release/internal/directories.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 )
 
-//const docsContentsDirectory = "docs/contents"
-
 var (
 	gitRootDirectory = GetGitRootDirectory()
 	docsContentsDirectory = filepath.Join(gitRootDirectory, "docs/contents")
@@ -57,11 +55,10 @@ func FormatKubeGitVersionFilePath(release *Release) string {
 	return filepath.Join(gitRootDirectory, "projects/kubernetes/kubernetes", release.Branch(), "KUBE_GIT_VERSION_FILE")
 }
 
-// FormatReleaseDocsDirectory returns path to the directory for the docs' directory for provided release.
-// Expects release.Branch() and release.Branch() to be non-empty values. Returned path is not guaranteed to exist or be
-// valid.
-func FormatReleaseDocsDirectory(release *Release) string {
-	return filepath.Join(docsContentsDirectory, FormatRelativeReleaseDocsDirectory(release.Branch(), release.Number()))
+// formatReleaseDocsDirectory returns path to the directory for the docs' directory for provided release.
+// Expects branch and number to be non-empty values. Returned path is not guaranteed to exist or be valid.
+func formatReleaseDocsDirectory(branch, number string) string {
+	return filepath.Join(docsContentsDirectory, FormatRelativeReleaseDocsDirectory(branch, number))
 }
 
 // FormatRelativeReleaseDocsDirectory return relative path to (example: "releases/1-20/1").
@@ -76,4 +73,8 @@ func GetREADMEPath() string {
 
 func GetDocsIndexPath() string {
 	return filepath.Join(docsContentsDirectory, "index.md")
+}
+
+func GetPreviousReleaseIndexFilePath(branch, number string) string {
+	return filepath.Join(formatReleaseDocsDirectory(branch, number), "index.md")
 }

--- a/cmd/release/internal/directories.go
+++ b/cmd/release/internal/directories.go
@@ -74,7 +74,3 @@ func GetREADMEPath() string {
 func GetDocsIndexPath() string {
 	return filepath.Join(docsContentsDirectory, "index.md")
 }
-
-func GetPreviousReleaseIndexFilePath(branch, number string) string {
-	return filepath.Join(formatReleaseDocsDirectory(branch, number), "index.md")
-}

--- a/cmd/release/internal/release.go
+++ b/cmd/release/internal/release.go
@@ -35,8 +35,8 @@ type Release struct {
 	VBranchEKSPreviousNumber   string // e.g. v1-20-eks-1
 	VBranchWithDotNumber       string // e.g. v1.20-2
 
-	// Expected url but release manifest may not exist
-	ManifestURL string
+	// URL for release manifest, which is not guaranteed to be valid or existing
+	ManifestURL string // e.g. https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-2.yaml
 }
 
 // NewReleaseWithOverrideNumber returns complete Release based on the provided ReleaseInput and overrideNumber.
@@ -48,7 +48,7 @@ func NewReleaseWithOverrideNumber(inputBranch, inputEnvironment string, override
 	return newRelease(inputBranch, inputEnvironment, overrideNumber)
 }
 
-// NewRelease returns complete Release based on the provided ReleaseInput
+// NewRelease returns complete Release based on the provided input
 func NewRelease(inputBranch, inputEnvironment string) (*Release, error) {
 	return newRelease(inputBranch, inputEnvironment, -1)
 }
@@ -84,7 +84,7 @@ func newRelease(inputBranch, inputEnvironment string, overrideNumber int) (*Rele
 		}
 	}
 
-	release.DocsDirectoryPath = FormatReleaseDocsDirectory(release)
+	release.DocsDirectoryPath = formatReleaseDocsDirectory(release.branch, release.number)
 
 	branchEKS := release.branch + "-eks"
 	release.BranchEKSNumber = fmt.Sprintf("%s-%s", branchEKS, release.number)

--- a/cmd/release/internal/release.go
+++ b/cmd/release/internal/release.go
@@ -36,7 +36,9 @@ type Release struct {
 	VBranchWithDotNumber       string // e.g. v1.20-2
 
 	// URL for release manifest, which is not guaranteed to be valid or existing
-	ManifestURL string // e.g. https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-2.yaml
+	// e.g. https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-2.yaml
+	ManifestURL         string
+	PreviousManifestURL string
 }
 
 // NewReleaseWithOverrideNumber returns complete Release based on the provided ReleaseInput and overrideNumber.
@@ -94,16 +96,13 @@ func newRelease(inputBranch, inputEnvironment string, overrideNumber int) (*Rele
 	release.EKSBranchPreviousNumber = fmt.Sprintf("eks-%s-%s", release.branch, release.previousNumber)
 	release.K8sBranchEKS = "kubernetes-" + branchEKS
 	release.K8sBranchEKSNumber = fmt.Sprintf("%s-%s", release.K8sBranchEKS, release.number)
-	release.K8sBranchEKSPreviousNumber =  fmt.Sprintf("%s-%s", release.K8sBranchEKS, release.previousNumber)
+	release.K8sBranchEKSPreviousNumber = fmt.Sprintf("%s-%s", release.K8sBranchEKS, release.previousNumber)
 	release.VBranchEKSNumber = "v" + release.BranchEKSNumber
 	release.VBranchEKSPreviousNumber = "v" + release.BranchEKSPreviousNumber
 	release.VBranchWithDotNumber = fmt.Sprintf("v%s-%s", release.BranchWithDot, release.number)
 
-	release.ManifestURL = fmt.Sprintf(
-		"https://distro.eks.amazonaws.com/kubernetes-%s/kubernetes-%s.yaml",
-		release.branch,
-		release.BranchEKSNumber,
-	)
+	release.ManifestURL = formatReleaseManifestURL(release.branch, release.BranchEKSNumber)
+	release.PreviousManifestURL = formatReleaseManifestURL(release.branch, release.BranchEKSPreviousNumber)
 
 	releaseJson, _ := json.MarshalIndent(release, "", "\t")
 	log.Printf("populated release with:%v", string(releaseJson))
@@ -135,4 +134,11 @@ func checkInput(inputBranch, inputEnvironment string) error {
 		return errors.New("inputEnvironment cannot be an empty string")
 	}
 	return nil
+}
+
+func formatReleaseManifestURL(branch, branchEKSNumber string) string {
+	return fmt.Sprintf(
+		"https://distro.eks.amazonaws.com/kubernetes-%s/kubernetes-%s.yaml",
+		branch,
+		branchEKSNumber)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Added function (`GetComponentVersionsTableWithSameComponentVersionsAsPrevRelease`) to generate components version table for new release by using the previous patch release. 
  * This change is needed because the only existing means of generation (`GetComponentVersionsTable()`) requires the release manifest to exist, which would make the workflow for the bot cumbersome. 
  * This PR does not remove the function to use the manifest, as this is still helpful in manual releases where there could be changes to the components versions.
* Made the generation of the table use the previous patch release's table as the default means of generation. Again, this change was made with the bot in mind and what makes sense for its workflow.
* Minor refactoring and improved comments. For some reason, GitHub makes the changes to existing features, especially in `component_table.go`, look waaaay more intense than they are.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
