### PR TITLE
kubernete: no need to generate sha256 files for licenses

### DIFF
--- a/projects/kubernetes/kubernetes/build/create_release_checksums.sh
+++ b/projects/kubernetes/kubernetes/build/create_release_checksums.sh
@@ -42,7 +42,7 @@ rm -f $SHA256SUM
 rm -f $SHA512SUM
 echo "Writing artifact hashes to SHA256SUM/SHA512SUM files..."
 cd $ASSET_ROOT
-for file in $(find ${ASSET_ROOT} -type f -not -path '*\.sha[25][51][62]' ); do
+for file in $(find ${ASSET_ROOT} -type f -not -path '*\.sha[25][51][62]' -not -path '*\.docker_*' \( -path '*bin/linux*' -o -path '*bin/windows*' -o -path '*bin/darwin*' -o -name '*tar\.gz' \) ); do
     filepath=$(realpath --relative-base=${ASSET_ROOT} $file )
     sha256sum "$filepath" | tee -a $SHA256SUM > "$file.sha256" || return 1
     sha512sum "$filepath" | tee -a $SHA512SUM > "$file.sha512" || return 1
@@ -53,4 +53,6 @@ sha256sum SHA256SUM > "SHA256SUM.sha256" || return 1
 sha512sum SHA256SUM > "SHA256SUM.sha512" || return 1
 sha256sum SHA512SUM > "SHA512SUM.sha256" || return 1
 sha512sum SHA512SUM > "SHA512SUM.sha512" || return 1
+
+cat SHA256SUM
 cd -

--- a/projects/kubernetes/kubernetes/build/lib/binaries.sh
+++ b/projects/kubernetes/kubernetes/build/lib/binaries.sh
@@ -58,6 +58,9 @@ function build::binaries::kube_bins() {
         cmd/kube-controller-manager \
         cmd/kube-scheduler
 
+    # In presubmit builds space is very limited
+    rm -rf ./_output/local/go/cache
+    
     # Windows
     export KUBE_BUILD_PLATFORMS="windows/amd64"
     hack/make-rules/build.sh -trimpath cmd/kubelet \

--- a/projects/kubernetes/kubernetes/build/lib/binaries.sh
+++ b/projects/kubernetes/kubernetes/build/lib/binaries.sh
@@ -15,30 +15,30 @@
 
 function build::binaries::kube_bins() {
     local -r repository="$1"
-	local -r release_branch="$2"
-	local -r git_tag="$3"
+    local -r release_branch="$2"
+    local -r git_tag="$3"
 
-	# ensure consistent build date tag on final binary based on
-	# last change in the patches directory
-	export SOURCE_DATE_EPOCH=$(git log -n 1 --pretty=format:%ct $release_branch/patches)
-	export KUBE_GIT_COMMIT=$(git -C $repository rev-list -n 1 $git_tag)
+    # ensure consistent build date tag on final binary based on
+    # last change in the patches directory
+    export SOURCE_DATE_EPOCH=$(git log -n 1 --pretty=format:%ct $release_branch/patches)
+    export KUBE_GIT_COMMIT=$(git -C $repository rev-list -n 1 $git_tag)
 	
-	cd $repository
-
-	# avoid checksum differences due to modules being installed on 
-	# build machine before building kubernetes since that will sometimes
-	# add additional hashs for vendor modules in the final binary
-	./hack/update-vendor.sh
+    cd $repository
     
-	# Build all core components for linux arm64 and amd64
+    # avoid checksum differences due to modules being installed on 
+    # build machine before building kubernetes since that will sometimes
+    # add additional hashs for vendor modules in the final binary
+    ./hack/update-vendor.sh
+    
+    # Build all core components for linux arm64 and amd64
     # GOLDFLASGS
     # * strip symbol, debug, and DWARF tables
     # * set an empty build id for reproducibility
     # * build static binaries
-	# Run in two steps to support passing -trimpath
-	export CGO_ENABLED=0
-	export GOLDFLAGS='-s -w -buildid=""'
-	export KUBE_STATIC_OVERRIDES="cmd/kubelet \
+    # Run in two steps to support passing -trimpath
+    export CGO_ENABLED=0
+    export GOLDFLAGS='-s -w -buildid=""'
+    export KUBE_STATIC_OVERRIDES="cmd/kubelet \
         cmd/kube-proxy \
         cmd/kubeadm \
         cmd/kubectl \
@@ -46,9 +46,9 @@ function build::binaries::kube_bins() {
         cmd/kube-controller-manager \
         cmd/kube-scheduler"
 
-	make generated_files
+    make generated_files
 
-	# Linux
+    # Linux
     export KUBE_BUILD_PLATFORMS="linux/amd64 linux/arm64"
 	hack/make-rules/build.sh -trimpath cmd/kubelet \
         cmd/kube-proxy \


### PR DESCRIPTION
During release we generate sha256 for all the files in the asset folder and upload to s3.  We have been doing this for everything in the asset folder, including the licenses files which feels unnecessary.  This tightens up the find a bit to just the tarballs and the binaries.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
