### PR TITLE
kops: generate key before running kops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,12 @@ kops-prow-amd: postsubmit-build
 kops-prow: kops-prow-amd kops-prow-arm
 	@echo 'Done kops-prow'
 
+.PHONT: generate-ssh-key
+generate-ssh-key: 
+	ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ""
+
 .PHONY: postsubmit-conformance
-postsubmit-conformance: postsubmit-build kops-prow 
+postsubmit-conformance: postsubmit-build generate-ssh-key kops-prow 
 	@echo 'Done postsubmit-conformance'
 
 .PHONY: tag

--- a/development/kops/run_sonobuoy.sh
+++ b/development/kops/run_sonobuoy.sh
@@ -50,7 +50,8 @@ mkdir ./${KOPS_CLUSTER_NAME}/results
 tar xzf $results -C ./${KOPS_CLUSTER_NAME}/results
 if [ -w /logs/artifacts ]
 then
-  cp ./${KOPS_CLUSTER_NAME}/results/plugins/e2e/results/global/* /logs/artifacts
+  mkdir -p /logs/artifacts/$NODE_ARCHITECTURE
+  cp ./${KOPS_CLUSTER_NAME}/results/plugins/e2e/results/global/* /logs/artifacts/$NODE_ARCHITECTURE
 fi
 ./sonobuoy --context ${KOPS_CLUSTER_NAME} e2e ${results}
 ./sonobuoy --context ${KOPS_CLUSTER_NAME} e2e ${results} | grep 'failed tests: 0' >/dev/null


### PR DESCRIPTION
For 1.21 we are running amd64 and arm tests concurrently.  Kops will generate an ssh key if one doesnt exist, but this creates an issue for which ever cluster starts the process second since it tries to overwrite the key that was just created.  This creates the key before calling kops.  Also, store the e2e results in separate folders.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
