### PR TITLE
kops test: switch back to kops managed cilium and fix session affin

### DIFF
--- a/development/kops/cluster_wait.sh
+++ b/development/kops/cluster_wait.sh
@@ -19,52 +19,56 @@ BASEDIR=$(dirname "$0")
 source ${BASEDIR}/set_environment.sh
 $PREFLIGHT_CHECK_PASSED || exit 1
 
+
+function retry {
+  local n=1
+  local max=120
+  local delay=5
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        echo "Command failed. Attempt $n/$max:"
+        sleep $delay;
+      else
+        fail "The command has failed after $n attempts."
+      fi
+    }
+  done
+}
+
+function k {
+    retry kubectl --context $KOPS_CLUSTER_NAME "$@"
+}
+
 # Add IAM configmap
 COUNT=0
 echo 'Waiting for cluster to come up...'
-while ! kubectl --context $KOPS_CLUSTER_NAME apply -f ./${KOPS_CLUSTER_NAME}/aws-iam-authenticator.yaml
-do
-    sleep 5
-    COUNT=$(expr $COUNT + 1)
-    if [ $COUNT -gt 120 ]
-    then
-        echo "Failed to configure IAM"
-        exit 1
-    fi
-    echo 'Waiting for cluster to come up...'
-done
+k apply -f ./${KOPS_CLUSTER_NAME}/aws-iam-authenticator.yaml
+
 
 # In kops 1-22 metrics was updated and the port was changed to 443 from 4443. In the verison of metrics server we ship for kube versions < 1-22, it does not support binding to 443
 # patching back to old port and behavior
 if [ "${RELEASE_BRANCH}" != "1-22" ]; then
     PATCH='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--secure-port=4443" },{"op": "replace", "path": "/spec/template/spec/containers/0/ports/0/containerPort", "value": 4443 }]'
-    while ! kubectl --context $KOPS_CLUSTER_NAME  -n kube-system patch deployments metrics-server --type=json -p="$PATCH"
-    do
-        sleep 5
-        COUNT=$(expr $COUNT + 1)
-        if [ $COUNT -gt 120 ]
-        then
-            echo "Failed to configure metrics server"
-            exit 1
-        fi
-        echo 'Waiting for cluster to come up...'
-    done
+    k  -n kube-system patch deployments metrics-server --type=json -p="$PATCH"    
 fi
 
 # kops 1-22 installs an older metrics server than we ship with eksd 1.22 along with an older clusterrole def.  The 0.6 version of metrics requires a slightly different rbac setup
 # Appling the clusterrole from the metrics repo fixes the permissions
 if [ "${RELEASE_BRANCH}" == "1-22" ]; then
-    kubectl --context $KOPS_CLUSTER_NAME apply -f metrics-server-0.6-clusterrole.yaml
+    k apply -f metrics-server-0.6-clusterrole.yaml
 fi
 
-# We do not let kops install the cni, instead we install the eks-a cilium build to better match eksa
-export HELM_EXPERIMENTAL_OCI=1
-CILIUM_REGISTRY="public.ecr.aws/isovalent"
-CILIUM_TAG="v1.9.13-eksa.2"
-helm install cilium oci://$CILIUM_REGISTRY/cilium  --version ${CILIUM_TAG#"v"} --namespace kube-system  \
-    --set operator.image.tag=$CILIUM_TAG --set image.tag=$CILIUM_TAG \
-    --set image.repository="$CILIUM_REGISTRY/cilium" --set operator.image.repository="$CILIUM_REGISTRY/operator" \
-    --set cni.chainingMode="portmap" --set rollOutCiliumPods=true
+# kops doesnt support setting these cilium values
+# session affinity for conformance tess
+# kube-proxy disabled to make sure we are validating our kube-proxy
+k -n kube-system patch cm/cilium-config --type merge -p '{"data":{"enable-session-affinity":"true"}}'
+k -n kube-system rollout restart deployment/cilium-operator
+k -n kube-system rollout status deployment/cilium-operator --timeout=30s
+k -n kube-system delete pods -lk8s-app=cilium
 
 set -x
 ${KOPS} validate cluster --wait 15m
+
+# --set ipam.mode="kubernetes" 

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -46,7 +46,8 @@ spec:
   masterPublicName: api.{{ .clusterName }}
   networkCIDR: 172.20.0.0/16
   networking:
-    cni: {}      
+    cilium:
+      chainingMode: portmap
   {{if .ipv6}}
   nonMasqueradeCIDR: ::/0
   {{else}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This switches back to the kops managed cilium and settings enable session affinity to fix the 3 failing conformance.  From local testing, I believe this configuration should show passes for all the ipv4 runs and then the ipv6/arm 1.21 cluster *should* pass and then the 1.22 one should fail due to the bad kube-proxy. 🤞  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
