### PR TITLE
Fixes windows manifest validation

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -295,7 +295,7 @@ function retry() {
     "$@" && break || {
       if [[ $n -lt $max ]]; then
         ((n++))
-        echo "Command failed. Attempt $n/$max:"
+        >&2 echo "Command failed. Attempt $n/$max:"
         sleep $delay;
       else
         fail "The command has failed after $n attempts."

--- a/build/lib/create_windows_manifest_list.sh
+++ b/build/lib/create_windows_manifest_list.sh
@@ -71,11 +71,11 @@ fi
 
 retry docker buildx imagetools create $CREATE_ARGS -t $IMAGE -t $LATEST_IMAGE
 
-if [ "$(docker buildx imagetools inspect $IMAGE --raw)" != "$(docker buildx imagetools inspect $LATEST_IMAGE --raw)" ]; then
+retry docker buildx imagetools inspect $IMAGE
+
+if ! diff <(retry docker buildx imagetools inspect $IMAGE --raw) <(retry docker buildx imagetools inspect $LATEST_IMAGE --raw); then
     echo "image manifest and latest manifest do not match!"
     exit 1
 fi
-
-retry docker buildx imagetools inspect $IMAGE
 
 rm -rf /tmp/$IMAGE_NAME-*.json


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Did not run into this during my testing or in presubmit, but the postubmits failed on this validation. I suspect it has to do with the manifest not be immediately ready and returned from ecr.  I added the retry to ensure we get the manifest and added a diff command so we can see the actual diff next time.

As a point to remember, any time we deal with public.ecr we need to make sure we retry we have seen random connection issues in the past like this, this is why the ones above were already retry'd but I missed this case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
