### PR TITLE
Conditional for --short flag for kubectl version

### DIFF
--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -47,8 +47,15 @@ then
     echo "kubectl could not be found. Downloading..."
     KUBECTL_VERSION=$(cat ${BASEDIR}/../../projects/kubernetes/kubernetes/${RELEASE_BRANCH}/GIT_TAG)
     KUBECTL_PATH=${BASEDIR}/bin/kubectl
+    # Starting with Kubernetes 1.24, the short version output became the default, and the `--short`
+    # flag was deprecated. See https://github.com/kubernetes/kubernetes/pull/108987. Once Kubernetes
+    # 1.24 is the oldest version EKS-D supports, SHORT_FLAG_IF_NEEDED can be removed.
+    # The variable KUBERNETES_VERSION is presumed to start with a "v".
+    SHORT_FLAG_IF_NEEDED=$(awk -v k8s_minor_version="${KUBERNETES_VERSION:1:4}" '
+      BEGIN { print (k8s_minor_version < "1.24") ? "--short" : "" }
+    ')
     COUNT=0
-    while [ ! "$(${KUBECTL_PATH} version --client true --short)" ]; do
+    while [ ! "$(${KUBECTL_PATH} version --client true "$SHORT_FLAG_IF_NEEDED")" ]; do
         sleep 5
         COUNT=$(expr $COUNT + 1)
         if [ $COUNT -gt 120 ]

--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -47,15 +47,8 @@ then
     echo "kubectl could not be found. Downloading..."
     KUBECTL_VERSION=$(cat ${BASEDIR}/../../projects/kubernetes/kubernetes/${RELEASE_BRANCH}/GIT_TAG)
     KUBECTL_PATH=${BASEDIR}/bin/kubectl
-    # Starting with Kubernetes 1.24, the short version output became the default, and the `--short`
-    # flag was deprecated. See https://github.com/kubernetes/kubernetes/pull/108987. Once Kubernetes
-    # 1.24 is the oldest version EKS-D supports, SHORT_FLAG_IF_NEEDED can be removed.
-    # The variable KUBERNETES_VERSION is presumed to start with a "v".
-    SHORT_FLAG_IF_NEEDED=$(awk -v k8s_minor_version="${KUBERNETES_VERSION:1:4}" '
-      BEGIN { print (k8s_minor_version < "1.24") ? "--short" : "" }
-    ')
     COUNT=0
-    while [ ! "$(${KUBECTL_PATH} version --client true "$SHORT_FLAG_IF_NEEDED")" ]; do
+    while [ ! "$(${KUBECTL_PATH} version --client true)" ]; do
         sleep 5
         COUNT=$(expr $COUNT + 1)
         if [ $COUNT -gt 120 ]


### PR DESCRIPTION
### Description of changes:
* Fixed broken [build-1-24-postsubmit](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/build-1-24-postsubmit/1563204199812960256). See logs with errors below.
*  What caused this: starting with Kubernetes 1.24, the short version output became the default, and the `--short` flag was deprecated. See https://github.com/kubernetes/kubernetes/pull/108987.

### Logs with errors

```
 kubectl could not be found. Downloading...
./install_requirements.sh: line 51: ./bin/kubectl: No such file or directory
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
+ curl -sSL https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kubernetes-1-24/releases/1.pre/artifacts/kubernetes/v1.24.4/bin/linux/amd64/kubectl -o ./bin/kubectl
+ chmod +x ./bin/kubectl
+ set +x
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
error: extra arguments: [true]
Failed to download kubectl
make: *** [kops-prereqs] Error 1
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
