### PR TITLE
kops: fix metrics server for 1.22 now that it uses a newer version

### DIFF
--- a/development/kops/cluster_wait.sh
+++ b/development/kops/cluster_wait.sh
@@ -34,21 +34,28 @@ do
     echo 'Waiting for cluster to come up...'
 done
 
-# In kops 1-22 metrics was updated and the port was changed to 443 from 4443. In the verison of metrics server we ship, it does not support binding to 443
+# In kops 1-22 metrics was updated and the port was changed to 443 from 4443. In the verison of metrics server we ship for kube versions < 1-22, it does not support binding to 443
 # patching back to old port and behavior
-PATCH='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--secure-port=4443" },{"op": "replace", "path": "/spec/template/spec/containers/0/ports/0/containerPort", "value": 4443 }]'
-while ! kubectl --context $KOPS_CLUSTER_NAME  -n kube-system patch deployments metrics-server --type=json -p="$PATCH"
-do
-    sleep 5
-    COUNT=$(expr $COUNT + 1)
-    if [ $COUNT -gt 120 ]
-    then
-        echo "Failed to configure metrics server"
-        exit 1
-    fi
-    echo 'Waiting for cluster to come up...'
-done
+if [ "${RELEASE_BRANCH}" != "1-22" ]; then
+    PATCH='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--secure-port=4443" },{"op": "replace", "path": "/spec/template/spec/containers/0/ports/0/containerPort", "value": 4443 }]'
+    while ! kubectl --context $KOPS_CLUSTER_NAME  -n kube-system patch deployments metrics-server --type=json -p="$PATCH"
+    do
+        sleep 5
+        COUNT=$(expr $COUNT + 1)
+        if [ $COUNT -gt 120 ]
+        then
+            echo "Failed to configure metrics server"
+            exit 1
+        fi
+        echo 'Waiting for cluster to come up...'
+    done
+fi
 
+# kops 1-22 installs an older metrics server than we ship with eksd 1.22 along with an older clusterrole def.  The 0.6 version of metrics requires a slightly different rbac setup
+# Appling the clusterrole from the metrics repo fixes the permissions
+if [ "${RELEASE_BRANCH}" == "1-22" ]; then
+    kubectl --context $KOPS_CLUSTER_NAME apply -f metrics-server-0.6-clusterrole.yaml
+fi
 
 set -x
 ${KOPS} validate cluster --wait 15m

--- a/development/kops/metrics-server-0.6-clusterrole.yaml
+++ b/development/kops/metrics-server-0.6-clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/metrics
+  - namespaces
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the 0.6 release metrics server requires nodes/metrics RBAC resource instead of nodes/stats.  This patches the clusterrole that kops created, which is for the .5 release to have the proper rbac.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
