### PR TITLE
Store image digests for pushed images in file

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -176,6 +176,8 @@ validate-checksums: $(BINARY_TARGET)
 %/images/push: IMAGE_OUTPUT?=push=true
 %/images/push: $(GATHER_LICENSES_TARGET) $(OUTPUT_DIR)/ATTRIBUTION.txt
 	$(BUILDCTL)
+	$(eval IMAGE_DIGEST=$(shell aws ecr-public describe-images --region us-east-1 --repository-name $(ECR_IMAGE_NAME) --image-ids imageTag=$(IMAGE_TAG) | jq -r '.imageDetails[].imageDigest'))
+	@echo "$(IMAGE_DIGEST)  $(IMAGE)" >> $(BASE_DIRECTORY)/image_digests
 
 %/images/amd64: ## Build image using buildkit only builds linux/amd64 and saves to local tar.
 %/images/amd64: IMAGE_PLATFORMS?=linux/amd64

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ postsubmit-build: setup
 		--image-repo=${IMAGE_REPO} \
 		--artifact-bucket=$(ARTIFACT_BUCKET) \
 		--dry-run=false
+	cat $(BASE_DIRECTORY)/image_digests
 
 .PHONY: kops-prow-arm
 kops-prow-arm: export NODE_INSTANCE_TYPE=t4g.medium
@@ -91,6 +92,7 @@ tag:
 
 .PHONY: upload
 upload:
+	@cat $(BASE_DIRECTORY)/image_digests
 	release/generate_crd.sh $(RELEASE_BRANCH) $(RELEASE) $(IMAGE_REPO)
 	release/s3_sync.sh $(RELEASE_BRANCH) $(RELEASE) $(ARTIFACT_BUCKET)
 	@echo 'Done' $(TARGET)


### PR DESCRIPTION
Creating a local file in checksum format (hash followed by two spaces, followed by artifact name) to fetch image digests for an image that was pushed in a previous step. This will be parsed during the release process to embed the digests into the manifest. This file will be created in the Prowjobs that push EKS Distro images, namely the build postsubmits and release postsubmits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
