### PR TITLE
kops: only run ipv6 for 122

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,11 @@ postsubmit-build: setup
 .PHONY: kops-prow-arm
 kops-prow-arm: export NODE_INSTANCE_TYPE=t4g.medium
 kops-prow-arm: export NODE_ARCHITECTURE=arm64
-kops-prow-arm: export IPV6=true
 kops-prow-arm: kops-prereqs
 	$(eval MINOR_VERSION=$(subst 1-,,$(RELEASE_BRANCH)))
+	if [[ $(MINOR_VERSION) -ge 22 ]]; then \
+		export IPV6=true; \
+	fi; \
 	if [[ $(MINOR_VERSION) -ge 21 ]]; then \
 		sleep 5m; \
 		RELEASE=$(RELEASE) development/kops/prow.sh; \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
121 seems to have issues, change it to only run ipv6 for the 122 arm cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
