### PR TITLE
iam-auth: remove v from version to match upstream

### DIFF
--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-18/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-18/CHECKSUMS
@@ -1,4 +1,4 @@
-a224e3b1f5424539cec7a91c862c3baee36a9a7fa8e0fa3ef7278aedb0a19752  _output/1-18/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-78b8ed62b8352d024d1f6ca66c42ea7c3a482cc8463b5af5c2a0e2e6ea4ac2d7  _output/1-18/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-9ccbcd3ac656f1168b7b2661af00a1df85d9a764d427cd556e0afaa60839096e  _output/1-18/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-974b8aaa05a60b1c4bf10282f6c9bbd2bf5365cc72785579a21a399ff58b9656  _output/1-18/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+e2ebf0e864863022ce32777278f2d2a9fc43fcd756822bbbc67b5099b1d947a2  _output/1-18/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+078361f0b70cb33da05675c383d568215b1e21768c07dcac73810a9b7314eab9  _output/1-18/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+47fad9b8d4c7d8c9a1168005fce46805c8162a812aebf17c8dc02368eca6d895  _output/1-18/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+6f1bc8650a0151e06fb6432f71a179697c913814fbd3a239e443a7c24f75661f  _output/1-18/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-19/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-19/CHECKSUMS
@@ -1,4 +1,4 @@
-a224e3b1f5424539cec7a91c862c3baee36a9a7fa8e0fa3ef7278aedb0a19752  _output/1-19/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-78b8ed62b8352d024d1f6ca66c42ea7c3a482cc8463b5af5c2a0e2e6ea4ac2d7  _output/1-19/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-9ccbcd3ac656f1168b7b2661af00a1df85d9a764d427cd556e0afaa60839096e  _output/1-19/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-974b8aaa05a60b1c4bf10282f6c9bbd2bf5365cc72785579a21a399ff58b9656  _output/1-19/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+e2ebf0e864863022ce32777278f2d2a9fc43fcd756822bbbc67b5099b1d947a2  _output/1-19/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+078361f0b70cb33da05675c383d568215b1e21768c07dcac73810a9b7314eab9  _output/1-19/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+47fad9b8d4c7d8c9a1168005fce46805c8162a812aebf17c8dc02368eca6d895  _output/1-19/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+6f1bc8650a0151e06fb6432f71a179697c913814fbd3a239e443a7c24f75661f  _output/1-19/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-20/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-20/CHECKSUMS
@@ -1,4 +1,4 @@
-a224e3b1f5424539cec7a91c862c3baee36a9a7fa8e0fa3ef7278aedb0a19752  _output/1-20/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-78b8ed62b8352d024d1f6ca66c42ea7c3a482cc8463b5af5c2a0e2e6ea4ac2d7  _output/1-20/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-9ccbcd3ac656f1168b7b2661af00a1df85d9a764d427cd556e0afaa60839096e  _output/1-20/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-974b8aaa05a60b1c4bf10282f6c9bbd2bf5365cc72785579a21a399ff58b9656  _output/1-20/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+e2ebf0e864863022ce32777278f2d2a9fc43fcd756822bbbc67b5099b1d947a2  _output/1-20/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+078361f0b70cb33da05675c383d568215b1e21768c07dcac73810a9b7314eab9  _output/1-20/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+47fad9b8d4c7d8c9a1168005fce46805c8162a812aebf17c8dc02368eca6d895  _output/1-20/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+6f1bc8650a0151e06fb6432f71a179697c913814fbd3a239e443a7c24f75661f  _output/1-20/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-21/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-21/CHECKSUMS
@@ -1,4 +1,4 @@
-a224e3b1f5424539cec7a91c862c3baee36a9a7fa8e0fa3ef7278aedb0a19752  _output/1-21/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-78b8ed62b8352d024d1f6ca66c42ea7c3a482cc8463b5af5c2a0e2e6ea4ac2d7  _output/1-21/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-9ccbcd3ac656f1168b7b2661af00a1df85d9a764d427cd556e0afaa60839096e  _output/1-21/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-974b8aaa05a60b1c4bf10282f6c9bbd2bf5365cc72785579a21a399ff58b9656  _output/1-21/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+e2ebf0e864863022ce32777278f2d2a9fc43fcd756822bbbc67b5099b1d947a2  _output/1-21/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+078361f0b70cb33da05675c383d568215b1e21768c07dcac73810a9b7314eab9  _output/1-21/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+47fad9b8d4c7d8c9a1168005fce46805c8162a812aebf17c8dc02368eca6d895  _output/1-21/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+6f1bc8650a0151e06fb6432f71a179697c913814fbd3a239e443a7c24f75661f  _output/1-21/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-22/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-22/CHECKSUMS
@@ -1,4 +1,4 @@
-a224e3b1f5424539cec7a91c862c3baee36a9a7fa8e0fa3ef7278aedb0a19752  _output/1-22/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-78b8ed62b8352d024d1f6ca66c42ea7c3a482cc8463b5af5c2a0e2e6ea4ac2d7  _output/1-22/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-9ccbcd3ac656f1168b7b2661af00a1df85d9a764d427cd556e0afaa60839096e  _output/1-22/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-974b8aaa05a60b1c4bf10282f6c9bbd2bf5365cc72785579a21a399ff58b9656  _output/1-22/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+e2ebf0e864863022ce32777278f2d2a9fc43fcd756822bbbc67b5099b1d947a2  _output/1-22/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+078361f0b70cb33da05675c383d568215b1e21768c07dcac73810a9b7314eab9  _output/1-22/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+47fad9b8d4c7d8c9a1168005fce46805c8162a812aebf17c8dc02368eca6d895  _output/1-22/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+6f1bc8650a0151e06fb6432f71a179697c913814fbd3a239e443a7c24f75661f  _output/1-22/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
@@ -10,7 +10,7 @@ SOURCE_PATTERNS=./cmd/aws-iam-authenticator
 
 PKG=sigs.k8s.io/aws-iam-authenticator
 GIT_COMMIT=$(shell git -C $(REPO) describe --always --abbrev=0)
-EXTRA_GO_LDFLAGS=-X $(PKG)/pkg.Version=$(GIT_TAG) -X $(PKG)/pkg.CommitID=$(GIT_COMMIT)
+EXTRA_GO_LDFLAGS=-X $(PKG)/pkg.Version=$(GIT_TAG:v%=%) -X $(PKG)/pkg.CommitID=$(GIT_COMMIT)
 
 BINARY_PLATFORMS=linux/amd64 linux/arm64 darwin/amd64 windows/amd64
 
@@ -29,7 +29,7 @@ release: validate-cli-version
 validate-cli-version: CLI=./$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$(REPO)
 validate-cli-version: $(BINARY_TARGETS)
 	$(CLI) version
-	@if [[ "$$($(CLI) version --short)" != "$(GIT_TAG)" ]]; then \
+	@if [[ "$$($(CLI) version --short)" != "$(GIT_TAG:v%=%)" ]]; then \
 		echo "Version set incorrectly on cli!"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When calling `version` on the upstream cli the version is `0.5.5` vs `v0.5.5`.  I believe this [goreleaser.yaml](https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/.goreleaser.yaml#L21) should be considered the source of truth for their build flags.  I am not sure how/where it gets the `{{.Version}}` from, but its obviously 0.5.5 since thats what the cli returns.

As a side note, this does not match their [Makefile](https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/Makefile#L6) which includes the `v`.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
