### PR TITLE
Changed number generation defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,7 @@ update-attribution-files: attribution-files
 update-release-number:
 	go vet ./cmd/release/number
 	go run ./cmd/release/number/main.go \
-		--branch=$(RELEASE_BRANCH) \
-		--environment=$(RELEASE_ENVIRONMENT)
+		--branch=$(RELEASE_BRANCH)
 
 .PHONY: release-docs
 release-docs:

--- a/cmd/release/internal/directories.go
+++ b/cmd/release/internal/directories.go
@@ -33,11 +33,22 @@ func GetKubernetesReleaseGitTag(releaseBranch string) (string, error) {
 	return strings.TrimSpace(string(fileOutput)), nil
 }
 
-// FormatEnvironmentReleasePath returns path to RELEASE for provided release.
-// Expects release.Branch() and release.Environment() to return non-empty values.  Returned path is not guaranteed
-// to exist or be valid.
-func FormatEnvironmentReleasePath(release *Release) string {
-	return filepath.Join(gitRootDirectory, "release", release.Branch(), release.Environment(), "RELEASE")
+// FormatDevelopmentReleasePath returns path to RELEASE in development for provided branch.
+// Returned path is not guaranteed to exist or be valid.
+func FormatDevelopmentReleasePath(branch string) string {
+	return formatEnvironmentReleasePath(branch, DevelopmentRelease.String())
+}
+
+// FormatProductionReleasePath returns path to RELEASE in production for provided branch.
+// Returned path is not guaranteed to exist or be valid.
+func FormatProductionReleasePath(branch string) string {
+	return formatEnvironmentReleasePath(branch, ProductionRelease.String())
+}
+
+// formatEnvironmentReleasePath returns path to RELEASE for provided branch and environment, which is expected to be
+// "production" or "development". Returned path is not guaranteed to exist or be valid.
+func formatEnvironmentReleasePath(branch, environment string) string {
+	return filepath.Join(gitRootDirectory, "release", branch, environment, "RELEASE")
 }
 
 // FormatKubeGitVersionFilePath returns path to KUBE_GIT_VERSION_FILE for provided release.

--- a/cmd/release/internal/release_environments.go
+++ b/cmd/release/internal/release_environments.go
@@ -1,0 +1,14 @@
+package internal
+
+type ReleaseEnvironment string
+
+const (
+	DevelopmentRelease ReleaseEnvironment = "development"
+	ProductionRelease  ReleaseEnvironment = "production"
+)
+
+func (re ReleaseEnvironment) String() string {
+	return string(re)
+}
+
+

--- a/cmd/release/internal/release_numbers.go
+++ b/cmd/release/internal/release_numbers.go
@@ -8,16 +8,12 @@ import (
 )
 
 func determinePreviousReleaseNumber(release *Release) (string, error) {
-	if len(release.prevNumber) > 0 {
-		log.Printf("previous release number %q already known and is not re-sought\n", release.prevNumber)
-		return release.prevNumber, nil
+	if len(release.previousNumber) > 0 {
+		log.Printf("previous release number %q already known and is not re-sought\n", release.previousNumber)
+		return release.previousNumber, nil
 	}
 
-	environmentReleasePath := release.EnvironmentReleasePath
-	if len(environmentReleasePath) == 0 {
-		environmentReleasePath = FormatEnvironmentReleasePath(release)
-	}
-
+	environmentReleasePath := formatEnvironmentReleasePath(release.branch, release.environment)
 	fileOutput, err := ioutil.ReadFile(environmentReleasePath)
 	if err != nil {
 		return "", err
@@ -31,7 +27,7 @@ func determineReleaseNumber(release *Release) (string, error) {
 		return release.number, nil
 	}
 
-	prevNumber := release.prevNumber
+	prevNumber := release.previousNumber
 	if len(prevNumber) == 0 {
 		prevNumber, err := determinePreviousReleaseNumber(release)
 		if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* The release numbers used to be generated one at a time, but this change makes them generate at the same time. The purpose of this change is to help the bot's workflow with automated releases.
* Renamed Release field `prevNumber` to `previousNumber` to resolve confusion with local variables


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
