### PR TITLE
Updates gather licenses for new version of go-licenses

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -103,11 +103,12 @@ function build::gather_licenses() {
   # go-licenses are all the dependencies found from the module(s) that were passed in via patterns
   go list -deps=true -json ./... | jq -s ''  > "${outputdir}/attribution/go-deps.json"
 
-  go-licenses save --force $patterns --save_path="${outputdir}/LICENSES"
-  
   # go-licenses can be a bit noisy with its output and lot of it can be confusing 
   # the following messages are safe to ignore since we do not need the license url for our process
-  NOISY_MESSAGES="cannot determine URL for|Error discovering URL|unsupported package host"
+  NOISY_MESSAGES="cannot determine URL for|Error discovering license URL|unsupported package host|contains non-Go code|has empty version|vendor.*\.s$"
+
+  go-licenses save --force $patterns --save_path="${outputdir}/LICENSES" 2>  >(grep -vE "$NOISY_MESSAGES" >&2)
+  
   go-licenses csv $patterns > "${outputdir}/attribution/go-license.csv" 2>  >(grep -vE "$NOISY_MESSAGES" >&2)
 
   if cat "${outputdir}/attribution/go-license.csv" | grep -q "^vendor\/golang.org\/x"; then

--- a/build/lib/install_go_versions.sh
+++ b/build/lib/install_go_versions.sh
@@ -45,10 +45,11 @@ setupgo "${GOLANG118_VERSION:-1.18.2}"
 # go-licenses needs to be installed by the same version of go that is being used
 # to generate the deps list during the attribution generation process
 build::common::use_go_version "1.16"
-GOBIN=${GOPATH}/go1.17/bin go install github.com/google/go-licenses@v1.0.0
+GOBIN=${GOPATH}/go1.16/bin go install github.com/google/go-licenses@v1.2.1
 
 build::common::use_go_version "1.17"
-GOBIN=${GOPATH}/go1.17/bin go install github.com/google/go-licenses@v1.0.0
+GOBIN=${GOPATH}/go1.17/bin go install github.com/google/go-licenses@v1.2.1
 
 # 1.16 is the default so symlink it to /go/bin
+unlink ${GOPATH}/bin/go-licenses
 ln -s ${GOPATH}/go1.16/bin/go-licenses ${GOPATH}/bin

--- a/projects/kubernetes/release/Makefile
+++ b/projects/kubernetes/release/Makefile
@@ -29,8 +29,12 @@ DOCKERFILE_FOLDER=./docker/$(IMAGE_NAME)
 
 HAS_RELEASE_BRANCHES=true
 
+FIX_LICENSES_GO_RUNNER_TARGET=$(REPO)/images/build/go-runner/LICENSE
+
 include $(BASE_DIRECTORY)/Common.mk
 
+
+$(GATHER_LICENSES_TARGETS): | $(FIX_LICENSES_GO_RUNNER_TARGET)
 
 $(call IMAGE_TARGETS_FOR_NAME, kube-proxy-base): $(IPTABLES_WRAPPER)
 $(call IMAGE_TARGETS_FOR_NAME, kube-proxy-base): IMAGE_TARGET=$(RELEASE_VARIANT)
@@ -46,6 +50,9 @@ $(IPTABLES_WRAPPER): $(GIT_CHECKOUT_TARGET)
 fix-licenses: $(GATHER_LICENSES_TARGETS)
 	build/fix_licenses.sh $(OUTPUT_DIR)
 
+$(FIX_LICENSES_GO_RUNNER_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
+#go-licenses requires a LICENSE file in each folder with the go.mod
+	cp $(REPO)/LICENSE $@
 
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The go-licenses update introduced some new noisy messages and on the eks-a side required a couple project changes to support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
