### PR TITLE
Added labels to PR

### DIFF
--- a/cmd/release/pull_request/create_release_pr.sh
+++ b/cmd/release/pull_request/create_release_pr.sh
@@ -64,12 +64,19 @@ if "$IS_BOT"; then
   PR_TITLE="[BOT RELEASE] ${PR_TITLE}"
 fi
 
+labels="do-not-merge/hold release"
+
 pr_arguments=(
   --title "${PR_TITLE}"
   --body "${PR_BODY}"
   --head "${ORIGIN_ORG}:${PR_BRANCH}"
   --repo "${PR_ORG_REPO}"
 )
+
+for label in $labels; do
+     pr_arguments+=(--label "${label}")
+done
+
 if ! "$IS_BOT"; then
     pr_arguments+=(--web)
 fi

--- a/cmd/release/pull_request/create_release_pr.sh
+++ b/cmd/release/pull_request/create_release_pr.sh
@@ -64,15 +64,13 @@ if "$IS_BOT"; then
   PR_TITLE="[BOT RELEASE] ${PR_TITLE}"
 fi
 
-labels="do-not-merge/hold release"
-
 pr_arguments=(
   --title "${PR_TITLE}"
   --body "${PR_BODY}"
   --head "${ORIGIN_ORG}:${PR_BRANCH}"
   --repo "${PR_ORG_REPO}"
 )
-
+labels="do-not-merge/hold release"
 for label in $labels; do
      pr_arguments+=(--label "${label}")
 done


### PR DESCRIPTION
*Description of changes:*
* Adds `do-not-merge/hold` and `release` labels by default
  * `do-not-merge/hold` helps us make sure things get approved in the correct order
  * `release` helps with filtering if we have a lot of open, non-release PRs while we're cutting a lot of releases


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
