### PR TITLE
use latest LTS ubuntu AMI for kOps

### DIFF
--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -155,7 +155,7 @@ spec:
   iam:
     profile: {{ .nodeInstanceProfileArn }}
   {{- end }}
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-{{ .architecture }}-server-20201026
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-{{ .architecture }}-server-20221018
   machineType: {{ .instanceType }}
   maxSize: 3
   minSize: 3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The AMI we were using was deprecated; use latest Focal AMI build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
