### PR TITLE
patch coredns v1.8.3 associated with release 1-20 to fix CVE-2020-27813

### DIFF
--- a/build/lib/update_vendor.sh
+++ b/build/lib/update_vendor.sh
@@ -33,7 +33,7 @@ build::common::use_go_version $GOLANG_VERSION
 build::common::set_go_cache $CACHE_KEY $TAG
 
 # force a full download of deps to properly clean up the go.sum
-rm -rf go.sum vendor
+rm -rf vendor
 
 if [ ! -f "$CUSTOM_VENDOR_UPDATE_SCRIPT" ]; then
     go mod vendor

--- a/build/lib/update_vendor.sh
+++ b/build/lib/update_vendor.sh
@@ -33,7 +33,7 @@ build::common::use_go_version $GOLANG_VERSION
 build::common::set_go_cache $CACHE_KEY $TAG
 
 # force a full download of deps to properly clean up the go.sum
-rm -rf vendor
+rm -rf go.sum vendor
 
 if [ ! -f "$CUSTOM_VENDOR_UPDATE_SCRIPT" ]; then
     go mod vendor

--- a/projects/coredns/coredns/1-20/patches/0001-Upgrade-github.com-gorilla-websocket-to-fix-CVE-2020.patch
+++ b/projects/coredns/coredns/1-20/patches/0001-Upgrade-github.com-gorilla-websocket-to-fix-CVE-2020.patch
@@ -1,0 +1,52 @@
+From 45aafbc560842b0d1078fc9c6d926b90242bf9d9 Mon Sep 17 00:00:00 2001
+From: Daniel Budris <budris@amazon.com>
+Date: Fri, 5 Aug 2022 14:31:47 -0400
+Subject: [PATCH] Upgrade github.com/gorilla/websocket to fix CVE-2020-27813 in
+ projects/coredns/coredns/1-20/go.sum
+
+ https://github.com/coredns/coredns/commit/9e7fe18088d1f91467eb02d3fbb329eaaf77c029
+
+Signed-off-by: Daniel Budris <budris@amazon.com>
+---
+ go.mod | 4 +++-
+ go.sum | 5 ++---
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index dfa5a80c..e6b7f8b5 100644
+--- a/go.mod
++++ b/go.mod
+@@ -14,7 +14,7 @@ require (
+ 	github.com/dustin/go-humanize v1.0.0 // indirect
+ 	github.com/farsightsec/golang-framestream v0.3.0
+ 	github.com/golang/protobuf v1.4.3
+-	github.com/gorilla/websocket v1.4.0 // indirect
++	github.com/gorilla/websocket v1.4.1 // indirect
+ 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
+ 	github.com/hashicorp/golang-lru v0.5.4 // indirect
+ 	github.com/imdario/mergo v0.3.9 // indirect
+@@ -40,3 +40,5 @@ require (
+ 	k8s.io/client-go v0.20.2
+ 	k8s.io/klog v1.0.0
+ )
++
++replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.1
+diff --git a/go.sum b/go.sum
+index 74b372aa..9bdb9798 100644
+--- a/go.sum
++++ b/go.sum
+@@ -245,9 +245,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
+ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+ github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
+ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+-github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+-github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
+-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
++github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
++github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4 h1:z53tR0945TRRQO/fLEVPI6SMv7ZflF0TEaTAoU7tOzg=
+ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
patch coredns v1.8.3 associated with release 1-20 to fix CVE-2020-27813

update vendoring script used in make target

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
