### PR TITLE
introduce buildctl helper from eks-a and add retry logic

### DIFF
--- a/build/lib/buildkit.sh
+++ b/build/lib/buildkit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BUILD_LIB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/" && pwd -P)"
+
+CMD="buildctl"
+if [ -f "/buildkit.sh" ] && ! buildctl debug workers > /dev/null 2>&1; then
+    # on the builder base this helper file exists to run buildkitd
+    # in prow buildkitd is run as a seperate container so it will be running already
+    # in codebuild its run directly on the instance so we want to use this helper
+    CMD="/buildkit.sh"
+    
+fi
+# From time to time we see random failures when creating/pushing images that fix on reruning the job
+# this is an attempt to avoid failing key jobs, like the release job, with a flaky failure
+for i in $(seq 1 5); do [ $i -gt 1 ] && sleep 15; $CMD "$@" && s=0 && break || s=$?; done; (exit $s)

--- a/projects/coredns/coredns/build/lib/images.sh
+++ b/projects/coredns/coredns/build/lib/images.sh
@@ -14,6 +14,8 @@
 
 #/usr/bin/env bash
 
+BUILD_LIB="${MAKE_ROOT}/../../../build/lib"
+
 readonly KUBE_LINUX_IMAGE_PLATFORMS=(
     amd64
     arm64
@@ -37,7 +39,7 @@ function build::images::release_image_tar(){
         image=${repository}/${component}:${image_tag}
         image_dir=${context_dir}/_output/images/bin/linux/${platform}
         mkdir -p ${image_dir}
-        buildctl \
+        $BUILD_LIB/buildkit.sh \
             build \
             --frontend dockerfile.v0 \
             --opt platform=linux/${platform} \
@@ -63,7 +65,7 @@ function build::images::push(){
     local -r context_dir="$6"
 
     image=${repository}/${component}:${image_tag}
-    buildctl \
+    $BUILD_LIB/buildkit.sh \
         build \
         --frontend dockerfile.v0 \
         --opt platform=linux/amd64,linux/arm64 \

--- a/projects/etcd-io/etcd/build/lib/images.sh
+++ b/projects/etcd-io/etcd/build/lib/images.sh
@@ -14,6 +14,8 @@
 
 #/usr/bin/env bash
 
+BUILD_LIB="${MAKE_ROOT}/../../../build/lib"
+
 readonly KUBE_LINUX_IMAGE_PLATFORMS=(
     amd64
     arm64
@@ -37,7 +39,7 @@ function build::images::release_image_tar(){
         image=${repository}/${component}:${image_tag}
         image_dir=${context_dir}/_output/images/bin/linux/${platform}
         mkdir -p ${image_dir}
-        buildctl \
+        $BUILD_LIB/buildkit.sh \
             build \
             --frontend dockerfile.v0 \
             --opt platform=linux/${platform} \
@@ -63,7 +65,7 @@ function build::images::push(){
     local -r context_dir="$6"
 
     image=${repository}/${component}:${image_tag}
-    buildctl \
+    $BUILD_LIB/buildkit.sh \
         build \
         --frontend dockerfile.v0 \
         --opt platform=linux/amd64,linux/arm64 \

--- a/projects/kubernetes-csi/external-attacher/Makefile
+++ b/projects/kubernetes-csi/external-attacher/Makefile
@@ -1,4 +1,5 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
+BUILD_LIB=$(BASE_DIRECTORY)/build/lib
 RELEASE_BRANCH?=$(shell cat $(BASE_DIRECTORY)/release/DEFAULT_RELEASE_BRANCH)
 RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
@@ -31,7 +32,7 @@ binaries:
 
 .PHONY: local-images
 local-images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
@@ -42,7 +43,7 @@ local-images: binaries
 
 .PHONY: images
 images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64 \

--- a/projects/kubernetes-csi/external-provisioner/Makefile
+++ b/projects/kubernetes-csi/external-provisioner/Makefile
@@ -1,4 +1,5 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
+BUILD_LIB=$(BASE_DIRECTORY)/build/lib
 RELEASE_BRANCH?=$(shell cat $(BASE_DIRECTORY)/release/DEFAULT_RELEASE_BRANCH)
 RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
@@ -33,7 +34,7 @@ binaries:
 
 .PHONY: local-images
 local-images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
@@ -44,7 +45,7 @@ local-images: binaries
 
 .PHONY: images
 images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64 \

--- a/projects/kubernetes-csi/external-resizer/Makefile
+++ b/projects/kubernetes-csi/external-resizer/Makefile
@@ -1,4 +1,5 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
+BUILD_LIB=$(BASE_DIRECTORY)/build/lib
 RELEASE_BRANCH?=$(shell cat $(BASE_DIRECTORY)/release/DEFAULT_RELEASE_BRANCH)
 RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
@@ -31,7 +32,7 @@ binaries:
 
 .PHONY: local-images
 local-images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
@@ -42,7 +43,7 @@ local-images: binaries
 
 .PHONY: images
 images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64 \

--- a/projects/kubernetes-csi/external-snapshotter/Makefile
+++ b/projects/kubernetes-csi/external-snapshotter/Makefile
@@ -1,4 +1,5 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
+BUILD_LIB=$(BASE_DIRECTORY)/build/lib
 RELEASE_BRANCH?=$(shell cat $(BASE_DIRECTORY)/release/DEFAULT_RELEASE_BRANCH)
 RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
@@ -36,7 +37,7 @@ binaries:
 
 .PHONY: local-images
 local-images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
@@ -44,7 +45,7 @@ local-images: binaries
 		--local dockerfile=./docker/linux/csi-snapshotter \
 		--local context=. \
 		--output type=oci,oci-mediatypes=true,name=$(CSI_SNAPSHOTTER_IMAGE),dest=/tmp/csi-snapshotter.tar
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
@@ -52,7 +53,7 @@ local-images: binaries
 		--local dockerfile=./docker/linux/snapshot-controller \
 		--local context=. \
 		--output type=oci,oci-mediatypes=true,name=$(SNAPSHOT_CONTROLLER_IMAGE),dest=/tmp/snapshot-controller.tar
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
@@ -63,7 +64,7 @@ local-images: binaries
 
 .PHONY: images
 images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64 \
@@ -71,7 +72,7 @@ images: binaries
 		--local dockerfile=./docker/linux/csi-snapshotter \
 		--local context=. \
 		--output type=image,oci-mediatypes=true,name=$(CSI_SNAPSHOTTER_IMAGE),push=true
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64 \
@@ -79,7 +80,7 @@ images: binaries
 		--local dockerfile=./docker/linux/snapshot-controller \
 		--local context=. \
 		--output type=image,oci-mediatypes=true,name=$(SNAPSHOT_CONTROLLER_IMAGE),push=true
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64 \

--- a/projects/kubernetes-csi/livenessprobe/Makefile
+++ b/projects/kubernetes-csi/livenessprobe/Makefile
@@ -1,4 +1,5 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
+BUILD_LIB=$(BASE_DIRECTORY)/build/lib
 RELEASE_BRANCH?=$(shell cat $(BASE_DIRECTORY)/release/DEFAULT_RELEASE_BRANCH)
 RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
@@ -31,7 +32,7 @@ binaries:
 
 .PHONY: local-images
 local-images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
@@ -42,7 +43,7 @@ local-images: binaries
 
 .PHONY: images
 images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64 \

--- a/projects/kubernetes-csi/node-driver-registrar/Makefile
+++ b/projects/kubernetes-csi/node-driver-registrar/Makefile
@@ -1,4 +1,5 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
+BUILD_LIB=$(BASE_DIRECTORY)/build/lib
 RELEASE_BRANCH?=$(shell cat $(BASE_DIRECTORY)/release/DEFAULT_RELEASE_BRANCH)
 RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
@@ -31,7 +32,7 @@ binaries:
 
 .PHONY: local-images
 local-images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
@@ -42,7 +43,7 @@ local-images: binaries
 
 .PHONY: images
 images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64 \

--- a/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
@@ -1,4 +1,5 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
+BUILD_LIB=$(BASE_DIRECTORY)/build/lib
 RELEASE_BRANCH?=$(shell cat $(BASE_DIRECTORY)/release/DEFAULT_RELEASE_BRANCH)
 RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
@@ -31,7 +32,7 @@ binaries:
 
 .PHONY: local-images
 local-images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
@@ -43,7 +44,7 @@ local-images: binaries
 
 .PHONY: images
 images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64 \

--- a/projects/kubernetes-sigs/metrics-server/Makefile
+++ b/projects/kubernetes-sigs/metrics-server/Makefile
@@ -1,4 +1,5 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
+BUILD_LIB=$(BASE_DIRECTORY)/build/lib
 RELEASE_BRANCH?=$(shell cat $(BASE_DIRECTORY)/release/DEFAULT_RELEASE_BRANCH)
 RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
@@ -34,7 +35,7 @@ binaries:
 
 .PHONY: local-images
 local-images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
@@ -46,7 +47,7 @@ local-images: binaries
 
 .PHONY: images
 images: binaries
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64 \

--- a/projects/kubernetes/kubernetes/build/lib/images.sh
+++ b/projects/kubernetes/kubernetes/build/lib/images.sh
@@ -14,6 +14,8 @@
 
 #/usr/bin/env bash
 
+BUILD_LIB="${MAKE_ROOT}/../../../build/lib"
+
 readonly KUBE_LINUX_IMAGE_PLATFORMS=(
     amd64
     arm64
@@ -48,7 +50,7 @@ function build::images::release_image_tar(){
 
             image=${repository}/${repo_prefix}/${binary}:${image_tag}
             image_dir=${context_dir}/linux/${platform}
-            buildctl \
+            $BUILD_LIB/buildkit.sh \
                 build \
                 --frontend dockerfile.v0 \
                 --opt platform=linux/${platform} \
@@ -82,7 +84,7 @@ function build::images::push(){
             base_image=$kube_proxy_base_image
         fi
         image=${repository}/${repo_prefix}/${binary}:${image_tag}
-        buildctl \
+        $BUILD_LIB/buildkit.sh \
             build \
             --frontend dockerfile.v0 \
             --opt platform=linux/amd64,linux/arm64 \
@@ -152,7 +154,7 @@ function build::images::pause_tar(){
         if [ "$platform" == "arm64" ] && [ $skip_arm == true ]; then
             continue
         fi
-        buildctl \
+        $BUILD_LIB/buildkit.sh \
             build \
             --frontend dockerfile.v0 \
             --opt platform=linux/${platform} \
@@ -171,7 +173,7 @@ function build::images::pause_push(){
     local -r image_tag="$3"
     local -r context_dir="$4"
 
-    buildctl \
+    $BUILD_LIB/buildkit.sh \
         build \
         --frontend dockerfile.v0 \
         --opt platform=linux/amd64,linux/arm64 \

--- a/projects/kubernetes/release/Makefile
+++ b/projects/kubernetes/release/Makefile
@@ -1,4 +1,5 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
+BUILD_LIB=$(BASE_DIRECTORY)/build/lib
 RELEASE_BRANCH?=$(shell cat $(BASE_DIRECTORY)/release/DEFAULT_RELEASE_BRANCH)
 RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
@@ -37,7 +38,7 @@ binaries:
 .PHONY: local-images
 local-images: binaries
 	cp release/images/build/debian-iptables/buster/iptables-wrapper _output/
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64  \
@@ -46,7 +47,7 @@ local-images: binaries
 		--local dockerfile=./docker/go-runner/ \
 		--local context=. \
 		--output type=oci,oci-mediatypes=true,name=$(GO_RUNNER_IMAGE),dest=/tmp/go-runner.tar
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
@@ -59,7 +60,7 @@ local-images: binaries
 .PHONY: images
 images: binaries
 	cp release/images/build/debian-iptables/buster/iptables-wrapper _output/
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64  \
@@ -68,7 +69,7 @@ images: binaries
 		--local dockerfile=./docker/go-runner/ \
 		--local context=. \
 		--output type=image,oci-mediatypes=true,name=$(GO_RUNNER_IMAGE),push=true
-	buildctl \
+	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64,linux/arm64  \


### PR DESCRIPTION
In our prod release jobs we will somethings get "random" errors from buildkit.  This copies the buildkit helper from eks-a and adds retry logic around the buildctl call to try and avoid this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
