### PR TITLE
Adds windows containers for livenessprobe/node-registrar

### DIFF
--- a/build/lib/create_windows_manifest_list.sh
+++ b/build/lib/create_windows_manifest_list.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
+IMAGE_NAME="$1"
+IMAGE="$2"
+LATEST_IMAGE="$3"
+WINDOWS_IMAGE_VERSIONS="$4"
+WINDOWS_IMAGE_REGISTRY="$5"
+WINDOWS_BASE_IMAGE_NAME="$6"
+
+# this metadate file contains the linux/amd+arm images
+if [ ! -f /tmp/$IMAGE_NAME-metadata.json ]; then
+    echo "No metadata file for image: /tmp/$IMAGE_NAME-metadata.json!"
+    exit 1
+fi
+
+# need to remove mediaType from descri since buildx segfaults when it is set
+jq -r '."containerimage.descriptor"  | {size, digest}' /tmp/$IMAGE_NAME-metadata.json > /tmp/$IMAGE_NAME-descr-final.json
+
+CREATE_ARGS="-f /tmp/$IMAGE_NAME-descr-final.json "
+VERSIONS=(${WINDOWS_IMAGE_VERSIONS// / })
+for version in "${VERSIONS[@]}"; do
+    if [ ! -f /tmp/$IMAGE_NAME-$version-metadata.json ]; then
+        echo "No metadata file for image: /tmp/$IMAGE_NAME-$version-metadata.json!"
+        exit 1
+    fi
+    # need to remove mediaType from descri since buildx segfaults when it is set
+    jq -r '."containerimage.descriptor"  | {size, digest}' /tmp/$IMAGE_NAME-$version-metadata.json > /tmp/$IMAGE_NAME-$version-descr.json
+    retry docker buildx imagetools inspect --raw $WINDOWS_IMAGE_REGISTRY/$WINDOWS_BASE_IMAGE_NAME:$version | jq '.manifests[0] | {platform}' | jq add -s - /tmp/$IMAGE_NAME-$version-descr.json > /tmp/$IMAGE_NAME-$version-descr-final.json
+    CREATE_ARGS+="-f /tmp/$IMAGE_NAME-$version-descr-final.json "
+done
+
+
+retry docker buildx imagetools create --dry-run $CREATE_ARGS -t $IMAGE -t $LATEST_IMAGE > /tmp/$IMAGE_NAME-manfiest-final.json
+
+cat  /tmp/$IMAGE_NAME-manfiest-final.json
+
+if [ "$(jq '.manifests[].platform.os' /tmp/$IMAGE_NAME-manfiest-final.json |  grep -w -c windows)" != "${#VERSIONS[@]}" ]; then
+    echo "image manifest does not contain correct number of windows images!"
+    exit 1
+fi
+
+if [ "$(jq '.manifests[].platform.os' /tmp/$IMAGE_NAME-manfiest-final.json |  grep -w -c linux)" != "2" ]; then
+    echo "image manifest does not contain correct number of linux images!"
+    exit 1
+fi
+
+if [ "$(jq '.manifests[].platform | select( has("os.version") == true ) | ."os.version"' /tmp/$IMAGE_NAME-manfiest-final.json | wc -l | xargs)" != "${#VERSIONS[@]}" ]; then
+    echo "windows images do not have os.version set!"
+    exit 1
+fi
+
+retry docker buildx imagetools create $CREATE_ARGS -t $IMAGE -t $LATEST_IMAGE
+
+if [ "$(docker buildx imagetools inspect $IMAGE --raw)" != "$(docker buildx imagetools inspect $LATEST_IMAGE --raw)" ]; then
+    echo "image manifest and latest manifest do not match!"
+    exit 1
+fi
+
+retry docker buildx imagetools inspect $IMAGE
+
+rm -rf /tmp/$IMAGE_NAME-*.json

--- a/projects/kubernetes-csi/external-attacher/1-21/CHECKSUMS
+++ b/projects/kubernetes-csi/external-attacher/1-21/CHECKSUMS
@@ -1,2 +1,2 @@
-30bf6109c20ae610978afa45ce4686f30136ee7fbb6fa9f9d4ebf8feaf08145f  _output/1-21/bin/external-attacher/linux-amd64/csi-attacher
-3a4d02546c63d3c632faaed54089d11fd159e08ee7ba886f6e9231cffd97e494  _output/1-21/bin/external-attacher/linux-arm64/csi-attacher
+9b6ae442ba5b0ae8fe9f9ea15660c3129869f47c75b652d83a3d5dc0e12c49f9  _output/1-21/bin/external-attacher/linux-amd64/csi-attacher
+8547d17be087bdc24a13a50167a2e14cb9bba5b4c328f2e85133e8989cdda328  _output/1-21/bin/external-attacher/linux-arm64/csi-attacher

--- a/projects/kubernetes-csi/external-attacher/1-22/CHECKSUMS
+++ b/projects/kubernetes-csi/external-attacher/1-22/CHECKSUMS
@@ -1,2 +1,2 @@
-30bf6109c20ae610978afa45ce4686f30136ee7fbb6fa9f9d4ebf8feaf08145f  _output/1-22/bin/external-attacher/linux-amd64/csi-attacher
-3a4d02546c63d3c632faaed54089d11fd159e08ee7ba886f6e9231cffd97e494  _output/1-22/bin/external-attacher/linux-arm64/csi-attacher
+9b6ae442ba5b0ae8fe9f9ea15660c3129869f47c75b652d83a3d5dc0e12c49f9  _output/1-22/bin/external-attacher/linux-amd64/csi-attacher
+8547d17be087bdc24a13a50167a2e14cb9bba5b4c328f2e85133e8989cdda328  _output/1-22/bin/external-attacher/linux-arm64/csi-attacher

--- a/projects/kubernetes-csi/external-attacher/1-23/CHECKSUMS
+++ b/projects/kubernetes-csi/external-attacher/1-23/CHECKSUMS
@@ -1,2 +1,2 @@
-30bf6109c20ae610978afa45ce4686f30136ee7fbb6fa9f9d4ebf8feaf08145f  _output/1-23/bin/external-attacher/linux-amd64/csi-attacher
-3a4d02546c63d3c632faaed54089d11fd159e08ee7ba886f6e9231cffd97e494  _output/1-23/bin/external-attacher/linux-arm64/csi-attacher
+9b6ae442ba5b0ae8fe9f9ea15660c3129869f47c75b652d83a3d5dc0e12c49f9  _output/1-23/bin/external-attacher/linux-amd64/csi-attacher
+8547d17be087bdc24a13a50167a2e14cb9bba5b4c328f2e85133e8989cdda328  _output/1-23/bin/external-attacher/linux-arm64/csi-attacher

--- a/projects/kubernetes-csi/external-attacher/1-24/CHECKSUMS
+++ b/projects/kubernetes-csi/external-attacher/1-24/CHECKSUMS
@@ -1,2 +1,2 @@
-30bf6109c20ae610978afa45ce4686f30136ee7fbb6fa9f9d4ebf8feaf08145f  _output/1-24/bin/external-attacher/linux-amd64/csi-attacher
-3a4d02546c63d3c632faaed54089d11fd159e08ee7ba886f6e9231cffd97e494  _output/1-24/bin/external-attacher/linux-arm64/csi-attacher
+9b6ae442ba5b0ae8fe9f9ea15660c3129869f47c75b652d83a3d5dc0e12c49f9  _output/1-24/bin/external-attacher/linux-amd64/csi-attacher
+8547d17be087bdc24a13a50167a2e14cb9bba5b4c328f2e85133e8989cdda328  _output/1-24/bin/external-attacher/linux-arm64/csi-attacher

--- a/projects/kubernetes-csi/external-attacher/Makefile
+++ b/projects/kubernetes-csi/external-attacher/Makefile
@@ -10,8 +10,22 @@ SOURCE_PATTERNS=./cmd/csi-attacher
 
 HAS_RELEASE_BRANCHES=true
 
+EXTRA_GO_LDFLAGS=-X main.version=$(GIT_TAG)
+
 include $(BASE_DIRECTORY)/Common.mk
 
+
+build: validate-cli-version
+release: validate-cli-version
+
+.PHONY: validate-cli-version
+validate-cli-version: CLI=./$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$(BINARY_TARGET_FILES)
+validate-cli-version: $(BINARY_TARGETS)
+	$(CLI) --version
+	@if [[ "$$($(CLI) --version)" != *"$(GIT_TAG)"* ]]; then \
+		echo "Version set incorrectly on cli!"; \
+		exit 1; \
+	fi
 
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block

--- a/projects/kubernetes-csi/external-provisioner/1-21/CHECKSUMS
+++ b/projects/kubernetes-csi/external-provisioner/1-21/CHECKSUMS
@@ -1,2 +1,2 @@
-673e6dd44fa1a59b8fece4e21cd507e14905d77241ce3ee39cc754487f171887  _output/1-21/bin/external-provisioner/linux-amd64/csi-provisioner
-142f5f0ef85b524ba20ba11cca850751e506cb8bfe0ae5b0ced75da14002fa57  _output/1-21/bin/external-provisioner/linux-arm64/csi-provisioner
+8447c758f4fa51d42825495406cbb4ba7a534832cecb744c07a53d78b02a975c  _output/1-21/bin/external-provisioner/linux-amd64/csi-provisioner
+9a0032c0b5eef3122bfefeadde975d78fa5423e0b56e33cf0ecad1fe4d9f5361  _output/1-21/bin/external-provisioner/linux-arm64/csi-provisioner

--- a/projects/kubernetes-csi/external-provisioner/1-22/CHECKSUMS
+++ b/projects/kubernetes-csi/external-provisioner/1-22/CHECKSUMS
@@ -1,2 +1,2 @@
-673e6dd44fa1a59b8fece4e21cd507e14905d77241ce3ee39cc754487f171887  _output/1-22/bin/external-provisioner/linux-amd64/csi-provisioner
-142f5f0ef85b524ba20ba11cca850751e506cb8bfe0ae5b0ced75da14002fa57  _output/1-22/bin/external-provisioner/linux-arm64/csi-provisioner
+8447c758f4fa51d42825495406cbb4ba7a534832cecb744c07a53d78b02a975c  _output/1-22/bin/external-provisioner/linux-amd64/csi-provisioner
+9a0032c0b5eef3122bfefeadde975d78fa5423e0b56e33cf0ecad1fe4d9f5361  _output/1-22/bin/external-provisioner/linux-arm64/csi-provisioner

--- a/projects/kubernetes-csi/external-provisioner/1-23/CHECKSUMS
+++ b/projects/kubernetes-csi/external-provisioner/1-23/CHECKSUMS
@@ -1,2 +1,2 @@
-673e6dd44fa1a59b8fece4e21cd507e14905d77241ce3ee39cc754487f171887  _output/1-23/bin/external-provisioner/linux-amd64/csi-provisioner
-142f5f0ef85b524ba20ba11cca850751e506cb8bfe0ae5b0ced75da14002fa57  _output/1-23/bin/external-provisioner/linux-arm64/csi-provisioner
+8447c758f4fa51d42825495406cbb4ba7a534832cecb744c07a53d78b02a975c  _output/1-23/bin/external-provisioner/linux-amd64/csi-provisioner
+9a0032c0b5eef3122bfefeadde975d78fa5423e0b56e33cf0ecad1fe4d9f5361  _output/1-23/bin/external-provisioner/linux-arm64/csi-provisioner

--- a/projects/kubernetes-csi/external-provisioner/1-24/CHECKSUMS
+++ b/projects/kubernetes-csi/external-provisioner/1-24/CHECKSUMS
@@ -1,2 +1,2 @@
-673e6dd44fa1a59b8fece4e21cd507e14905d77241ce3ee39cc754487f171887  _output/1-24/bin/external-provisioner/linux-amd64/csi-provisioner
-142f5f0ef85b524ba20ba11cca850751e506cb8bfe0ae5b0ced75da14002fa57  _output/1-24/bin/external-provisioner/linux-arm64/csi-provisioner
+8447c758f4fa51d42825495406cbb4ba7a534832cecb744c07a53d78b02a975c  _output/1-24/bin/external-provisioner/linux-amd64/csi-provisioner
+9a0032c0b5eef3122bfefeadde975d78fa5423e0b56e33cf0ecad1fe4d9f5361  _output/1-24/bin/external-provisioner/linux-arm64/csi-provisioner

--- a/projects/kubernetes-csi/external-provisioner/Makefile
+++ b/projects/kubernetes-csi/external-provisioner/Makefile
@@ -10,10 +10,24 @@ SOURCE_PATTERNS=./cmd/csi-provisioner
 
 HAS_RELEASE_BRANCHES=true
 
+EXTRA_GO_LDFLAGS=-X main.version=$(GIT_TAG)
+
 VENDOR_UPDATE_SCRIPT=release-tools/update-vendor.sh
 
 include $(BASE_DIRECTORY)/Common.mk
 
+build: validate-cli-version
+release: validate-cli-version
+
+
+.PHONY: validate-cli-version
+validate-cli-version: CLI=./$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$(BINARY_TARGET_FILES)
+validate-cli-version: $(BINARY_TARGETS)
+	$(CLI) --version
+	@if [[ "$$($(CLI) --version)" != *"$(GIT_TAG)"* ]]; then \
+		echo "Version set incorrectly on cli!"; \
+		exit 1; \
+	fi
 
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block

--- a/projects/kubernetes-csi/external-resizer/1-21/CHECKSUMS
+++ b/projects/kubernetes-csi/external-resizer/1-21/CHECKSUMS
@@ -1,2 +1,2 @@
-0e6a43deb1d57d27c5a4b8650776da2982f0934ad298990327e836c116e029a1  _output/1-21/bin/external-resizer/linux-amd64/csi-resizer
-52470d6b27927df37fdc64d73837db41dca1f4c3b94b878deedeca096f3a5965  _output/1-21/bin/external-resizer/linux-arm64/csi-resizer
+da1c8f0f280a085bfa61acde8a46577b7a6aa12220074a5021eefde056d5e663  _output/1-21/bin/external-resizer/linux-amd64/csi-resizer
+83ad2bf039f497ddb869e5cc947e694a8e990a0ce67a2661639faf50ad7f2f8e  _output/1-21/bin/external-resizer/linux-arm64/csi-resizer

--- a/projects/kubernetes-csi/external-resizer/1-22/CHECKSUMS
+++ b/projects/kubernetes-csi/external-resizer/1-22/CHECKSUMS
@@ -1,2 +1,2 @@
-0e6a43deb1d57d27c5a4b8650776da2982f0934ad298990327e836c116e029a1  _output/1-22/bin/external-resizer/linux-amd64/csi-resizer
-52470d6b27927df37fdc64d73837db41dca1f4c3b94b878deedeca096f3a5965  _output/1-22/bin/external-resizer/linux-arm64/csi-resizer
+da1c8f0f280a085bfa61acde8a46577b7a6aa12220074a5021eefde056d5e663  _output/1-22/bin/external-resizer/linux-amd64/csi-resizer
+83ad2bf039f497ddb869e5cc947e694a8e990a0ce67a2661639faf50ad7f2f8e  _output/1-22/bin/external-resizer/linux-arm64/csi-resizer

--- a/projects/kubernetes-csi/external-resizer/1-23/CHECKSUMS
+++ b/projects/kubernetes-csi/external-resizer/1-23/CHECKSUMS
@@ -1,2 +1,2 @@
-0e6a43deb1d57d27c5a4b8650776da2982f0934ad298990327e836c116e029a1  _output/1-23/bin/external-resizer/linux-amd64/csi-resizer
-52470d6b27927df37fdc64d73837db41dca1f4c3b94b878deedeca096f3a5965  _output/1-23/bin/external-resizer/linux-arm64/csi-resizer
+da1c8f0f280a085bfa61acde8a46577b7a6aa12220074a5021eefde056d5e663  _output/1-23/bin/external-resizer/linux-amd64/csi-resizer
+83ad2bf039f497ddb869e5cc947e694a8e990a0ce67a2661639faf50ad7f2f8e  _output/1-23/bin/external-resizer/linux-arm64/csi-resizer

--- a/projects/kubernetes-csi/external-resizer/1-24/CHECKSUMS
+++ b/projects/kubernetes-csi/external-resizer/1-24/CHECKSUMS
@@ -1,2 +1,2 @@
-0e6a43deb1d57d27c5a4b8650776da2982f0934ad298990327e836c116e029a1  _output/1-24/bin/external-resizer/linux-amd64/csi-resizer
-52470d6b27927df37fdc64d73837db41dca1f4c3b94b878deedeca096f3a5965  _output/1-24/bin/external-resizer/linux-arm64/csi-resizer
+da1c8f0f280a085bfa61acde8a46577b7a6aa12220074a5021eefde056d5e663  _output/1-24/bin/external-resizer/linux-amd64/csi-resizer
+83ad2bf039f497ddb869e5cc947e694a8e990a0ce67a2661639faf50ad7f2f8e  _output/1-24/bin/external-resizer/linux-arm64/csi-resizer

--- a/projects/kubernetes-csi/external-resizer/Makefile
+++ b/projects/kubernetes-csi/external-resizer/Makefile
@@ -10,8 +10,22 @@ SOURCE_PATTERNS=./cmd/csi-resizer
 
 HAS_RELEASE_BRANCHES=true
 
+EXTRA_GO_LDFLAGS=-X main.version=$(GIT_TAG)
+
 include $(BASE_DIRECTORY)/Common.mk
 
+
+build: validate-cli-version
+release: validate-cli-version
+
+.PHONY: validate-cli-version
+validate-cli-version: CLI=./$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$(BINARY_TARGET_FILES)
+validate-cli-version: $(BINARY_TARGETS)
+	$(CLI) --version
+	@if [[ "$$($(CLI) --version)" != *"$(GIT_TAG)"* ]]; then \
+		echo "Version set incorrectly on cli!"; \
+		exit 1; \
+	fi
 
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block

--- a/projects/kubernetes-csi/external-snapshotter/1-21/CHECKSUMS
+++ b/projects/kubernetes-csi/external-snapshotter/1-21/CHECKSUMS
@@ -1,6 +1,6 @@
-807fccb07cfac58e646fa61a50c22623d40ddf06955d5bf26011f5c32b5ac66d  _output/1-21/bin/external-snapshotter/linux-amd64/csi-snapshotter
-1d89a3f69f5c65f177cdefbc9f75c3f65313ff6a3b94f778eeefabacf623d397  _output/1-21/bin/external-snapshotter/linux-amd64/snapshot-controller
+cc3e58b4bbc5d8a1f5f8c51a84a7175ab08e09a70f8ae9b1fa485a3862109e01  _output/1-21/bin/external-snapshotter/linux-amd64/csi-snapshotter
+5c062b38e4433079e81bf8f3603b61b840028385cdefe74ac47c331cb4e5ef81  _output/1-21/bin/external-snapshotter/linux-amd64/snapshot-controller
 d6164f6139deb98173e4c2038050673a2ef03b051730b293af5b99ee5f1b8ff1  _output/1-21/bin/external-snapshotter/linux-amd64/snapshot-validation-webhook
-1f5fd3d3d1e31093c9aae4bcf05cd4854c35f377e672e06a8b21e8775ff3698e  _output/1-21/bin/external-snapshotter/linux-arm64/csi-snapshotter
-83f239dc3acbc661266ae5d3831a069197e823b6fa6280131b92885df6576219  _output/1-21/bin/external-snapshotter/linux-arm64/snapshot-controller
+0799432f6d9545733ca7948bb38816e974183c8f7bdc2b73d245e6a4fdad90db  _output/1-21/bin/external-snapshotter/linux-arm64/csi-snapshotter
+b6642c56ac3d5aca6d200edbbe18e4a3fbe0f6d468f4221ce7d51199ae8e87eb  _output/1-21/bin/external-snapshotter/linux-arm64/snapshot-controller
 48a53ad345401a0d2e41c0e404695cd745acbd0f6208e5ab30a9409e59dd81aa  _output/1-21/bin/external-snapshotter/linux-arm64/snapshot-validation-webhook

--- a/projects/kubernetes-csi/external-snapshotter/1-22/CHECKSUMS
+++ b/projects/kubernetes-csi/external-snapshotter/1-22/CHECKSUMS
@@ -1,6 +1,6 @@
-807fccb07cfac58e646fa61a50c22623d40ddf06955d5bf26011f5c32b5ac66d  _output/1-22/bin/external-snapshotter/linux-amd64/csi-snapshotter
-1d89a3f69f5c65f177cdefbc9f75c3f65313ff6a3b94f778eeefabacf623d397  _output/1-22/bin/external-snapshotter/linux-amd64/snapshot-controller
+cc3e58b4bbc5d8a1f5f8c51a84a7175ab08e09a70f8ae9b1fa485a3862109e01  _output/1-22/bin/external-snapshotter/linux-amd64/csi-snapshotter
+5c062b38e4433079e81bf8f3603b61b840028385cdefe74ac47c331cb4e5ef81  _output/1-22/bin/external-snapshotter/linux-amd64/snapshot-controller
 d6164f6139deb98173e4c2038050673a2ef03b051730b293af5b99ee5f1b8ff1  _output/1-22/bin/external-snapshotter/linux-amd64/snapshot-validation-webhook
-1f5fd3d3d1e31093c9aae4bcf05cd4854c35f377e672e06a8b21e8775ff3698e  _output/1-22/bin/external-snapshotter/linux-arm64/csi-snapshotter
-83f239dc3acbc661266ae5d3831a069197e823b6fa6280131b92885df6576219  _output/1-22/bin/external-snapshotter/linux-arm64/snapshot-controller
+0799432f6d9545733ca7948bb38816e974183c8f7bdc2b73d245e6a4fdad90db  _output/1-22/bin/external-snapshotter/linux-arm64/csi-snapshotter
+b6642c56ac3d5aca6d200edbbe18e4a3fbe0f6d468f4221ce7d51199ae8e87eb  _output/1-22/bin/external-snapshotter/linux-arm64/snapshot-controller
 48a53ad345401a0d2e41c0e404695cd745acbd0f6208e5ab30a9409e59dd81aa  _output/1-22/bin/external-snapshotter/linux-arm64/snapshot-validation-webhook

--- a/projects/kubernetes-csi/external-snapshotter/1-23/CHECKSUMS
+++ b/projects/kubernetes-csi/external-snapshotter/1-23/CHECKSUMS
@@ -1,6 +1,6 @@
-807fccb07cfac58e646fa61a50c22623d40ddf06955d5bf26011f5c32b5ac66d  _output/1-23/bin/external-snapshotter/linux-amd64/csi-snapshotter
-1d89a3f69f5c65f177cdefbc9f75c3f65313ff6a3b94f778eeefabacf623d397  _output/1-23/bin/external-snapshotter/linux-amd64/snapshot-controller
+cc3e58b4bbc5d8a1f5f8c51a84a7175ab08e09a70f8ae9b1fa485a3862109e01  _output/1-23/bin/external-snapshotter/linux-amd64/csi-snapshotter
+5c062b38e4433079e81bf8f3603b61b840028385cdefe74ac47c331cb4e5ef81  _output/1-23/bin/external-snapshotter/linux-amd64/snapshot-controller
 d6164f6139deb98173e4c2038050673a2ef03b051730b293af5b99ee5f1b8ff1  _output/1-23/bin/external-snapshotter/linux-amd64/snapshot-validation-webhook
-1f5fd3d3d1e31093c9aae4bcf05cd4854c35f377e672e06a8b21e8775ff3698e  _output/1-23/bin/external-snapshotter/linux-arm64/csi-snapshotter
-83f239dc3acbc661266ae5d3831a069197e823b6fa6280131b92885df6576219  _output/1-23/bin/external-snapshotter/linux-arm64/snapshot-controller
+0799432f6d9545733ca7948bb38816e974183c8f7bdc2b73d245e6a4fdad90db  _output/1-23/bin/external-snapshotter/linux-arm64/csi-snapshotter
+b6642c56ac3d5aca6d200edbbe18e4a3fbe0f6d468f4221ce7d51199ae8e87eb  _output/1-23/bin/external-snapshotter/linux-arm64/snapshot-controller
 48a53ad345401a0d2e41c0e404695cd745acbd0f6208e5ab30a9409e59dd81aa  _output/1-23/bin/external-snapshotter/linux-arm64/snapshot-validation-webhook

--- a/projects/kubernetes-csi/external-snapshotter/1-24/CHECKSUMS
+++ b/projects/kubernetes-csi/external-snapshotter/1-24/CHECKSUMS
@@ -1,6 +1,6 @@
-807fccb07cfac58e646fa61a50c22623d40ddf06955d5bf26011f5c32b5ac66d  _output/1-24/bin/external-snapshotter/linux-amd64/csi-snapshotter
-1d89a3f69f5c65f177cdefbc9f75c3f65313ff6a3b94f778eeefabacf623d397  _output/1-24/bin/external-snapshotter/linux-amd64/snapshot-controller
+cc3e58b4bbc5d8a1f5f8c51a84a7175ab08e09a70f8ae9b1fa485a3862109e01  _output/1-24/bin/external-snapshotter/linux-amd64/csi-snapshotter
+5c062b38e4433079e81bf8f3603b61b840028385cdefe74ac47c331cb4e5ef81  _output/1-24/bin/external-snapshotter/linux-amd64/snapshot-controller
 d6164f6139deb98173e4c2038050673a2ef03b051730b293af5b99ee5f1b8ff1  _output/1-24/bin/external-snapshotter/linux-amd64/snapshot-validation-webhook
-1f5fd3d3d1e31093c9aae4bcf05cd4854c35f377e672e06a8b21e8775ff3698e  _output/1-24/bin/external-snapshotter/linux-arm64/csi-snapshotter
-83f239dc3acbc661266ae5d3831a069197e823b6fa6280131b92885df6576219  _output/1-24/bin/external-snapshotter/linux-arm64/snapshot-controller
+0799432f6d9545733ca7948bb38816e974183c8f7bdc2b73d245e6a4fdad90db  _output/1-24/bin/external-snapshotter/linux-arm64/csi-snapshotter
+b6642c56ac3d5aca6d200edbbe18e4a3fbe0f6d468f4221ce7d51199ae8e87eb  _output/1-24/bin/external-snapshotter/linux-arm64/snapshot-controller
 48a53ad345401a0d2e41c0e404695cd745acbd0f6208e5ab30a9409e59dd81aa  _output/1-24/bin/external-snapshotter/linux-arm64/snapshot-validation-webhook

--- a/projects/kubernetes-csi/external-snapshotter/Makefile
+++ b/projects/kubernetes-csi/external-snapshotter/Makefile
@@ -20,10 +20,14 @@ DOCKERFILE_FOLDER=./docker/linux/$(IMAGE_NAME)
 
 HAS_RELEASE_BRANCHES=true
 
+EXTRA_GO_LDFLAGS=-X main.version=$(GIT_TAG)
+
 VENDOR_UPDATE_SCRIPT=release-tools/update-vendor.sh
 
 include $(BASE_DIRECTORY)/Common.mk
 
+build: validate-cli-version
+release: validate-cli-version
 
 $(GATHER_LICENSES_TARGETS): $(SNAPSHOTTER_LICENSE)
 
@@ -33,6 +37,18 @@ $(GATHER_LICENSES_TARGETS): $(SNAPSHOTTER_LICENSE)
 $(SNAPSHOTTER_LICENSE): | $(GO_MOD_DOWNLOAD_TARGETS)
 	mkdir -p $(@D)
 	cp $(REPO)/LICENSE $@
+
+
+%/validate-cli-version: CLI=./$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$*
+%/validate-cli-version: $(BINARY_TARGETS)
+	$(CLI) --version
+	@if [[ "$$($(CLI) --version)" != *"$(GIT_TAG)"* ]]; then \
+		echo "Version set incorrectly on cli!"; \
+		exit 1; \
+	fi
+
+.PHONY: validate-cli-version
+validate-cli-version: csi-snapshotter/validate-cli-version snapshot-controller/validate-cli-version
 
 
 ########### DO NOT EDIT #############################

--- a/projects/kubernetes-csi/livenessprobe/1-21/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-21/CHECKSUMS
@@ -1,2 +1,3 @@
 9088c3828d893b883c375095e768876ba2f3f4cc50508805f118caa2e157dd39  _output/1-21/bin/livenessprobe/linux-amd64/livenessprobe
 637e9b238cae1c1ab60d2ca8bf8117c8069456ca762c7403764c6f0fce9dc2e0  _output/1-21/bin/livenessprobe/linux-arm64/livenessprobe
+2ea77d8c7cfee03073a9602f433d2def8c24bf08aa52dcc1c15677b03b865529  _output/1-21/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-22/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-22/CHECKSUMS
@@ -1,2 +1,3 @@
 9088c3828d893b883c375095e768876ba2f3f4cc50508805f118caa2e157dd39  _output/1-22/bin/livenessprobe/linux-amd64/livenessprobe
 637e9b238cae1c1ab60d2ca8bf8117c8069456ca762c7403764c6f0fce9dc2e0  _output/1-22/bin/livenessprobe/linux-arm64/livenessprobe
+2ea77d8c7cfee03073a9602f433d2def8c24bf08aa52dcc1c15677b03b865529  _output/1-22/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-23/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-23/CHECKSUMS
@@ -1,2 +1,3 @@
 9088c3828d893b883c375095e768876ba2f3f4cc50508805f118caa2e157dd39  _output/1-23/bin/livenessprobe/linux-amd64/livenessprobe
 637e9b238cae1c1ab60d2ca8bf8117c8069456ca762c7403764c6f0fce9dc2e0  _output/1-23/bin/livenessprobe/linux-arm64/livenessprobe
+2ea77d8c7cfee03073a9602f433d2def8c24bf08aa52dcc1c15677b03b865529  _output/1-23/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-24/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-24/CHECKSUMS
@@ -1,2 +1,3 @@
 9088c3828d893b883c375095e768876ba2f3f4cc50508805f118caa2e157dd39  _output/1-24/bin/livenessprobe/linux-amd64/livenessprobe
 637e9b238cae1c1ab60d2ca8bf8117c8069456ca762c7403764c6f0fce9dc2e0  _output/1-24/bin/livenessprobe/linux-arm64/livenessprobe
+2ea77d8c7cfee03073a9602f433d2def8c24bf08aa52dcc1c15677b03b865529  _output/1-24/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/Makefile
+++ b/projects/kubernetes-csi/livenessprobe/Makefile
@@ -8,13 +8,18 @@ REPO_OWNER=kubernetes-csi
 BINARY_TARGET_FILES=livenessprobe
 SOURCE_PATTERNS=./cmd/livenessprobe
 
+BINARY_PLATFORMS=linux/amd64 linux/arm64 windows/amd64
+
 HAS_RELEASE_BRANCHES=true
 
 include $(BASE_DIRECTORY)/Common.mk
 
+
+livenessprobe/images/push: IMAGE_PLATFORMS=linux/amd64,linux/arm64,windows/amd64
+
 $(ATTRIBUTION_TARGETS): fix-licenses
 
-.PHONE: fix-licenses
+.PHONY: fix-licenses
 fix-licenses: $(GATHER_LICENSES_TARGETS)
 	build/fix_licenses.sh $(RELEASE_BRANCH)
 

--- a/projects/kubernetes-csi/livenessprobe/docker/windows/Dockerfile
+++ b/projects/kubernetes-csi/livenessprobe/docker/windows/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BUILDER_IMAGE
+ARG BASE_IMAGE
+FROM $BUILDER_IMAGE as servercore
+FROM $BASE_IMAGE
+
+COPY --from=servercore /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
+
+ARG TARGETARCH
+ARG TARGETOS
+ARG RELEASE_BRANCH
+
+COPY _output/$RELEASE_BRANCH/LICENSES /LICENSES
+COPY $RELEASE_BRANCH/ATTRIBUTION.txt /ATTRIBUTION.txt
+COPY _output/$RELEASE_BRANCH/bin/livenessprobe/$TARGETOS-$TARGETARCH/livenessprobe.exe /livenessprobe.exe
+
+USER ContainerAdministrator
+ENTRYPOINT ["/livenessprobe.exe"]

--- a/projects/kubernetes-csi/node-driver-registrar/1-21/CHECKSUMS
+++ b/projects/kubernetes-csi/node-driver-registrar/1-21/CHECKSUMS
@@ -1,2 +1,3 @@
-c2240dcd82350e86b3bcac979a9ce78a8c7a6d370604053b57d4ed13013063ff  _output/1-21/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
-60fd9e4879ec212df985139470b6977c5da5130b2ca2eb2f44765f3e060636b9  _output/1-21/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+e8d34211afa706cbc482c6defd1e4412778ee4f3a46043472582f19c0bbbdc59  _output/1-21/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
+6d79afdfac4bf4117a55240e14bd150fe84f53160d0e198ab3b4f226ac9cca23  _output/1-21/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+adf22001cae45ff60efc393afa715f6271b68449afa8cbb301ad891aa2ecba5d  _output/1-21/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe

--- a/projects/kubernetes-csi/node-driver-registrar/1-22/CHECKSUMS
+++ b/projects/kubernetes-csi/node-driver-registrar/1-22/CHECKSUMS
@@ -1,2 +1,3 @@
-c2240dcd82350e86b3bcac979a9ce78a8c7a6d370604053b57d4ed13013063ff  _output/1-22/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
-60fd9e4879ec212df985139470b6977c5da5130b2ca2eb2f44765f3e060636b9  _output/1-22/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+e8d34211afa706cbc482c6defd1e4412778ee4f3a46043472582f19c0bbbdc59  _output/1-22/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
+6d79afdfac4bf4117a55240e14bd150fe84f53160d0e198ab3b4f226ac9cca23  _output/1-22/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+adf22001cae45ff60efc393afa715f6271b68449afa8cbb301ad891aa2ecba5d  _output/1-22/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe

--- a/projects/kubernetes-csi/node-driver-registrar/1-23/CHECKSUMS
+++ b/projects/kubernetes-csi/node-driver-registrar/1-23/CHECKSUMS
@@ -1,2 +1,3 @@
-c2240dcd82350e86b3bcac979a9ce78a8c7a6d370604053b57d4ed13013063ff  _output/1-23/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
-60fd9e4879ec212df985139470b6977c5da5130b2ca2eb2f44765f3e060636b9  _output/1-23/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+e8d34211afa706cbc482c6defd1e4412778ee4f3a46043472582f19c0bbbdc59  _output/1-23/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
+6d79afdfac4bf4117a55240e14bd150fe84f53160d0e198ab3b4f226ac9cca23  _output/1-23/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+adf22001cae45ff60efc393afa715f6271b68449afa8cbb301ad891aa2ecba5d  _output/1-23/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe

--- a/projects/kubernetes-csi/node-driver-registrar/1-24/CHECKSUMS
+++ b/projects/kubernetes-csi/node-driver-registrar/1-24/CHECKSUMS
@@ -1,2 +1,3 @@
-c2240dcd82350e86b3bcac979a9ce78a8c7a6d370604053b57d4ed13013063ff  _output/1-24/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
-60fd9e4879ec212df985139470b6977c5da5130b2ca2eb2f44765f3e060636b9  _output/1-24/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+e8d34211afa706cbc482c6defd1e4412778ee4f3a46043472582f19c0bbbdc59  _output/1-24/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
+6d79afdfac4bf4117a55240e14bd150fe84f53160d0e198ab3b4f226ac9cca23  _output/1-24/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+adf22001cae45ff60efc393afa715f6271b68449afa8cbb301ad891aa2ecba5d  _output/1-24/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe

--- a/projects/kubernetes-csi/node-driver-registrar/Makefile
+++ b/projects/kubernetes-csi/node-driver-registrar/Makefile
@@ -8,16 +8,34 @@ REPO_OWNER=kubernetes-csi
 BINARY_TARGET_FILES=csi-node-driver-registrar
 SOURCE_PATTERNS=./cmd/csi-node-driver-registrar
 
+BINARY_PLATFORMS=linux/amd64 linux/arm64 windows/amd64
+
 HAS_RELEASE_BRANCHES=true
+
+EXTRA_GO_LDFLAGS=-X main.version=$(GIT_TAG)
 
 include $(BASE_DIRECTORY)/Common.mk
 
+
+build: validate-cli-version
+release: validate-cli-version
+
+node-driver-registrar/images/push: IMAGE_PLATFORMS=linux/amd64,linux/arm64,windows/amd64
+
 $(ATTRIBUTION_TARGETS): fix-licenses
 
-.PHONE: fix-licenses
+.PHONY: fix-licenses
 fix-licenses: $(GATHER_LICENSES_TARGETS)
 	build/fix_licenses.sh $(RELEASE_BRANCH)
 
+.PHONY: validate-cli-version
+validate-cli-version: CLI=./$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$(BINARY_TARGET_FILES)
+validate-cli-version: $(BINARY_TARGETS)
+	$(CLI) --version
+	@if [[ "$$($(CLI) --version)" != *"$(GIT_TAG)"* ]]; then \
+		echo "Version set incorrectly on cli!"; \
+		exit 1; \
+	fi
 
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block

--- a/projects/kubernetes-csi/node-driver-registrar/docker/windows/Dockerfile
+++ b/projects/kubernetes-csi/node-driver-registrar/docker/windows/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BUILDER_IMAGE
+ARG BASE_IMAGE
+FROM $BUILDER_IMAGE as servercore
+FROM $BASE_IMAGE
+
+COPY --from=servercore /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
+
+ARG TARGETARCH
+ARG TARGETOS
+ARG RELEASE_BRANCH
+
+COPY _output/$RELEASE_BRANCH/LICENSES /LICENSES
+COPY $RELEASE_BRANCH/ATTRIBUTION.txt /ATTRIBUTION.txt
+COPY _output/$RELEASE_BRANCH/bin/node-driver-registrar/$TARGETOS-$TARGETARCH/csi-node-driver-registrar.exe /csi-node-driver-registrar.exe
+
+USER ContainerAdministrator
+ENTRYPOINT ["/csi-node-driver-registrar.exe"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

My boy @torredil requested we build the Windows container images for livenessprobe and node-registrar.  These two containers are the only two sidecars that actually run on a per node basis so when an EKS user has Windows based nodes these two need to be available for Windows.  Windows containers have some specific rules that make building them a bit unique.  Read more about the specific images [here](https://hub.docker.com/_/microsoft-windows-servercore) and [here](https://hub.docker.com/_/microsoft-windows-nanoserver).

You can only run windows container images that match the underlying host OS version, which as of now requires that we build 3 versions of windows containers. I modeled the list to match the upstream csi sidecar [builds](https://github.com/kubernetes-csi/livenessprobe/blob/master/release-tools/prow.sh#L78).  They use the nanoserver image, which is the windows version of a "minimal" base, I think it excludes powershell and other full feature items, as the base but pull a specific dll from the servercore image. I am not sure if this common across other windows container builds, but this feels like a good start for us and we can adjust if/when we ever add other windows builds.

Building the windows binary for the two project was [simple](https://github.com/aws/eks-distro/pull/1494/files#diff-478e69913c4cb9286674c600b3338a70d18e88550ffa8711d39365e4ebfc6f94R11) we were already doing this for the iam-authenticator build.

Building the images is where things get interesting.  Buildkit (and buildx + docker) support building windows containers, mainly because they are just simple dockerfiles with COPY layers so no windows executable code is ever running. However, because of the requirement to have containers that match the host an additional field "os.version" is added to the manifest list which is pushed to ecr.  buildctl does not appear to natively handle this field because its not officially apart of the spec(?).  To properly create the manifest list this PR pushed the windows builds individually to ecr as digest only, no tags.  Once all images have been built, including the arm/amd linux builds, a manifest is generated using `docker buildx imagetools`.  When this is done, the manifest list is pushed and tagged with both the latest tag and the version tag. Ex:

```
{
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "schemaVersion": 2,
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "digest": "sha256:b95d34919fb929c140534fa6834a0ab75ac1fa1cd54d421042aaf0aeeb0c7988",
         "size": 1116,
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "digest": "sha256:e6232b52a6d1f252ba0a4e37a77ccb90cfc56d9fd4ef6a79efa3fe5378139db6",
         "size": 1116,
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "digest": "sha256:d4da68e5f7a25ce5ce8b524127ea4f33b287993efab5110b4fb7ee16f25b3bb6",
         "size": 1321,
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.3650"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "digest": "sha256:ce09995785806eb1f711f84c487e03a05d7ae74d1b31a7c4da3bee4ffe4c0dcf",
         "size": 1321,
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.19042.1889"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "digest": "sha256:5285e0cd663afea22b135855664fdb80f33aae21dcfe88532083f95fc5e63977",
         "size": 1321,
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.1249"
         }
      }
   ]
}
```

The os.version fields are used on the windows container runtime side to pull the correct image based on host os version.

While testing, @torredil noticed that the --version flag was returning `unknown` for the node-registrar. I went ahead and fixed this for all the sidecars that expose a --version flag, we were missing the ldflag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
