### PR TITLE
kops: add simple csi and etcd tests

### DIFF
--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -30,6 +30,11 @@ function get_container_yaml() {
     REPOSITORY_NAME="${1}"
     RELEASE="${2}"
     VERSION="$(get_project_version $REPOSITORY_NAME)"
+
+    if  [[ $REPOSITORY_NAME == "kubernetes-csi/external-snapshotter" ]] 
+    then
+        REPOSITORY_NAME="kubernetes-csi/external-snapshotter/csi-snapshotter"
+    fi
     echo "    repository: ${IMAGE_REPO}/${REPOSITORY_NAME}
     tag: ${VERSION}-eks-${RELEASE_BRANCH}-${RELEASE}"
 }
@@ -78,4 +83,18 @@ awsiamauth:
 $(get_container_yaml kubernetes-sigs/aws-iam-authenticator $RELEASE)
 coredns:
 $(get_container_yaml coredns/coredns $RELEASE)
+node_driver_registrar:
+$(get_container_yaml kubernetes-csi/node-driver-registrar $RELEASE)
+csi_resizer:
+$(get_container_yaml kubernetes-csi/external-resizer $RELEASE)
+csi_attacher:
+$(get_container_yaml kubernetes-csi/external-attacher $RELEASE)
+csi_snapshotter:
+$(get_container_yaml kubernetes-csi/external-snapshotter $RELEASE)
+csi_provisioner:
+$(get_container_yaml kubernetes-csi/external-provisioner $RELEASE)
+csi_livenessprobe:
+$(get_container_yaml kubernetes-csi/livenessprobe $RELEASE)
+etcd:
+$(get_container_yaml etcd-io/etcd $RELEASE)
 EOF

--- a/development/kops/run_all.sh
+++ b/development/kops/run_all.sh
@@ -59,6 +59,7 @@ trap cleanup_and_error SIGINT SIGTERM ERR
 ./set_nodeport_access.sh
 ./cluster_wait.sh
 ./validate_dns.sh
+./run_tests.sh
 ./validate_eks.sh
 ./run_sonobuoy.sh
 

--- a/development/kops/run_tests.sh
+++ b/development/kops/run_tests.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+BASEDIR=$(dirname "$0")
+source ${BASEDIR}/set_environment.sh
+$PREFLIGHT_CHECK_PASSED || exit 1
+
+function fail {
+  echo $1 >&2
+  exit 1
+}
+
+function retry {
+  local n=1
+  local max=5
+  local delay=1
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        echo "Command failed. Attempt $n/$max:"
+        sleep $delay;
+      else
+        fail "The command has failed after $n attempts."
+      fi
+    }
+  done
+}
+
+function k {
+    retry kubectl --context ${KOPS_CLUSTER_NAME} "$@"
+}
+
+function node_driver_registrar_expect {
+    echo "node_driver_registrar_expect"
+    k logs --selector app=csi-mockplugin --container node-driver-registrar  | \
+        grep "Registration Server started at: /registration/io.kubernetes.storage.mock-reg.sock"
+}
+
+function liveness_probe_expect {
+    echo "liveness_probe_expect"
+    k logs --selector app=csi-mockplugin --container liveness-probe | \
+        grep "io.kubernetes.storage.mock"
+}
+
+function provisioning_expect {
+    echo "provisioning_expect"
+    [ $(k get events --field-selector involvedObject.name=example-pvc,reason=ProvisioningSucceeded | wc -l) -ge 1 ]
+}
+
+function attach_expect {
+    echo "attach_expect"
+    k logs --selector app=csi-mockplugin --container csi-attacher | \
+        grep "Fully attached"
+}
+
+function resize_expect {
+    echo "resize_expect"
+    [ $(k get events --field-selector involvedObject.name=example-pvc,reason=VolumeResizeSuccessful | wc -l) -ge 1 ]    
+}
+
+function validate_csi {
+    # Launch mock csi driver and validate all sidecars launch and trigger specific
+    # events and/or log messages
+    # Not a full suite but at least verifies all containers launch and 
+    # executes some of the flows
+
+    ${KOPS} toolbox template --template ${BASEDIR}/tests/csi/deploy/csi-mock-driver-deployment.yaml.tpl \
+        --values ./${KOPS_CLUSTER_NAME}/values.yaml > "./${KOPS_CLUSTER_NAME}/csi-mock-driver-deployment.yaml"
+
+    k apply -f ${BASEDIR}/tests/csi/deploy/csi-mock-driver-rbac.yaml
+
+    k apply -f "./${KOPS_CLUSTER_NAME}/csi-mock-driver-deployment.yaml"
+
+    k wait deploy/csi-mockplugin --for condition=available --timeout=5m
+    
+    retry node_driver_registrar_expect
+    retry liveness_probe_expect
+
+    k apply -f "tests/csi/pvc-test.yaml"
+    retry provisioning_expect
+    
+    k apply -f tests/csi/pod-test.yaml 
+    k wait pod/web-server --for condition=ready --timeout=5m
+    retry attach_expect
+
+    k patch pvc example-pvc -p '{"spec":{"resources":{"requests":{"storage": "2Mi"}}}}'  
+    retry resize_expect
+
+}
+
+function etcd_expect {
+    echo "etcd_expect"
+    [ $(k exec etcd0  -- etcdctl --endpoints=http://etcd0:2379 member list | wc -l) = 3 ]
+}
+
+function validate_etcd {
+    # Not a full suite
+    # Launch a 3 node etcd cluster using etcd images to validate they launch correctly
+    
+    ${KOPS} toolbox template --template ${BASEDIR}/tests/etcd/deploy/etcd.yaml.tpl \
+        --values ./${KOPS_CLUSTER_NAME}/values.yaml > "./${KOPS_CLUSTER_NAME}/etcd.yaml"
+    
+    k apply -f "./${KOPS_CLUSTER_NAME}/etcd.yaml"
+    k wait pod/etcd0 --for condition=ready --timeout=5m
+    k wait pod/etcd1 --for condition=ready --timeout=5m
+    k wait pod/etcd2 --for condition=ready --timeout=5m
+    retry etcd_expect
+
+}
+
+validate_csi
+validate_etcd

--- a/development/kops/tests/csi/README.md
+++ b/development/kops/tests/csi/README.md
@@ -1,0 +1,4 @@
+# CSI Tests
+
+Examples from https://github.com/kubernetes-csi/csi-test/tree/master/mock to validate
+images launch properly

--- a/development/kops/tests/csi/deploy/csi-mock-driver-deployment.yaml.tpl
+++ b/development/kops/tests/csi/deploy/csi-mock-driver-deployment.yaml.tpl
@@ -1,0 +1,159 @@
+# This YAML file contains the deployment of the CSIDriver
+# including node-driver-registrar, external-provisioner, external-snapshotter
+# external-resizer and mock-driver
+#
+# This YAML file also includes deployment of the CSIDriver, StorageClass
+# VolumeSnapshotClass for the mock driver.
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: csi-mockplugin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-mockplugin
+  template:
+    metadata:
+      labels:
+        app: csi-mockplugin
+    spec:
+      serviceAccount: csi-mock
+      containers:
+        - name: csi-provisioner
+          image: {{ .csi_provisioner.repository }}:{{ .csi_provisioner.tag }}
+          args:
+            - "--csi-address=/csi/csi.sock"
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          # Normally privileged: true is only required for the driver container to perform 
+          # the mount operation. However, privileged container is necessary for systems with 
+          # SELinux, where non-privileged sidecar containers cannot access unix domain socket
+          # created by privileged CSI driver container. The other containers in this file being 
+          # granted privileged permission are for the same reason.
+          securityContext:
+            privileged: true
+        - name: node-driver-registrar
+          image: {{ .node_driver_registrar.repository }}:{{ .node_driver_registrar.tag }}
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/io.kubernetes.storage.mock/csi.sock
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+          - mountPath: /registration
+            name: registration-dir
+        - name: csi-resizer
+          image: {{ .csi_resizer.repository }}:{{ .csi_resizer.tag }}
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+        - name: csi-attacher
+          image: {{ .csi_attacher.repository }}:{{ .csi_attacher.tag }}
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+        - name: csi-snapshotter
+          image: {{ .csi_snapshotter.repository }}:{{ .csi_snapshotter.tag }}
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          securityContext:
+            privileged: true
+        - name: liveness-probe
+          args:
+          - --csi-address=/csi/csi.sock
+          image: {{ .csi_livenessprobe.repository }}:{{ .csi_livenessprobe.tag }}
+          resources: {}
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+        - name: mock-driver
+          image: k8s.gcr.io/sig-storage/mock-driver:v4.1.0
+          args:
+            - "--attach-limit=50"
+            # Required for e2e test log parsing
+            - "--v=5"
+          env:
+            - name: CSI_ENDPOINT
+              value: /csi/csi.sock
+          # The driver container has to be privileged in order to do mount operation
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: kubelet-pods-dir
+              mountPath: /var/lib/kubelet/pods
+            - name: kubelet-csi-dir
+              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/io.kubernetes.storage.mock
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - name: kubelet-pods-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+            # mock driver doesn't make mounts and therefore doesn't need mount propagation.
+            # mountPropagation: Bidirectional
+        - name: kubelet-csi-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/kubernetes.io/csi
+            type: DirectoryOrCreate
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: io.kubernetes.storage.mock
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: test-csi-mock 
+provisioner: io.kubernetes.storage.mock
+allowVolumeExpansion: true
+parameters:
+
+# Not testing snapshotter
+# ---
+# apiVersion: snapshot.storage.k8s.io/v1beta1
+# kind: VolumeSnapshotClass
+# metadata:
+#   name: csi-mock-snapclass
+# driver: io.kubernetes.storage.mock
+# deletionPolicy: Delete

--- a/development/kops/tests/csi/deploy/csi-mock-driver-rbac.yaml
+++ b/development/kops/tests/csi/deploy/csi-mock-driver-rbac.yaml
@@ -1,0 +1,126 @@
+# This YAML file contains all RBAC objects that are necessary to run external
+# CSI provisioner, resizer and snapshotter.
+#
+# In production, each CSI driver deployment has to be customized:
+# - to avoid conflicts, use non-default namespace and different names
+#   for non-namespaced entities like the ClusterRole
+# - decide whether the deployment replicates the external CSI
+#   provisioner and resizer, in which case leadership election must be enabled;
+#   this influences the RBAC setup, see below
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-mock
+  # replace with non-default namespace name
+  namespace: default
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mock-runner
+rules:
+  # The following rule should be uncommented for plugins that require secrets
+  # for provisioning.
+  # - apiGroups: [""]
+  #   resources: ["secrets"]
+  #   verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status", "volumesnapshotcontents/status"]
+    verbs: ["update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-mock-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-mock
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mock-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Provisioner must be able to work with endpoints in current namespace
+# if (and only if) leadership election is enabled
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # replace with non-default namespace name
+  namespace: default
+  name: mock-cfg
+rules:
+# Only one of the following rules for endpoints or leases is required based on
+# what is set for `--leader-election-type`. Endpoints are deprecated in favor of Leases.
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-mock-role-cfg
+  # replace with non-default namespace name
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: csi-mock
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: Role
+  name: mock-cfg
+  apiGroup: rbac.authorization.k8s.io

--- a/development/kops/tests/csi/pod-test.yaml
+++ b/development/kops/tests/csi/pod-test.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web-server
+spec:
+  # TODO: As a future improvement, if we add topology support to the mock driver, 
+  # then we don't need podAffinity in this pod. The pv provisioned will have a 
+  # nodeaffinity on it, and the pod will always get scheduled to the correct node.
+  #
+  # Deploy this pod only on where csi-mock-driver exists.
+  # This is because csi-mock-driver keeps all states in memory and the process that
+  # provisioned the PV needs to be the same process that's mounting it.
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - csi-mockplugin
+        topologyKey: "kubernetes.io/hostname"
+  containers:
+   - name: web-server
+     image: nginx 
+     volumeMounts:
+       - mountPath: /var/lib/www/html
+         name: mypvc
+  volumes:
+   - name: mypvc
+     persistentVolumeClaim:
+       claimName: example-pvc
+       readOnly: false

--- a/development/kops/tests/csi/pvc-test.yaml
+++ b/development/kops/tests/csi/pvc-test.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: example-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: test-csi-mock 
+  resources:
+    requests:
+      storage: 1Mi

--- a/development/kops/tests/etcd/README.md
+++ b/development/kops/tests/etcd/README.md
@@ -1,0 +1,3 @@
+# etcd tests
+
+Deployment yaml pulled from upstream: https://github.com/etcd-io/etcd/tree/main/hack/kubernetes-deploy

--- a/development/kops/tests/etcd/deploy/etcd.yaml.tpl
+++ b/development/kops/tests/etcd/deploy/etcd.yaml.tpl
@@ -1,0 +1,189 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-client
+spec:
+  ports:
+  - name: etcd-client-port
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  selector:
+    app: etcd
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: etcd
+    etcd_node: etcd0
+  name: etcd0
+spec:
+  containers:
+  - command:
+    - /usr/local/bin/etcd
+    - --name
+    - etcd0
+    - --initial-advertise-peer-urls
+    - http://etcd0:2380
+    - --listen-peer-urls
+    - http://0.0.0.0:2380
+    - --listen-client-urls
+    - http://0.0.0.0:2379
+    - --advertise-client-urls
+    - http://etcd0:2379
+    - --initial-cluster
+    - etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380
+    - --initial-cluster-state
+    - new
+    image: {{ .etcd.repository }}:{{ .etcd.tag }}
+    name: etcd0
+    ports:
+    - containerPort: 2379
+      name: client
+      protocol: TCP
+    - containerPort: 2380
+      name: server
+      protocol: TCP
+  restartPolicy: Always
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    etcd_node: etcd0
+  name: etcd0
+spec:
+  ports:
+  - name: client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  - name: server
+    port: 2380
+    protocol: TCP
+    targetPort: 2380
+  selector:
+    etcd_node: etcd0
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: etcd
+    etcd_node: etcd1
+  name: etcd1
+spec:
+  containers:
+  - command:
+    - /usr/local/bin/etcd
+    - --name
+    - etcd1
+    - --initial-advertise-peer-urls
+    - http://etcd1:2380
+    - --listen-peer-urls
+    - http://0.0.0.0:2380
+    - --listen-client-urls
+    - http://0.0.0.0:2379
+    - --advertise-client-urls
+    - http://etcd1:2379
+    - --initial-cluster
+    - etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380
+    - --initial-cluster-state
+    - new
+    image: {{ .etcd.repository }}:{{ .etcd.tag }}
+    name: etcd1
+    ports:
+    - containerPort: 2379
+      name: client
+      protocol: TCP
+    - containerPort: 2380
+      name: server
+      protocol: TCP
+  restartPolicy: Always
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    etcd_node: etcd1
+  name: etcd1
+spec:
+  ports:
+  - name: client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  - name: server
+    port: 2380
+    protocol: TCP
+    targetPort: 2380
+  selector:
+    etcd_node: etcd1
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: etcd
+    etcd_node: etcd2
+  name: etcd2
+spec:
+  containers:
+  - command:
+    - /usr/local/bin/etcd
+    - --name
+    - etcd2
+    - --initial-advertise-peer-urls
+    - http://etcd2:2380
+    - --listen-peer-urls
+    - http://0.0.0.0:2380
+    - --listen-client-urls
+    - http://0.0.0.0:2379
+    - --advertise-client-urls
+    - http://etcd2:2379
+    - --initial-cluster
+    - etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380
+    - --initial-cluster-state
+    - new
+    image: {{ .etcd.repository }}:{{ .etcd.tag }}
+    name: etcd2
+    ports:
+    - containerPort: 2379
+      name: client
+      protocol: TCP
+    - containerPort: 2380
+      name: server
+      protocol: TCP
+  restartPolicy: Always
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    etcd_node: etcd2
+  name: etcd2
+spec:
+  ports:
+  - name: client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  - name: server
+    port: 2380
+    protocol: TCP
+    targetPort: 2380
+  selector:
+    etcd_node: etcd2


### PR DESCRIPTION
This is by no means a complete suite, but while switching us over to building minimal base images, it would be great to at least have something that launches our containers and validates they do something right.

The deployment yamls are pulled from upstream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
