### PR TITLE
Use same image target for presubmit and postsubmit

### DIFF
--- a/projects/kubernetes-csi/external-attacher/Makefile
+++ b/projects/kubernetes-csi/external-attacher/Makefile
@@ -25,21 +25,9 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-
 .PHONY: binaries
 binaries:
 	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_TAG) $(GOLANG_VERSION)
-
-.PHONY: local-images
-local-images: binaries
-	$(BUILD_LIB)/buildkit.sh \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--local dockerfile=./docker/linux \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=/tmp/external-attacher.tar
 
 .PHONY: images
 images: binaries
@@ -50,7 +38,7 @@ images: binaries
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
 		--local dockerfile=./docker/linux \
 		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(IMAGE),push=true
+		--output type=$(OUTPUT_TYPE),oci-mediatypes=true,name=$(IMAGE),$(OUTPUT)
 
 .PHONY: docker
 docker: binaries
@@ -64,20 +52,25 @@ docker: binaries
 .PHONY: docker-push
 docker-push:
 	docker push $(IMAGE)
-
-.PHONY: build
-build: local-images attribution
 	
-.PHONY: release
-release: images
+.PHONY: build release
+build: OUTPUT_TYPE=oci
+build: OUTPUT=dest=/tmp/external-attacher.tar
+release: OUTPUT_TYPE=image
+release: OUTPUT=push=true
+build release:
+	make images OUTPUT_TYPE=$(OUTPUT_TYPE) OUTPUT=$(OUTPUT)
+	if [ $@ = "build" ]; then \
+		make attribution; \
+	fi
 	echo "Done $(COMPONENT)"
-
-.PHONY: all
-all: release
 
 .PHONY: attribution
 attribution: 
 	build/create_attribution.sh $(GOLANG_VERSION)
+
+.PHONY: all
+all: release
 
 .PHONY: clean
 clean:

--- a/projects/kubernetes-csi/external-provisioner/Makefile
+++ b/projects/kubernetes-csi/external-provisioner/Makefile
@@ -27,21 +27,9 @@ IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 GOPROXY_DNS?=direct
 export GOPROXY=$(GOPROXY_DNS)
 
-
 .PHONY: binaries
 binaries:
 	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_TAG) $(GOLANG_VERSION)
-
-.PHONY: local-images
-local-images: binaries
-	$(BUILD_LIB)/buildkit.sh \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--local dockerfile=./docker/linux \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=/tmp/external-provisioner.tar
 
 .PHONY: images
 images: binaries
@@ -52,7 +40,7 @@ images: binaries
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
 		--local dockerfile=./docker/linux \
 		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(IMAGE),push=true
+		--output type=$(OUTPUT_TYPE),oci-mediatypes=true,name=$(IMAGE),$(OUTPUT)
 
 .PHONY: docker
 docker: binaries
@@ -66,20 +54,25 @@ docker: binaries
 .PHONY: docker-push
 docker-push:
 	docker push $(IMAGE)
-
-.PHONY: build
-build: local-images attribution
-
-.PHONY: release
-release: images
+	
+.PHONY: build release
+build: OUTPUT_TYPE=oci
+build: OUTPUT=dest=/tmp/external-provisioner.tar
+release: OUTPUT_TYPE=image
+release: OUTPUT=push=true
+build release:
+	make images OUTPUT_TYPE=$(OUTPUT_TYPE) OUTPUT=$(OUTPUT)
+	if [ $@ = "build" ]; then \
+		make attribution; \
+	fi
 	echo "Done $(COMPONENT)"
-
-.PHONY: all
-all: release
 
 .PHONY: attribution
 attribution: 
 	build/create_attribution.sh $(GOLANG_VERSION)
+
+.PHONY: all
+all: release
 
 .PHONY: clean
 clean:

--- a/projects/kubernetes-csi/external-resizer/Makefile
+++ b/projects/kubernetes-csi/external-resizer/Makefile
@@ -25,21 +25,9 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-
 .PHONY: binaries
 binaries:
 	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_TAG) $(GOLANG_VERSION)
-
-.PHONY: local-images
-local-images: binaries
-	$(BUILD_LIB)/buildkit.sh \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--local dockerfile=./docker/linux \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=/tmp/external-resizer.tar
 
 .PHONY: images
 images: binaries
@@ -50,7 +38,7 @@ images: binaries
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
 		--local dockerfile=./docker/linux \
 		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(IMAGE),push=true
+		--output type=$(OUTPUT_TYPE),oci-mediatypes=true,name=$(IMAGE),$(OUTPUT)
 
 .PHONY: docker
 docker: binaries
@@ -64,20 +52,25 @@ docker: binaries
 .PHONY: docker-push
 docker-push:
 	docker push $(IMAGE)
-
-.PHONY: build
-build: local-images attribution
-
-.PHONY: release
-release: images
+	
+.PHONY: build release
+build: OUTPUT_TYPE=oci
+build: OUTPUT=dest=/tmp/external-resizer.tar
+release: OUTPUT_TYPE=image
+release: OUTPUT=push=true
+build release:
+	make images OUTPUT_TYPE=$(OUTPUT_TYPE) OUTPUT=$(OUTPUT)
+	if [ $@ = "build" ]; then \
+		make attribution; \
+	fi
 	echo "Done $(COMPONENT)"
-
-.PHONY: all
-all: release
 
 .PHONY: attribution
 attribution: 
 	build/create_attribution.sh $(GOLANG_VERSION)
+
+.PHONY: all
+all: release
 
 .PHONY: clean
 clean:

--- a/projects/kubernetes-csi/external-snapshotter/Makefile
+++ b/projects/kubernetes-csi/external-snapshotter/Makefile
@@ -30,37 +30,9 @@ SNAPSHOT_VALIDATION_WEBHOOK_IMAGE?=$(IMAGE_REPO)/kubernetes-csi/external-snapsho
 GOPROXY_DNS?=direct
 export GOPROXY=$(GOPROXY_DNS)
 
-
 .PHONY: binaries
 binaries:
 	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_TAG) $(GOLANG_VERSION)
-
-.PHONY: local-images
-local-images: binaries
-	$(BUILD_LIB)/buildkit.sh \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--local dockerfile=./docker/linux/csi-snapshotter \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(CSI_SNAPSHOTTER_IMAGE),dest=/tmp/csi-snapshotter.tar
-	$(BUILD_LIB)/buildkit.sh \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--local dockerfile=./docker/linux/snapshot-controller \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(SNAPSHOT_CONTROLLER_IMAGE),dest=/tmp/snapshot-controller.tar
-	$(BUILD_LIB)/buildkit.sh \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--local dockerfile=./docker/linux/snapshot-validation-webhook \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(SNAPSHOT_VALIDATION_WEBHOOK_IMAGE),dest=/tmp/snapshot-validation-webhook.tar
 
 .PHONY: images
 images: binaries
@@ -71,7 +43,7 @@ images: binaries
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
 		--local dockerfile=./docker/linux/csi-snapshotter \
 		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(CSI_SNAPSHOTTER_IMAGE),push=true
+		--output type=$(OUTPUT_TYPE),oci-mediatypes=true,name=$(CSI_SNAPSHOTTER_IMAGE),$(CSI_SNAPSHOTTER_OUTPUT)
 	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
@@ -79,7 +51,7 @@ images: binaries
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
 		--local dockerfile=./docker/linux/snapshot-controller \
 		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(SNAPSHOT_CONTROLLER_IMAGE),push=true
+		--output type=$(OUTPUT_TYPE),oci-mediatypes=true,name=$(SNAPSHOT_CONTROLLER_IMAGE),$(SNAPSHOT_CONTROLLER_OUTPUT)
 	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
@@ -87,7 +59,7 @@ images: binaries
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
 		--local dockerfile=./docker/linux/snapshot-validation-webhook \
 		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(SNAPSHOT_VALIDATION_WEBHOOK_IMAGE),push=true
+		--output type=$(OUTPUT_TYPE),oci-mediatypes=true,name=$(SNAPSHOT_VALIDATION_WEBHOOK_IMAGE),$(SNAPSHOT_VALIDATION_WEBHOOK_OUTPUT)
 
 .PHONY: docker
 docker: binaries
@@ -116,19 +88,31 @@ docker-push:
 	docker push $(SNAPSHOT_CONTROLLER_IMAGE)
 	docker push $(SNAPSHOT_VALIDATION_WEBHOOK_IMAGE)
 
-.PHONY: build
-build: local-images attribution
-
-.PHONY: release
-release: images
+.PHONY: build release
+build: OUTPUT_TYPE=oci
+build: CSI_SNAPSHOTTER_OUTPUT=dest=/tmp/csi-snapshotter.tar
+build: SNAPSHOT_CONTROLLER_OUTPUT=dest=/tmp/snapshot-controller.tar
+build: SNAPSHOT_VALIDATION_WEBHOOK_OUTPUT=dest=/tmp/snapshot-validation-webhook.tar
+release: OUTPUT_TYPE=image
+release: CSI_SNAPSHOTTER_OUTPUT=push=true
+release: SNAPSHOT_CONTROLLER_OUTPUT=push=true
+release: SNAPSHOT_VALIDATION_WEBHOOK_OUTPUT=push=true
+build release:
+	make images OUTPUT_TYPE=$(OUTPUT_TYPE) \
+		CSI_SNAPSHOTTER_OUTPUT=$(CSI_SNAPSHOTTER_OUTPUT) \
+		SNAPSHOT_CONTROLLER_OUTPUT=$(SNAPSHOT_CONTROLLER_OUTPUT) \
+		SNAPSHOT_VALIDATION_WEBHOOK_OUTPUT=$(SNAPSHOT_VALIDATION_WEBHOOK_OUTPUT)
+	if [ $@ = "build" ]; then \
+		make attribution; \
+	fi
 	echo "Done $(COMPONENT)"
-
-.PHONY: all
-all: release
 
 .PHONY: attribution
 attribution: 
 	build/create_attribution.sh $(GOLANG_VERSION)
+
+.PHONY: all
+all: release
 
 .PHONY: clean
 clean:

--- a/projects/kubernetes-csi/livenessprobe/Makefile
+++ b/projects/kubernetes-csi/livenessprobe/Makefile
@@ -25,21 +25,9 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-
 .PHONY: binaries
 binaries:
 	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_TAG) $(GOLANG_VERSION)
-
-.PHONY: local-images
-local-images: binaries
-	$(BUILD_LIB)/buildkit.sh \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--local dockerfile=./docker/linux \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=/tmp/livenessprobe.tar
 
 .PHONY: images
 images: binaries
@@ -50,7 +38,7 @@ images: binaries
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
 		--local dockerfile=./docker/linux \
 		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(IMAGE),push=true
+		--output type=$(OUTPUT_TYPE),oci-mediatypes=true,name=$(IMAGE),$(OUTPUT)
 
 .PHONY: docker
 docker: binaries
@@ -59,26 +47,31 @@ docker: binaries
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg TARGETARCH=amd64 \
 		--build-arg TARGETOS=linux \
-		-f ./docker/linux/Dockerfile .	
+		-f ./docker/linux/Dockerfile .
 
 .PHONY: docker-push
 docker-push:
 	docker push $(IMAGE)
-
-.PHONY: build
-build: local-images attribution
-
-.PHONY: release
-release: images
+	
+.PHONY: build release
+build: OUTPUT_TYPE=oci
+build: OUTPUT=dest=/tmp/livenessprobe.tar
+release: OUTPUT_TYPE=image
+release: OUTPUT=push=true
+build release:
+	make images OUTPUT_TYPE=$(OUTPUT_TYPE) OUTPUT=$(OUTPUT)
+	if [ $@ = "build" ]; then \
+		make attribution; \
+	fi
 	echo "Done $(COMPONENT)"
-
-.PHONY: all
-all: release
 
 .PHONY: attribution
 attribution: 
 	build/create_attribution.sh $(GOLANG_VERSION)
-	
+
+.PHONY: all
+all: release
+
 .PHONY: clean
 clean:
 	rm -rf $(REPO)

--- a/projects/kubernetes-csi/node-driver-registrar/Makefile
+++ b/projects/kubernetes-csi/node-driver-registrar/Makefile
@@ -25,21 +25,9 @@ IMAGE_NAME?=$(COMPONENT)
 IMAGE_TAG?=$(GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-
 .PHONY: binaries
 binaries:
 	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_TAG) $(GOLANG_VERSION)
-
-.PHONY: local-images
-local-images: binaries
-	$(BUILD_LIB)/buildkit.sh \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--local dockerfile=./docker/linux \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=/tmp/node-driver-registrar.tar
 
 .PHONY: images
 images: binaries
@@ -50,7 +38,7 @@ images: binaries
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
 		--local dockerfile=./docker/linux \
 		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(IMAGE),push=true
+		--output type=$(OUTPUT_TYPE),oci-mediatypes=true,name=$(IMAGE),$(OUTPUT)
 
 .PHONY: docker
 docker: binaries
@@ -59,26 +47,31 @@ docker: binaries
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg TARGETARCH=amd64 \
 		--build-arg TARGETOS=linux \
-		-f docker/linux/Dockerfile .
+		-f ./docker/linux/Dockerfile .
 
 .PHONY: docker-push
 docker-push:
 	docker push $(IMAGE)
-
-.PHONY: build
-build: local-images attribution
-
-.PHONY: release
-release: images
+	
+.PHONY: build release
+build: OUTPUT_TYPE=oci
+build: OUTPUT=dest=/tmp/node-driver-registrar.tar
+release: OUTPUT_TYPE=image
+release: OUTPUT=push=true
+build release:
+	make images OUTPUT_TYPE=$(OUTPUT_TYPE) OUTPUT=$(OUTPUT)
+	if [ $@ = "build" ]; then \
+		make attribution; \
+	fi
 	echo "Done $(COMPONENT)"
-
-.PHONY: all
-all: release
 
 .PHONY: attribution
 attribution: 
 	build/create_attribution.sh $(GOLANG_VERSION)
-	
+
+.PHONY: all
+all: release
+
 .PHONY: clean
 clean:
 	rm -rf $(REPO)

--- a/projects/kubernetes-sigs/metrics-server/Makefile
+++ b/projects/kubernetes-sigs/metrics-server/Makefile
@@ -27,23 +27,9 @@ IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 GOPROXY_DNS?=direct
 export GOPROXY=$(GOPROXY_DNS)
 
-
-#Make sure GOPATH is set
 .PHONY: binaries
 binaries:
 	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_TAG) $(GOLANG_VERSION)
-
-.PHONY: local-images
-local-images: binaries
-	$(BUILD_LIB)/buildkit.sh \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--opt build-arg:RELEASE_BRANCH=$(RELEASE_BRANCH) \
-		--local dockerfile=./docker/linux \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(IMAGE),dest=/tmp/metrics-server.tar
 
 .PHONY: images
 images: binaries
@@ -55,7 +41,7 @@ images: binaries
 		--opt build-arg:RELEASE_BRANCH=$(RELEASE_BRANCH) \
 		--local dockerfile=./docker/linux \
 		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(IMAGE),push=true
+		--output type=$(OUTPUT_TYPE),oci-mediatypes=true,name=$(IMAGE),$(OUTPUT)
 
 .PHONY: docker
 docker: binaries
@@ -71,26 +57,26 @@ docker: binaries
 docker-push:
 	docker push $(IMAGE)
 
-.PHONY: tarballs
-tarballs:
-	# empty target
-
-.PHONY: build
-build: local-images tarballs attribution
-
-.PHONY: release
-release: images tarballs
+.PHONY: build release
+build: OUTPUT_TYPE=oci
+build: OUTPUT=dest=/tmp/metrics-server.tar
+release: OUTPUT_TYPE=image
+release: OUTPUT=push=true
+build release:
+	make images OUTPUT_TYPE=$(OUTPUT_TYPE) OUTPUT=$(OUTPUT)
+	if [ $@ = "build" ]; then \
+		make attribution; \
+	fi
 	echo "Done $(COMPONENT)"
-
-.PHONY: all
-all: release
 
 .PHONY: attribution
 attribution: 
 	build/create_attribution.sh $(RELEASE_BRANCH) $(GOLANG_VERSION)
+
+.PHONY: all
+all: release
 	
 .PHONY: clean
 clean:
 	rm -rf $(REPO)
 	rm -rf "_output"
-

--- a/projects/kubernetes/release/Makefile
+++ b/projects/kubernetes/release/Makefile
@@ -30,32 +30,9 @@ KUBE_PROXY_BASE_IMAGE_NAME?=kubernetes/kube-proxy-base
 KUBE_PROXY_BASE_IMAGE_TAG?=${GIT_TAG}-eks-${RELEASE_BRANCH}-${RELEASE}
 KUBE_PROXY_BASE_IMAGE?=$(IMAGE_REPO)/$(KUBE_PROXY_BASE_IMAGE_NAME):$(KUBE_PROXY_BASE_IMAGE_TAG)
 
-
 .PHONY: binaries
 binaries:
 	build/create_binaries.sh $(CLONE_URL) $(REPO) $(GIT_TAG) $(GOLANG_VERSION)
-
-.PHONY: local-images
-local-images: binaries
-	cp release/images/build/debian-iptables/buster/iptables-wrapper _output/
-	$(BUILD_LIB)/buildkit.sh \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64,linux/arm64  \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--opt build-arg:RELEASE_BRANCH=$(RELEASE_BRANCH) \
-		--local dockerfile=./docker/go-runner/ \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(GO_RUNNER_IMAGE),dest=/tmp/go-runner.tar
-	$(BUILD_LIB)/buildkit.sh \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--opt build-arg:RELEASE_BRANCH=$(RELEASE_BRANCH) \
-		--local dockerfile=./docker/kube-proxy-base/ \
-		--local context=. \
-		--output type=oci,oci-mediatypes=true,name=$(KUBE_PROXY_BASE_IMAGE),dest=/tmp/kube-proxy-base.tar
 
 .PHONY: images
 images: binaries
@@ -68,7 +45,7 @@ images: binaries
 		--opt build-arg:RELEASE_BRANCH=$(RELEASE_BRANCH) \
 		--local dockerfile=./docker/go-runner/ \
 		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(GO_RUNNER_IMAGE),push=true
+		--output type=$(OUTPUT_TYPE),oci-mediatypes=true,name=$(GO_RUNNER_IMAGE),$(GO_RUNNER_OUTPUT)
 	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
@@ -77,7 +54,7 @@ images: binaries
 		--opt build-arg:RELEASE_BRANCH=$(RELEASE_BRANCH) \
 		--local dockerfile=./docker/kube-proxy-base/ \
 		--local context=. \
-		--output type=image,oci-mediatypes=true,name=$(KUBE_PROXY_BASE_IMAGE),push=true
+		--output type=$(OUTPUT_TYPE),oci-mediatypes=true,name=$(KUBE_PROXY_BASE_IMAGE),$(KUBE_PROXY_BASE_OUTPUT)
 
 .PHONY: docker
 docker: binaries
@@ -102,15 +79,18 @@ docker-push:
 	docker push $(GO_RUNNER_IMAGE)
 	docker push $(KUBE_PROXY_BASE_IMAGE)
 
-.PHONY: clean
-clean:
-	rm -rf ./_output ./release
-
-.PHONY: build
-build: local-images attribution
-
-.PHONY: release
-release: images
+.PHONY: build release
+build: OUTPUT_TYPE=oci
+build: GO_RUNNER_OUTPUT=dest=/tmp/go-runner.tar
+build: KUBE_PROXY_BASE_OUTPUT=dest=/tmp/kube-proxy-base.tar
+release: OUTPUT_TYPE=image
+release: GO_RUNNER_OUTPUT=push=true
+release: KUBE_PROXY_BASE_OUTPUT=push=true
+build release:
+	make images OUTPUT_TYPE=$(OUTPUT_TYPE) GO_RUNNER_OUTPUT=$(GO_RUNNER_OUTPUT) KUBE_PROXY_BASE_OUTPUT=$(KUBE_PROXY_BASE_OUTPUT)
+	if [ $@ = "build" ]; then \
+		make attribution; \
+	fi
 	echo "Done $(COMPONENT)"
 
 .PHONY: attribution
@@ -119,3 +99,7 @@ attribution:
 
 .PHONY: all
 all: release
+
+.PHONY: clean
+clean:
+	rm -rf ./_output ./release


### PR DESCRIPTION
Most often the only thing that differs between presubmits and postsubmits is the former creates a local OCI tar of the image, while the latter pushes the image. So we could use the same image target and pass appropriate args for `buildctl` output type and destination.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
