### PR TITLE
Fix the logic for finding the last document release date

### DIFF
--- a/cmd/release/utils/values/searchprs.go
+++ b/cmd/release/utils/values/searchprs.go
@@ -17,11 +17,13 @@ func GetChangelogPRs(releaseVersion string) (string, error) {
 
 	ctx := context.Background()
 	opts := &github.SearchOptions{}
+	//Get the date of the last document release for the release version
 	prs, _, err := githubClient.Search.Issues(ctx, "is:pr is:merged label:release label:documentation repo:aws/eks-distro label:" + releaseVersion, opts)
 	if err != nil {
 		return "", fmt.Errorf("getting PRs from %v: %w", githubClient, err)
 	}
 
+	//Select the most recent pr from the above query and format the date expected for the go-github client
 	lastDocRelease := prs.Issues[0].ClosedAt.Format("2006-01-02T15:04:05+00:00")
 
 	patchPRs, _, err := githubClient.Search.Issues(ctx,

--- a/cmd/release/utils/values/searchprs.go
+++ b/cmd/release/utils/values/searchprs.go
@@ -17,7 +17,7 @@ func GetChangelogPRs(releaseVersion string) (string, error) {
 
 	ctx := context.Background()
 	opts := &github.SearchOptions{}
-	prs, _, err := githubClient.Search.Issues(ctx, "is:pr label:documentation repo:aws/eks-distro label:"+releaseVersion, opts)
+	prs, _, err := githubClient.Search.Issues(ctx, "is:pr is:merged label:documentation repo:aws/eks-distro label:" + releaseVersion, opts)
 	if err != nil {
 		return "", fmt.Errorf("getting PRs from %v: %w", githubClient, err)
 	}

--- a/cmd/release/utils/values/searchprs.go
+++ b/cmd/release/utils/values/searchprs.go
@@ -17,7 +17,7 @@ func GetChangelogPRs(releaseVersion string) (string, error) {
 
 	ctx := context.Background()
 	opts := &github.SearchOptions{}
-	prs, _, err := githubClient.Search.Issues(ctx, "is:pr is:merged label:documentation repo:aws/eks-distro label:" + releaseVersion, opts)
+	prs, _, err := githubClient.Search.Issues(ctx, "is:pr is:merged label:release label:documentation repo:aws/eks-distro label:" + releaseVersion, opts)
 	if err != nil {
 		return "", fmt.Errorf("getting PRs from %v: %w", githubClient, err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When pulling Release documentation, e.g. new changelog, to get the date of last release, it was also pulling closed prs that weren't merged. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
