### PR TITLE
Adds buildkit cache to image builds

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -155,8 +155,12 @@ IMAGE_USERADD_USER_NAME?=
 # $2 - release number
 CACHE_IMPORT_IMAGE=$(1)/$(call IF_OVERRIDE_VARIABLE,$(IMAGE_COMPONENT_VARIABLE),$(IMAGE_COMPONENT)):$(GIT_TAG)-eks-$(RELEASE_BRANCH)-$(2)
 
+# pause images have multiple tags, for caching import grab just the first
+COMMA=,
+FIRST_IMAGE_TAG?=$(word 1,$(subst $(COMMA), ,$(IMAGE)))
+
 IMAGE_IMPORT_CACHE?=type=registry,ref=$(call CACHE_IMPORT_IMAGE,$(PROD_ECR_REG),$(LAST_PROD_RELEASE)) \
-	type=registry,ref=$(call CACHE_IMPORT_IMAGE,$(DEV_ECR_REG),$(LAST_DEV_RELEASE)) type=registry,ref=$(IMAGE) type=registry,ref=$(IMAGE).pre
+	type=registry,ref=$(call CACHE_IMPORT_IMAGE,$(DEV_ECR_REG),$(LAST_DEV_RELEASE)) type=registry,ref=$(FIRST_IMAGE_TAG) type=registry,ref=$(FIRST_IMAGE_TAG).pre
 
 BUILD_OCI_TARS?=false
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Weve been doing this for a while on the eks-a side, but never retrofitted eks-d to do the same.

Buildkit allows embedding the "build cache", I believe this is basically just the hash of the content for a given layer, into the final image which can then be imported on subsequent builds. If on the subsequent build the hash of the content for a given layer matches what is in the previous image's cache, buildkit will reuse the same layer vs building it again, which would result in a new layer id/sha.  This is basically what would happen if you build the same image over and over on the same buildkit builder, each subsequent build would finish almost instantly since its able to reuse the cache.

We should benefit from this since when we cut new releases, rarely are all component changed, which means between releases if etcd, for ex, did not change, the resulting images across these releases would end up being the same exact image, with multiple tags.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
