### PR TITLE
when validating dns wait for 8 successfully resolves before moving on

### DIFF
--- a/development/kops/validate_dns.sh
+++ b/development/kops/validate_dns.sh
@@ -26,8 +26,17 @@ source ./set_environment.sh
 $PREFLIGHT_CHECK_PASSED || exit 1
 
 APISERVER="api.$KOPS_CLUSTER_NAME"
-for i in {1..12}
+SUCCESS_COUNT=0
+while [ $SUCCESS_COUNT -lt 8 ]
 do
-  echo "$APISERVER resolves to $(dig +short $APISERVER)"
+  ip=$(dig +short $APISERVER)
+  if [ -z "$ip" ]; then
+    echo "$APISERVER did not resolve!"
+    SUCCESS_COUNT=0
+  else
+    echo "$APISERVER resolves to $ip"
+    SUCCESS_COUNT=$((SUCCESS_COUNT+1))
+  fi
+  
   sleep 5s
 done


### PR DESCRIPTION
From time to time we have a dns issue in prow when creating the kops cluster.  We have a number of retrys in place throughout the script to try and work around this and this validate_dns script was added to give the cluster more time being up to make sure that the dns is in good shape.  Tweaking the script to wait until there are 8 successfully resolves before moving on.

/hold


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
