### PR TITLE
Modify flag for Github-release command

### DIFF
--- a/cmd/release/gh-release/create.sh
+++ b/cmd/release/gh-release/create.sh
@@ -33,4 +33,4 @@ releaseNotes="$(sed '1,3d' "$CHANGELOG_FILEPATH")
 
 $(sed '1,4d' "$INDEX_FILEPATH")"
 
-gh release create "$GIT_TAG" --title "EKS Distro $GIT_TAG Release" --notes "$releaseNotes"
+gh release create "$GIT_TAG" --title "EKS Distro $GIT_TAG Release" --notes "$releaseNotes" --repo "aws/eks-distro"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Without the flag you have to clone and run the make github-release command from the aws/eks-distro vs a fork.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
