### PR TITLE
Fix bug in tag and created make github-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ RELEASE_BRANCH?=$(shell cat $(BASE_DIRECTORY)/release/DEFAULT_RELEASE_BRANCH)
 SUPPORTED_RELEASE_BRANCHES?=$(shell cat $(BASE_DIRECTORY)/release/SUPPORTED_RELEASE_BRANCHES)
 RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
+PROD_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/production/RELEASE)
 ARTIFACT_BUCKET?=my-s3-bucket
 
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
@@ -14,7 +15,7 @@ USE_PREV_RELEASE_MANIFEST?=false
 OPEN_PR?=true
 IS_LOCAL_RELEASE_NUMBER_FOR_NEW_RELEASE?=true
 
-RELEASE_GIT_TAG?=v$(RELEASE_BRANCH)-eks-$(RELEASE)
+RELEASE_GIT_TAG?=v$(RELEASE_BRANCH)-eks-$(PROD_RELEASE)
 RELEASE_GIT_COMMIT_HASH?=$(shell git rev-parse @)
 
 ALL_PROJECTS=containernetworking_plugins coredns_coredns etcd-io_etcd kubernetes-csi_external-attacher kubernetes-csi_external-resizer \
@@ -236,4 +237,10 @@ only-index-md-from-existing-release-manifest:
 		--includeDocsIndex=false \
 		--force=true
 
+.PHONY: github-release
+github-release:
+	go vet ./cmd/release/github_release
+	go run ./cmd/release/github_release/main.go \
+		--branch=$(RELEASE_BRANCH) \
+		--number=$(PROD_RELEASE)
 

--- a/cmd/release/github_release/create_github_release.sh
+++ b/cmd/release/github_release/create_github_release.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generates release on GitHub.
+# IMPORTANT!! GIT_TAG for release must already exist.
+set -e
+set -o pipefail
+set -x
+
+GIT_TAG="${1?...}"
+VERSION="${2?...}"
+CHANGELOG_FILEPATH="${3?...}"
+INDEX_FILEPATH="${4?...}"
+
+# Removes the first to lines to get rid of H1 headers and an empty line.
+# The H1 headers are larger than the release titles on GitHub, and it
+# looks confusing with them.
+releaseNotes="$(sed '1,2d' "$CHANGELOG_FILEPATH")
+
+$(sed '1,2d' "$INDEX_FILEPATH")"
+
+gh release create "$GIT_TAG" --title "EKS Distro $VERSION Release" --notes "$releaseNotes"

--- a/cmd/release/github_release/main.go
+++ b/cmd/release/github_release/main.go
@@ -16,6 +16,9 @@ var (
 	errStream    io.Writer = os.Stderr
 )
 
+// Generates a release on GitHub.
+// IMPORTANT! Only run after the release is out, you've pulled own the
+// latest changes, and the release is tagged on GitHub.
 func main() {
 	branch := flag.String("branch", "", "Release branch, e.g. 1-22")
 	number := flag.String("number", "", "Release branch, e.g. 5")

--- a/cmd/release/github_release/main.go
+++ b/cmd/release/github_release/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	. "../utils"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+var (
+	outputStream io.Writer = os.Stdout
+	errStream    io.Writer = os.Stderr
+)
+
+func main() {
+	branch := flag.String("branch", "", "Release branch, e.g. 1-22")
+	number := flag.String("number", "", "Release branch, e.g. 5")
+
+	flag.Parse()
+
+	err := createRelease(*branch, *number)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func createRelease(branch, number string) error {
+	docsDirectory := fmt.Sprintf("%s/docs/contents/releases/%s/%s", GetGitRootDirectory(), branch, number)
+	changelogFilepath := fmt.Sprintf("%s/CHANGELOG-v%s-eks-%s.md", docsDirectory, branch, number)
+	indexFilepath := fmt.Sprintf("%s/index.md", docsDirectory)
+
+	releaseGitTag := fmt.Sprintf("v%s-eks-%s", branch, number)
+	releaseVersion := "v" + GetBranchWithDotAndNumberWithDashFormat(branch, number)
+
+	cmd := exec.Command(
+		"/bin/bash",
+		filepath.Join(GetGitRootDirectory(), "cmd/release/github_release/create_github_release.sh"),
+		releaseGitTag,
+		releaseVersion,
+		changelogFilepath,
+		indexFilepath,
+	)
+
+	cmd.Stdout = outputStream
+	cmd.Stderr = errStream
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error creating release: %v", err)
+	}
+
+	log.Printf(
+		"Published release!\nYou can view at it https://github.com/aws/eks-distro/releases/tag/%s",
+		releaseGitTag)
+	return nil
+}


### PR DESCRIPTION
### Issue #, if available:
Closes #1056

### Description of changes:
* Fixed bug in make tag.
  * The prod number should always be the ones used for the tag, but the default before this change was the dev one.
* Added make command to generate a release on GitHub
  * This code isn't great but it does work. There is some redundant code in `make docs` and `make github-release`. But I'm in the middle of refactoring the make docs commands and don't want to mess with this now, as I can imagine it'll be a huge merge conflict pain. So it's good enough for now.
  * Example of what it generated: https://github.com/aws/eks-distro/releases/tag/v1-22-eks-8

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
