### PR TITLE
snapshotter: fix licenses target

### DIFF
--- a/projects/kubernetes-csi/external-snapshotter/Makefile
+++ b/projects/kubernetes-csi/external-snapshotter/Makefile
@@ -28,7 +28,8 @@ $(GATHER_LICENSES_TARGETS): $(SNAPSHOTTER_LICENSE)
 # external-snapshotter ends up vendoring some deps that exist in the main repo, but there
 # is no license file in the subfolder and go-license is not able to find it
 # manually copying the root license to the vendor directory
-$(SNAPSHOTTER_LICENSE): $(GIT_CHECKOUT_TARGET)
+$(SNAPSHOTTER_LICENSE): | $(GO_MOD_DOWNLOAD_TARGETS)
+	mkdir -p $(@D)
 	cp $(REPO)/LICENSE $@
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

With the recent changes to the go mod handling and changing some of the common.mk targets to be % based, the ordering got shifted a bit.  The normal build target is working fine, but when running gather-licenses directly there is an issue, which is breaking the attribution job.  

This target should have always been dependent on the GO_MOD_DOWNLOAD_TARGETS, most of the projects in the eks-a-building-tooling side were handling this proper except for one.  This was previously working because the GATHER_LICENSES_TARGETS which we were adding this as a pre-req for matched exactly the target in Common.mk, ie there were % usage.  Now that the gather licenses target is % based, the one in the project [makefile](https://github.com/aws/eks-distro/pull/900/files#diff-a2d191cda2c98aa90c7236d7f431bf4224774a861c083b05cd881a181b032942R26) is taking a higher priority and triggering the fix-licenses target to run before go mod download, whereas it used to run after.  Add the expect pre-req is the way to go.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
