### PR TITLE
kops: handle kubectl download failure and amd/arm overwriting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ kops-prow-arm: export NODE_ARCHITECTURE=arm64
 kops-prow-arm: postsubmit-build
 	$(eval MINOR_VERSION=$(subst 1-,,$(RELEASE_BRANCH)))
 	if [[ $(MINOR_VERSION) -ge 21 ]]; then \
+		sleep 5m; \
 		RELEASE=$(RELEASE) development/kops/prow.sh; \
 	fi;
 

--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -49,9 +49,19 @@ then
     KUBECTL_VERSION=$(cat ${BASEDIR}/../../projects/kubernetes/kubernetes/${RELEASE_BRANCH}/GIT_TAG)
     KUBECTL_PATH=${BASEDIR}/bin/kubectl
     mkdir -p ${BASEDIR}/bin
-    set -x
-    curl -sSL "${ARTIFACT_URL}/kubernetes/${KUBECTL_VERSION}/bin/${OS}/${ARCH}/kubectl" -o ${KUBECTL_PATH}
-    chmod +x ${KUBECTL_PATH}
-    set +x
+    COUNT=0
+    while [ ! "$(${KUBECTL_PATH} version --client true --short)" ]; do
+        sleep 5
+        COUNT=$(expr $COUNT + 1)
+        if [ $COUNT -gt 120 ]
+        then
+            echo "Failed to download kubectl"
+            exit 1
+        fi
+        set -x
+        curl -sSL "${ARTIFACT_URL}/kubernetes/${KUBECTL_VERSION}/bin/${OS}/${ARCH}/kubectl" -o ${KUBECTL_PATH}
+        chmod +x ${KUBECTL_PATH}
+        set +x
+    done
 fi
 exit 0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There we two postsubmit failures earlier today.

- We have seen this a number of times before and I believe its due to multiple postsubmits running at once, but sometimes kubectl fails to download from s3.  I believe this is a timing thing where one job is updating it and another is trying to download at the same time...  
```
/home/prow/go/src/github.com/aws/eks-distro/development/kops/bin/kubectl: line 1: syntax error near unexpected token `newline'
/home/prow/go/src/github.com/aws/eks-distro/development/kops/bin/kubectl: line 1: `<?xml version="1.0" encoding="UTF-8"?>'
```
This PR adds a retry loop making sure it gets downloaded correctly before continuing.

- We have also the other one that has to do with the arm and amd tests, which only run for 1.21+, trying to update the kubeconfig at the same time.  

`Error: open /root/.kube/config.lock: file exists`
This PRs adds a 5m sleep before kicking off the arm tests to try avoid these overlaps.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
