### PR TITLE
coredns/etcd: build oci targets

### DIFF
--- a/projects/coredns/coredns/Makefile
+++ b/projects/coredns/coredns/Makefile
@@ -20,7 +20,6 @@ BASE_TAG?=$(shell cat $(MAKE_ROOT)/../../../EKS_DISTRO_BASE_TAG_FILE)
 BASE_IMAGE?=$(BASE_REPO)/$(BASE_IMAGE_NAME):$(BASE_TAG)
 
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
-IMAGE_REPO_PREFIX=coredns
 IMAGE_NAME?=$(COMPONENT)
 # This tag is overwritten in the prow job to point to the upstream git tag and this repo's commit hash
 IMAGE_TAG?=${GIT_TAG}-eks-${RELEASE_BRANCH}-${RELEASE}
@@ -34,16 +33,16 @@ binaries:
 .PHONY: local-images
 local-images: binaries
 	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
-		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false true
+		$(IMAGE_REPO) $(COMPONENT) $(IMAGE_TAG) false true
 		
 .PHONY: images
 images: binaries
 	# we publish oci tarballs in release mode in addition to pushing images for installer tools
 	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
-		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false
+		$(IMAGE_REPO) $(COMPONENT) $(IMAGE_TAG) false
 
 	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
-		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) true
+		$(IMAGE_REPO) $(COMPONENT) $(IMAGE_TAG) true
 
 .PHONY: docker		
 docker: binaries

--- a/projects/coredns/coredns/Makefile
+++ b/projects/coredns/coredns/Makefile
@@ -20,6 +20,7 @@ BASE_TAG?=$(shell cat $(MAKE_ROOT)/../../../EKS_DISTRO_BASE_TAG_FILE)
 BASE_IMAGE?=$(BASE_REPO)/$(BASE_IMAGE_NAME):$(BASE_TAG)
 
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+IMAGE_REPO_PREFIX=coredns
 IMAGE_NAME?=$(COMPONENT)
 # This tag is overwritten in the prow job to point to the upstream git tag and this repo's commit hash
 IMAGE_TAG?=${GIT_TAG}-eks-${RELEASE_BRANCH}-${RELEASE}
@@ -32,27 +33,17 @@ binaries:
 
 .PHONY: local-images
 local-images: binaries
-	buildctl \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--opt build-arg:RELEASE_BRANCH=$(RELEASE_BRANCH) \
-		--local dockerfile=./docker/linux \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=/tmp/coredns.tar
+	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
+		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false true
 		
 .PHONY: images
 images: binaries
-	buildctl \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64,linux/arm64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--opt build-arg:RELEASE_BRANCH=$(RELEASE_BRANCH) \
-		--local dockerfile=./docker/linux \
-		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(IMAGE),push=true
+	# we publish oci tarballs in release mode in addition to pushing images for installer tools
+	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
+		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false
+
+	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
+		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) true
 
 .PHONY: docker		
 docker: binaries

--- a/projects/coredns/coredns/Makefile
+++ b/projects/coredns/coredns/Makefile
@@ -64,6 +64,8 @@ build: local-images attribution
 
 .PHONY: release
 release: images
+	$(BASE_DIRECTORY)/release/copy_artifacts.sh $(COMPONENT) $(RELEASE_BRANCH) $(RELEASE)
+	$(BASE_DIRECTORY)/release/s3_sync.sh $(RELEASE_BRANCH) $(RELEASE) $(ARTIFACT_BUCKET) $(REPO)
 	echo "Done $(COMPONENT)"
 
 .PHONY: all

--- a/projects/coredns/coredns/build/create_images.sh
+++ b/projects/coredns/coredns/build/create_images.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+RELEASE_BRANCH="$1"
+BASE_IMAGE="$2"
+REPOSITORY_BASE="$3"
+REPO_PREFIX="$4"
+IMAGE_TAG="$5"
+PUSH="$6"
+SKIP_ARM=${7-false}
+
+MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+source "${MAKE_ROOT}/build/lib/images.sh"
+
+OUTPUT_DIR="_output"
+BIN_DIR=${OUTPUT_DIR}/bin/coredns
+
+if [ ! -d ${BIN_DIR} ]; then
+    echo "${BIN_DIR} not present! Run 'make binaries'"
+    exit 1
+fi
+
+if [ "$PUSH" != "true" ]; then
+    echo "Placing images under in $BIN_DIR"
+    build::images::release_image_tar $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $MAKE_ROOT $SKIP_ARM
+else
+    build::images::push $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $MAKE_ROOT
+fi
+

--- a/projects/coredns/coredns/build/create_images.sh
+++ b/projects/coredns/coredns/build/create_images.sh
@@ -22,7 +22,7 @@ set -o pipefail
 RELEASE_BRANCH="$1"
 BASE_IMAGE="$2"
 REPOSITORY_BASE="$3"
-REPO_PREFIX="$4"
+COMPONENT="$4"
 IMAGE_TAG="$5"
 PUSH="$6"
 SKIP_ARM=${7-false}
@@ -41,8 +41,8 @@ fi
 
 if [ "$PUSH" != "true" ]; then
     echo "Placing images under in $BIN_DIR"
-    build::images::release_image_tar $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $MAKE_ROOT $SKIP_ARM
+    build::images::release_image_tar $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $COMPONENT $IMAGE_TAG $MAKE_ROOT $SKIP_ARM
 else
-    build::images::push $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $MAKE_ROOT
+    build::images::push $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $COMPONENT $IMAGE_TAG $MAKE_ROOT
 fi
 

--- a/projects/coredns/coredns/build/lib/images.sh
+++ b/projects/coredns/coredns/build/lib/images.sh
@@ -1,0 +1,76 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#/usr/bin/env bash
+
+readonly KUBE_LINUX_IMAGE_PLATFORMS=(
+    amd64
+    arm64
+)
+
+# Create platform-specific OCI image tars
+function build::images::release_image_tar(){
+    local -r release_branch="$1"
+    local -r base_image="$2"
+    local -r repository="$3"
+    local -r repo_prefix="$4"
+    local -r image_tag="$5"
+    local -r context_dir="$6"
+    local -r skip_arm="$7"
+    
+    for platform in "${KUBE_LINUX_IMAGE_PLATFORMS[@]}"; do
+        if [ "$platform" == "arm64" ] && [ $skip_arm == true ]; then
+            continue
+        fi
+
+        image=${repository}/${repo_prefix}/coredns:${image_tag}
+        image_dir=${context_dir}/_output/images/bin/linux/${platform}
+        mkdir -p ${image_dir}
+        buildctl \
+            build \
+            --frontend dockerfile.v0 \
+            --opt platform=linux/${platform} \
+            --opt build-arg:BASE_IMAGE=${base_image} \
+            --opt build-arg:RELEASE_BRANCH=${release_branch} \
+            --local dockerfile=./docker/linux \
+            --local context=${context_dir} \
+            --output type=oci,oci-mediatypes=true,name=${image},dest=${image_dir}/coredns.tar
+        echo ${image_tag} > ${image_dir}/coredns.docker_tag
+        # TODO: Add `.docker_image_name` upstream so tooling like kops can
+        # read the embedded image name
+        # https://github.com/kubernetes/kubernetes/blob/73375fbdac6be4b308004cda49174172fa8d740b/build/lib/release.sh#L396
+        echo ${image} > ${image_dir}/coredns.docker_image_name
+    done
+}
+
+function build::images::push(){
+    local -r release_branch="$1"
+    local -r base_image="$2"
+    local -r repository="$3"
+    local -r repo_prefix="$4"
+    local -r image_tag="$5"
+    local -r context_dir="$6"
+
+    image=${repository}/${repo_prefix}/coredns:${image_tag}
+    buildctl \
+        build \
+        --frontend dockerfile.v0 \
+        --opt platform=linux/amd64,linux/arm64 \
+        --opt build-arg:BASE_IMAGE=${base_image} \
+        --opt build-arg:RELEASE_BRANCH=${release_branch} \
+        --local dockerfile=./docker/linux \
+        --local context=${context_dir} \
+        --output type=image,oci-mediatypes=true,name=${image},push=true
+
+}

--- a/projects/coredns/coredns/build/lib/images.sh
+++ b/projects/coredns/coredns/build/lib/images.sh
@@ -24,7 +24,7 @@ function build::images::release_image_tar(){
     local -r release_branch="$1"
     local -r base_image="$2"
     local -r repository="$3"
-    local -r repo_prefix="$4"
+    local -r component="$4"
     local -r image_tag="$5"
     local -r context_dir="$6"
     local -r skip_arm="$7"
@@ -34,7 +34,7 @@ function build::images::release_image_tar(){
             continue
         fi
 
-        image=${repository}/${repo_prefix}/coredns:${image_tag}
+        image=${repository}/${component}:${image_tag}
         image_dir=${context_dir}/_output/images/bin/linux/${platform}
         mkdir -p ${image_dir}
         buildctl \
@@ -58,11 +58,11 @@ function build::images::push(){
     local -r release_branch="$1"
     local -r base_image="$2"
     local -r repository="$3"
-    local -r repo_prefix="$4"
+    local -r component="$4"
     local -r image_tag="$5"
     local -r context_dir="$6"
 
-    image=${repository}/${repo_prefix}/coredns:${image_tag}
+    image=${repository}/${component}:${image_tag}
     buildctl \
         build \
         --frontend dockerfile.v0 \

--- a/projects/etcd-io/etcd/Makefile
+++ b/projects/etcd-io/etcd/Makefile
@@ -20,7 +20,6 @@ BASE_TAG?=$(shell cat $(MAKE_ROOT)/../../../EKS_DISTRO_BASE_TAG_FILE)
 BASE_IMAGE?=$(BASE_REPO)/$(BASE_IMAGE_NAME):$(BASE_TAG)
 
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
-IMAGE_REPO_PREFIX=etcd-io
 IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
@@ -33,16 +32,16 @@ binaries:
 .PHONY: local-images
 local-images: binaries
 	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
-		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false true
+		$(IMAGE_REPO) $(COMPONENT) $(IMAGE_TAG) false true
 
 .PHONY: images
 images: binaries
 	# we publish oci tarballs in release mode in addition to pushing images for installer tools
 	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
-		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false
+		$(IMAGE_REPO) $(COMPONENT) $(IMAGE_TAG) false
 
 	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
-		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) true
+		$(IMAGE_REPO) $(COMPONENT) $(IMAGE_TAG) true
 
 .PHONY: docker
 docker: binaries

--- a/projects/etcd-io/etcd/Makefile
+++ b/projects/etcd-io/etcd/Makefile
@@ -20,6 +20,7 @@ BASE_TAG?=$(shell cat $(MAKE_ROOT)/../../../EKS_DISTRO_BASE_TAG_FILE)
 BASE_IMAGE?=$(BASE_REPO)/$(BASE_IMAGE_NAME):$(BASE_TAG)
 
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+IMAGE_REPO_PREFIX=etcd-io
 IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
@@ -31,27 +32,17 @@ binaries:
 
 .PHONY: local-images
 local-images: binaries
-	buildctl \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--opt build-arg:RELEASE_BRANCH=$(RELEASE_BRANCH) \
-		--local dockerfile=./docker/linux \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=/tmp/etcd.tar
+	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
+		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false true
 
 .PHONY: images
 images: binaries
-	buildctl \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64,linux/arm64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--opt build-arg:RELEASE_BRANCH=$(RELEASE_BRANCH) \
-		--local dockerfile=./docker/linux \
-		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(IMAGE),push=true
+	# we publish oci tarballs in release mode in addition to pushing images for installer tools
+	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
+		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) false
+
+	build/create_images.sh $(RELEASE_BRANCH) $(BASE_IMAGE) \
+		$(IMAGE_REPO) $(IMAGE_REPO_PREFIX) $(IMAGE_TAG) true
 
 .PHONY: docker
 docker: binaries

--- a/projects/etcd-io/etcd/build/create_images.sh
+++ b/projects/etcd-io/etcd/build/create_images.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+RELEASE_BRANCH="$1"
+BASE_IMAGE="$2"
+REPOSITORY_BASE="$3"
+REPO_PREFIX="$4"
+IMAGE_TAG="$5"
+PUSH="$6"
+SKIP_ARM=${7-false}
+
+MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+source "${MAKE_ROOT}/build/lib/images.sh"
+
+OUTPUT_DIR="_output"
+BIN_DIR=${OUTPUT_DIR}/bin/etcd
+
+if [ ! -d ${BIN_DIR} ]; then
+    echo "${BIN_DIR} not present! Run 'make binaries'"
+    exit 1
+fi
+
+if [ "$PUSH" != "true" ]; then
+    echo "Placing images under in $BIN_DIR"
+    build::images::release_image_tar $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $MAKE_ROOT $SKIP_ARM
+else
+    build::images::push $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $MAKE_ROOT
+fi
+

--- a/projects/etcd-io/etcd/build/create_images.sh
+++ b/projects/etcd-io/etcd/build/create_images.sh
@@ -22,7 +22,7 @@ set -o pipefail
 RELEASE_BRANCH="$1"
 BASE_IMAGE="$2"
 REPOSITORY_BASE="$3"
-REPO_PREFIX="$4"
+COMPONENT="$4"
 IMAGE_TAG="$5"
 PUSH="$6"
 SKIP_ARM=${7-false}
@@ -41,8 +41,8 @@ fi
 
 if [ "$PUSH" != "true" ]; then
     echo "Placing images under in $BIN_DIR"
-    build::images::release_image_tar $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $MAKE_ROOT $SKIP_ARM
+    build::images::release_image_tar $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $COMPONENT $IMAGE_TAG $MAKE_ROOT $SKIP_ARM
 else
-    build::images::push $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $REPO_PREFIX $IMAGE_TAG $MAKE_ROOT
+    build::images::push $RELEASE_BRANCH $BASE_IMAGE $REPOSITORY_BASE $COMPONENT $IMAGE_TAG $MAKE_ROOT
 fi
 

--- a/projects/etcd-io/etcd/build/lib/images.sh
+++ b/projects/etcd-io/etcd/build/lib/images.sh
@@ -1,0 +1,76 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#/usr/bin/env bash
+
+readonly KUBE_LINUX_IMAGE_PLATFORMS=(
+    amd64
+    arm64
+)
+
+# Create platform-specific OCI image tars
+function build::images::release_image_tar(){
+    local -r release_branch="$1"
+    local -r base_image="$2"
+    local -r repository="$3"
+    local -r repo_prefix="$4"
+    local -r image_tag="$5"
+    local -r context_dir="$6"
+    local -r skip_arm="$7"
+    
+    for platform in "${KUBE_LINUX_IMAGE_PLATFORMS[@]}"; do
+        if [ "$platform" == "arm64" ] && [ $skip_arm == true ]; then
+            continue
+        fi
+
+        image=${repository}/${repo_prefix}/etcd:${image_tag}
+        image_dir=${context_dir}/_output/images/bin/linux/${platform}
+        mkdir -p ${image_dir}
+        buildctl \
+            build \
+            --frontend dockerfile.v0 \
+            --opt platform=linux/${platform} \
+            --opt build-arg:BASE_IMAGE=${base_image} \
+            --opt build-arg:RELEASE_BRANCH=${release_branch} \
+            --local dockerfile=./docker/linux \
+            --local context=${context_dir} \
+            --output type=oci,oci-mediatypes=true,name=${image},dest=${image_dir}/etcd.tar
+        echo ${image_tag} > ${image_dir}/etcd.docker_tag
+        # TODO: Add `.docker_image_name` upstream so tooling like kops can
+        # read the embedded image name
+        # https://github.com/kubernetes/kubernetes/blob/73375fbdac6be4b308004cda49174172fa8d740b/build/lib/release.sh#L396
+        echo ${image} > ${image_dir}/etcd.docker_image_name
+    done
+}
+
+function build::images::push(){
+    local -r release_branch="$1"
+    local -r base_image="$2"
+    local -r repository="$3"
+    local -r repo_prefix="$4"
+    local -r image_tag="$5"
+    local -r context_dir="$6"
+
+    image=${repository}/${repo_prefix}/etcd:${image_tag}
+    buildctl \
+        build \
+        --frontend dockerfile.v0 \
+        --opt platform=linux/amd64,linux/arm64 \
+        --opt build-arg:BASE_IMAGE=${base_image} \
+        --opt build-arg:RELEASE_BRANCH=${release_branch} \
+        --local dockerfile=./docker/linux \
+        --local context=${context_dir} \
+        --output type=image,oci-mediatypes=true,name=${image},push=true
+
+}

--- a/projects/etcd-io/etcd/build/lib/images.sh
+++ b/projects/etcd-io/etcd/build/lib/images.sh
@@ -23,8 +23,8 @@ readonly KUBE_LINUX_IMAGE_PLATFORMS=(
 function build::images::release_image_tar(){
     local -r release_branch="$1"
     local -r base_image="$2"
-    local -r component="$3"
-    local -r repo_prefix="$4"
+    local -r repository="$3"
+    local -r component="$4"
     local -r image_tag="$5"
     local -r context_dir="$6"
     local -r skip_arm="$7"

--- a/projects/etcd-io/etcd/build/lib/images.sh
+++ b/projects/etcd-io/etcd/build/lib/images.sh
@@ -23,7 +23,7 @@ readonly KUBE_LINUX_IMAGE_PLATFORMS=(
 function build::images::release_image_tar(){
     local -r release_branch="$1"
     local -r base_image="$2"
-    local -r repository="$3"
+    local -r component="$3"
     local -r repo_prefix="$4"
     local -r image_tag="$5"
     local -r context_dir="$6"
@@ -34,7 +34,7 @@ function build::images::release_image_tar(){
             continue
         fi
 
-        image=${repository}/${repo_prefix}/etcd:${image_tag}
+        image=${repository}/${component}:${image_tag}
         image_dir=${context_dir}/_output/images/bin/linux/${platform}
         mkdir -p ${image_dir}
         buildctl \
@@ -58,11 +58,11 @@ function build::images::push(){
     local -r release_branch="$1"
     local -r base_image="$2"
     local -r repository="$3"
-    local -r repo_prefix="$4"
+    local -r component="$4"
     local -r image_tag="$5"
     local -r context_dir="$6"
 
-    image=${repository}/${repo_prefix}/etcd:${image_tag}
+    image=${repository}/${component}:${image_tag}
     buildctl \
         build \
         --frontend dockerfile.v0 \

--- a/release/copy_artifacts.sh
+++ b/release/copy_artifacts.sh
@@ -31,6 +31,11 @@ elif [ $PROJECT = "etcd-io/etcd" ] || [ $PROJECT = "coredns/coredns" ]; then
   KUBERNETES_ARTIFACT_DIR=${DEST_DIR}/kubernetes/${KUBERNETES_GIT_TAG}
   mkdir -p $KUBERNETES_ARTIFACT_DIR
   cp -r _output/images/* $KUBERNETES_ARTIFACT_DIR
+  
+  # coredns has no tars to upload, just the oci target which is uploaded above
+  if [ $PROJECT = "coredns/coredns" ]; then
+    exit 0
+  fi
 
   SOURCE_DIR=_output/tar/
   GIT_TAG=$(cat ${RELEASE_BRANCH}/GIT_TAG)

--- a/release/copy_artifacts.sh
+++ b/release/copy_artifacts.sh
@@ -25,6 +25,15 @@ DEST_DIR=${BASE_DIRECTORY}/kubernetes-${RELEASE_BRANCH}/releases/${RELEASE}/arti
 if [ $PROJECT = "kubernetes/kubernetes" ]; then
   SOURCE_DIR=_output/${RELEASE_BRANCH}
   GIT_TAG=$(cat ${RELEASE_BRANCH}/GIT_TAG)
+elif [ $PROJECT = "etcd-io/etcd" ] || [ $PROJECT = "coredns/coredns" ]; then
+  # Copy oci tars into kubernetes directory for use by capi image-builder
+  KUBERNETES_GIT_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/kubernetes/${RELEASE_BRANCH}/GIT_TAG)
+  KUBERNETES_ARTIFACT_DIR=${DEST_DIR}/kubernetes/${KUBERNETES_GIT_TAG}
+  mkdir -p $KUBERNETES_ARTIFACT_DIR
+  cp -r _output/images/* $KUBERNETES_ARTIFACT_DIR
+
+  SOURCE_DIR=_output/tar/
+  GIT_TAG=$(cat ${RELEASE_BRANCH}/GIT_TAG)
 elif [ ! -f GIT_TAG ]; then
   SOURCE_DIR=_output/tar/
   GIT_TAG=$(cat ${RELEASE_BRANCH}/GIT_TAG)


### PR DESCRIPTION
CAPI's image-builder will try to embed coredns and etcd into the final image it produces if there is an oci tar in the kubernetes directory next to the kube component tars.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
