### PR TITLE
Explicitly disable CGO when building

### DIFF
--- a/projects/etcd-io/etcd/build/create_binaries.sh
+++ b/projects/etcd-io/etcd/build/create_binaries.sh
@@ -46,7 +46,7 @@ function build::etcd::binaries(){
   do
     OS="$(cut -d '/' -f1 <<< ${platform})"
     ARCH="$(cut -d '/' -f2 <<< ${platform})"
-    GOOS=$OS GOARCH=$ARCH GO_LDFLAGS="-s -w -buildid=''" ./build
+    CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GO_LDFLAGS="-s -w -buildid=''" ./build
     mkdir -p ../${BIN_PATH}/${OS}-${ARCH}
     mv bin/* ../${BIN_PATH}/${OS}-${ARCH}
     make clean


### PR DESCRIPTION
Disabling CGO explicitly when building etcd binary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
