### PR TITLE
buildkit: fix retry logic

### DIFF
--- a/build/lib/buildkit.sh
+++ b/build/lib/buildkit.sh
@@ -13,20 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 BUILD_LIB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/" && pwd -P)"
 
 CMD="buildctl"
-if [ -f "/buildkit.sh" ] && ! buildctl debug workers > /dev/null 2>&1; then
+if [ -f "/buildkit.sh" ] && ! buildctl debug workers >/dev/null 2>&1; then
     # on the builder base this helper file exists to run buildkitd
     # in prow buildkitd is run as a seperate container so it will be running already
     # in codebuild its run directly on the instance so we want to use this helper
     CMD="/buildkit.sh"
-	
-	# From time to time we see random failures when creating/pushing images that fix on reruning the job
-	# this is an attempt to avoid failing key jobs, like the release job, with a flaky failure
-    for i in $(seq 1 5); do [ $i -gt 1 ] && sleep 15; $CMD "$@" && s=0 && break || s=$?; done; (exit $s)
-else
-	# skip retry when running locally
-	$CMD "$@"
-fi
 
+fi
+# From time to time we see random failures when creating/pushing images that fix on reruning the job
+# this is an attempt to avoid failing key jobs, like the release job, with a flaky failure
+# If running in builder base, most likely we are running in prow/codebuild, us retry logic
+# if not in builder base, probably running locally so skip the retry
+if [ -f "/buildkit.sh" ]; then
+    for i in $(seq 1 5); do
+        [ $i -gt 1 ] && sleep 15
+        $CMD "$@" && s=0 && break || s=$?
+    done
+    (exit $s)
+else
+    # skip retry when running locally
+    $CMD "$@"
+fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I incorrectly changed this script to not retry when running locally, but since prow uses buildctl directly I disabled retry in prow and then saw a failure in a postsubmit.  This fixes the logic to retry if in builder base at all.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
