### PR TITLE
Use new ccm build in kops

### DIFF
--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -35,13 +35,19 @@ function get_container_yaml() {
     then
         REPOSITORY_NAME="kubernetes-csi/external-snapshotter/csi-snapshotter"
     fi
+
+    if  [[ $REPOSITORY_NAME == "kubernetes/cloud-provider-aws" ]] 
+    then
+        REPOSITORY_NAME="kubernetes/cloud-provider-aws/cloud-controller-manager"
+    fi
+    
     echo "    repository: ${IMAGE_REPO}/${REPOSITORY_NAME}
     tag: ${VERSION}-eks-${RELEASE_BRANCH}-${RELEASE}"
 }
 
 function get_project_version(){
     REPOSITORY_NAME="${1}"
-    if  [[ $REPOSITORY_NAME == kubernetes/* ]] 
+    if  [[ $REPOSITORY_NAME == kubernetes/* ]] && [[ $REPOSITORY_NAME != "kubernetes/cloud-provider-aws" ]] 
     then
         REPOSITORY_NAME="kubernetes/kubernetes"
     fi
@@ -98,4 +104,6 @@ csi_livenessprobe:
 $(get_container_yaml kubernetes-csi/livenessprobe $RELEASE)
 etcd:
 $(get_container_yaml etcd-io/etcd $RELEASE)
+cloud_controller_manager:
+$(get_container_yaml kubernetes/cloud-provider-aws $RELEASE)
 EOF

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -7,10 +7,9 @@ spec:
     dns: {}
   authorization:
     rbac: {}
-  channel: stable
-  {{if .ipv6}}
-  cloudControllerManager: {}
-  {{end}}
+  channel: stable  
+  cloudControllerManager:
+    image: {{ .cloud_controller_manager.repository }}:{{ .cloud_controller_manager.tag }}  
   cloudProvider: aws
   configBase: {{ .configBase }}
   containerRuntime: containerd


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We were already using the external ccm for ipv6 case since it was required.  This changes it to use it always and use our new custom build so we can validate it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
