### PR TITLE
Changed ECR url in SNS template

### DIFF
--- a/cmd/release/docs/internal/templates.go
+++ b/cmd/release/docs/internal/templates.go
@@ -21,5 +21,5 @@ Download the release manifest here: [{{.K8sBranchEKSNumber}}.yaml]({{.ManifestUR
 `
 
 // Template for release announcement
-const ReleaseAnnouncement = `Amazon EKS Distro {{.VBranchWithDotNumber}} is now available. This release includes an update to Amazon Linux 2, which contains the latest security fixes. Amazon EKS Distro {{.VBranchWithDotNumber}} builds are available through ECR Public Gallery (https://gallery.ecr.aws/?searchTerm=EKS+Distro) and GitHub (https://github.com/aws/eks-distro)
+const ReleaseAnnouncement = `Amazon EKS Distro {{.VBranchWithDotNumber}} is now available. This release includes an update to Amazon Linux 2, which contains the latest security fixes. Amazon EKS Distro {{.VBranchWithDotNumber}} builds are available through ECR Public Gallery (https://gallery.ecr.aws/eks-distro) and GitHub (https://github.com/aws/eks-distro)
 `


### PR DESCRIPTION
### Description of changes
* Changed ECR url
  * `https://gallery.ecr.aws/?searchTerm=eks-distro` --> `https://gallery.ecr.aws/eks-distro`
  * This was done to be consistent throughout project and to get just the artifacts
  
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
