### PR TITLE
Cleans yum after pause build

### DIFF
--- a/projects/kubernetes/kubernetes/docker/pause/Dockerfile
+++ b/projects/kubernetes/kubernetes/docker/pause/Dockerfile
@@ -23,7 +23,7 @@ COPY pause/pause.c /pause.c
 RUN yum update -y && \
   yum install -y gcc glibc-static && \
   gcc -Os -Wall -Werror -static -DVERSION=${PAUSE_VERSION} -o /pause /pause.c && \
-  yum history undo 1 && \
+  yum autoremove -y gcc glibc-static && \
   yum clean all && \
   rm -rf /var/cache/yum
 

--- a/projects/kubernetes/kubernetes/docker/pause/Dockerfile
+++ b/projects/kubernetes/kubernetes/docker/pause/Dockerfile
@@ -18,11 +18,14 @@ FROM ${BUILDER_IMAGE}
 
 ARG PAUSE_VERSION
 
-RUN yum update -y
-RUN yum install -y gcc glibc-static
-# Use as small a context as possible so Docker doesn't read all of _output
 COPY pause/pause.c /pause.c
-RUN gcc -Os -Wall -Werror -static -DVERSION=${PAUSE_VERSION} -o /pause /pause.c
+
+RUN yum update -y && \
+  yum install -y gcc glibc-static && \
+  gcc -Os -Wall -Werror -static -DVERSION=${PAUSE_VERSION} -o /pause /pause.c && \
+  yum history undo 1 && \
+  yum clean all && \
+  rm -rf /var/cache/yum
 
 FROM ${BASE_IMAGE}
 COPY --from=0 /pause /pause


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To avoid ballooning on presubmit which run on fargate without an overlayfs.  This hasnt been and isnt an issue, but a small cleanup I noticed could be made while testing builds on fargate for something else.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
