### PR TITLE
kubernetes: fix version file validation by remove .pre for postsubmits

### DIFF
--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -98,7 +98,7 @@ fix-licenses:
 
 .PHONY: update-version
 update-version:
-	build/create_version_file.sh $(GIT_TAG) $(RELEASE_BRANCH) $(IMAGE_TAG:.minimal=)
+	build/create_version_file.sh $(GIT_TAG) $(RELEASE_BRANCH) $(IMAGE_TAG:.pre=)
 
 .PHONY: validate-version-file
 validate-version-file: update-version


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In postsubmits we now make the tag `(release+1).pre` to avoid overwriting the artifacts pushed for the actual release build.  This removes the code we used to use to remove the .minimal and replaces it with removing the .pre for the kube-verison-file validation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
