### PR TITLE
Enables csi driver in kops

### DIFF
--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -10,6 +10,9 @@ spec:
   channel: stable  
   cloudControllerManager:
     image: {{ .cloud_controller_manager.repository }}:{{ .cloud_controller_manager.tag }}  
+  cloudConfig:
+    awsEBSCSIDriver:
+      enabled: true
   cloudProvider: aws
   configBase: {{ .configBase }}
   containerRuntime: containerd


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is the default for versions >1.21 which explains why they are working in post submit since the CCM change and 1.21 is not.  I have not tested this locally, but have hope...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
