### PR TITLE
Fix incorrect variable name of Go version

### DIFF
--- a/build/lib/install_go_versions.sh
+++ b/build/lib/install_go_versions.sh
@@ -40,7 +40,7 @@ setupgo "${GOLANG115_VERSION:-1.15.15}"
 setupgo "${GOLANG116_VERSION:-1.16.15}"
 setupgo "${GOLANG117_VERSION:-1.17.13}"
 setupgo "${GOLANG118_VERSION:-1.18.7}"
-setupgo "${GOLANG118_VERSION:-1.19.2}"
+setupgo "${GOLANG119_VERSION:-1.19.2}"
 
 # use 1.16 or 1.17 when installing and running go-licenses
 # go-licenses needs to be installed by the same version of go that is being used


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes incorrect variable name of new go version [introduced recently](https://github.com/aws/eks-distro/pull/1394/commits/e2529624ee473aae29a5bd60ade18e21fc8d0f6e).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
