### PR TITLE
kubeadm: CoreDNS permissions for endpointslices

### DIFF
--- a/projects/kubernetes/kubernetes/1-20/patches/0012-PATCH-kubeadm-CoreDNS-permissions-for-endpointslices.patch
+++ b/projects/kubernetes/kubernetes/1-20/patches/0012-PATCH-kubeadm-CoreDNS-permissions-for-endpointslices.patch
@@ -1,0 +1,32 @@
+From 74feb0759484202496e7639c5645e49a7258c9d5 Mon Sep 17 00:00:00 2001
+From: Antonio Ojea <antonio.ojea.garcia@gmail.com>
+Date: Wed, 12 May 2021 19:15:56 +0200
+Subject: [PATCH] kubeadm: CoreDNS permissions for endpointslices
+
+Signed-off-by: Antonio Ojea <antonio.ojea.garcia@gmail.com>
+Co-authored-by: pacoxu <paco.xu@daocloud.io>
+---
+ cmd/kubeadm/app/phases/addons/dns/manifests.go | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/cmd/kubeadm/app/phases/addons/dns/manifests.go b/cmd/kubeadm/app/phases/addons/dns/manifests.go
+index 3ac6856bfc6..97c7f8b3e60 100644
+--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
++++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
+@@ -197,6 +197,13 @@ rules:
+   - nodes
+   verbs:
+   - get
++- apiGroups:
++  - discovery.k8s.io
++  resources:
++  - endpointslices
++  verbs:
++  - list
++  - watch
+ `
+ 	// CoreDNSClusterRoleBinding is the CoreDNS Clusterrolebinding manifest
+ 	CoreDNSClusterRoleBinding = `
+-- 
+2.25.1
+

--- a/projects/kubernetes/kubernetes/1-21/patches/0010-PATCH-kubeadm-CoreDNS-permissions-for-endpointslices.patch
+++ b/projects/kubernetes/kubernetes/1-21/patches/0010-PATCH-kubeadm-CoreDNS-permissions-for-endpointslices.patch
@@ -1,0 +1,32 @@
+From 74feb0759484202496e7639c5645e49a7258c9d5 Mon Sep 17 00:00:00 2001
+From: Antonio Ojea <antonio.ojea.garcia@gmail.com>
+Date: Wed, 12 May 2021 19:15:56 +0200
+Subject: [PATCH] kubeadm: CoreDNS permissions for endpointslices
+
+Signed-off-by: Antonio Ojea <antonio.ojea.garcia@gmail.com>
+Co-authored-by: pacoxu <paco.xu@daocloud.io>
+---
+ cmd/kubeadm/app/phases/addons/dns/manifests.go | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/cmd/kubeadm/app/phases/addons/dns/manifests.go b/cmd/kubeadm/app/phases/addons/dns/manifests.go
+index 3ac6856bfc6..97c7f8b3e60 100644
+--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
++++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
+@@ -197,6 +197,13 @@ rules:
+   - nodes
+   verbs:
+   - get
++- apiGroups:
++  - discovery.k8s.io
++  resources:
++  - endpointslices
++  verbs:
++  - list
++  - watch
+ `
+ 	// CoreDNSClusterRoleBinding is the CoreDNS Clusterrolebinding manifest
+ 	CoreDNSClusterRoleBinding = `
+-- 
+2.25.1
+


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-distro/issues/545

*Description of changes:*
I just added patches for 1-20 and 1-21 to cherry-pick https://github.com/kubernetes/kubernetes/commit/74feb0759484202496e7639c5645e49a7258c9d5.
Not sure if that's the right approach, as the other patches seem to come from an existing (private?) fork of kubernetes.
I've tested by building kubeadm 1.21 and it fixes the issue for me.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
