### PR TITLE
fix 1-22 dev release build and kops script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ stop-docker-builder:
 
 .PHONY: run-buildkit-and-registry
 run-buildkit-and-registry:
-	docker run -d --name buildkitd --net host --privileged moby/buildkit:v0.9.0-rootless
+	docker run -d --name buildkitd --net host --privileged moby/buildkit:v0.9.3-rootless
 	docker run -d --name registry  --net host registry:2
 
 .PHONY: stop-buildkit-and-registry

--- a/projects/kubernetes/release/1-22/ATTRIBUTION.txt
+++ b/projects/kubernetes/release/1-22/ATTRIBUTION.txt
@@ -1,5 +1,5 @@
 
-** k8s.io/release/images/build/go-runner; version v0.9.0 --
+** k8s.io/release/images/build/go-runner; version v0.12.0 --
 https://github.com/kubernetes/release
 
 

--- a/release/prow-release.sh
+++ b/release/prow-release.sh
@@ -28,10 +28,6 @@ cd ${BASE_DIRECTORY}
 RELEASE_ENVIRONMENT=${RELEASE_ENVIRONMENT:-development}
 
 export RELEASE=$(cat ${BASE_DIRECTORY}/release/${RELEASE_BRANCH}/${RELEASE_ENVIRONMENT}/RELEASE)
-export KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/${RELEASE_BRANCH}/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
-export PRESUBMIT_KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/${RELEASE_BRANCH}/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
-export BASE_REPO=${BASE_REPO:-${IMAGE_REPO}}
-export BASE_IMAGE=${BASE_IMAGE:-public.ecr.aws/eks-distro-build-tooling/eks-distro-base:$(cat ${BASE_DIRECTORY}/EKS_DISTRO_BASE_TAG_FILE)}
 
 if [ "${RELEASE}" == "0" ]
 then

--- a/release/prow.sh
+++ b/release/prow.sh
@@ -25,7 +25,7 @@ export RELEASE=$(cat ${BASE_DIRECTORY}/release/${RELEASE_BRANCH}/${RELEASE_ENVIR
 
 if [ "${RELEASE}" == "0" ]
 then
-    echo "No production release zero"
+    echo "No dev release zero"
     exit 0
 fi
 

--- a/release/prow.sh
+++ b/release/prow.sh
@@ -22,10 +22,12 @@ cd ${BASE_DIRECTORY}
 RELEASE_ENVIRONMENT=${RELEASE_ENVIRONMENT:-development}
 
 export RELEASE=$(cat ${BASE_DIRECTORY}/release/${RELEASE_BRANCH}/${RELEASE_ENVIRONMENT}/RELEASE)
-export KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/${RELEASE_BRANCH}/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
-export PRESUBMIT_KUBE_BASE_TAG=$(cat ${BASE_DIRECTORY}/projects/kubernetes/release/${RELEASE_BRANCH}/GIT_TAG)-eks-${RELEASE_BRANCH}-${RELEASE}
-export BASE_REPO=${BASE_REPO:-${IMAGE_REPO}}
-export BASE_IMAGE=${BASE_IMAGE:-public.ecr.aws/eks-distro-build-tooling/eks-distro-base:$(cat ${BASE_DIRECTORY}/EKS_DISTRO_BASE_TAG_FILE)}
+
+if [ "${RELEASE}" == "0" ]
+then
+    echo "No production release zero"
+    exit 0
+fi
 
 cp -r /$HOME/.docker ${BASE_DIRECTORY}
 export DOCKER_CONFIG=${BASE_DIRECTORY}/.docker


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- The 1-22 builds were getting overwritten by the dev-release build settings and using the non-minimal images.  This should fix that
- Tweaked the kops script to better handle the new version esp wrt the older kube versions.

The kops roles changes to add the newly required perm has been rolled out to prod so we should see passing conformance builds for at least 1.18-1.21.

Testing

Created 1.18-1.21 clusters with kops locally and they all came up correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
