### PR TITLE
kops: add support for arm based clusters and fix running locally

### DIFF
--- a/development/kops/create_cluster.sh
+++ b/development/kops/create_cluster.sh
@@ -19,4 +19,9 @@ BASEDIR=$(dirname "$0")
 source ${BASEDIR}/set_environment.sh
 $PREFLIGHT_CHECK_PASSED || exit 1
 
-${KOPS} update cluster --admin --name ${KOPS_CLUSTER_NAME} --yes --lifecycle-overrides IAMRole=ExistsAndWarnIfChanges,IAMRolePolicy=ExistsAndWarnIfChanges,IAMInstanceProfileRole=ExistsAndWarnIfChanges
+ADDITIONAL_ARGS=""
+if [ -n "$NODE_INSTANCE_PROFILE" ]; then
+    ADDITIONAL_ARGS="--lifecycle-overrides IAMRole=ExistsAndWarnIfChanges,IAMRolePolicy=ExistsAndWarnIfChanges,IAMInstanceProfileRole=ExistsAndWarnIfChanges"
+fi
+
+${KOPS} update cluster --admin --name ${KOPS_CLUSTER_NAME} --yes $ADDITIONAL_ARGS

--- a/development/kops/create_configuration.sh
+++ b/development/kops/create_configuration.sh
@@ -73,3 +73,15 @@ fi
 if [ -n "$NODE_INSTANCE_PROFILE" ]; then
     echo "export NODE_INSTANCE_PROFILE=$NODE_INSTANCE_PROFILE" | tee -a ./${KOPS_CLUSTER_NAME}/env.sh
 fi
+if [ -n "$NODE_INSTANCE_TYPE" ]; then
+    echo "export NODE_INSTANCE_TYPE=$NODE_INSTANCE_TYPE" | tee -a ./${KOPS_CLUSTER_NAME}/env.sh
+fi
+if [ -n "$NODE_ARCHITECTURE" ]; then
+    echo "export NODE_ARCHITECTURE=$NODE_ARCHITECTURE" | tee -a ./${KOPS_CLUSTER_NAME}/env.sh
+fi
+if [ -n "$ARTIFACT_BUCKET" ]; then
+    echo "export ARTIFACT_BUCKET=$ARTIFACT_BUCKET" | tee -a ./${KOPS_CLUSTER_NAME}/env.sh
+fi
+if [ -n "$IMAGE_REPO" ]; then
+    echo "export IMAGE_REPO=$IMAGE_REPO" | tee -a ./${KOPS_CLUSTER_NAME}/env.sh
+fi

--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -60,6 +60,8 @@ configBase: $KOPS_STATE_STORE/$KOPS_CLUSTER_NAME
 awsRegion: $AWS_DEFAULT_REGION
 controlPlaneInstanceProfileArn: $CONTROL_PLANE_INSTANCE_PROFILE
 nodeInstanceProfileArn: $NODE_INSTANCE_PROFILE
+instanceType: $NODE_INSTANCE_TYPE
+architecture: $NODE_ARCHITECTURE
 pause:
 $(get_container_yaml kubernetes/pause $RELEASE)
 kube_apiserver:

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -102,8 +102,8 @@ spec:
   iam:
     profile: {{ .controlPlaneInstanceProfileArn }}
   {{- end }}
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026
-  machineType: t3.medium
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-{{ .architecture }}-server-20201026
+  machineType: {{ .instanceType }}
   maxSize: 1
   minSize: 1
   nodeLabels:
@@ -132,8 +132,8 @@ spec:
   iam:
     profile: {{ .nodeInstanceProfileArn }}
   {{- end }}
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026
-  machineType: t3.medium
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-{{ .architecture }}-server-20201026
+  machineType: {{ .instanceType }}
   maxSize: 3
   minSize: 3
   nodeLabels:

--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -20,6 +20,8 @@ RELEASE_ENVIRONMENT=${RELEASE_ENVIRONMENT:-development}
 export DEFAULT_RELEASE=$(cat ${BASE_DIRECTORY}/release/${RELEASE_BRANCH}/${RELEASE_ENVIRONMENT}/RELEASE)
 export RELEASE=${RELEASE:-${DEFAULT_RELEASE}}
 export ARTIFACT_BASE_URL="https://distro.eks.amazonaws.com"
+export NODE_INSTANCE_TYPE=${NODE_INSTANCE_TYPE:-t3.medium}
+export NODE_ARCHITECTURE=${NODE_ARCHITECTURE:-amd64}
 
 if [ -n "$ARTIFACT_BUCKET" ]; then
     export ARTIFACT_BASE_URL="https://$ARTIFACT_BUCKET.s3.amazonaws.com"
@@ -72,7 +74,7 @@ export KUBERNETES_VERSION=$(cat ../../projects/kubernetes/kubernetes/${RELEASE_B
 export IMAGE_REPO=${IMAGE_REPO:-public.ecr.aws/eks-distro}
 export ARTIFACT_URL=${ARTIFACT_URL:-$ARTIFACT_BASE_URL/kubernetes-${RELEASE_BRANCH}/releases/${RELEASE}/artifacts}
 export CNI_VERSION=$(cat ../../projects/containernetworking/plugins/GIT_TAG)
-export CNI_VERSION_URL=${ARTIFACT_URL}/plugins/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tar.gz
+export CNI_VERSION_URL=${ARTIFACT_URL}/plugins/${CNI_VERSION}/cni-plugins-linux-${NODE_ARCHITECTURE}-${CNI_VERSION}.tar.gz
 export CNI_ASSET_HASH_STRING=${CNI_ASSET_HASH_STRING:-sha256:$(curl -s ${CNI_VERSION_URL}.sha256 | cut -f1 -d' ')}
 export KOPS=bin/kops
 mkdir -p bin

--- a/development/kops/set_nodeport_access.sh
+++ b/development/kops/set_nodeport_access.sh
@@ -25,4 +25,10 @@ $PREFLIGHT_CHECK_PASSED || exit 1
 export KOPS_FEATURE_FLAGS=SpecOverrideFlag
 ${KOPS} set cluster "${KOPS_CLUSTER_NAME}" 'cluster.spec.nodePortAccess=0.0.0.0/0'
 
-${KOPS} update cluster --yes --lifecycle-overrides IAMRole=ExistsAndWarnIfChanges,IAMRolePolicy=ExistsAndWarnIfChanges,IAMInstanceProfileRole=ExistsAndWarnIfChanges
+
+ADDITIONAL_ARGS=""
+if [ -n "$NODE_INSTANCE_PROFILE" ]; then
+    ADDITIONAL_ARGS="--lifecycle-overrides IAMRole=ExistsAndWarnIfChanges,IAMRolePolicy=ExistsAndWarnIfChanges,IAMInstanceProfileRole=ExistsAndWarnIfChanges"
+fi
+
+${KOPS} update cluster --yes $ADDITIONAL_ARGS


### PR DESCRIPTION
Fix running kops with no predefined instanceprofilerole.

Added support for creating arm64 based clusters.  Intention is to setup postsubmit jobs that run conformance tests against our arm builds as well as the amd64.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
