### PR TITLE
Moves clean up to proper location for postsubmit cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ postsubmit-build: setup
 		--artifact-bucket=$(ARTIFACT_BUCKET) \
 		--dry-run=false \
 		--rebuild-all=${REBUILD_ALL}
-
+	$(MAKE) clean-go-cache clean
+	
 .PHONY: kops-prow-arm
 kops-prow-arm: export NODE_INSTANCE_TYPE=t4g.medium
 kops-prow-arm: export NODE_ARCHITECTURE=arm64
@@ -89,7 +90,7 @@ kops-prereqs: postsubmit-build
 
 .PHONY: postsubmit-conformance
 postsubmit-conformance: RELEASE:=$(shell echo  $$(($(RELEASE) + 1))).pre
-postsubmit-conformance: postsubmit-build clean-go-cache clean kops-prow 
+postsubmit-conformance: postsubmit-build kops-prow 
 	@echo 'Done postsubmit-conformance'
 
 .PHONY: tag


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

My previous fix was incorrect. The postsubmit-conformance job runs make with -j, so in parallel.  That meant this cleanup actually ran at the same time as the build which isnt what we want. Moving to the end of the postsubmit-build target instead.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
