### PR TITLE
Fix regex in main postsubmits

### DIFF
--- a/cmd/main_postsubmit.go
+++ b/cmd/main_postsubmit.go
@@ -125,7 +125,7 @@ func main() {
 				projects[projectPath].changed = true
 			}
 		}
-		r := regexp.MustCompile("Makefile|cmd/main_postsubmit.go|EKS_DISTRO_BASE_TAG_FILE|release/.*")
+		r := regexp.MustCompile("^Makefile$|cmd/main_postsubmit.go|EKS_DISTRO_BASE_TAG_FILE|^release/.*")
 		if r.MatchString(file) {
 			allChanged = true
 		}


### PR DESCRIPTION
Building all projects must be scoped only to the Makefile at the root.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
