### PR TITLE
Fixes checksums difference when building multiple versions

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -785,6 +785,14 @@ clean-go-cache:
 # adding the perms neccessary to perform the delete
 	@chmod -fR 777 $(GO_MOD_CACHE) &> /dev/null || :
 	$(foreach folder,$(GO_MOD_CACHE) $(GO_BUILD_CACHE),$(if $(wildcard $(folder)),du -hs $(folder) && rm -rf $(folder);,))
+# When building go bins using mods which have been downloaded by go mod download/vendor which will exist in the go_mod_cache
+# there is additional checksum (?) information that is not preserved in the vendor directory within the project folder
+# This additional information gets written out into the resulting binary. If we did not run go mod vendor, which we do 
+# for all project builds, we could get checksum mismatches on the final binaries due to sometimes having the mod previously
+# downloaded in the go_mod_cahe.  Running go mod vendor always ensures that the go mod has always been downloaded
+# to the go_mod_cache directory. If we clear the go_mod_cache we need to delete the go_mod_download sentinel file
+# so the next time we run build go mods will be redownloaded
+	$(foreach file,$(GO_MOD_DOWNLOAD_TARGETS),$(if $(wildcard $(file)),rm -f $(file);,))
 
 .PHONY: clean-repo
 clean-repo:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The attribution and checksums jobs are the only places we build components for all versions of kube, all other jobs are always specific to a release branch.  Refer to comment I put in the Common.mk, but its very important that go mod vendor be ran to ensure go mods have been download to the global cache and not just in the pre-checked in vendor directory, which a lot of projects do.  On friday the checksums job was [changed](https://github.com/aws/eks-distro/pull/1531/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R172) to run the clean-output target instead of clean, since the repo does not need to be cleaned up between version builds, but this had the side effect of leaving the <project> directory, along with its vendor dir, around with the go-mod-download sentinel file but the global go-mod-cache had been cleaned.  This meant when the next version of the component was built, it did not run go mod vendor thus resulting in a checksum mismatch due to some additional hash which only exists for go mods which have been download to the global cache.

As a side note, the resulting binaries were almost def just fine and functionally the same, just the checksums mismatch due to this additional hash which is embedded per module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
