### PR TITLE
fix kops subcommand from set to edit

### DIFF
--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -31,7 +31,7 @@ fi
 if [ ! -x ${KOPS} ]
 then
     echo "Determine kops version"
-    KOPS_VERSION="v1.22.0"
+    KOPS_VERSION="v1.22.3"
     echo "Download kops"
     KOPS_URL="https://github.com/kubernetes/kops/releases/download/${KOPS_VERSION}/kops-${OS}-${ARCH}"
     set -x

--- a/development/kops/set_nodeport_access.sh
+++ b/development/kops/set_nodeport_access.sh
@@ -23,7 +23,7 @@ $PREFLIGHT_CHECK_PASSED || exit 1
 # NodePort setting
 #
 export KOPS_FEATURE_FLAGS=SpecOverrideFlag
-${KOPS} set cluster "${KOPS_CLUSTER_NAME}" 'cluster.spec.nodePortAccess=0.0.0.0/0'
+${KOPS} edit cluster "${KOPS_CLUSTER_NAME}" 'cluster.spec.nodePortAccess=0.0.0.0/0'
 
 
 ADDITIONAL_ARGS=""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It looks like they have removed the set subcommand.  I *believe* edit will work the same way.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
