### PR TITLE
kops: use api server ip instead of relying on dns

### DIFF
--- a/development/kops/validate_dns.sh
+++ b/development/kops/validate_dns.sh
@@ -20,7 +20,6 @@
 
 set -eo pipefail
 BASEDIR=$(dirname "$0")
-echo "This script will create a cluster"
 cd "$BASEDIR"
 source ./set_environment.sh
 $PREFLIGHT_CHECK_PASSED || exit 1
@@ -29,14 +28,17 @@ APISERVER="api.$KOPS_CLUSTER_NAME"
 SUCCESS_COUNT=0
 while [ $SUCCESS_COUNT -lt 8 ]
 do
-  ip=$(dig +short $APISERVER)
-  if [ -z "$ip" ]; then
+  API_SERVER_IP=$(dig +short $APISERVER)
+  if [ -z "$API_SERVER_IP" ]; then
     echo "$APISERVER did not resolve!"
     SUCCESS_COUNT=0
   else
-    echo "$APISERVER resolves to $ip"
+    echo "$APISERVER resolves to $API_SERVER_IP"
     SUCCESS_COUNT=$((SUCCESS_COUNT+1))
   fi
   
   sleep 5s
 done
+
+kubectl --context ${KOPS_CLUSTER_NAME} config set-cluster ${KOPS_CLUSTER_NAME} \
+    --insecure-skip-tls-verify=true --server=https://${API_SERVER_IP}


### PR DESCRIPTION
In the postsubmits we often run into a seemingly random issue resolving the ip from domain name for the new cluster.  It seems like a dns issue, this will force the api calls to go over IP instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
