### PR TITLE
kube: tag head in source tarball for downstream building

### DIFF
--- a/projects/kubernetes/kubernetes/build/create_tarballs.sh
+++ b/projects/kubernetes/kubernetes/build/create_tarballs.sh
@@ -41,6 +41,16 @@ TAR_OUTPUT_DIR=${OUTPUT_DIR}/tar/${RELEASE_BRANCH}
 mkdir -p $TAR_OUTPUT_DIR
 build::common::ensure_tar
 build::tarballs::create_tarballs $BIN $OUTPUT_RELEASE_DIR $TAR_OUTPUT_DIR
+
+# exclude helper files used for make targets
+echo "eks-distro-checkout-$GIT_TAG export-ignore" >> $SOURCE_DIR/.git/info/attributes
+echo "eks-distro-patched export-ignore" >> $SOURCE_DIR/.git/info/attributes
+
+# Tag current HEAD of repo which includes the patches so that when the archive is created
+# the proper tag will be written into the hack/lib/version.sh file for anyone building from 
+# this source tarball
+git -C $SOURCE_DIR tag -f $GIT_TAG-eks
+
 git \
     -C $SOURCE_DIR \
     archive \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We have always published the kubernetes source with our patches applied during releases.  We know have another team looking to build from this source tarball.

When git archive is used to create a tarball, it excludes the .git directory to avoid unnecessary size of the final tarball.  This matches what upstream kube does as well.  To deal with this, the upstream file, [verison.sh](https://github.com/kubernetes/kubernetes/blob/master/hack/lib/version.sh#L51) is modified on export, via .[gitattributes](https://github.com/kubernetes/kubernetes/blob/master/hack/lib/.gitattributes), to have the current tag value hardcoded in the script source.  This way if someone builds from this source, it will use that tag as the version.  

Since we patch kubernetes when building, we do not have a tag that points to HEAD.  This caused git archive to just hardcode HEAD into the version.sh script instead of a more reasonable tag.  This PR tags the local repo before exporting the source so that on export the version.sh file is properly modified.

Note: I have am using `${GIT_TAG}-eks` for now, which kind of matches how we tag our images.  I think in the future I want to change this to be `${GIT_TAG}-eks-${SHORT_GITCOMMIT}` to be more informative when someone runs `{binary} version` and closer match the EKS pattern.  I do not want to make that change super quick so for now I think this proposed change is a solid improvement.

I have also gone ahead and exclude a couple files we create during the make process.

I ran this locally and this is what is in the verison.sh file after export:

```
 if [[ 'HEAD, tag: v1.21.5-eks' =~ tag:\ (v[^ ,]+) ]]; then
     KUBE_GIT_VERSION="${BASH_REMATCH[1]}"
 fi
```

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
