### PR TITLE
Change number in Changelog generation

### DIFF
--- a/cmd/release/utils/values/searchprs.go
+++ b/cmd/release/utils/values/searchprs.go
@@ -1,9 +1,9 @@
 package values
 
 import (
+	"context"
 	"fmt"
 	"strings"
-	"context"
 
 	"github.com/google/go-github/v47/github"
 )
@@ -17,26 +17,29 @@ func GetChangelogPRs(releaseVersion string) (string, error) {
 
 	ctx := context.Background()
 	opts := &github.SearchOptions{}
-	prs, _, err := githubClient.Search.Issues(ctx, "is:pr label:documentation repo:aws/eks-distro label:" + releaseVersion, opts)
+	prs, _, err := githubClient.Search.Issues(ctx, "is:pr label:documentation repo:aws/eks-distro label:"+releaseVersion, opts)
 	if err != nil {
-		return "", fmt.Errorf("Getting PRs from %v: %v", githubClient, err)
+		return "", fmt.Errorf("getting PRs from %v: %w", githubClient, err)
 	}
 
 	lastDocRelease := prs.Issues[0].ClosedAt.Format("2006-01-02T15:04:05+00:00")
-	
-	patchPRs, _, err := githubClient.Search.Issues(ctx, fmt.Sprintf("%v merged:>%v label:patch label:%v", baseQuery, lastDocRelease, releaseVersion), opts)
+
+	patchPRs, _, err := githubClient.Search.Issues(ctx,
+		fmt.Sprintf("%v merged:>%v label:patch label:%v", baseQuery, lastDocRelease, releaseVersion), opts)
 	if err != nil {
-		return "", fmt.Errorf("Getting patch prs: %v", err)
+		return "", fmt.Errorf("getting patch prs: %w", err)
 	}
 
-	baseImgPRs, _, err := githubClient.Search.Issues(ctx, fmt.Sprintf("%v merged:>%v label:base-img-pkg-update label:%v",baseQuery, lastDocRelease, releaseVersion), opts)
+	baseImgPRs, _, err := githubClient.Search.Issues(ctx,
+		fmt.Sprintf("%v merged:>%v label:base-img-pkg-update label:%v", baseQuery, lastDocRelease, releaseVersion), opts)
 	if err != nil {
-		return "", fmt.Errorf("Getting base image prs: %v", err)
+		return "", fmt.Errorf("getting base image prs: %w", err)
 	}
 
-	versPRs, _, err := githubClient.Search.Issues(ctx, fmt.Sprintf("%v merged:>%v label:project label:%v",baseQuery, lastDocRelease, releaseVersion), opts)
+	versPRs, _, err := githubClient.Search.Issues(ctx, fmt.Sprintf("%v merged:>%v label:project label:%v",
+		baseQuery, lastDocRelease, releaseVersion), opts)
 	if err != nil {
-		return "", fmt.Errorf("Getting project prs: %v", err)
+		return "", fmt.Errorf("getting project prs: %w", err)
 	}
 
 	var changelog []string
@@ -47,7 +50,7 @@ func GetChangelogPRs(releaseVersion string) (string, error) {
 	return strings.Join(changelog, "\n"), nil
 }
 
-func PRsSinceLastRelease(prs *github.IssuesSearchResult, sectionName string) (string) {
+func PRsSinceLastRelease(prs *github.IssuesSearchResult, sectionName string) string {
 	var section []string
 	section = append(section, sectionName)
 
@@ -56,7 +59,7 @@ func PRsSinceLastRelease(prs *github.IssuesSearchResult, sectionName string) (st
 	}
 
 	for _, pr := range prs.Issues {
-		section = append(section, fmt.Sprintf("* %v ([%v](%v))", *pr.Title, *pr.ID, *pr.URL))
+		section = append(section, fmt.Sprintf("* %v ([%v](%v))", *pr.Title, *pr.Number, *pr.URL))
 	}
-	return strings.Join(section, "\n")
+	return strings.Join(section, "\n") + "\n"
 }

--- a/cmd/release/utils/values/searchprs.go
+++ b/cmd/release/utils/values/searchprs.go
@@ -59,7 +59,7 @@ func PRsSinceLastRelease(prs *github.IssuesSearchResult, sectionName string) str
 	}
 
 	for _, pr := range prs.Issues {
-		section = append(section, fmt.Sprintf("* %v ([%v](%v))", *pr.Title, *pr.Number, *pr.URL))
+		section = append(section, fmt.Sprintf("* %v ([%v](%v))", *pr.Title, *pr.Number, *pr.HTMLURL))
 	}
 	return strings.Join(section, "\n") + "\n"
 }


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Only two of these changes is "real". The rest are just things nitpicky thing Intellij's go formatting had flagged. 

#### Real change 1:
``` diff
-	section = append(section, fmt.Sprintf("* %v ([%v](%v))", *pr.Title, *pr.ID, *pr.URL))
+	section = append(section, fmt.Sprintf("* %v ([%v](%v))", *pr.Title, *pr.Number, *pr.URL))
```
See [change](https://github.com/aws/eks-distro/pull/1334/commits/9526cbf133c58f52d5b019499685111a1e56cb25#diff-eadc261eb69b4bca3b66dc7e797f27e449916aee25c21061e38ad87975d95919L59-R62) in this PR. It changes the PR ID to PR number for changelog generation. Currently, it generates an ID number that probably isn't as meaningful to the average person (See [example](https://github.com/aws/eks-distro/pull/1333/commits/10f5ad3e698601f9b1339b04faefed18a93b4258#diff-987a1a8b6118da07ba082f593e8c8376a81d4453525511c1acc8fa24f00c9a8aR8-R16) PR). The example response [in the docs](https://docs.github.com/en/rest/search#search-issues-and-pull-requests) seems like `Number` is what we want.

#### Real change 2:
``` diff
-	section = append(section, fmt.Sprintf("* %v ([%v](%v))", *pr.Title, *pr.Number, *pr.URL))
+	section = append(section, fmt.Sprintf("* %v ([%v](%v))", *pr.Title, *pr.Number, *pr.HTMLURL))
```
See [change](https://github.com/aws/eks-distro/pull/1334/commits/5a77b80129b7b702f03fa59d9928210f4db33831#diff-eadc261eb69b4bca3b66dc7e797f27e449916aee25c21061e38ad87975d95919L62-R62) in this PR. 

Change the URL. Currently, it formats URLs like this `https://api.github.com/repos/aws/eks-distro/issues/1275` (see link to example PR above). But we want them to be `https://www.github.com/...` and not `https://api.github.com/...`. Again, see  the example response [in the docs](https://docs.github.com/en/rest/search#search-issues-and-pull-requests) for what this change should return


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
