### PR TITLE
run arm and amd for 1-21 release branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ postsubmit-build: setup
 kops-prow-arm: export NODE_INSTANCE_TYPE=t4g.medium
 kops-prow-arm: export NODE_ARCHITECTURE=arm64
 kops-prow-arm: postsubmit-build
-	if [[ ! " 1-18 1-19 1-20 " =~ " ${RELEASE_BRANCH} " ]]; then \
+	$(eval MINOR_VERSION=$(subst 1-,,$(RELEASE_BRANCH)))
+	if [[ $(MINOR_VERSION) -ge 21 ]]; then \
 		development/kops/prow.sh; \
 	fi;
 

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,25 @@ postsubmit-build: setup
 		--artifact-bucket=$(ARTIFACT_BUCKET) \
 		--dry-run=false
 
-.PHONY: postsubmit-conformance
-postsubmit-conformance: postsubmit-build
+.PHONY: kops-prow-arm
+kops-prow-arm: export NODE_INSTANCE_TYPE=t4g.medium
+kops-prow-arm: export NODE_ARCHITECTURE=arm64
+kops-prow-arm: postsubmit-build
+	if [[ ! " 1-18 1-19 1-20 " =~ " ${RELEASE_BRANCH} " ]]; then \
+		development/kops/prow.sh; \
+	fi;
+
+.PHONY: kops-prow-amd
+kops-prow-amd: postsubmit-build
 	development/kops/prow.sh
+
+.PHONY: kops-prow
+kops-prow: kops-prow-amd kops-prow-arm
+	@echo 'Done kops-prow'
+
+.PHONY: postsubmit-conformance
+postsubmit-conformance: postsubmit-build kops-prow 
+	@echo 'Done postsubmit-conformance'
 
 .PHONY: tag
 tag:

--- a/development/kops/cluster_wait.sh
+++ b/development/kops/cluster_wait.sh
@@ -58,7 +58,7 @@ fi
 # UseKopsControllerForNodeBootstrap is only true when 1.19 and above
 if [ "${RELEASE_BRANCH}" == "1-18" ]; then
     PATCH='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kubelet-insecure-tls" }]'
-    while ! kubectl -n kube-system patch deployments metrics-server --type=json -p="$PATCH"
+    while ! kubectl --context $KOPS_CLUSTER_NAME  -n kube-system patch deployments metrics-server --type=json -p="$PATCH"
     do
         sleep 5
         COUNT=$(expr $COUNT + 1)

--- a/development/kops/validate_eks.sh
+++ b/development/kops/validate_eks.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kubectl get po --all-namespaces -o json | jq -r '.items[].spec.containers[].image' | sort -u
+kubectl --context $KOPS_CLUSTER_NAME get po --all-namespaces -o json | jq -r '.items[].spec.containers[].image' | sort -u


### PR DESCRIPTION
Instead of a separate job, run arm and amd64 conformance in parallel.

TODO

- [x] prow job - https://github.com/aws/eks-distro-prow-jobs/pull/209

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
