### PR TITLE
Pass cluster name as flag instead of positional argument

### DIFF
--- a/development/kops/set_nodeport_access.sh
+++ b/development/kops/set_nodeport_access.sh
@@ -23,7 +23,7 @@ $PREFLIGHT_CHECK_PASSED || exit 1
 # NodePort setting
 #
 export KOPS_FEATURE_FLAGS=SpecOverrideFlag
-${KOPS} edit cluster "${KOPS_CLUSTER_NAME}" --set 'cluster.spec.nodePortAccess=0.0.0.0/0'
+${KOPS} edit cluster --name "${KOPS_CLUSTER_NAME}" --set 'cluster.spec.nodePortAccess=0.0.0.0/0'
 
 
 ADDITIONAL_ARGS=""


### PR DESCRIPTION
We set `KOPS_CLUSTER_NAME` as an env var, which gets set as the [default value for the `--name` flag](https://github.com/kubernetes/kops/blob/v1.22.3/cmd/kops/root.go#L138-L139). So passing it as a positional argument makes kOps see the value as coming from two places, so it fails.

Note: Just removing the cluster name (positional arg) from the command would also work, but explicitly specifying it with `--name` helps us track exactly what values were passed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
