### PR TITLE
make release command work with both SSH and HTTPS git clients

### DIFF
--- a/cmd/release/utils/git/open-pr.sh
+++ b/cmd/release/utils/git/open-pr.sh
@@ -28,9 +28,14 @@ echo "pushed!"
 PR_REPO="eks-distro"
 
 GITHUB_USERNAME_REGEX="s/(https:\/\/|git@)github\.com(\/|:)(.*)\/${PR_REPO}.git/\3/p"
+GITHUB_USERNAME=$(git remote get-url origin | sed -n -E "$GITHUB_USERNAME_REGEX")
+if [ -z "$GITHUB_USERNAME" ]
+then
+echo "Failed to parse Github username! Ensure you have a remote 'origin' set." && return 1
+fi
 
 pr_arguments=(
-  --head "$(git remote get-url origin | sed -n -E "$GITHUB_USERNAME_REGEX"):${PR_BRANCH}"
+  --head "${GITHUB_USERNAME}:${PR_BRANCH}"
   --repo "aws/${PR_REPO}"
   --title "${PR_TITLE}"
   --web

--- a/cmd/release/utils/git/open-pr.sh
+++ b/cmd/release/utils/git/open-pr.sh
@@ -27,8 +27,10 @@ echo "pushed!"
 
 PR_REPO="eks-distro"
 
+GITHUB_USERNAME_REGEX="s/(https:\/\/|git@)github\.com(\/|:)(.*)\/${PR_REPO}.git/\3/p"
+
 pr_arguments=(
-  --head "$(git remote get-url origin | sed -n -e "s|git@github.com:\(.*\)/${PR_REPO}.git|\1|p"):${PR_BRANCH}"
+  --head "$(git remote get-url origin | sed -n -E "$GITHUB_USERNAME_REGEX"):${PR_BRANCH}"
   --repo "aws/${PR_REPO}"
   --title "${PR_TITLE}"
   --web


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The URL format of SSH and HTTPS remotes differs. For those of us with HTTPS remotes, the dev release number bump script wasn't extracting the username from the remote name and the 'head' value in the create-pr command was empty.

This updates the command to match against the remote URL format for both HTTPS and SSH.

`-E` tells it to use modern regex

the regex then checks for both the https and ssh url formats and matches against the username capture group 3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
