### PR TITLE
Fixes copying checksum files between versions by using double quote

### DIFF
--- a/build/update-attribution-files/make_attribution.sh
+++ b/build/update-attribution-files/make_attribution.sh
@@ -65,7 +65,7 @@ else
             if [[ $TARGET == *"checksums"* ]]; then
                 echo "Copying $LAST_RELEASE_BRANCH CHECKSUMS to $release"
                 mkdir -p $PROJECT_ROOT/_output/$release
-                sed 's/$LAST_RELEASE_BRANCH/$release/' $PROJECT_ROOT/$LAST_RELEASE_BRANCH/CHECKSUMS > $PROJECT_ROOT/$release/CHECKSUMS
+                sed "s/$LAST_RELEASE_BRANCH/$release/" $PROJECT_ROOT/$LAST_RELEASE_BRANCH/CHECKSUMS > $PROJECT_ROOT/$release/CHECKSUMS
             fi
 
             if [[ $TARGET == *"attribution"* ]]; then


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
