### PR TITLE
Added base image tag to table through automated workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,4 +152,4 @@ update-release-number:
 release-docs:
 	go vet ./cmd/release/docs
 	go run ./cmd/release/docs/main.go \
-		--branch=$(RELEASE_BRANCH) \
+		--branch=$(RELEASE_BRANCH)

--- a/README.md
+++ b/README.md
@@ -28,27 +28,27 @@ To receive notifications about new EKS-D releases, subscribe to the EKS-D update
 
 ### Kubernetes 1-18
 
-| Release | Manifest |
-| --- | --- |
-| 8 | [kubernetes-1-18-eks-8](https://distro.eks.amazonaws.com/kubernetes-1-18/kubernetes-1-18-eks-8.yaml) |
+| Release | Manifest | Base Image Tag |
+| --- | --- | --- |
+| 8 | [kubernetes-1-18-eks-8](https://distro.eks.amazonaws.com/kubernetes-1-18/kubernetes-1-18-eks-8.yaml) | |
 
 ### Kubernetes 1-19
 
-| Release | Manifest |
-| --- | --- |
-| 7 | [kubernetes-1-19-eks-7](https://distro.eks.amazonaws.com/kubernetes-1-19/kubernetes-1-19-eks-7.yaml) |
+| Release | Manifest | Base Image Tag |
+| --- | --- | --- |
+| 7 | [kubernetes-1-19-eks-7](https://distro.eks.amazonaws.com/kubernetes-1-19/kubernetes-1-19-eks-7.yaml) | |
 
 ### Kubernetes 1-20
 
-| Release | Manifest |
-| --- | --- |
-| 4 | [kubernetes-1-20-eks-4](https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-4.yaml) |
+| Release | Manifest | Base Image Tag |
+| --- | --- | --- |
+| 4 | [kubernetes-1-20-eks-4](https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-4.yaml) | |
 
 ### Kubernetes 1-21
 
-| Release | Manifest |
-| --- | --- |
-| 2 | [kubernetes-1-21-eks-2](https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-2.yaml) |
+| Release | Manifest | Base Image Tag |
+| --- | --- | --- |
+| 2 | [kubernetes-1-21-eks-2](https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-2.yaml) | |
 
 ## Development
 

--- a/cmd/release/docs/internal/docs_updater.go
+++ b/cmd/release/docs/internal/docs_updater.go
@@ -43,12 +43,19 @@ func UpdateREADME(release *Release, force bool) (DocStatus, error) {
 			continue
 		}
 		hasFoundLine = true
+
+		baseImageTag, err := GetBaseImageTag()
+		if err != nil {
+			return ds, fmt.Errorf("error when getting image tag: %v", err)
+		}
+
 		newLine := fmt.Sprintf(
-			"%s %s | [%s](%s) |",
+			"%s %s | [%s](%s) | %s |",
 			prefix,
 			release.Number(),
 			release.K8sBranchEKSNumber,
 			release.ManifestURL,
+			baseImageTag,
 		)
 		splitData[i] = []byte(newLine)
 		break

--- a/cmd/release/internal/base_image.go
+++ b/cmd/release/internal/base_image.go
@@ -1,0 +1,14 @@
+package internal
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func GetBaseImageTag() (string, error) {
+	fileOutput, err := ioutil.ReadFile(baseImagePath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(fileOutput)), nil
+}

--- a/cmd/release/internal/directories.go
+++ b/cmd/release/internal/directories.go
@@ -11,6 +11,7 @@ import (
 var (
 	gitRootDirectory = GetGitRootDirectory()
 	docsContentsDirectory = filepath.Join(gitRootDirectory, "docs/contents")
+	baseImagePath = filepath.Join(gitRootDirectory, "EKS_DISTRO_BASE_TAG_FILE")
 )
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add "Base Image Tag" to releases table when automated docs command is run. This makes it easier to know what they're using
* Removed extra `/` from makefile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
