### PR TITLE
Remove unneeded code in release generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ AWS_REGION?=us-west-2
 IMAGE_REPO?=$(if $(AWS_ACCOUNT_ID),$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com,localhost:5000)
 RELEASE_AWS_PROFILE?=default
 
-IS_BOT?=false
 USE_PREV_RELEASE_MANIFEST?=false
 OPEN_PR?=true
 IS_LOCAL_RELEASE_NUMBER_FOR_NEW_RELEASE?=true
@@ -186,7 +185,6 @@ update-release-number:
 	go vet ./cmd/release/number
 	go run ./cmd/release/number/main.go \
 		--branch=$(RELEASE_BRANCH) \
-		--isBot=$(IS_BOT) \
 		--openPR=$(OPEN_PR)
 
 .PHONY: update-all-release-numbers
@@ -198,7 +196,6 @@ release-docs:
 	go vet ./cmd/release/docs
 	go run ./cmd/release/docs/main.go \
 		--branch=$(RELEASE_BRANCH) \
-		--isBot=$(IS_BOT) \
 		--usePrevReleaseManifestForComponentTable=$(USE_PREV_RELEASE_MANIFEST) \
 		--openPR=$(OPEN_PR) \
 		--isLocalReleaseNumberForNewRelease=$(IS_LOCAL_RELEASE_NUMBER_FOR_NEW_RELEASE)

--- a/cmd/release/docs/internal/docs_pr.go
+++ b/cmd/release/docs/internal/docs_pr.go
@@ -7,11 +7,10 @@ import (
 type docsPRRequest struct {
 	branch, version string
 	filesChanged    []string
-	bot             bool
 }
 
-func OpenDocsPR(release *Release, docStatuses []DocStatus, isBot bool) error {
-	prRequest := newDocsPRRequest(release, GetPaths(docStatuses), isBot)
+func OpenDocsPR(release *Release, docStatuses []DocStatus) error {
+	prRequest := newDocsPRRequest(release, GetPaths(docStatuses))
 	pr, err := NewPullRequestForDocs(&prRequest)
 	if err != nil {
 		return err
@@ -19,12 +18,11 @@ func OpenDocsPR(release *Release, docStatuses []DocStatus, isBot bool) error {
 	return pr.Open()
 }
 
-func newDocsPRRequest(release *Release, filesChanged []string, isBot bool) docsPRRequest {
+func newDocsPRRequest(release *Release, filesChanged []string) docsPRRequest {
 	return docsPRRequest{
 		branch:       release.Branch(),
 		version:      release.Version(),
 		filesChanged: filesChanged,
-		bot:          isBot,
 	}
 }
 
@@ -38,8 +36,4 @@ func (prReq *docsPRRequest) Version() string {
 
 func (prReq *docsPRRequest) FilePaths() []string {
 	return prReq.filesChanged
-}
-
-func (prReq *docsPRRequest) IsBot() bool {
-	return prReq.bot
 }

--- a/cmd/release/docs/internal/release.go
+++ b/cmd/release/docs/internal/release.go
@@ -24,10 +24,7 @@ type Release struct {
 	DocsDirectoryPath string
 
 	// Version notations
-	BranchEKSNumber            string // e.g. 1-20-eks-2
-	BranchEKSPreviousNumber    string // e.g. 1-20-eks-1
 	BranchWithDot              string // e.g. 1.20
-	BranchWithDotNumber        string // e.g. 1.20-2
 	EKSBranchNumber            string // e.g. eks-1-20-2
 	EKSBranchPreviousNumber    string // e.g. eks-1-20-1
 	K8sBranchEKS               string // e.g. Kubernetes-1-20-eks
@@ -36,6 +33,10 @@ type Release struct {
 	VBranchEKSNumber           string // e.g. v1-20-eks-2
 	VBranchEKSPreviousNumber   string // e.g. v1-20-eks-1
 	VBranchWithDotNumber       string // e.g. v1.20-2
+
+	branchEKSNumber            string // e.g. 1-20-eks-2
+	branchEKSPreviousNumber    string // e.g. 1-20-eks-1
+	branchWithDotNumber        string // e.g. 1.20-2
 
 	// URL for release manifest, which is not guaranteed to be valid or existing.
 	// Example: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-2.yaml
@@ -82,21 +83,21 @@ func newRelease(inputBranch string, num, prevNum string) (Release, error) {
 	release.DocsDirectoryPath = formatReleaseDocsDirectory(release.branch, release.number)
 
 	branchEKS := release.branch + "-eks"
-	release.BranchEKSNumber = fmt.Sprintf("%s-%s", branchEKS, release.number)
-	release.BranchEKSPreviousNumber = fmt.Sprintf("%s-%s", branchEKS, release.previousNumber)
+	release.branchEKSNumber = fmt.Sprintf("%s-%s", branchEKS, release.number)
+	release.branchEKSPreviousNumber = fmt.Sprintf("%s-%s", branchEKS, release.previousNumber)
 	release.BranchWithDot = GetBranchWithDotFormat(release.branch)
-	release.BranchWithDotNumber = GetBranchWithDotAndNumberWithDashFormat(release.BranchWithDot, release.number)
+	release.branchWithDotNumber = GetBranchWithDotAndNumberWithDashFormat(release.BranchWithDot, release.number)
 	release.EKSBranchNumber = fmt.Sprintf("eks-%s-%s", release.branch, release.number)
 	release.EKSBranchPreviousNumber = fmt.Sprintf("eks-%s-%s", release.branch, release.previousNumber)
 	release.K8sBranchEKS = "kubernetes-" + branchEKS
 	release.K8sBranchEKSNumber = fmt.Sprintf("%s-%s", release.K8sBranchEKS, release.number)
 	release.K8sBranchEKSPreviousNumber = fmt.Sprintf("%s-%s", release.K8sBranchEKS, release.previousNumber)
-	release.VBranchEKSNumber = "v" + release.BranchEKSNumber
-	release.VBranchEKSPreviousNumber = "v" + release.BranchEKSPreviousNumber
-	release.VBranchWithDotNumber = "v" + release.BranchWithDotNumber
+	release.VBranchEKSNumber = "v" + release.branchEKSNumber
+	release.VBranchEKSPreviousNumber = "v" + release.branchEKSPreviousNumber
+	release.VBranchWithDotNumber = "v" + release.branchWithDotNumber
 
-	release.ManifestURL = formatReleaseManifestURL(release.branch, release.BranchEKSNumber)
-	release.PreviousManifestURL = formatReleaseManifestURL(release.branch, release.BranchEKSPreviousNumber)
+	release.ManifestURL = formatReleaseManifestURL(release.branch, release.branchEKSNumber)
+	release.PreviousManifestURL = formatReleaseManifestURL(release.branch, release.branchEKSPreviousNumber)
 
 	releaseJson, _ := json.MarshalIndent(release, "", "\t")
 	log.Printf("populated release with:%v", string(releaseJson))
@@ -117,7 +118,7 @@ func (release *Release) PreviousNumber() string {
 }
 
 func (release *Release) Version() string {
-	return release.BranchWithDotNumber
+	return release.branchWithDotNumber
 }
 
 func formatReleaseManifestURL(branch, branchEKSNumber string) string {
@@ -125,8 +126,4 @@ func formatReleaseManifestURL(branch, branchEKSNumber string) string {
 		"https://distro.eks.amazonaws.com/kubernetes-%s/kubernetes-%s.yaml",
 		branch,
 		branchEKSNumber)
-}
-
-func convertToNumberAndPrevNumber(overrideNumber int) (num, prevNum string) {
-	return strconv.Itoa(overrideNumber), strconv.Itoa(overrideNumber - 1)
 }

--- a/cmd/release/docs/internal/release.go
+++ b/cmd/release/docs/internal/release.go
@@ -2,10 +2,8 @@ package internal
 
 import (
 	. "../../utils"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 )
@@ -98,9 +96,6 @@ func newRelease(inputBranch string, num, prevNum string) (Release, error) {
 
 	release.ManifestURL = formatReleaseManifestURL(release.branch, release.branchEKSNumber)
 	release.PreviousManifestURL = formatReleaseManifestURL(release.branch, release.branchEKSPreviousNumber)
-
-	releaseJson, _ := json.MarshalIndent(release, "", "\t")
-	log.Printf("populated release with:%v", string(releaseJson))
 
 	return release, nil
 }

--- a/cmd/release/docs/main.go
+++ b/cmd/release/docs/main.go
@@ -5,6 +5,7 @@ import (
 	. "./internal"
 	. "./new_docs"
 	. "./new_docs/templates"
+	"encoding/json"
 	"fmt"
 
 	"flag"
@@ -12,6 +13,7 @@ import (
 )
 
 const skipOverrideNumber = -1
+const verboseLogging=false
 
 /*
 Generate docs for release. Value for 'branch' flag must be provided.
@@ -78,6 +80,11 @@ func main() {
 	release, err := initializeRelease(*branch, *overrideNumber, *isLocalReleaseNumberForNewRelease)
 	if err != nil {
 		log.Fatalf("Error initializing release values: %v", err)
+	}
+
+	if verboseLogging {
+		releaseJson, _ := json.MarshalIndent(release, "", "\t")
+		log.Printf("populated release with:%v", string(releaseJson))
 	}
 
 	var docStatuses []DocStatus

--- a/cmd/release/docs/main.go
+++ b/cmd/release/docs/main.go
@@ -68,7 +68,6 @@ func main() {
 	includeDocsIndex := flag.Bool("includeDocsIndex", true, "If index.md in docs should be updated")
 
 	openPR := flag.Bool("openPR", true, "If a PR should be opened for changed")
-	isBot := flag.Bool("isBot", false, "If a PR is created by bot")
 
 	// WARNING: use of these flags can produce errors that are not easily identifiable. See comment at top.
 	force := flag.Bool("force", false, "Replaces existing files with newly-generated ones")
@@ -126,7 +125,7 @@ func main() {
 	log.Printf("Finished writing to %v doc(s)\n", len(docStatuses))
 
 	if *openPR {
-		err = OpenDocsPR(&release, docStatuses, *isBot)
+		err = OpenDocsPR(&release, docStatuses)
 		if err != nil {
 			log.Fatalf("error opening PR: %v", err)
 		}

--- a/cmd/release/number/internal/number_pr.go
+++ b/cmd/release/number/internal/number_pr.go
@@ -8,16 +8,14 @@ import (
 type prRequest struct {
 	branch, environment, version string
 	filesChanged                 []string
-	bot                          bool
 }
 
-func OpenNumberPR(branch, number string, files []string, isBot bool, environment ReleaseEnvironment) error {
+func OpenNumberPR(branch, number string, files []string, environment ReleaseEnvironment) error {
 	request := prRequest{
 		branch:       branch,
 		environment:  environment.String(),
 		version:      GetBranchWithDotAndNumberWithDashFormat(branch, number),
 		filesChanged: files,
-		bot:          isBot,
 	}
 	return openNumberPR(&request)
 }
@@ -44,8 +42,4 @@ func (prReq *prRequest) Version() string {
 
 func (prReq *prRequest) FilePaths() []string {
 	return prReq.filesChanged
-}
-
-func (prReq *prRequest) IsBot() bool {
-	return prReq.bot
 }

--- a/cmd/release/number/main.go
+++ b/cmd/release/number/main.go
@@ -18,7 +18,6 @@ func main() {
 	includeProd := flag.Bool("includeProd", true, "If production RELEASE should be incremented")
 	includeDev := flag.Bool("includeDev", true, "If development RELEASE should be incremented")
 	includePR := flag.Bool("openPR", true, "If a PR should be opened for changed")
-	isBot := flag.Bool("isBot", false, "If a PR is created by bot")
 
 	flag.Parse()
 
@@ -58,12 +57,12 @@ func main() {
 
 	if *includePR {
 		if *includeProd {
-			if err = OpenNumberPR(*branch, prodNumber.Next(), changedProdFiles, *isBot, Production); err != nil {
+			if err = OpenNumberPR(*branch, prodNumber.Next(), changedProdFiles, Production); err != nil {
 				log.Fatal(err)
 			}
 		}
 		if *includeDev {
-			if err = OpenNumberPR(*branch, devNumber.Next(), changedDevFiles, *isBot, Development); err != nil {
+			if err = OpenNumberPR(*branch, devNumber.Next(), changedDevFiles, Development); err != nil {
 				log.Fatal(err)
 			}
 		}

--- a/cmd/release/pull_request/create_release_pr.sh
+++ b/cmd/release/pull_request/create_release_pr.sh
@@ -22,10 +22,12 @@ PR_BRANCH="${1?...}"
 PR_COMMIT_MESSAGE="${2?...}"
 PR_FILE_PATHS="${3?...}"
 
+ORIGINAL_BRANCH=$(git branch --show-current)
+
 function cleanup {
   echo "Encountered error! Cleaning up..."
   git checkout HEAD^ -- "${PR_FILE_PATHS}"
-  git checkout -
+  git checkout "${ORIGINAL_BRANCH}"
   git push -d origin "${PR_BRANCH}"
   git branch -D "${PR_BRANCH}"
   echo "Cleaned up as much as possible"
@@ -69,5 +71,5 @@ echo "pushed!"
 
 gh pr create "${pr_arguments[@]}"
 
-git co -
+git co "${ORIGINAL_BRANCH}"
 git br -D "${PR_BRANCH}"

--- a/cmd/release/pull_request/create_release_pr.sh
+++ b/cmd/release/pull_request/create_release_pr.sh
@@ -53,6 +53,7 @@ pr_arguments=(
   --body "${PR_BODY}"
   --head "${ORIGIN_ORG}:${PR_BRANCH}"
   --repo "${PR_ORG_REPO}"
+  --web
 )
 labels="do-not-merge/hold release"
 for label in $labels; do

--- a/cmd/release/pull_request/create_release_pr.sh
+++ b/cmd/release/pull_request/create_release_pr.sh
@@ -22,12 +22,10 @@ PR_BRANCH="${1?...}"
 PR_COMMIT_MESSAGE="${2?...}"
 PR_FILE_PATHS="${3?...}"
 
-ORIGINAL_BRANCH=$(git branch --show-current)
-
 function cleanup {
   echo "Encountered error! Cleaning up..."
   git checkout HEAD^ -- "${PR_FILE_PATHS}"
-  git checkout "${ORIGINAL_BRANCH}"
+  git checkout -
   git push -d origin "${PR_BRANCH}"
   git branch -D "${PR_BRANCH}"
   echo "Cleaned up as much as possible"
@@ -36,7 +34,6 @@ function cleanup {
 trap cleanup ERR
 
 PR_REPO="eks-distro"
-PR_ORG_REPO="aws/${PR_REPO}"
 ORIGIN_ORG=$(git remote get-url origin | sed -n -e "s|git@github.com:\(.*\)/${PR_REPO}.git|\1|p")
 
 PR_BODY=$(cat <<EOF
@@ -52,7 +49,7 @@ pr_arguments=(
   --title "${PR_TITLE}"
   --body "${PR_BODY}"
   --head "${ORIGIN_ORG}:${PR_BRANCH}"
-  --repo "${PR_ORG_REPO}"
+  --repo "aws/${PR_REPO}"
   --web
 )
 labels="do-not-merge/hold release"
@@ -72,5 +69,5 @@ echo "pushed!"
 
 gh pr create "${pr_arguments[@]}"
 
-git co "${ORIGINAL_BRANCH}"
+git co -
 git br -D "${PR_BRANCH}"

--- a/cmd/release/pull_request/open_pr.go
+++ b/cmd/release/pull_request/open_pr.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 )
 
 var (
@@ -21,7 +20,6 @@ type PullRequest struct {
 	branch        string
 	commitMessage string
 	filesPaths    string
-	isBot         bool
 }
 
 func (pr PullRequest) Open() error {
@@ -31,7 +29,6 @@ func (pr PullRequest) Open() error {
 		pr.branch,
 		pr.commitMessage,
 		pr.filesPaths,
-		strconv.FormatBool(pr.isBot),
 	)
 
 	cmd.Stdout = outputStream

--- a/cmd/release/pull_request/pr_input.go
+++ b/cmd/release/pull_request/pr_input.go
@@ -13,7 +13,6 @@ type PullRequestInputBase interface {
 	Branch() string
 	Version() string
 	FilePaths() []string
-	IsBot() bool
 }
 
 type NumberPullRequestInput interface {
@@ -47,7 +46,6 @@ func getCommonPullRequest(branchBase string, input PullRequestInputBase) (PullRe
 	return PullRequest{
 		branch:     formatBranch(branchBase),
 		filesPaths: convertedFilePaths,
-		isBot:      input.IsBot(),
 	}, nil
 }
 


### PR DESCRIPTION
*Description of changes:*
* These changes are part of a refactor of the make release commands. I'm trying to clean things up and the goal is was to remove things that are unused
* Removed bot-related features, as these are not used or tested. If we set up a bot in the future, I imagine we'd delete 99% of this anyways.
* Removed unused function and made some fields private

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
