### PR TITLE
add checksum updating to attribution periodic

### DIFF
--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -57,7 +57,7 @@ function pr:create()
 
 	ssh-agent bash -c 'ssh-add /secrets/ssh-secrets/ssh-key; ssh -o StrictHostKeyChecking=no git@github.com; git push -u origin $pr_branch -f'
 
-	local -r pr_exists=$(gh pr list | grep -c "${PR_BRANCH}" || true)
+	local -r pr_exists=$(gh pr list | grep -c "$pr_branch" || true)
 	if [ $pr_exists -eq 0 ]; then
 		gh pr create --title "$pr_title" --body "$pr_body"
 	fi

--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -106,7 +106,7 @@ pr::create::attribution
 git checkout main
 
 git stash pop
-# Add attribution files
+# Add checksum files
 for FILE in $(find . -type f -name CHECKSUMS); do    
     git add $FILE
 done

--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -22,46 +22,93 @@ SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 ORIGIN_ORG="eks-distro-pr-bot"
 UPSTREAM_ORG="aws"
 
-PR_TITLE="Update ATTRIBUTION.txt files"
-COMMIT_MESSAGE="[PR BOT] Update ATTRIBUTION.txt files"
-
-PR_BODY=$(cat <<EOF
-This PR updates the ATTRIBUTION.txt files across all dependency projects if there have been changes.
-
-By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
-EOF
-)
-
-PR_BRANCH="attribution-files-update"
-
 cd ${SCRIPT_ROOT}/../../
 git config --global push.default current
 git config user.name "EKS Distro PR Bot"
 git config user.email "aws-model-rocket-bots+eksdistroprbot@amazon.com"
 git remote add origin git@github.com:${ORIGIN_ORG}/eks-distro.git
 git remote add upstream https://github.com/${UPSTREAM_ORG}/eks-distro.git
-git checkout -b $PR_BRANCH
 
-for FILE in $(find . -type f \( -name ATTRIBUTION.txt ! -path "*/_output/*" \)); do    
-    git add $FILE
-done
-FILES_ADDED=$(git diff --staged --name-only)
-if [ "$FILES_ADDED" = "" ]; then
-    exit 0
-fi
+gh auth login --with-token < /secrets/github-secrets/token
 
-git commit -m "$COMMIT_MESSAGE" || true
-
+# Files have already changed, stash to perform rebase
+git stash
 git fetch upstream
 # there will be conflicts before we are on the bots fork at this point
 # -Xtheirs instructs git to favor the changes from the current branch
 git rebase -Xtheirs upstream/main
 
-ssh-agent bash -c 'ssh-add /secrets/ssh-secrets/ssh-key; ssh -o StrictHostKeyChecking=no git@github.com; git push -u origin $PR_BRANCH -f'
+git stash pop
 
-gh auth login --with-token < /secrets/github-secrets/token
+function pr:create()
+{
+	local -r pr_title="$1"
+	local -r commit_message="$2"
+	local -r pr_branch="$3"
+	local -r pr_body="$4"
 
-PR_EXISTS=$(gh pr list | grep -c "${PR_BRANCH}" || true)
-if [ $PR_EXISTS -eq 0 ]; then
-  gh pr create --title "$PR_TITLE" --body "$PR_BODY"
-fi
+	local -r files_added=$(git diff --staged --name-only)
+	if [ "$files_added" = "" ]; then
+		return 0
+	fi
+
+	git checkout -b $pr_branch
+	git commit -m "$commit_message" || true
+
+	ssh-agent bash -c 'ssh-add /secrets/ssh-secrets/ssh-key; ssh -o StrictHostKeyChecking=no git@github.com; git push -u origin $pr_branch -f'
+
+	local -r pr_exists=$(gh pr list | grep -c "${PR_BRANCH}" || true)
+	if [ $pr_exists -eq 0 ]; then
+		gh pr create --title "$pr_title" --body "$pr_body"
+	fi
+}
+
+function pr::create::attribution() {
+	local -r pr_title="Update ATTRIBUTION.txt files"
+	local -r commit_message="[PR BOT] Update ATTRIBUTION.txt files"
+	local -r pr_branch="attribution-files-update"
+	local -r pr_body=$(cat <<EOF
+This PR updates the ATTRIBUTION.txt files across all dependency projects if there have been changes.
+
+This files should only be changing due to project GIT_TAG bumps or golang version upgrades.  If changes are for any other reason please review carefully! 
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
+EOF
+)
+	pr:create "$pr_title" "$commit_message" "$pr_branch" "$pr_body"
+}
+
+function pr::create::checksums() {
+	local -r pr_title="Update CHECKSUMS files"
+	local -r commit_message="[PR BOT] Update CHECKSUMS files"
+	local -r pr_branch="checksums-files-update"
+	local -r pr_body=$(cat <<EOF
+This PR updates the CHECKSUMS files across all dependency projects if there have been changes.
+
+This files should only be changing due to golang version upgrades.  If changes are for any other reason please do not merge!
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
+EOF
+)
+	pr:create "$pr_title" "$commit_message" "$pr_branch" "$pr_body"
+}
+
+# Add attribution files
+for FILE in $(find . -type f \( -name ATTRIBUTION.txt ! -path "*/_output/*" \)); do    
+    git add $FILE
+done
+
+# stash checksums files
+git stash --keep-index
+
+pr::create::attribution
+
+git checkout main
+
+git stash pop
+# Add attribution files
+for FILE in $(find . -type f -name CHECKSUMS); do    
+    git add $FILE
+done
+
+pr::create::checksums

--- a/build/update-attribution-files/make_attribution.sh
+++ b/build/update-attribution-files/make_attribution.sh
@@ -31,8 +31,7 @@ function build::attribution::generate(){
     if [ $# -ge 1 ]; then
         export RELEASE_BRANCH="$1"
     fi
-    make -C $PROJECT_ROOT binaries
-    make -C $PROJECT_ROOT attribution
+    make -C $PROJECT_ROOT binaries attribution checksums    
     for summary in $PROJECT_ROOT/_output/**/summary.txt; do
         sed -i "s/+.*=/ =/g" $summary
         awk -F" =\> " '{ count[$1]+=$2} END { for (item in count) printf("%s => %d\n", item, count[item]) }' \


### PR DESCRIPTION
Checksums may need updating when new versions of golang are being used.  This adds generation to the attribution job which already runs the same targets we need.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
