### PR TITLE
build and install kops from source with patch removing req on flannel…

### DIFF
--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -33,13 +33,19 @@ mkdir -p ${BASEDIR}/bin
 if [ ! -x ${KOPS} ]
 then
     echo "Determine kops version"
-    KOPS_VERSION="v1.23.2"
-    echo "Download kops"
-    KOPS_URL="https://github.com/kubernetes/kops/releases/download/${KOPS_VERSION}/kops-${OS}-${ARCH}"
-    set -x
-    curl -L -o ${KOPS} "${KOPS_URL}"
-    chmod 755 ${KOPS}
-    set +x
+    KOPS_VERSION_TAG="v1.23.2"
+
+    echo "Cloning kops"
+    KOPS_FLANNEL_PLUGIN_PATCH="0001-remove-hardcoded-requierment-on-flannel-plugin.patch"
+    KOPS_GIT_URL="https://github.com/kubernetes/kops.git"
+    git clone ${KOPS_GIT_URL}
+
+    echo "Patching kops"
+    git -C ${BASEDIR}/kops checkout ${KOPS_VERSION_TAG} 
+    git -C ${BASEDIR}/kops am ../patches/${KOPS_FLANNEL_PLUGIN_PATCH}
+
+    echo "Building kops"
+    (cd ${BASEDIR}/kops && make kops-install)
 fi
 
 if ! command -v kubectl &> /dev/null

--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -45,7 +45,8 @@ then
     git -C ${BASEDIR}/kops am ../patches/${KOPS_FLANNEL_PLUGIN_PATCH}
 
     echo "Building kops"
-    (cd ${BASEDIR}/kops && make kops-install)
+    KOPS_BIN_DIR="$(pwd)/bin"
+    (cd ${BASEDIR}/kops && GOBIN=${KOPS_BIN_DIR}/bin make kops-install)
 fi
 
 if ! command -v kubectl &> /dev/null

--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -46,7 +46,7 @@ then
 
     echo "Building kops"
     KOPS_BIN_DIR="$(pwd)/bin"
-    (cd ${BASEDIR}/kops && GOBIN=${KOPS_BIN_DIR}/bin make kops-install)
+    (cd ${BASEDIR}/kops && GOBIN=${KOPS_BIN_DIR} make kops-install)
 fi
 
 if ! command -v kubectl &> /dev/null

--- a/development/kops/patches/0001-remove-hardcoded-requierment-on-flannel-plugin.patch
+++ b/development/kops/patches/0001-remove-hardcoded-requierment-on-flannel-plugin.patch
@@ -1,0 +1,24 @@
+From 2ec5afbedada5688c13aa8e8d9ac9ffba3ae4511 Mon Sep 17 00:00:00 2001
+From: Daniel Budris <budris@amazon.com>
+Date: Wed, 3 Aug 2022 11:50:10 -0400
+Subject: [PATCH] remove hardcoded requierment on flannel plugin
+
+---
+ nodeup/pkg/model/networking/common.go | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/nodeup/pkg/model/networking/common.go b/nodeup/pkg/model/networking/common.go
+index a7a08cb235..4d78eb4836 100644
+--- a/nodeup/pkg/model/networking/common.go
++++ b/nodeup/pkg/model/networking/common.go
+@@ -34,7 +34,6 @@ func (b *CommonBuilder) Build(c *fi.ModelBuilderContext) error {
+ 	assets := []string{
+ 		"bridge",
+ 		"dhcp",
+-		"flannel",
+ 		"host-device",
+ 		"host-local",
+ 		"ipvlan",
+-- 
+2.30.1 (Apple Git-130)
+

--- a/development/kops/patches/0001-remove-hardcoded-requierment-on-flannel-plugin.patch
+++ b/development/kops/patches/0001-remove-hardcoded-requierment-on-flannel-plugin.patch
@@ -3,6 +3,11 @@ From: Daniel Budris <budris@amazon.com>
 Date: Wed, 3 Aug 2022 11:50:10 -0400
 Subject: [PATCH] remove hardcoded requierment on flannel plugin
 
+In CNI v1.0.0 the flannel plugin was removed; so, when building EKS Distro 1.23 
+or greater the plugin is not present and cannot be loaded.
+However, EKS Distro does not use the flannel plugin in any cases 
+and the requierment hard-coded in kOps can be safely removed.
+
 ---
  nodeup/pkg/model/networking/common.go | 1 -
  1 file changed, 1 deletion(-)


### PR DESCRIPTION
… plugin

*Issue #, if available:*

*Description of changes:*
Apply patch to kOps to remove flannel plugin from hardcoded list of CNI plugins.

Do this by cloing kops from the desired tag, patching it and installing it, rather than just curling the release version.

ran `./install_requierments.sh` to test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
