### PR TITLE
Fix kubectl version --client flag

### DIFF
--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -47,7 +47,7 @@ then
     KUBECTL_VERSION=$(cat ${BASEDIR}/../../projects/kubernetes/kubernetes/${RELEASE_BRANCH}/GIT_TAG)
     KUBECTL_PATH=${BASEDIR}/bin/kubectl
     COUNT=0
-    while [ ! "$(${KUBECTL_PATH} version --client)" ]; do
+    while [ ! "$(${KUBECTL_PATH} version)" ]; do
         sleep 5
         COUNT=$(expr $COUNT + 1)
         if [ $COUNT -gt 120 ]

--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -47,7 +47,7 @@ then
     KUBECTL_VERSION=$(cat ${BASEDIR}/../../projects/kubernetes/kubernetes/${RELEASE_BRANCH}/GIT_TAG)
     KUBECTL_PATH=${BASEDIR}/bin/kubectl
     COUNT=0
-    while [ ! "$(${KUBECTL_PATH} version --client true)" ]; do
+    while [ ! "$(${KUBECTL_PATH} version --client)" ]; do
         sleep 5
         COUNT=$(expr $COUNT + 1)
         if [ $COUNT -gt 120 ]


### PR DESCRIPTION
### Description of changes:
* https://github.com/aws/eks-distro/pull/1186 was intended to fix the broken build-1-24-postsubmit, but it didn't. We were still getting the same error. This one change should fix it. See testing below
* We will still get the deprecation warning, but I think that's fine

### Testing
```
$ kubectl version --client true # <- before this PR's change ❗️
error: extra arguments: [true]  # <- error we saw in prow ❗️

$ kubectl version --client
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.4", ...}

$ kubectl version --short 
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
Client Version: v1.24.4
Server Version: v1.24.4

$ kubectl version  # <- With this PR's change ✅
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.4", ...}
Server Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.4",  ...}}
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
