### PR TITLE
add option to skip checksum validation for binaries during the build,…

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -385,7 +385,7 @@ SPECIAL_TARGET_SECONDARY=$(strip $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BIN
 
 #################### TARGETS FOR OVERRIDING ########
 BUILD_TARGETS?=validate-checksums attribution $(if $(IMAGE_NAMES),local-images,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,) attribution-pr
-RELEASE_TARGETS?=$(if $(filter true,$(SKIP_CHECKSUM_VALIDATION),$(BINARY_TARGETS),validate-checksums) $(if $(IMAGE_NAMES),images,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,))
+RELEASE_TARGETS?=$(if $(filter true,$(SKIP_CHECKSUM_VALIDATION)),$(BINARY_TARGETS),validate-checksums) $(if $(IMAGE_NAMES),images,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,))
 ####################################################
 
 define BUILDCTL

--- a/Common.mk
+++ b/Common.mk
@@ -25,6 +25,8 @@ PROJECT_PATH?=$(subst $(BASE_DIRECTORY)/,,$(MAKE_ROOT))
 BUILD_LIB=${BASE_DIRECTORY}/build/lib
 OUTPUT_BIN_DIR?=$(OUTPUT_DIR)/bin/$(REPO)
 
+SKIP_CHECKSUM_VALIDATION?=false
+
 #################### AWS ###########################
 AWS_REGION?=us-west-2
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
@@ -383,7 +385,7 @@ SPECIAL_TARGET_SECONDARY=$(strip $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BIN
 
 #################### TARGETS FOR OVERRIDING ########
 BUILD_TARGETS?=validate-checksums attribution $(if $(IMAGE_NAMES),local-images,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,) attribution-pr
-RELEASE_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),images,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,)
+RELEASE_TARGETS?=$(if $(filter true,$(SKIP_CHECKSUM_VALIDATION),$(BINARY_TARGETS),validate-checksums) $(if $(IMAGE_NAMES),images,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,))
 ####################################################
 
 define BUILDCTL


### PR DESCRIPTION
… in order to allow for post-submit builds with custom base images

*Issue #, if available:*

*Description of changes:*
Add the option to skip checksum validation in the project builds. This will allow us to run builds with custom builder bases and execute conformance tests without automatically failing on checksum mis-matches. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
