### PR TITLE
Fixes checksums and attribution when running all release branches

### DIFF
--- a/build/update-attribution-files/make_attribution.sh
+++ b/build/update-attribution-files/make_attribution.sh
@@ -63,14 +63,16 @@ else
             # if the git_tags match across release branches, save the output state to avoid
             # rebuilding/regenerating
             if [[ $TARGET == *"checksums"* ]]; then
+                echo "Copying $LAST_RELEASE_BRANCH CHECKSUMS to $release"
                 mkdir -p $PROJECT_ROOT/_output/$release
-                cp -rf $PROJECT_ROOT/_output/$LAST_RELEASE_BRANCH/bin $PROJECT_ROOT/_output/$release
+                sed 's/$LAST_RELEASE_BRANCH/$release/' $PROJECT_ROOT/$LAST_RELEASE_BRANCH/CHECKSUMS > $PROJECT_ROOT/$release/CHECKSUMS
             fi
+
             if [[ $TARGET == *"attribution"* ]]; then
+                echo "Copying $LAST_RELEASE_BRANCH ATTRIBUTION to $release"
                 mkdir -p $PROJECT_ROOT/_output/$release
-                cp -rf $PROJECT_ROOT/_output/$LAST_RELEASE_BRANCH/{attribution,LICENSES} $PROJECT_ROOT/_output/$release
-            fi
-            build::attribution::generate $release
+                cp -rf $PROJECT_ROOT/$LAST_RELEASE_BRANCH/*TTRIBUTION.txt $PROJECT_ROOT/$release
+            fi            
         fi
         LAST_GIT_TAG="$GIT_TAG"
         LAST_RELEASE_BRANCH="$release"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Follow up to: https://github.com/aws/eks-distro/pull/1568

Two issues came up since merging the above:

- the nightly attribution jobs were still running the generate attribution script.  Even tho all the intermediate files existed and the ATTRIBUTION.txt file was in the output directory, the make target does not copy it from it, it generates and saves to the final location in the release_branch folder.  This changes the all logic to just copy the attribution(s) directly.
- The cni checksums did not generate for 1-22 and 1-24 during the checksum run last night. This ended up being due to the fact that since all output files and repo existed locally after being copied during the 1-21 build, when the `checksums` target ran for 1.22 it didnt actually run the target because... The cni plugins has to dynamically generate its [binary_target_files](https://github.com/aws/eks-distro/blob/main/projects/containernetworking/plugins/Makefile#L25) which requires the repo to be cloned.  For some reason, I cant explain, when everything is in place it regenerates the source_patterns file but make doesnt actually reload it or something. So the BINARY_TARGE_FILES var is not re-evaled therefore when the checksums target goes to run there is nothing to do because there are no binary targets.  Again the simple fix is to just copy the checksums directly instead of calling the target again for the new release branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
