### PR TITLE
Fixes kubernetes attribution target

### DIFF
--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -103,7 +103,7 @@ test: $(BINARY_TARGETS)
 	build/run_tests.sh $(RELEASE_BRANCH) $(GOLANG_VERSION)
 
 .PHONY: fix-licenses
-fix-licenses:
+fix-licenses: $(GIT_PATCH_TARGET)
 	build/fix_licenses.sh $(REPO) $(OUTPUT_DIR)
 
 $(KUBE_GIT_VERSION_FILE): $(GIT_PATCH_TARGET)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I broke this the other day due to some makefile refactoring, similar fix as https://github.com/aws/eks-distro/pull/900

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
