### PR TITLE
Removed 1.19 from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,15 @@
 
 ### 🚨🚨🚨 IMPORTANT INFORMATION ABOUT 1.19 SUPPORT 🚨🚨🚨
 
-EKS-D will be discontinuing support of Kubernetes v1.19 soon. While there are no
-plans to removed EKS-D 1.19 images from the ECR, there will be no more updates 
-to 1.19 once support has stopped. **Due to the increased security risk this poses, 
-it is HIGHLY recommended that users of 1.19 update to a supported version 
-(1.20 - 1.22) as soon as possible.**
+EKS-D has discontinued support of Kubernetes 1.19. While there are no plans to 
+removed EKS-D 1.19 images from the ECR, there will be no more updates to 1.19. 
+**Due to the increased security risk this poses, it is HIGHLY recommended that 
+users of 1.19 update to a supported version (1.20 - 1.22) as soon as possible.**
 
 ---
 
 | Release | Development Build Status |
 | --- | --- |
-| 1-19 | [![1-19](https://prow.eks.amazonaws.com/badge.svg?jobs=build-1-19-postsubmit)](https://prow.eks.amazonaws.com/?job=build-1-19-postsubmit) |
 | 1-20 | [![1-20](https://prow.eks.amazonaws.com/badge.svg?jobs=build-1-20-postsubmit)](https://prow.eks.amazonaws.com/?job=build-1-20-postsubmit) |
 | 1-21 | [![1-21](https://prow.eks.amazonaws.com/badge.svg?jobs=build-1-21-postsubmit)](https://prow.eks.amazonaws.com/?job=build-1-21-postsubmit) |
 | 1-22 | [![1-22](https://prow.eks.amazonaws.com/badge.svg?jobs=build-1-22-postsubmit)](https://prow.eks.amazonaws.com/?job=build-1-22-postsubmit) |
@@ -56,20 +54,16 @@ To receive notifications about new EKS-D releases, subscribe to the EKS-D update
 | --- | --- |
 | 19 | [kubernetes-1-20-eks-19](https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-19.yaml) |
 
-### Kubernetes 1-19
 
-| Release | Manifest |
-| --- | --- |
-| 22 | [kubernetes-1-19-eks-22](https://distro.eks.amazonaws.com/kubernetes-1-19/kubernetes-1-19-eks-22.yaml) |
+### Kubernetes 1.18 and 1.19: DEPRECATED
 
-### Kubernetes 1-18: DEPRECATED
-
-EKS Distro has discontinued support of Kubernetes v1.18. While there are no
-plans to remove the 1.18 images from EKS Distro ECR, there will be no more 
-updates, including security updates, for 1.18.
+EKS Distro has discontinued support of Kubernetes 1.18 and 1.19. While there are
+no plans to remove these versions' images from EKS Distro ECR, there will be no
+more updates, including security fixes, for them.
 
 **Due to the increased security risk this poses, it is HIGHLY recommended that
-users of 1.18 update to a supported version (1.20 - 1.22) as soon as possible.**
+users of 1.18 and 1.19 update to a supported version (1.20 - 1.22) as soon as 
+possible.**
 
 ## Development
 

--- a/docs/contents/index.md
+++ b/docs/contents/index.md
@@ -172,7 +172,7 @@ if you are interested in the AL2 container runtime kernel version.
 * [v1-20-eks-2](releases/1-20/2/index.md) (June 30, 2021)
 * [v1-20-eks-1](releases/1-20/1/index.md) (May 18, 2021)
 
-#### EKS-D 1.19 Version Dependencies
+#### EKS-D 1.19 Version Dependencies (DEPRECATED)
 * [v1-19-eks-22](releases/1-19/22/index.md) (July 28, 2022)
 * [v1-19-eks-21](releases/1-19/21/index.md) (July 2, 2022)
 * [v1-19-eks-20](releases/1-19/20/index.md) (June 20, 2022)
@@ -196,7 +196,7 @@ if you are interested in the AL2 container runtime kernel version.
 * [v1-19-eks-2](releases/1-19/2/index.md) (March 30, 2021)
 * [v1-19-eks-1](releases/1-19/1/index.md) (March 4, 2021)
 
-#### EKS-D 1.18 Version Dependencies
+#### EKS-D 1.18 Version Dependencies (DEPRECATED)
 * [v1-18-eks-17](releases/1-18/17/index.md) (March 17, 2022)
 * [v1-18-eks-16](releases/1-18/16/index.md) (March 17, 2022)
 * [v1-18-eks-15](releases/1-18/15/index.md) (February 18, 2022)

--- a/projects/containernetworking/plugins/README.md
+++ b/projects/containernetworking/plugins/README.md
@@ -2,7 +2,6 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-19    | ![Version](https://img.shields.io/badge/version-v0.8.7-blue) |
 | 1-20    | ![Version](https://img.shields.io/badge/version-v0.8.7-blue) |
 | 1-21    | ![Version](https://img.shields.io/badge/version-v0.8.7-blue) |
 | 1-22    | ![Version](https://img.shields.io/badge/version-v0.8.7-blue) |

--- a/projects/coredns/coredns/README.md
+++ b/projects/coredns/coredns/README.md
@@ -2,7 +2,6 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-19    | ![Version](https://img.shields.io/badge/version-v1.8.0-blue) |
 | 1-20    | ![Version](https://img.shields.io/badge/version-v1.8.3-blue) |
 | 1-21    | ![Version](https://img.shields.io/badge/version-v1.8.4-blue) |
 | 1-22    | ![Version](https://img.shields.io/badge/version-v1.8.7-blue) |

--- a/projects/etcd-io/etcd/README.md
+++ b/projects/etcd-io/etcd/README.md
@@ -2,7 +2,6 @@
 
 | Release | Version                                                       |
 |---------|---------------------------------------------------------------|
-| 1-19    | ![Version](https://img.shields.io/badge/version-v3.4.18-blue) |
 | 1-20    | ![Version](https://img.shields.io/badge/version-v3.4.18-blue) |
 | 1-21    | ![Version](https://img.shields.io/badge/version-v3.4.18-blue) |
 | 1-22    | ![Version](https://img.shields.io/badge/version-v3.5.4-blue)  |

--- a/projects/kubernetes-csi/external-attacher/README.md
+++ b/projects/kubernetes-csi/external-attacher/README.md
@@ -2,7 +2,6 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-19    | ![Version](https://img.shields.io/badge/version-v3.5.0-blue) |
 | 1-20    | ![Version](https://img.shields.io/badge/version-v3.5.0-blue) |
 | 1-21    | ![Version](https://img.shields.io/badge/version-v3.5.0-blue) |
 | 1-22    | ![Version](https://img.shields.io/badge/version-v3.5.0-blue) |

--- a/projects/kubernetes-csi/external-provisioner/README.md
+++ b/projects/kubernetes-csi/external-provisioner/README.md
@@ -2,7 +2,6 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-19    | ![Version](https://img.shields.io/badge/version-v2.2.2-blue) |
 | 1-20    | ![Version](https://img.shields.io/badge/version-v3.2.1-blue) |
 | 1-21    | ![Version](https://img.shields.io/badge/version-v3.2.1-blue) |
 | 1-22    | ![Version](https://img.shields.io/badge/version-v3.2.1-blue) |

--- a/projects/kubernetes-csi/external-resizer/README.md
+++ b/projects/kubernetes-csi/external-resizer/README.md
@@ -2,7 +2,6 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-19    | ![Version](https://img.shields.io/badge/version-v1.5.0-blue) |
 | 1-20    | ![Version](https://img.shields.io/badge/version-v1.5.0-blue) |
 | 1-21    | ![Version](https://img.shields.io/badge/version-v1.5.0-blue) |
 | 1-22    | ![Version](https://img.shields.io/badge/version-v1.5.0-blue) |

--- a/projects/kubernetes-csi/external-snapshotter/README.md
+++ b/projects/kubernetes-csi/external-snapshotter/README.md
@@ -2,7 +2,6 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-19    | ![Version](https://img.shields.io/badge/version-v3.0.3-blue) |
 | 1-20    | ![Version](https://img.shields.io/badge/version-v6.0.1-blue) |
 | 1-21    | ![Version](https://img.shields.io/badge/version-v6.0.1-blue) |
 | 1-22    | ![Version](https://img.shields.io/badge/version-v6.0.1-blue) |

--- a/projects/kubernetes-csi/livenessprobe/README.md
+++ b/projects/kubernetes-csi/livenessprobe/README.md
@@ -2,7 +2,6 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-19    | ![Version](https://img.shields.io/badge/version-v2.7.0-blue) |
 | 1-20    | ![Version](https://img.shields.io/badge/version-v2.7.0-blue) |
 | 1-21    | ![Version](https://img.shields.io/badge/version-v2.7.0-blue) |
 | 1-22    | ![Version](https://img.shields.io/badge/version-v2.7.0-blue) |

--- a/projects/kubernetes-csi/node-driver-registrar/README.md
+++ b/projects/kubernetes-csi/node-driver-registrar/README.md
@@ -2,7 +2,6 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-19    | ![Version](https://img.shields.io/badge/version-v2.5.1-blue) |
 | 1-20    | ![Version](https://img.shields.io/badge/version-v2.5.1-blue) |
 | 1-21    | ![Version](https://img.shields.io/badge/version-v2.5.1-blue) |
 | 1-22    | ![Version](https://img.shields.io/badge/version-v2.5.1-blue) |

--- a/projects/kubernetes-sigs/aws-iam-authenticator/README.md
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/README.md
@@ -2,7 +2,6 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-19    | ![Version](https://img.shields.io/badge/version-v0.5.9-blue) |
 | 1-20    | ![Version](https://img.shields.io/badge/version-v0.5.9-blue) |
 | 1-21    | ![Version](https://img.shields.io/badge/version-v0.5.9-blue) |
 | 1-22    | ![Version](https://img.shields.io/badge/version-v0.5.9-blue) |

--- a/projects/kubernetes-sigs/metrics-server/README.md
+++ b/projects/kubernetes-sigs/metrics-server/README.md
@@ -2,7 +2,6 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-19    | ![Version](https://img.shields.io/badge/version-v0.6.1-blue) |
 | 1-20    | ![Version](https://img.shields.io/badge/version-v0.6.1-blue) |
 | 1-21    | ![Version](https://img.shields.io/badge/version-v0.6.1-blue) |
 | 1-22    | ![Version](https://img.shields.io/badge/version-v0.6.1-blue) |


### PR DESCRIPTION
*Issue #, if available:*
Related to #983 

*Description of changes:*
Removed 1.19 from docs and updated docs about it being no longer supported 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
