### PR TITLE
fix versions for metrics server and iam auth and add validation for v…

### DIFF
--- a/projects/coredns/coredns/Makefile
+++ b/projects/coredns/coredns/Makefile
@@ -28,6 +28,23 @@ SIMPLE_CREATE_TARBALLS=false
 include $(BASE_DIRECTORY)/Common.mk
 
 
+build: validate-cli-version
+release: validate-cli-version
+
+# To ensure this will work on mac, instead of building those archs
+# only build it when run. on a linux builder this extra make will be a noop
+.PHONY: validate-cli-version
+validate-cli-version: CLI=$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$(REPO)
+validate-cli-version:
+	$(MAKE) $(CLI) BINARY_PLATFORMS=$(BUILDER_PLATFORM)
+	$(CLI) --version
+	@if [[ "$$($(CLI) --version)" != *"CoreDNS-$(GIT_TAG:v%=%)"* ]]; then \
+		echo "Version set incorrectly on cli!"; \
+		exit 1; \
+	fi
+
+
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/etcd-io/etcd/Makefile
+++ b/projects/etcd-io/etcd/Makefile
@@ -23,6 +23,22 @@ HAS_S3_ARTIFACTS=true
 include $(BASE_DIRECTORY)/Common.mk
 
 
+build: validate-cli-version
+release: validate-cli-version
+
+# To ensure this will work on mac, instead of building those archs
+# only build it when run. on a linux builder this extra make will be a noop
+.PHONY: validate-cli-version
+validate-cli-version: CLI=$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$(REPO)
+validate-cli-version:
+	$(MAKE) $(CLI) BINARY_PLATFORMS=$(BUILDER_PLATFORM)
+	$(CLI) --version
+	@if [[ "$$($(CLI) --version)" != *"etcd Version: $(GIT_TAG:v%=%)"* ]]; then \
+		echo "Version set incorrectly on cli!"; \
+		exit 1; \
+	fi
+
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/etcd-io/etcd/README.md
+++ b/projects/etcd-io/etcd/README.md
@@ -16,7 +16,8 @@ version if greater than the one used in upstream Kubernetes.
 1. Update the `GIT_TAG` file to have the new desired version based on the upstream release tags.
 1. Compare the old tag to the new, looking specifically for changes to the `build` file in the root of the repo. 
 ex: [3.4.14 compared to 3.4.15](https://github.com/etcd-io/etcd/compare/v3.4.14...v3.4.15). Check for any build flag changes, tag changes, dependencies, etc.
-The EKS-D build does not call the build script from usptream directly so pay close attention to any `go build` changes.
+The EKS-D build does not call the build script from usptream directly so pay close attention [build.sh](https://github.com/etcd-io/etcd/blob/main/scripts/build.sh) for changes
+to ldflags.
 1. Verify the golang version has not changed. The version specified in `go.mod` seems to be kept up to date.
 1. Update checksums and attribution using `make update-attribution-checksums-docker PROJECT=etcd-io/etcd RELEASE_BRANCH=<release_branch>` from the root of the repo.
 1. Update the version at the top of this Readme.

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-18/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-18/CHECKSUMS
@@ -1,4 +1,4 @@
-97ba109cf2c7f0c52cbe99ee3beec637fcebecde29cef73aa53a537acd157287  _output/1-18/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-da0dc57a95d934a143d43b245dae979c996072ac91d3b8ce0e1ba89fc4a33227  _output/1-18/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-8f0e5891d9da2fbdf51203cfd8c9bf493f417e2c97b711cae8c87f20398dcb8e  _output/1-18/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-5d92bdcd64b50b44ffc6c99a13fd6e4c651e3774d2d44d23a8f266dbb28ae256  _output/1-18/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+a224e3b1f5424539cec7a91c862c3baee36a9a7fa8e0fa3ef7278aedb0a19752  _output/1-18/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+78b8ed62b8352d024d1f6ca66c42ea7c3a482cc8463b5af5c2a0e2e6ea4ac2d7  _output/1-18/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+9ccbcd3ac656f1168b7b2661af00a1df85d9a764d427cd556e0afaa60839096e  _output/1-18/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+974b8aaa05a60b1c4bf10282f6c9bbd2bf5365cc72785579a21a399ff58b9656  _output/1-18/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-19/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-19/CHECKSUMS
@@ -1,4 +1,4 @@
-97ba109cf2c7f0c52cbe99ee3beec637fcebecde29cef73aa53a537acd157287  _output/1-19/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-da0dc57a95d934a143d43b245dae979c996072ac91d3b8ce0e1ba89fc4a33227  _output/1-19/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-8f0e5891d9da2fbdf51203cfd8c9bf493f417e2c97b711cae8c87f20398dcb8e  _output/1-19/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-5d92bdcd64b50b44ffc6c99a13fd6e4c651e3774d2d44d23a8f266dbb28ae256  _output/1-19/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+a224e3b1f5424539cec7a91c862c3baee36a9a7fa8e0fa3ef7278aedb0a19752  _output/1-19/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+78b8ed62b8352d024d1f6ca66c42ea7c3a482cc8463b5af5c2a0e2e6ea4ac2d7  _output/1-19/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+9ccbcd3ac656f1168b7b2661af00a1df85d9a764d427cd556e0afaa60839096e  _output/1-19/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+974b8aaa05a60b1c4bf10282f6c9bbd2bf5365cc72785579a21a399ff58b9656  _output/1-19/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-20/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-20/CHECKSUMS
@@ -1,4 +1,4 @@
-97ba109cf2c7f0c52cbe99ee3beec637fcebecde29cef73aa53a537acd157287  _output/1-20/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-da0dc57a95d934a143d43b245dae979c996072ac91d3b8ce0e1ba89fc4a33227  _output/1-20/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-8f0e5891d9da2fbdf51203cfd8c9bf493f417e2c97b711cae8c87f20398dcb8e  _output/1-20/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-5d92bdcd64b50b44ffc6c99a13fd6e4c651e3774d2d44d23a8f266dbb28ae256  _output/1-20/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+a224e3b1f5424539cec7a91c862c3baee36a9a7fa8e0fa3ef7278aedb0a19752  _output/1-20/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+78b8ed62b8352d024d1f6ca66c42ea7c3a482cc8463b5af5c2a0e2e6ea4ac2d7  _output/1-20/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+9ccbcd3ac656f1168b7b2661af00a1df85d9a764d427cd556e0afaa60839096e  _output/1-20/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+974b8aaa05a60b1c4bf10282f6c9bbd2bf5365cc72785579a21a399ff58b9656  _output/1-20/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-21/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-21/CHECKSUMS
@@ -1,4 +1,4 @@
-97ba109cf2c7f0c52cbe99ee3beec637fcebecde29cef73aa53a537acd157287  _output/1-21/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-da0dc57a95d934a143d43b245dae979c996072ac91d3b8ce0e1ba89fc4a33227  _output/1-21/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-8f0e5891d9da2fbdf51203cfd8c9bf493f417e2c97b711cae8c87f20398dcb8e  _output/1-21/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-5d92bdcd64b50b44ffc6c99a13fd6e4c651e3774d2d44d23a8f266dbb28ae256  _output/1-21/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+a224e3b1f5424539cec7a91c862c3baee36a9a7fa8e0fa3ef7278aedb0a19752  _output/1-21/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+78b8ed62b8352d024d1f6ca66c42ea7c3a482cc8463b5af5c2a0e2e6ea4ac2d7  _output/1-21/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+9ccbcd3ac656f1168b7b2661af00a1df85d9a764d427cd556e0afaa60839096e  _output/1-21/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+974b8aaa05a60b1c4bf10282f6c9bbd2bf5365cc72785579a21a399ff58b9656  _output/1-21/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-22/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-22/CHECKSUMS
@@ -1,4 +1,4 @@
-97ba109cf2c7f0c52cbe99ee3beec637fcebecde29cef73aa53a537acd157287  _output/1-22/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-da0dc57a95d934a143d43b245dae979c996072ac91d3b8ce0e1ba89fc4a33227  _output/1-22/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-8f0e5891d9da2fbdf51203cfd8c9bf493f417e2c97b711cae8c87f20398dcb8e  _output/1-22/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-5d92bdcd64b50b44ffc6c99a13fd6e4c651e3774d2d44d23a8f266dbb28ae256  _output/1-22/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+a224e3b1f5424539cec7a91c862c3baee36a9a7fa8e0fa3ef7278aedb0a19752  _output/1-22/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+78b8ed62b8352d024d1f6ca66c42ea7c3a482cc8463b5af5c2a0e2e6ea4ac2d7  _output/1-22/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+9ccbcd3ac656f1168b7b2661af00a1df85d9a764d427cd556e0afaa60839096e  _output/1-22/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+974b8aaa05a60b1c4bf10282f6c9bbd2bf5365cc72785579a21a399ff58b9656  _output/1-22/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
@@ -7,7 +7,10 @@ REPO_OWNER=kubernetes-sigs
 
 BINARY_TARGET_FILES=aws-iam-authenticator
 SOURCE_PATTERNS=./cmd/aws-iam-authenticator
-EXTRA_GO_LDFLAGS=-X main.version=$(GIT_TAG) -X main.commit=$(shell git -C $(REPO) rev-list -n 1  "${GIT_TAG}")
+
+PKG=sigs.k8s.io/aws-iam-authenticator
+GIT_COMMIT=$(shell git -C $(REPO) describe --always --abbrev=0)
+EXTRA_GO_LDFLAGS=-X $(PKG)/pkg.Version=$(GIT_TAG) -X $(PKG)/pkg.CommitID=$(GIT_COMMIT)
 
 BINARY_PLATFORMS=linux/amd64 linux/arm64 darwin/amd64 windows/amd64
 
@@ -18,6 +21,18 @@ IMAGE_TARGET=$(RELEASE_VARIANT)
 BUILDER_IMAGE=$(EKS_DISTRO_BASE_IMAGE)
 
 include $(BASE_DIRECTORY)/Common.mk
+
+build: validate-cli-version
+release: validate-cli-version
+
+.PHONY: validate-cli-version
+validate-cli-version: CLI=./$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$(REPO)
+validate-cli-version: $(BINARY_TARGETS)
+	$(CLI) version
+	@if [[ "$$($(CLI) version --short)" != "$(GIT_TAG)" ]]; then \
+		echo "Version set incorrectly on cli!"; \
+		exit 1; \
+	fi
 
 
 ########### DO NOT EDIT #############################

--- a/projects/kubernetes-sigs/aws-iam-authenticator/README.md
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/README.md
@@ -20,9 +20,9 @@
 3. Compare the old tag to the new one, looking specifically for Makefile changes.
    For example:
    [v0.5.2 compared to v0.5.3](https://github.com/kubernetes-sigs/aws-iam-authenticator/compare/v0.5.2...v0.5.3). 
-   Check the `aws-iam-authenticator` target for any build flag changes, tag 
-   changes, dependencies, etc. Check that the manifest target, which is called 
-   from the EKS-D Makefile, has not changed.
+   Check the `$(OUTPUT)/bin/%: $(SOURCES)` target for any build flag changes, tag 
+   changes, dependencies, etc. Check the [gorelease config](https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/.goreleaser.yaml)
+   for LDFLAGS changes, these should match what is in their Makefile and the EKS-D Makefile.
 4. Verify the Golang version has not changed. The version specified in
    [`go.mod`](https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/go.mod)
    seems to be kept up to date. Be sure to select the correct branch for the 

--- a/projects/kubernetes-sigs/metrics-server/1-18/CHECKSUMS
+++ b/projects/kubernetes-sigs/metrics-server/1-18/CHECKSUMS
@@ -1,2 +1,2 @@
-4612e28b6a56d1a59a2f34e4c8c1ad910f8451f9aa3c74d821662b6c6b415e7a  _output/1-18/bin/metrics-server/linux-amd64/metrics-server
-cc5a5c5be5a27fa2275bd3653e77c735308ca617c88ecff4320e0474ca881e8d  _output/1-18/bin/metrics-server/linux-arm64/metrics-server
+d7e137d8a87edf1c28037ddbd2932eb4fb06db6d81a4022e0a40a890599a20e1  _output/1-18/bin/metrics-server/linux-amd64/metrics-server
+8cf2fafec95d03cbbe5f614c44f1de7ea2eedc96dbb9badcc705ec03c3ec3337  _output/1-18/bin/metrics-server/linux-arm64/metrics-server

--- a/projects/kubernetes-sigs/metrics-server/1-19/CHECKSUMS
+++ b/projects/kubernetes-sigs/metrics-server/1-19/CHECKSUMS
@@ -1,2 +1,2 @@
-57c48c9a15f4194f33203a8668e4082de6837ab74d19a175e1e21134f9495be6  _output/1-19/bin/metrics-server/linux-amd64/metrics-server
-d79509bfa3180f6374f9e954122b137565488b2825f01f78165ba2ae23ac61f3  _output/1-19/bin/metrics-server/linux-arm64/metrics-server
+6a01c95453d8825eaf9bacacbc9cb1edad610cc4140c7964200300a5c299c3f9  _output/1-19/bin/metrics-server/linux-amd64/metrics-server
+57bc09b8e54af6cc804c031f389abb3441bea6d943cba09641e368716cb859f8  _output/1-19/bin/metrics-server/linux-arm64/metrics-server

--- a/projects/kubernetes-sigs/metrics-server/1-20/CHECKSUMS
+++ b/projects/kubernetes-sigs/metrics-server/1-20/CHECKSUMS
@@ -1,2 +1,2 @@
-57c48c9a15f4194f33203a8668e4082de6837ab74d19a175e1e21134f9495be6  _output/1-20/bin/metrics-server/linux-amd64/metrics-server
-d79509bfa3180f6374f9e954122b137565488b2825f01f78165ba2ae23ac61f3  _output/1-20/bin/metrics-server/linux-arm64/metrics-server
+6a01c95453d8825eaf9bacacbc9cb1edad610cc4140c7964200300a5c299c3f9  _output/1-20/bin/metrics-server/linux-amd64/metrics-server
+57bc09b8e54af6cc804c031f389abb3441bea6d943cba09641e368716cb859f8  _output/1-20/bin/metrics-server/linux-arm64/metrics-server

--- a/projects/kubernetes-sigs/metrics-server/1-21/CHECKSUMS
+++ b/projects/kubernetes-sigs/metrics-server/1-21/CHECKSUMS
@@ -1,2 +1,2 @@
-57c48c9a15f4194f33203a8668e4082de6837ab74d19a175e1e21134f9495be6  _output/1-21/bin/metrics-server/linux-amd64/metrics-server
-d79509bfa3180f6374f9e954122b137565488b2825f01f78165ba2ae23ac61f3  _output/1-21/bin/metrics-server/linux-arm64/metrics-server
+6a01c95453d8825eaf9bacacbc9cb1edad610cc4140c7964200300a5c299c3f9  _output/1-21/bin/metrics-server/linux-amd64/metrics-server
+57bc09b8e54af6cc804c031f389abb3441bea6d943cba09641e368716cb859f8  _output/1-21/bin/metrics-server/linux-arm64/metrics-server

--- a/projects/kubernetes-sigs/metrics-server/1-22/CHECKSUMS
+++ b/projects/kubernetes-sigs/metrics-server/1-22/CHECKSUMS
@@ -1,2 +1,2 @@
-57c48c9a15f4194f33203a8668e4082de6837ab74d19a175e1e21134f9495be6  _output/1-22/bin/metrics-server/linux-amd64/metrics-server
-d79509bfa3180f6374f9e954122b137565488b2825f01f78165ba2ae23ac61f3  _output/1-22/bin/metrics-server/linux-arm64/metrics-server
+6a01c95453d8825eaf9bacacbc9cb1edad610cc4140c7964200300a5c299c3f9  _output/1-22/bin/metrics-server/linux-amd64/metrics-server
+57bc09b8e54af6cc804c031f389abb3441bea6d943cba09641e368716cb859f8  _output/1-22/bin/metrics-server/linux-arm64/metrics-server

--- a/projects/kubernetes-sigs/metrics-server/Makefile
+++ b/projects/kubernetes-sigs/metrics-server/Makefile
@@ -8,9 +8,9 @@ COMPONENT=kubernetes-sigs/$(REPO)
 BINARY_TARGET_FILES=metrics-server
 SOURCE_PATTERNS=./cmd/metrics-server
 
-PKG="sigs.k8s.io/metrics-server/pkg"
+PKG=k8s.io/client-go/pkg
 GIT_COMMIT=$(shell git -C $(REPO) describe --always --abbrev=0)
-BUILD_DATE=$(shell git -C $(REPO) show -s --format=format:%ct HEAD)
+BUILD_DATE=$(shell git -C $(REPO) show -s --format=format:%cd --date=format:'%Y-%m-%dT%H:%M:%SZ' HEAD)
 EXTRA_GO_LDFLAGS=-X $(PKG)/version.gitVersion=$(GIT_TAG) -X $(PKG)/version.gitCommit=$(GIT_COMMIT) -X $(PKG)/version.buildDate=$(BUILD_DATE)
 
 HAS_RELEASE_BRANCHES=true
@@ -18,6 +18,22 @@ HAS_RELEASE_BRANCHES=true
 IMAGE_TARGET=$(RELEASE_VARIANT)
 
 include $(BASE_DIRECTORY)/Common.mk
+
+
+build: validate-cli-version
+release: validate-cli-version
+
+# To ensure this will work on mac, instead of building those archs
+# only build it when run. on a linux builder this extra make will be a noop
+.PHONY: validate-cli-version
+validate-cli-version: CLI=$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$(REPO)
+validate-cli-version:
+	$(MAKE) $(CLI) BINARY_PLATFORMS=$(BUILDER_PLATFORM)
+	$(CLI) --version
+	@if [[ "$$($(CLI) --version)" != "$(GIT_TAG)" ]]; then \
+		echo "Version set incorrectly on cli!"; \
+		exit 1; \
+	fi
 
 
 ########### DO NOT EDIT #############################

--- a/projects/kubernetes-sigs/metrics-server/README.md
+++ b/projects/kubernetes-sigs/metrics-server/README.md
@@ -21,9 +21,8 @@
 3. Compare the old tag to the new one, looking specifically for Makefile changes.
    For example:
    [v0.5.0 compared to v0.5.2](https://github.com/kubernetes-sigs/metrics-server/compare/v0.5.0...v0.5.2).
-   Check the `metrics-server` target for any build flag changes, tag changes,
-   dependencies, etc. Check that the manifest target, which is called from the
-   EKS-D Makefile, has not changed.
+   Check the [metrics-server](https://github.com/kubernetes-sigs/metrics-server/blob/master/Makefile#L35) 
+   target for any build flag changes especially LDFLAGS and PKG, tag changes, dependencies, etc. 
 4. Verify the Golang version has not changed. The version specified in
    [`go.mod`](https://github.com/kubernetes-sigs/metrics-server/blob/master/go.mod) 
    seems to be kept up to date. Be sure to select the correct branch for the 


### PR DESCRIPTION
…ersion

*Issue #, if available:*

*Description of changes:*
There was a bug due to the iam-auth binary not having the proper ldflag set for the version.  The package is super important here and must match the upstream. This also adds a validation to the build phase to make sure its what we expect it to be in case these change in the future.  I also updated the readmes some to call out more specific places to check for this kind of thing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
