### PR TITLE
trigger a full postubmit rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,3 +209,4 @@ only-index-md-from-existing-release-manifest:
 		--includeREADME=false \
 		--includeDocsIndex=false \
 		--force=true
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Because previous post submit jobs failed and didnt build all the projects and push all the artifacts all new post submits will continue failing.  This is the hack we usually do to trigger a full build in the post submit job.  That tool looks for a changes a couple files, like the main Makefile, and if there are changes triggers everything to build and push.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
