### PR TITLE
kops: rerun failed conformance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ kops-prow: kops-prow-amd kops-prow-arm
 .PHONT: kops-prereqs
 kops-prereqs: 
 	ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ""
-	development/kops/install_requirements.sh
+	cd development/kops && install_requirements.sh
 
 .PHONY: postsubmit-conformance
 postsubmit-conformance: postsubmit-build kops-prereqs kops-prow 


### PR DESCRIPTION
Doesnt happen often, but from time to time we do get a random failed conformance test.  This has a rerun using sonobuoy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
