### PR TITLE
kops: dont share cluster name between arm and amd

### DIFF
--- a/development/kops/prow.sh
+++ b/development/kops/prow.sh
@@ -42,5 +42,6 @@ export AWS_PROFILE=conformance-test
 unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE
 DEFAULT_KOPS_ZONE_NAME="prod-build-pdx.kops-ci.model-rocket.aws.dev"
 KOPS_ZONE_NAME=${KOPS_ZONE_NAME:-"${DEFAULT_KOPS_ZONE_NAME}"}
-export KOPS_CLUSTER_NAME=${RELEASE_BRANCH}-$(git rev-parse --short HEAD).${KOPS_ZONE_NAME}
+export NODE_ARCHITECTURE=${NODE_ARCHITECTURE:-amd64}
+export KOPS_CLUSTER_NAME=${RELEASE_BRANCH}-$(git rev-parse --short HEAD)-${NODE_ARCHITECTURE}.${KOPS_ZONE_NAME}
 ${BASEDIR}/run_all.sh


### PR DESCRIPTION
Add arch to the end of cluster name after git tag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
