### PR TITLE
Passes make targets comma seperated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build:
 postsubmit-build: setup
 	go vet cmd/main_postsubmit.go
 	go run cmd/main_postsubmit.go \
-		--target="release clean clean-go-cache" \
+		--target=release,clean,clean-go-cache \
 		--release-branch=${RELEASE_BRANCH} \
 		--release=${RELEASE} \
 		--region=${AWS_REGION} \

--- a/cmd/main_postsubmit.go
+++ b/cmd/main_postsubmit.go
@@ -34,8 +34,9 @@ func (c *Command) buildProject(projectPath string) error {
 	commandArgs := []string{
 		"-C",
 		filepath.Join(c.gitRoot, "projects", projectPath),
-		c.makeTarget,
 	}
+	allMakeTargets := strings.Split(c.makeTarget, ",")
+	commandArgs = append(commandArgs, allMakeTargets...)
 	commandArgs = append(commandArgs, c.makeArgs...)
 
 	cmd := exec.Command("make", commandArgs...)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The postsubmit app did not like the quotes around these targets. Changing to pass comma separated and split when passing to make.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
