### PR TITLE
Refactor of release number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,11 +186,23 @@ update-release-number:
 	go vet ./cmd/release/number
 	go run ./cmd/release/number/main.go \
 		--branch=$(RELEASE_BRANCH) \
+		--isProd=$(is_update_prod_number) \
 		--openPR=$(OPEN_PR)
+
+.PHONY: update-dev-release-number
+update-dev-release-number:
+	$(MAKE) is_update_prod_number=false update-release-number
+
+.PHONY: update-prod-release-number
+update-prod-release-number:
+	$(MAKE) is_update_prod_number=true update-release-number
+
+.PHONY: update-release-numbers
+update-release-numbers: update-dev-release-number update-prod-release-number
 
 .PHONY: update-all-release-numbers
 update-all-release-numbers:
-	for r_b in $(SUPPORTED_RELEASE_BRANCHES); do RELEASE_BRANCH=$$r_b $(MAKE) update-release-number; done
+	for r_b in $(SUPPORTED_RELEASE_BRANCHES); do RELEASE_BRANCH=$$r_b $(MAKE) update-release-numbers; done
 
 .PHONY: release-docs
 release-docs:

--- a/cmd/release/number/internal/number_pr.go
+++ b/cmd/release/number/internal/number_pr.go
@@ -10,12 +10,12 @@ type prRequest struct {
 	filesChanged                 []string
 }
 
-func OpenNumberPR(branch, number string, files []string, environment ReleaseEnvironment) error {
+func OpenNumberPR(branch string, releaseNum ReleaseNumber, environment ReleaseEnvironment) error {
 	request := prRequest{
 		branch:       branch,
 		environment:  environment.String(),
-		version:      GetBranchWithDotAndNumberWithDashFormat(branch, number),
-		filesChanged: files,
+		version:      GetBranchWithDotAndNumberWithDashFormat(branch, releaseNum.Next()),
+		filesChanged: []string{releaseNum.FilePath()},
 	}
 	return openNumberPR(&request)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Changed update release number to either to prod or dev instead of doing prod AND dev. This gets rid of a lot of redundant code and it part of a refactoring effort. 

Tested by running them.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
