### PR TITLE
Removed environment and fix num bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,4 +153,3 @@ release-docs:
 	go vet ./cmd/release/docs
 	go run ./cmd/release/docs/main.go \
 		--branch=$(RELEASE_BRANCH) \
-		--environment=$(RELEASE_ENVIRONMENT)

--- a/cmd/release/internal/directories.go
+++ b/cmd/release/internal/directories.go
@@ -31,22 +31,10 @@ func GetKubernetesReleaseGitTag(releaseBranch string) (string, error) {
 	return strings.TrimSpace(string(fileOutput)), nil
 }
 
-// FormatDevelopmentReleasePath returns path to RELEASE in development for provided branch.
-// Returned path is not guaranteed to exist or be valid.
-func FormatDevelopmentReleasePath(branch string) string {
-	return formatEnvironmentReleasePath(branch, DevelopmentRelease.String())
-}
-
-// FormatProductionReleasePath returns path to RELEASE in production for provided branch.
-// Returned path is not guaranteed to exist or be valid.
-func FormatProductionReleasePath(branch string) string {
-	return formatEnvironmentReleasePath(branch, ProductionRelease.String())
-}
-
-// formatEnvironmentReleasePath returns path to RELEASE for provided branch and environment, which is expected to be
-// "production" or "development". Returned path is not guaranteed to exist or be valid.
-func formatEnvironmentReleasePath(branch, environment string) string {
-	return filepath.Join(gitRootDirectory, "release", branch, environment, "RELEASE")
+// formatEnvironmentReleasePath returns path to RELEASE for provided branch and environment. Returned path is not
+// guaranteed to exist or be valid.
+func formatEnvironmentReleasePath(branch string, environment ReleaseEnvironment) string {
+	return filepath.Join(gitRootDirectory, "release", branch, environment.String(), "RELEASE")
 }
 
 // FormatKubeGitVersionFilePath returns path to KUBE_GIT_VERSION_FILE for provided release.

--- a/cmd/release/internal/release_environments.go
+++ b/cmd/release/internal/release_environments.go
@@ -3,8 +3,8 @@ package internal
 type ReleaseEnvironment string
 
 const (
-	DevelopmentRelease ReleaseEnvironment = "development"
-	ProductionRelease  ReleaseEnvironment = "production"
+	Development ReleaseEnvironment = "development"
+	Production  ReleaseEnvironment = "production"
 )
 
 func (re ReleaseEnvironment) String() string {

--- a/cmd/release/internal/release_numbers.go
+++ b/cmd/release/internal/release_numbers.go
@@ -43,13 +43,6 @@ func determineReleaseNumber(release *Release) (string, error) {
 	return strconv.Itoa(prevNumberAsInt + 1), nil
 }
 
-func determineOverrideNumberAndPrevNumber(overrideNumber int) (num, prevNum string) {
-	num = strconv.Itoa(overrideNumber)
-	if overrideNumber <= 0 {
-		log.Printf("Number overrode to be %q. Previous number cannot be negative, so it is left empty", num)
-	} else {
-		prevNum = strconv.Itoa(overrideNumber - 1)
-		log.Printf("Number overrode to be %q, and previous number set to %q\n", num, prevNum)
-	}
-	return
+func convertToNumberAndPrevNumber(overrideNumber int) (num, prevNum string) {
+	return strconv.Itoa(overrideNumber), strconv.Itoa(overrideNumber -1)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Concentrated `environment` under scope of Release.
	 * `environment` could be both in some cases and nothing outside of Release really needed to know that.
	 * Got rid of `--environment`flag for doc, as there is no need for the doc to know about this and giving that option only create potential problems by requiring the user to know how the generation works.
* Fixed bug if overrideNumber was 0. 
	* There will never be a use case for it to be 0.
	* Allowing it to be 0 let `previousNumber` be -1, which was causing a lot of trouble to deal with.
* Returned Release instead of a pointer because I [read](https://medium.com/@philpearl/bad-go-pointer-returns-340f2da8289) the memory management is better like this in Go.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
