### PR TITLE
add build_check script to wait for buildkitd before building

### DIFF
--- a/build/lib/buildkit_check.sh
+++ b/build/lib/buildkit_check.sh
@@ -1,0 +1,31 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+function buildkit_ready() {
+  for i in {1..24}
+  do
+    if [ ! -S "/run/buildkit/buildkitd.sock" ]
+    then
+      echo "Buildkit daemon is not running. Retrying."
+      sleep 5s
+    else
+      exit 0
+    fi
+  done
+  echo "Buildkit daemon is not available"
+  exit 1
+}
+
+buildkit_ready


### PR DESCRIPTION
https://github.com/aws/eks-distro-prow-jobs/pull/229

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
