### PR TITLE
update go versions in install helper and fix typo in common.mlk

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -472,7 +472,7 @@ $(KUSTOMIZE_TARGET):
 	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- $(OUTPUT_DIR)
 
 .PHONY: clone-repo
-clone-rpeo: $(REPO)
+clone-repo: $(REPO)
 
 .PHONY: checkout-repo
 checkout-repo: $(GIT_CHECKOUT_TARGET)

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -182,32 +182,11 @@ function build::generate_attribution(){
 
 function build::common::get_go_path() {
   local -r version=$1
-  local gobinaryversion=""
-
-  if [[ $version == "1.13"* ]]; then
-    gobinaryversion="1.13"
-  fi
-  if [[ $version == "1.14"* ]]; then
-    gobinaryversion="1.14"
-  fi
-  if [[ $version == "1.15"* ]]; then
-    gobinaryversion="1.15"
-  fi
-  if [[ $version == "1.16"* ]]; then
-    gobinaryversion="1.16"
-  fi
-  if [[ $version == "1.17"* ]]; then
-    gobinaryversion="1.17"
-  fi
-
-  if [[ "$gobinaryversion" == "" ]]; then
-    return
-  fi
 
   # This is the path where the specific go binary versions reside in our builder-base image
-  local -r gorootbinarypath="/go/go${gobinaryversion}/bin"
+  local -r gorootbinarypath="/go/go${version}/bin"
   # This is the path that will most likely be correct if running locally
-  local -r gopathbinarypath="$GOPATH/go${gobinaryversion}/bin"
+  local -r gopathbinarypath="$GOPATH/go${version}/bin"
   if [ -d "$gorootbinarypath" ]; then
     echo $gorootbinarypath
   elif [ -d "$gopathbinarypath" ]; then

--- a/build/lib/install_go_versions.sh
+++ b/build/lib/install_go_versions.sh
@@ -20,9 +20,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
 setupgo() {
     local -r version=$1
-    go get golang.org/dl/go${version}
+    go install golang.org/dl/go${version}@latest
     go${version} download
     # Removing the patch number as we only care about the minor version of golang
     local -r majorversion=${version%.*}
@@ -34,5 +37,12 @@ setupgo() {
 setupgo "${GOLANG113_VERSION:-1.13.15}"
 setupgo "${GOLANG114_VERSION:-1.14.15}"
 setupgo "${GOLANG115_VERSION:-1.15.15}"
-setupgo "${GOLANG116_VERSION:-1.16.12}"
-setupgo "${GOLANG116_VERSION:-1.17.5}"
+setupgo "${GOLANG116_VERSION:-1.16.15}"
+setupgo "${GOLANG116_VERSION:-1.17.8}"
+setupgo "${GOLANG116_VERSION:-1.18}"
+
+# always using 1.16 for now when installing and running go-licenses
+# go-licenses needs to be installed by the same version of go that is being used
+# to generate the deps list during the attribution generation process
+build::common::use_go_version "1.16"
+go install github.com/google/go-licenses@v1.0.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This brings the versions inline with whats in builder base in case people use this locally for setting up their machines.  Switches to go install to remove deprecation warning about using go get. Cleans up the goversion path handling since we never pass in a go version with a patch version none of this should have been necessary. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
