### PR TITLE
Remove first two lines from changelog and index.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.idea
 *.swp
 _output
 .DS_Store

--- a/cmd/release/gh-release/create.sh
+++ b/cmd/release/gh-release/create.sh
@@ -23,7 +23,10 @@ GIT_TAG="${1?...}"
 CHANGELOG_FILEPATH="${2?...}"
 INDEX_FILEPATH="${3?...}"
 
-# Removes the first to lines to get rid of H1 headers and an empty line.
+# Removes the first three lines to get rid of H1 headers and an empty line and the
+# changelog highlights from the changelog and first four lines from the index.md
+# including the additional information and the empty line for the github release
+# docs
 # The H1 headers are larger than the release titles on GitHub, and it
 # looks confusing with them.
 releaseNotes="$(sed '1,3d' "$CHANGELOG_FILEPATH")

--- a/cmd/release/gh-release/create.sh
+++ b/cmd/release/gh-release/create.sh
@@ -26,8 +26,8 @@ INDEX_FILEPATH="${3?...}"
 # Removes the first to lines to get rid of H1 headers and an empty line.
 # The H1 headers are larger than the release titles on GitHub, and it
 # looks confusing with them.
-releaseNotes="$(sed '1,2d' "$CHANGELOG_FILEPATH")
+releaseNotes="$(sed '1,3d' "$CHANGELOG_FILEPATH")
 
-$(sed '1,2d' "$INDEX_FILEPATH")"
+$(sed '1,4d' "$INDEX_FILEPATH")"
 
 gh release create "$GIT_TAG" --title "EKS Distro $GIT_TAG Release" --notes "$releaseNotes"


### PR DESCRIPTION
*Issue #1248 , if available:*

*Description of changes:*
Remove the first three lines in the changelog and first four lines in index.md for the github release docs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
