### PR TITLE
Validate stash exists before popping, dry-run PR script in presubmit

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -129,6 +129,11 @@ gather-licenses: $(GATHER_LICENSES_TARGET)
 attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
 attribution: $(ATTRIBUTION_TARGET)
 
+.PHONY: attribution-pr
+attribution-pr: ## Generates PR to update attribution files for projects
+attribution-pr:
+	$(BASE_DIRECTORY)/build/update-attribution-files/create_pr.sh
+
 ##@ Tarball Targets
 
 .PHONY: tarballs
@@ -194,9 +199,9 @@ validate-checksums: $(BINARY_TARGET)
 ##@ Build Targets
 
 .PHONY: build
-build: ## Called via prow presubmit, calls `binaries gather-licenses clean-repo local-images attribution checksums` by default
+build: ## Called via prow presubmit, calls `binaries gather-licenses clean-repo local-images attribution checksums attribution-pr(dry-run)` by default
 build: FAKE_ARM_IMAGES_FOR_VALIDATION=true
-build: $(BINARY_TARGET) validate-checksums $(GATHER_LICENSES_TARGET) local-images $(ATTRIBUTION_TARGET)
+build: $(BINARY_TARGET) validate-checksums $(GATHER_LICENSES_TARGET) local-images $(ATTRIBUTION_TARGET) attribution-pr
 
 .PHONY: release
 release: ## Called via prow postsubmit + release jobs, calls `binaries gather-licenses clean-repo images` by default

--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -26,10 +26,8 @@ cd ${SCRIPT_ROOT}/../../
 git config --global push.default current
 git config user.name "EKS Distro PR Bot"
 git config user.email "aws-model-rocket-bots+eksdistroprbot@amazon.com"
-git remote add origin git@github.com:${ORIGIN_ORG}/eks-distro.git
-git remote add upstream https://github.com/${UPSTREAM_ORG}/eks-distro.git
-
-gh auth login --with-token < /secrets/github-secrets/token
+git config remote.origin.url >&- || git remote add origin git@github.com:${ORIGIN_ORG}/eks-distro.git
+git config remote.upstream.url >&- || git remote add upstream https://github.com/${UPSTREAM_ORG}/eks-distro.git
 
 # Files have already changed, stash to perform rebase
 git stash
@@ -38,36 +36,44 @@ git fetch upstream
 # -Xtheirs instructs git to favor the changes from the current branch
 git rebase -Xtheirs upstream/main
 
-git stash pop
+if [ "$(git stash list)" != "" ]; then
+    git stash pop
+fi
 
 function pr:create()
 {
-	local -r pr_title="$1"
-	local -r commit_message="$2"
-	local -r pr_branch="$3"
-	local -r pr_body="$4"
+    local -r pr_title="$1"
+    local -r commit_message="$2"
+    local -r pr_branch="$3"
+    local -r pr_body="$4"
 
-	local -r files_added=$(git diff --staged --name-only)
-	if [ "$files_added" = "" ]; then
-		return 0
-	fi
+    git diff --staged
+    local -r files_added=$(git diff --staged --name-only)
+    if [ "$files_added" = "" ]; then
+        return 0
+    fi
 
-	git checkout -b $pr_branch
-	git commit -m "$commit_message" || true
+    git checkout -b $pr_branch
+    git commit -m "$commit_message" || true
 
-	ssh-agent bash -c 'ssh-add /secrets/ssh-secrets/ssh-key; ssh -o StrictHostKeyChecking=no git@github.com; git push -u origin $pr_branch -f'
+    if [ "$JOB_TYPE" != "periodic" ]; then
+        return 0
+    fi
 
-	local -r pr_exists=$(gh pr list | grep -c "$pr_branch" || true)
-	if [ $pr_exists -eq 0 ]; then
-		gh pr create --title "$pr_title" --body "$pr_body"
-	fi
+    ssh-agent bash -c 'ssh-add /secrets/ssh-secrets/ssh-key; ssh -o StrictHostKeyChecking=no git@github.com; git push -u origin $pr_branch -f'
+
+    gh auth login --with-token < /secrets/github-secrets/token
+    local -r pr_exists=$(gh pr list | grep -c "$pr_branch" || true)
+    if [ $pr_exists -eq 0 ]; then
+        gh pr create --title "$pr_title" --body "$pr_body"
+    fi
 }
 
 function pr::create::attribution() {
-	local -r pr_title="Update ATTRIBUTION.txt files"
-	local -r commit_message="[PR BOT] Update ATTRIBUTION.txt files"
-	local -r pr_branch="attribution-files-update"
-	local -r pr_body=$(cat <<EOF
+    local -r pr_title="Update ATTRIBUTION.txt files"
+    local -r commit_message="[PR BOT] Update ATTRIBUTION.txt files"
+    local -r pr_branch="attribution-files-update"
+    local -r pr_body=$(cat <<EOF
 This PR updates the ATTRIBUTION.txt files across all dependency projects if there have been changes.
 
 This files should only be changing due to project GIT_TAG bumps or golang version upgrades.  If changes are for any other reason please review carefully! 
@@ -75,14 +81,14 @@ This files should only be changing due to project GIT_TAG bumps or golang versio
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
 EOF
 )
-	pr:create "$pr_title" "$commit_message" "$pr_branch" "$pr_body"
+    pr:create "$pr_title" "$commit_message" "$pr_branch" "$pr_body"
 }
 
 function pr::create::checksums() {
-	local -r pr_title="Update CHECKSUMS files"
-	local -r commit_message="[PR BOT] Update CHECKSUMS files"
-	local -r pr_branch="checksums-files-update"
-	local -r pr_body=$(cat <<EOF
+    local -r pr_title="Update CHECKSUMS files"
+    local -r commit_message="[PR BOT] Update CHECKSUMS files"
+    local -r pr_branch="checksums-files-update"
+    local -r pr_body=$(cat <<EOF
 This PR updates the CHECKSUMS files across all dependency projects if there have been changes.
 
 This files should only be changing due to golang version upgrades.  If changes are for any other reason please do not merge!
@@ -90,7 +96,7 @@ This files should only be changing due to golang version upgrades.  If changes a
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
 EOF
 )
-	pr:create "$pr_title" "$commit_message" "$pr_branch" "$pr_body"
+    pr:create "$pr_title" "$commit_message" "$pr_branch" "$pr_body"
 }
 
 # Add attribution files
@@ -105,7 +111,9 @@ pr::create::attribution
 
 git checkout main
 
-git stash pop
+if [ "$(git stash list)" != "" ]; then
+    git stash pop
+fi
 # Add checksum files
 for FILE in $(find . -type f -name CHECKSUMS); do    
     git add $FILE


### PR DESCRIPTION
* Replace tabs with spaces in script.
* Perform dry-run of attribution/checksum PR creation in presubmits
* Pop stash only if local changes were stashed in a previous step.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
