### PR TITLE
Fixed automated clean up for appended doc

### DIFF
--- a/cmd/release/docs/internal/docs_creater.go
+++ b/cmd/release/docs/internal/docs_creater.go
@@ -37,10 +37,10 @@ func WriteToDocs(docs []GeneratedDoc, release *Release, overrideIfExisting bool)
 	for _, doc := range docs {
 		if doc.IsIncluded {
 			ds, err := writeToDoc(&doc, release, overrideIfExisting)
+			docStatuses = append(docStatuses, ds)
 			if err != nil {
 				return docStatuses, fmt.Errorf("error with writing to docs and failed to finish: %v", err)
 			}
-			docStatuses = append(docStatuses, ds)
 		}
 	}
 	return docStatuses, nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* If there was an error in writeToDoc(), that file would not be cleaned up


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
