### PR TITLE
kubernetes: avoid out of space in presubmit by using mv

### DIFF
--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -68,6 +68,11 @@ $(BINARY_TARGETS): $(KUBE_GIT_VERSION_FILE) | $(GIT_PATCH_TARGET)
 # There are a couple of fixes needed to the licenses and root-module name before running gather licenses
 $(GATHER_LICENSES_TARGETS): fix-licenses
 
+# Intentional override since this projects deps are vendored and handled a bit differently
+# there is no need to go mod download
+$(REPO)/./eks-distro-go-mod-download:
+	touch $@
+
 # For kube proxy images, use the kube proxy base
 kube-proxy/images/%: BASE_IMAGE=$(KUBE_PROXY_BASE_IMAGE)
 
@@ -90,7 +95,7 @@ tarballs: $(KUBE_GIT_VERSION_FILE)
 cleanup-artifacts:
 	@mkdir $(ARTIFACTS_PATH)/bin
 	rm -rf $(OUTPUT_DIR)/{attribution,LICENSES,pause} $(OUTPUT_DIR)/bin/{LICENSES,ATTRIBUTION.txt}
-	cp -rf $(OUTPUT_DIR)/bin/* $(ARTIFACTS_PATH)/bin
+	mv $(OUTPUT_DIR)/bin/* $(ARTIFACTS_PATH)/bin
 	cp $(OUTPUT_DIR)/ATTRIBUTION.txt $(ARTIFACTS_PATH)
 
 .PHONY: test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Space in presubmit is super tight. I think with our recent changes to the garbage collection settings of buildkit, we are hitting the limit right at the end of the build process when copying the binaries to the final artifacts directory.  This should fix that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
