### PR TITLE
Use set flag with kops to configure nodeport

### DIFF
--- a/development/kops/set_nodeport_access.sh
+++ b/development/kops/set_nodeport_access.sh
@@ -23,7 +23,7 @@ $PREFLIGHT_CHECK_PASSED || exit 1
 # NodePort setting
 #
 export KOPS_FEATURE_FLAGS=SpecOverrideFlag
-${KOPS} edit cluster "${KOPS_CLUSTER_NAME}" 'cluster.spec.nodePortAccess=0.0.0.0/0'
+${KOPS} edit cluster "${KOPS_CLUSTER_NAME}" --set 'cluster.spec.nodePortAccess=0.0.0.0/0'
 
 
 ADDITIONAL_ARGS=""


### PR DESCRIPTION
This seems to be the proper syntax for updating cluster spec fields since kops `v1.22.0`.

```
$ kops edit cluster --help
Usage:
  kops edit cluster [CLUSTER] [flags]

Examples:
  # Edit a cluster configuration in AWS.
  kops edit cluster k8s.cluster.site --state=s3://my-state-store

Flags:
  -h, --help            help for cluster
      --set strings     Directly set values in the spec
      --unset strings   Directly unset values in the spec
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
