### PR TITLE
kube: fix building twice due to path mismatch

### DIFF
--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -43,7 +43,10 @@ IMAGE_OUTPUT_DIR=$(OUTPUT_DIR)/images/bin/$(IMAGE_PLATFORMS)
 LICENSE_PACKAGE_FILTER=./cmd/kubelet ./cmd/kube-proxy ./cmd/kubeadm ./cmd/kubectl ./cmd/kube-apiserver ./cmd/kube-controller-manager ./cmd/kube-scheduler
 
 # Since we are overriding the building of binaries, just pick 1 of the binaries as the target
+# kubernetes outputs to linux/amd64 instead of linux-amd64, have to override binary_targets as well
 BINARY_TARGET_FILES=kubelet
+BINARY_TARGETS=$(OUTPUT_BIN_DIR)/linux/amd64/kubelet
+
 SIMPLE_CREATE_BINARIES=false
 SIMPLE_CREATE_TARBALLS=false
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Kubernetes was building twice because the default output path is `linux-amd64`, but kube was building to `linux/amd64` and I *think* always has been.  This overrides the binary_target to avoid this.  The dockerfile and everything else was already pointing to the correct `linux/amd64` paths.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
