### PR TITLE
kubernetes/livenessprobe: fix attribution file generation

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -89,7 +89,7 @@ help: ## Display this help
 $(REPO):
 	git clone $(CLONE_URL) $(REPO)
 
-$(GIT_CHECKOUT_TARGET): $(REPO)
+$(GIT_CHECKOUT_TARGET): | $(REPO)
 	git -C $(REPO) checkout -f $(GIT_TAG)
 	touch $@
 

--- a/projects/kubernetes-csi/livenessprobe/Makefile
+++ b/projects/kubernetes-csi/livenessprobe/Makefile
@@ -6,13 +6,13 @@ REPO=livenessprobe
 COMPONENT=kubernetes-csi/$(REPO)
 
 LICENSE_PACKAGE_FILTER=./cmd/livenessprobe
-ADDITIONAL_ATTRIBUTION_DEPS=fix-licenses
-
 BINARY_TARGET=$(OUTPUT_BIN_DIR)/linux-amd64/livenessprobe
 
 LIVENESSPROBE_IMAGE?=$(IMAGE_REPO)/$(ECR_IMAGE_NAME):$(IMAGE_TAG)
 
 include $(BASE_DIRECTORY)/Common.mk
+
+$(ATTRIBUTION_TARGET): fix-licenses
 
 .PHONY: images
 images: livenessprobe/images/push
@@ -21,5 +21,5 @@ images: livenessprobe/images/push
 local-images: livenessprobe/images/amd64
 
 .PHONE: fix-licenses
-fix-licenses: gather-licenses
+fix-licenses: $(GATHER_LICENSES_TARGET)
 	build/fix_licenses.sh

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -61,7 +61,7 @@ $(BINARY_TARGET): export KUBE_GIT_VERSION=$(IMAGE_TAG)
 $(BINARY_TARGET): MAKEFLAGS=
 
 # Patch source before building
-$(BINARY_TARGET): $(GIT_PATCH_TARGET)
+$(BINARY_TARGET): | $(GIT_PATCH_TARGET)
 
 # There are a couple of fixes needed to the licenses and root-module name before running gather licenses
 $(GATHER_LICENSES_TARGET): fix-licenses

--- a/projects/kubernetes/kubernetes/build/fix_licenses.sh
+++ b/projects/kubernetes/kubernetes/build/fix_licenses.sh
@@ -18,7 +18,7 @@ set -o nounset
 set -o pipefail
 
 REPO="$1"
-OUTPUT_DIR="$1"
+OUTPUT_DIR="$2"
 
 # The heketi/heketi dependency is dual licensed between Apache 2.0 or LGPLv3+
 # this was done at the request of the kubernetes project since the original license
@@ -28,7 +28,7 @@ OUTPUT_DIR="$1"
 # https://github.com/kubernetes/kubernetes/pull/70828
 # Copy the apache2 license into place in the vendor directory
 cp $REPO/vendor/github.com/heketi/heketi/LICENSE-APACHE2 $REPO/vendor/github.com/heketi/heketi/LICENSE 
-rm $REPO/vendor/github.com/heketi/heketi/COPYING-*
+rm -f $REPO/vendor/github.com/heketi/heketi/COPYING-*
 
 # a number of k8s.io dependencies which come from the main repo show
 # up in the list and since they are in the repo they have no version


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Kubernetes, fix variable arg number.  Livenessprobe, fix target deps/pre-reqs, missed this in refactor PR.

Also adds ordering-only pre-reqs to avoid unnecessary clones + checkouts + patches due to files changing in repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
