### PR TITLE
Fixed 1-23 cni build failure

### DIFF
--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -74,7 +74,7 @@ export PREFLIGHT_CHECK_PASSED
 export KUBERNETES_VERSION=$(cat ../../projects/kubernetes/kubernetes/${RELEASE_BRANCH}/GIT_TAG)
 export IMAGE_REPO=${IMAGE_REPO:-public.ecr.aws/eks-distro}
 export ARTIFACT_URL=${ARTIFACT_URL:-$ARTIFACT_BASE_URL/kubernetes-${RELEASE_BRANCH}/releases/${RELEASE}/artifacts}
-export CNI_VERSION=$(cat ../../projects/containernetworking/plugins/GIT_TAG)
+export CNI_VERSION=$(cat ../../projects/containernetworking/plugins/${RELEASE_BRANCH}/GIT_TAG)
 export CNI_VERSION_URL=${ARTIFACT_URL}/plugins/${CNI_VERSION}/cni-plugins-linux-${NODE_ARCHITECTURE}-${CNI_VERSION}.tar.gz
 export CNI_ASSET_HASH_STRING=${CNI_ASSET_HASH_STRING:-sha256:$(curl -s ${CNI_VERSION_URL}.sha256 | cut -f1 -d' ')}
 export KOPS=bin/kops


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Fixes `cp: cannot stat '1-23/ATTRIBUTION.txt': No such file or directory` error in build-1-23-postsubmit jobs ([example](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/build-1-23-postsubmit/1554617167255703552#2:build-container-build-log.txt%3A501)). This PR, which split CNI into release branches, caused this issue: https://github.com/aws/eks-distro/pull/1157

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
