### PR TITLE
Adds go.sums for each project to repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ attribution-files-project-%:
 	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH) attribution
 
 .PHONY: update-attribution-files
-update-attribution-files: add-generated-help-block attribution-files checksum-files
+update-attribution-files: add-generated-help-block attribution-files checksum-files go-mod-files
 	build/lib/update_go_versions.sh
 	build/update-attribution-files/create_pr.sh
 
@@ -170,6 +170,15 @@ checksum-files-project-%:
 
 .PHONY: checksum-files
 checksum-files: $(addprefix checksum-files-project-, $(ALL_PROJECTS))
+	build/update-attribution-files/create_pr.sh
+
+.PHONY: go-mod-files-project-%
+go-mod-files-project-%:
+	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
+	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH) update-go-mods
+
+.PHONY: go-mod-files
+go-mod-files: $(addprefix go-mod-files-project-, $(ALL_PROJECTS))
 	build/update-attribution-files/create_pr.sh
 
 .PHONY: add-generated-help-block-project-%

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ at https://prow.eks.amazonaws.com/. Please read our
 For building EKS Distro locally, refer to the 
 [building-locally](docs/development/building-locally.md) guide.
 
+For updating project dependencies, refer to the
+[update-project-dependency](docs/development/update-project-dependency.md) guide.
+
 ## Security
 
 If you discover a potential security issue in this project, or think you may

--- a/build/lib/patch_for_dep_update.sh
+++ b/build/lib/patch_for_dep_update.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO="$1"
+GIT_TAG="$2"
+PATCHES_DIR="${3:-../patches}"
+
+mkdir -p $PATCHES_DIR
+
+cd $REPO
+
+COMMIT=$(git rev-parse HEAD)
+LATEST_PATCH_NUMBER=$(ls -f $PATCHES_DIR | cut -d- -f1 | sort | tail -1)
+
+if [[ ! $LATEST_PATCH_NUMBER =~ ^[0-9] ]]; then
+    LATEST_PATCH_NUMBER=1
+fi
+
+git add go.mod go.sum
+
+# if the upstream project vends their deps, lets update them in the patch
+if [ $(git cat-file -t $GIT_TAG:vendor 2>/dev/null) ]; then
+    git add ./vendor
+fi
+
+git commit
+git format-patch --signoff --start-number $((LATEST_PATCH_NUMBER + 1)) -o $PATCHES_DIR $COMMIT --
+
+# Copy into project folder to check in for dependabot
+cp -f go.{mod,sum} $(dirname $PATCHES_DIR)

--- a/build/lib/update_vendor.sh
+++ b/build/lib/update_vendor.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+PROJECT_ROOT="$1"
+REPO="$2"
+TAG="$3"
+GOLANG_VERSION="$4"
+CUSTOM_VENDOR_UPDATE_SCRIPT="${5:-}"
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
+cd $REPO
+
+CACHE_KEY=$(echo $PROJECT_ROOT | sed 's/\(.*\)\//\1-/' | xargs basename)
+build::common::use_go_version $GOLANG_VERSION
+build::common::set_go_cache $CACHE_KEY $TAG
+
+# force a full download of deps to properly clean up the go.sum
+rm -rf go.sum vendor
+
+if [ ! -f "$CUSTOM_VENDOR_UPDATE_SCRIPT" ]; then
+    go mod vendor
+    go mod tidy
+else
+    exec $CUSTOM_VENDOR_UPDATE_SCRIPT
+fi

--- a/build/update-attribution-files/make_attribution.sh
+++ b/build/update-attribution-files/make_attribution.sh
@@ -50,7 +50,7 @@ RELEASE_FOLDER=$(find $PROJECT_ROOT -type d -name "1-*")
 if [ -z "${RELEASE_FOLDER}" ]; then
     build::attribution::generate
 else
-    for release in $PROJECT_ROOT/1-*/ ; do
-        build::attribution::generate $(basename $release)
+    for release in $(cat $MAKE_ROOT/release/SUPPORTED_RELEASE_BRANCHES) ; do
+        build::attribution::generate $release
     done
 fi

--- a/docs/development/update-project-dependency.md
+++ b/docs/development/update-project-dependency.md
@@ -1,0 +1,33 @@
+# Updating project dependencies
+
+The projects we maintain as part of EKS-D can not always be updated to the latest version from upstream.
+EKS-D matches the versions used in the cloud EKS service and generally dependency projects are not heavily updated
+during the life cycle of a specific Kubernetes release life cycle.  To account for security related fixes upstream
+we occasionally need to update specific dependencies for some of the projects in this repo.
+
+## Typical workflow
+
+1. Based on our automated Dependeabot alerts or Inspector V2 scans, identify dependencies in need of updating
+along with the fix version. **Note** Be sure to include the `RELEASE_BRANCH=<>` along with each make call
+if updating a released branch project. It may be easier to just `export RELEASE_BRANCH=<>` before starting this process.
+1. In the specific project folder:
+    * `make checkout-repo`
+    * Update $(REPO)/go.mod file to new version of dependency. There are various options:
+        * if it is a simple dependency, not overridden in a replace block, run `go get -u dep@version`
+        * if there are a number of dependencies to update, it may be easier to manually change the version in the go.mod file
+        * if the dependency is an implicit dependency brought in via another, you may need to add a replace override
+        * pay close attention to replace override blocks, these may need updating as well
+        * `go mod why` and `go mod graph` could be helpful in determining which dependency is pulling in implicit dependencies
+    * After go.mod has been updated run `make update-vendor-for-dep-patch`
+        * a number upstream projects which vendor their deps have a specific script for updating the vendor directly.
+        For ex [external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter/blob/master/release-tools/update-vendor.sh)
+        if this is the case, add `VENDOR_UPDATE_SCRIPT=<path-in-repo>` to the project Makefile
+        * by default, this will run `go mod vendor && go mod tidy`
+    * `make patch-for-dep-update` will generate a new patch file including the go.sum/mod file changes along with the vendor
+    directory if upstream vends deps.
+        * the script will launch your git editor to fill in the commit message and body. Please try to include the CVE number
+        along with any upstream PR this may be based off and which upstream version includes the fix.  This information will
+        help in future maintenance of these patches.
+    * `make build` to generate new checksums
+        * can use `make update-attribution-checksums-docker` if you prefer to build in docker. See [building locally](building-locally.md)
+        for more info


### PR DESCRIPTION
To help with automated vuln scanning, check in the go.sum
files for each project.  Adds update logic to the existing
attribution process

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
