### PR TITLE
Changed ECR url on index.md

### DIFF
--- a/docs/contents/users/index.md
+++ b/docs/contents/users/index.md
@@ -16,6 +16,7 @@ understand the components that make up EKS-D.
 You can pull the images that make up the EKS Distro from the Public ECR Gallery.
 A [pull-all.sh shell
 script](https://github.com/aws/eks-distro/blob/main/development/pull-all.sh) is
-provided to demonstrate how to do this. You can also browse the [EKS Distro
-Container Repository](https://gallery.ecr.aws/?searchTerm=eks-distro&verified=verified)
-to learn about those containers. EKS-D source code is available from the [eks-distro](https://github.com/aws/eks-distro) Github repository.
+provided to demonstrate how to do this. You can also browse the 
+[EKS Distro Container Repository](https://gallery.ecr.aws/eks-distro) to learn
+about those containers. EKS-D source code is available from the
+[eks-distro](https://github.com/aws/eks-distro) GitHub repository.

--- a/docs/contents/users/index.md
+++ b/docs/contents/users/index.md
@@ -17,6 +17,6 @@ You can pull the images that make up the EKS Distro from the Public ECR Gallery.
 A [pull-all.sh shell
 script](https://github.com/aws/eks-distro/blob/main/development/pull-all.sh) is
 provided to demonstrate how to do this. You can also browse the 
-[EKS Distro Container Repository](https://gallery.ecr.aws/eks-distro) to learn
+[EKS Distro Container Registry](https://gallery.ecr.aws/eks-distro) to learn
 about those containers. EKS-D source code is available from the
 [eks-distro](https://github.com/aws/eks-distro) GitHub repository.


### PR DESCRIPTION
### N.B.: diff make it look like changes are more significant than they really are.

### Description of changes

* Changed ECR url
  * `https://gallery.ecr.aws/?searchTerm=eks-distro&verified=verified` --> `https://gallery.ecr.aws/eks-distro`
  * This was done to be consistent throughout project and to get just the artifacts
* Minor refactor
  * `Github` --> `GitHub`
  * Standardized line breaks
  

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
