### PR TITLE
Tweaks Attribution job ordering and when PRs are created

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ makes-clean-%:
 .PHONY: attribution-files
 attribution-files: $(addprefix attribution-files-project-, $(ALL_PROJECTS))
 	cat _output/total_summary.txt
+	build/update-attribution-files/create_pr.sh
 
 .PHONY: attribution-files-project-%
 attribution-files-project-%:
@@ -159,9 +160,7 @@ attribution-files-project-%:
 	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH) attribution
 
 .PHONY: update-attribution-files
-update-attribution-files: add-generated-help-block attribution-files checksum-files go-mod-files
-	build/lib/update_go_versions.sh
-	build/update-attribution-files/create_pr.sh
+update-attribution-files: add-generated-help-block go-mod-files attribution-files checksum-files
 
 .PHONY: checksum-files-project-%
 checksum-files-project-%:
@@ -170,6 +169,7 @@ checksum-files-project-%:
 
 .PHONY: checksum-files
 checksum-files: $(addprefix checksum-files-project-, $(ALL_PROJECTS))
+	build/lib/update_go_versions.sh
 	build/update-attribution-files/create_pr.sh
 
 .PHONY: go-mod-files-project-%

--- a/build/lib/update_go_versions.sh
+++ b/build/lib/update_go_versions.sh
@@ -21,6 +21,10 @@ set -o pipefail
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_ROOT}/common.sh"
 
+if [[ -z "$JOB_TYPE" ]]; then
+    exit 0
+fi
+
 GOPATH=$GOPATH
 if [ -d "/go" ]; then
     GOPATH="/go"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This will change when the PRs the bot opens during the periodic job happen.  The parts are now ordered by how long each take, with checksums being last since that requires building.  Attribution/go.mods/help changes should now all have their PRs opened much earlier in the process, in case we are specifically waiting on attribution changes and want to get those merged asap.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
