### PR TITLE
use cilium for kops conformance tests runs

### DIFF
--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -67,6 +67,7 @@ controlPlaneInstanceProfileArn: $CONTROL_PLANE_INSTANCE_PROFILE
 nodeInstanceProfileArn: $NODE_INSTANCE_PROFILE
 instanceType: $NODE_INSTANCE_TYPE
 architecture: $NODE_ARCHITECTURE
+ipv6: false
 pause:
 $(get_container_yaml kubernetes/pause $RELEASE)
 kube_apiserver:

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -8,6 +8,9 @@ spec:
   authorization:
     rbac: {}
   channel: stable
+  {{if .ipv6}}
+  cloudControllerManager: {}
+  {{end}}
   cloudProvider: aws
   configBase: {{ .configBase }}
   containerRuntime: docker
@@ -36,24 +39,44 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
+  {{if .ipv6}}
+  - ::/0
+  {{end}}
   kubernetesVersion: {{ .kubernetesVersion }}
   masterPublicName: api.{{ .clusterName }}
   networkCIDR: 172.20.0.0/16
   networking:
-    kubenet: {}
-  nonMasqueradeCIDR: 100.64.0.0/10
+    cilium:
+      chainingMode: portmap
+  {{if .ipv6}}
+  nonMasqueradeCIDR: ::/0
+  {{else}}
+    nonMasqueradeCIDR: 100.64.0.0/10
+  {{end}}
   sshAccess:
   - 0.0.0.0/0
+  {{if .ipv6}}
+  - ::/0
+  {{end}}
   subnets:
   - cidr: 172.20.32.0/19
+    {{if .ipv6}}
+    ipv6CIDR: /64#0
+    {{end}}
     name: {{.awsRegion}}a
     type: Public
     zone: {{.awsRegion}}a
   - cidr: 172.20.64.0/19
+    {{if .ipv6}}
+    ipv6CIDR: /64#1
+    {{end}}
     name: {{.awsRegion}}b
     type: Public
     zone: {{.awsRegion}}b
   - cidr: 172.20.96.0/19
+    {{if .ipv6}}
+    ipv6CIDR: /64#2
+    {{end}}
     name: {{.awsRegion}}c
     type: Public
     zone: {{.awsRegion}}c

--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -31,7 +31,7 @@ fi
 if [ ! -x ${KOPS} ]
 then
     echo "Determine kops version"
-    KOPS_VERSION="v1.22.3"
+    KOPS_VERSION="v1.23.0"
     echo "Download kops"
     KOPS_URL="https://github.com/kubernetes/kops/releases/download/${KOPS_VERSION}/kops-${OS}-${ARCH}"
     set -x

--- a/development/kops/run_sonobuoy.sh
+++ b/development/kops/run_sonobuoy.sh
@@ -22,9 +22,9 @@ $PREFLIGHT_CHECK_PASSED || exit 1
 echo "Download sonobuoy"
 if [ "$(uname)" == "Darwin" ]
 then
-  SONOBUOY=https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.53.2/sonobuoy_0.53.2_darwin_amd64.tar.gz
+  SONOBUOY=https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.56.2/sonobuoy_0.56.2_darwin_amd64.tar.gz
 else
-  SONOBUOY=https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.53.2/sonobuoy_0.53.2_linux_amd64.tar.gz
+  SONOBUOY=https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.56.2/sonobuoy_0.56.2_linux_amd64.tar.gz
 fi
 CONFORMANCE_IMAGE=k8s.gcr.io/conformance:${KUBERNETES_VERSION}
 wget -qO- ${SONOBUOY} |tar -xz sonobuoy
@@ -60,8 +60,8 @@ function save_results() {
     cp ./${KOPS_CLUSTER_NAME}/results/plugins/e2e/results/global/* /logs/artifacts/$NODE_ARCHITECTURE-$run
   fi
 
-  ./sonobuoy --context ${KOPS_CLUSTER_NAME} e2e ${results}
-  if ./sonobuoy --context ${KOPS_CLUSTER_NAME} e2e ${results} | grep 'failed tests: 0'; then
+  ./sonobuoy results --plugin e2e ${results}
+  if ./sonobuoy results --plugin e2e ${results} | grep 'Status: passed'; then
     return 0
   else
     return 1
@@ -78,5 +78,5 @@ while ! save_results $COUNT; do
     exit 1
   fi
   ./sonobuoy --context ${KOPS_CLUSTER_NAME} delete --all --wait
-  ./sonobuoy --context ${KOPS_CLUSTER_NAME} e2e ${results} --rerun-failed --wait --kube-conformance-image ${CONFORMANCE_IMAGE}  
+  ./sonobuoy --context ${KOPS_CLUSTER_NAME} run --rerun-failed ${results} --wait --kube-conformance-image ${CONFORMANCE_IMAGE}  
 done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Kops supports ipv6 now, but not with the default cni.  Switching to use cilium which better matches eks-a.  I want to see if this passes for existing ipv4 based clusters.

Will probably revert this after testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
