### PR TITLE
install kops/kubectl before running prow.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,13 @@ kops-prow-amd: postsubmit-build
 kops-prow: kops-prow-amd kops-prow-arm
 	@echo 'Done kops-prow'
 
-.PHONT: generate-ssh-key
-generate-ssh-key: 
+.PHONT: kops-prereqs
+kops-prereqs: 
 	ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ""
+	development/kops/install_requirements.sh
 
 .PHONY: postsubmit-conformance
-postsubmit-conformance: postsubmit-build generate-ssh-key kops-prow 
+postsubmit-conformance: postsubmit-build kops-prereqs kops-prow 
 	@echo 'Done postsubmit-conformance'
 
 .PHONY: tag

--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -17,7 +17,7 @@ set -eo pipefail
 
 BASEDIR=$(dirname "$0")
 source ${BASEDIR}/set_environment.sh
-$PREFLIGHT_CHECK_PASSED || exit 1
+# Ignoring preflight check failures since we only need the env vars set
 
 if [ "$(uname)" == "Darwin" ]
 then


### PR DESCRIPTION
In 1-21 postsubmit we run both amd and arm clusters.  They both try to download kops and some times, happened last night, it looks like one overwrites the file while the other is trying to use it resulting in: `./create_configuration.sh: line 51: bin/kops: Text file busy`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
