### PR TITLE
Cleans go cache and project in prow

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -435,8 +435,8 @@ SKIP_CHECKSUM_VALIDATION?=false
 ####################################################
 
 #################### TARGETS FOR OVERRIDING ########
-BUILD_TARGETS?=validate-checksums attribution $(if $(IMAGE_NAMES),local-images,) $(if $(filter true,$(HAS_HELM_CHART)),helm/build,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,) attribution-pr $(if $(JOB_TYPE),clean clean-go-cache)
-RELEASE_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),images,) $(if $(filter true,$(HAS_HELM_CHART)),helm/push,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,) $(if $(JOB_TYPE),clean clean-go-cache)
+BUILD_TARGETS?=validate-checksums attribution $(if $(IMAGE_NAMES),local-images,) $(if $(filter true,$(HAS_HELM_CHART)),helm/build,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,) attribution-pr
+RELEASE_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),images,) $(if $(filter true,$(HAS_HELM_CHART)),helm/push,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,)
 ####################################################
 
 define BUILDCTL

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,6 @@ postsubmit-build: setup
 		--artifact-bucket=$(ARTIFACT_BUCKET) \
 		--dry-run=false \
 		--rebuild-all=${REBUILD_ALL}
-	$(MAKE) clean-go-cache clean
 	
 .PHONY: kops-prow-arm
 kops-prow-arm: export NODE_INSTANCE_TYPE=t4g.medium
@@ -148,10 +147,6 @@ stop-buildkit-and-registry:
 clean: $(addprefix makes-clean-, $(ALL_PROJECTS))
 	@echo 'Done' $(TARGET)
 
-.PHONY: clean-go-cache
-clean-go-cache:
-	rm -rf /root/.cache/go-build /home/prow/go/pkg/mod
-
 .PHONY: makes-clean-%
 makes-clean-%:
 	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
@@ -164,8 +159,7 @@ attribution-files: $(addprefix attribution-files-project-, $(ALL_PROJECTS))
 .PHONY: attribution-files-project-%
 attribution-files-project-%:
 	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
-	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH) attribution
-	$(if $(findstring periodic,$(JOB_TYPE)),$(MAKE) clean-go-cache && rm -rf $(PROJECT_PATH)/_output,)
+	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH) "attribution clean-output clean-go-cache"
 
 .PHONY: update-attribution-files
 update-attribution-files: add-generated-help-block go-mod-files attribution-files
@@ -175,8 +169,7 @@ update-attribution-files: add-generated-help-block go-mod-files attribution-file
 .PHONY: checksum-files-project-%
 checksum-files-project-%:
 	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
-	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH) checksums
-	$(if $(findstring periodic,$(JOB_TYPE)),$(MAKE) clean-go-cache && make -C $(PROJECT_PATH) clean,)
+	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH) "checksums clean-output clean-go-cache"
 
 .PHONY: update-checksum-files
 update-checksum-files: $(addprefix checksum-files-project-, $(ALL_PROJECTS))

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build:
 postsubmit-build: setup
 	go vet cmd/main_postsubmit.go
 	go run cmd/main_postsubmit.go \
-		--target=release \
+		--target="release clean clean-go-cache" \
 		--release-branch=${RELEASE_BRANCH} \
 		--release=${RELEASE} \
 		--region=${AWS_REGION} \
@@ -110,7 +110,7 @@ release: $(addprefix makes-release-, $(ALL_PROJECTS)) upload
 .PHONY: makes-release-%
 makes-release-%:
 	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
-	$(MAKE) release -C $(PROJECT_PATH)
+	$(MAKE) release clean clean-go-cache -C $(PROJECT_PATH)
 
 .PHONY: binaries
 binaries: $(addprefix makes-binaries-, $(ALL_PROJECTS))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We have always had space constraints in presubmits, but now that eks-d contains more and more the postsubmit jobs which rebuild the world (attribution/checksums/release/etc) can end up using the entire disk on the host mainly due to the gomodcache.  This introduces a couple new targets to Common.mk to make cleaning up these folders a bit easier.  

To validate presubmit: https://github.com/aws/eks-distro-prow-jobs/pull/429

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
