### PR TITLE
run 1-21 + 1-22 arm kops cluster as ipv6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ kops-prow-arm: kops-prereqs
 	$(eval MINOR_VERSION=$(subst 1-,,$(RELEASE_BRANCH)))
 	if [[ $(MINOR_VERSION) -ge 21 ]]; then \
 		sleep 5m; \
-		RELEASE=$(RELEASE) development/kops/prow.sh; \
+		IPV6=true RELEASE=$(RELEASE) development/kops/prow.sh; \
 	fi;
 
 .PHONY: kops-prow-amd

--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -67,7 +67,7 @@ controlPlaneInstanceProfileArn: $CONTROL_PLANE_INSTANCE_PROFILE
 nodeInstanceProfileArn: $NODE_INSTANCE_PROFILE
 instanceType: $NODE_INSTANCE_TYPE
 architecture: $NODE_ARCHITECTURE
-ipv6: false
+ipv6: $IPV6
 pause:
 $(get_container_yaml kubernetes/pause $RELEASE)
 kube_apiserver:

--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -22,7 +22,7 @@ export RELEASE=${RELEASE:-${DEFAULT_RELEASE}}
 export ARTIFACT_BASE_URL="https://distro.eks.amazonaws.com"
 export NODE_INSTANCE_TYPE=${NODE_INSTANCE_TYPE:-t3.medium}
 export NODE_ARCHITECTURE=${NODE_ARCHITECTURE:-amd64}
-export IPV6=${IPV6:false}
+export IPV6=${IPV6:-false}
 
 if [ -n "$ARTIFACT_BUCKET" ]; then
     export ARTIFACT_BASE_URL="https://$ARTIFACT_BUCKET.s3.amazonaws.com"

--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -22,6 +22,7 @@ export RELEASE=${RELEASE:-${DEFAULT_RELEASE}}
 export ARTIFACT_BASE_URL="https://distro.eks.amazonaws.com"
 export NODE_INSTANCE_TYPE=${NODE_INSTANCE_TYPE:-t3.medium}
 export NODE_ARCHITECTURE=${NODE_ARCHITECTURE:-amd64}
+export IPV6=${IPV6:false}
 
 if [ -n "$ARTIFACT_BUCKET" ]; then
     export ARTIFACT_BASE_URL="https://$ARTIFACT_BUCKET.s3.amazonaws.com"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Current 1-22 kube proxy is broken for ipv6. This test will hopefully confirm there are failing conformance tests due to this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
