### PR TITLE
Added date generator for index updater

### DIFF
--- a/cmd/release/docs/internal/docs_updater.go
+++ b/cmd/release/docs/internal/docs_updater.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"time"
 )
 
 var (
@@ -100,9 +101,10 @@ func UpdateDocsIndex(release *Release, force bool) (DocStatus, error) {
 				return ds, errors.New("non-sequential Version Dependencies list")
 			}
 			appendLine := fmt.Sprintf(
-				`* [%s](%s/index.md)`,
+				`* [%s](%s/index.md) (%s)`,
 				release.VBranchEKSNumber,
 				FormatRelativeReleaseDocsDirectory(release.Branch(), release.Number()),
+				getDate(),
 			)
 			splitData[i] = append(append(splitData[i], linebreak...), appendLine...)
 			break
@@ -111,4 +113,9 @@ func UpdateDocsIndex(release *Release, force bool) (DocStatus, error) {
 
 	ds = DocStatus{path: docsIndexPath, isAlreadyExisting: true}
 	return ds, os.WriteFile(docsIndexPath, bytes.Join(splitData, linebreak), 0644)
+}
+
+func getDate() string {
+	currentTime := time.Now()
+	return fmt.Sprintf("%s %d, %d", currentTime.Month(), currentTime.Day(), currentTime.Year())
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Adds date to index.md as part of the automated docs generation. This date is a new thing that added (manually) #423 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
