### PR TITLE
Added make minor-release-foundation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,3 +232,8 @@ github-release:
 	go run ./cmd/release/gh-release/main.go \
 		--branch=$(RELEASE_BRANCH) \
 		--overrideNumber=$(OVERRIDE_NUMBER)
+
+.PHONY: minor-release-foundation
+minor-release-foundation:
+	go vet ./cmd/release/minor
+	go run ./cmd/release/minor/main.go

--- a/cmd/release/minor/main.go
+++ b/cmd/release/minor/main.go
@@ -22,7 +22,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("getting the new release branch: %v", err)
 	}
-	log.Printf("Added %v to SUPPORTED_RELEASE_BRANCHES", addedReleaseBranch)
+	log.Printf("Added %s to SUPPORTED_RELEASE_BRANCHES", addedReleaseBranch)
 
 	prevReleaseBranch, nextReleaseBranch := string(latestSupportedReleaseBranch), string(addedReleaseBranch)
 

--- a/cmd/release/minor/main.go
+++ b/cmd/release/minor/main.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/aws/eks-distro/cmd/release/utils/changetype"
+	"github.com/aws/eks-distro/cmd/release/utils/values"
+)
+
+func main() {
+	latestSupportedReleaseBranch, err := values.GetLatestSupportedReleaseBranch()
+	if err != nil {
+		log.Fatalf("getting the latest supported release branch to create new minor release: %v", err)
+	}
+	newReleaseBranch, err := getNewReleaseBranch(string(latestSupportedReleaseBranch))
+	if err != nil {
+		log.Fatalf("getting the new release branch: %v", err)
+	}
+
+	// Adds new release branch to SUPPORTED_RELEASE_BRANCHES
+	err = addSupportedReleaseBranch([]byte(newReleaseBranch))
+	if err != nil {
+		log.Fatalf("adding %v as new supported release branch: %v", newReleaseBranch, err)
+	}
+
+	// Adds project files new release branch
+	err = createProjectFilesAndDirectories(latestSupportedReleaseBranch, newReleaseBranch)
+	if err != nil {
+		log.Fatalf("at the end: %v", err)
+	}
+
+	// Adds release directory and sets RELEASE values to "0"
+	err = createReleaseDirectoryAndFiles(newReleaseBranch)
+	if err != nil {
+		log.Fatalf("at the end: %v", err)
+	}
+}
+
+func getNewReleaseBranch(latestSupportedReleaseBranch string) (string, error) {
+	// latestSupportedReleaseBranch format expected to be 1-XX, e.g. 1-26
+	prefix := latestSupportedReleaseBranch[:2]
+	suffix := latestSupportedReleaseBranch[2:]
+
+	latestMinorNum, err := strconv.Atoi(suffix)
+	if err != nil {
+		return "", fmt.Errorf("converting the minor release number %v to int: %w\n\n\n", latestMinorNum, err)
+	}
+	nextMinorNum := latestMinorNum + 1
+	foo := prefix + strconv.Itoa(nextMinorNum)
+	return foo, nil
+}
+
+func addSupportedReleaseBranch(newSupportedReleaseBranch []byte) error {
+	releaseBranches, err := values.GetSupportedReleaseBranches()
+	if err != nil {
+		return fmt.Errorf("getting supported release branches to add %v: %w", newSupportedReleaseBranch, err)
+	}
+	releaseBranches = append(releaseBranches, newSupportedReleaseBranch)
+	return os.WriteFile(values.SupportedReleaseBranchesPath, append(bytes.Join(releaseBranches, []byte("\n")), []byte("\n")...), 0644)
+}
+
+func createReleaseDirectoryAndFiles(newReleaseBranch string) error {
+	newRBReleasePath := filepath.Join(values.GetGitRootDirectory(), "release", newReleaseBranch)
+	if err := os.Mkdir(newRBReleasePath, 0755); err != nil {
+		return fmt.Errorf("creating new directory for release: %w", err)
+	}
+
+	for _, ct := range []changetype.ChangeType{changetype.Dev, changetype.Prod} {
+		ctDirPath := filepath.Join(newRBReleasePath, ct.String())
+		if err := os.Mkdir(ctDirPath, 0755); err != nil {
+			return fmt.Errorf("creating new directory for %s release: %w", ct.String(), err)
+		}
+		if err := os.WriteFile(filepath.Join(ctDirPath, "RELEASE"), []byte("0\n"), 0744); err != nil {
+			return fmt.Errorf("writing to RELEASE file: %w", err)
+		}
+	}
+	return nil
+}
+
+func createProjectFilesAndDirectories(rbToDuplicateBytes []byte, rbToCreateBytes string) error {
+	rbToDuplicate := string(rbToDuplicateBytes)
+	rbToCreate := rbToCreateBytes
+
+	projects, err := values.GetProjects()
+	if err != nil {
+		return fmt.Errorf("getting projects: %w", err)
+	}
+	for _, project := range projects {
+		projectPath := project.GetFilePath()
+		repoRBToDuplicate := filepath.Join(projectPath, rbToDuplicate)
+		if _, err = os.Stat(repoRBToDuplicate); os.IsNotExist(err) {
+			return fmt.Errorf("expected %s to exist but it does not", repoRBToDuplicate)
+		}
+		// Create new release branch directory at projects/<org>/<repo>/<release_branch>
+		rbToCreatePath := filepath.Join(projectPath, rbToCreate)
+		if err = os.Mkdir(rbToCreatePath, 0755); err != nil {
+			return fmt.Errorf("crearing new directory %s", rbToCreatePath)
+		}
+		// Copy all files and directories from the latest release branch to new one
+		if err = copyDir(repoRBToDuplicate, rbToCreatePath, rbToDuplicate, rbToCreate); err != nil {
+			return fmt.Errorf("copying directories and files: %w", err)
+		}
+
+	}
+	return nil
+}
+
+func copyDir(existingBRPath, newRBPath, existingReleaseBranch, newReleaseBranch string) error {
+	existingBRDirs, err := os.ReadDir(existingBRPath)
+	if err != nil {
+		return fmt.Errorf("reading directory at path %s: %w", existingBRPath, err)
+	} else if len(existingBRPath) == 0 {
+		return nil
+	}
+
+	for _, existingChildDir := range existingBRDirs {
+		existingChildDirName := existingChildDir.Name()
+		existingChildPath := filepath.Join(existingBRPath, existingChildDirName)
+		newRBDirPath := filepath.Join(newRBPath, existingChildDirName)
+		if existingChildDir.IsDir() {
+			if err = os.Mkdir(newRBDirPath, 0755); err != nil {
+				return fmt.Errorf("creating new directory to copy %s", newRBDirPath)
+			}
+			return copyDir(existingChildPath, newRBDirPath, existingReleaseBranch, newReleaseBranch)
+		} else {
+			if err := copyFile(existingChildPath, newRBDirPath, existingReleaseBranch, newReleaseBranch); err != nil {
+				return fmt.Errorf("coping file: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func copyFile(existingFilePath, newFilePath, existingReleaseBranch, newReleaseBranch string) error {
+	existingFile, err := os.Open(existingFilePath)
+	if err != nil {
+		return err
+	}
+	defer existingFile.Close()
+
+	newFile, err := os.Create(newFilePath)
+	if err != nil {
+		return err
+	}
+	defer newFile.Close()
+
+	if filepath.Base(existingFile.Name()) == "CHECKSUMS" {
+		scanner := bufio.NewScanner(existingFile)
+		for scanner.Scan() {
+			updatedLine := strings.ReplaceAll(scanner.Text(), existingReleaseBranch, newReleaseBranch)
+			if _, err = fmt.Fprintln(newFile, updatedLine); err != nil {
+				return fmt.Errorf("modifying CHECKSUM file: %w", err)
+			}
+		}
+		if err = scanner.Err(); err != nil {
+			return fmt.Errorf("scanning CHECKSUMS: %w", err)
+		}
+	} else {
+		if _, err = io.Copy(newFile, existingFile); err != nil {
+			return fmt.Errorf("copying files: %w", err)
+		}
+	}
+	return nil
+}

--- a/cmd/release/minor/main.go
+++ b/cmd/release/minor/main.go
@@ -129,7 +129,9 @@ func copyDir(existingBRPath, newRBPath, existingReleaseBranch, newReleaseBranch 
 			if err = os.Mkdir(newRBDirPath, 0755); err != nil {
 				return fmt.Errorf("creating new directory to copy %s", newRBDirPath)
 			}
-			return copyDir(existingChildPath, newRBDirPath, existingReleaseBranch, newReleaseBranch)
+			if err = copyDir(existingChildPath, newRBDirPath, existingReleaseBranch, newReleaseBranch); err != nil {
+				return fmt.Errorf("copying child directory %s", existingChildPath)
+			}
 		} else {
 			if err := copyFile(existingChildPath, newRBDirPath, existingReleaseBranch, newReleaseBranch); err != nil {
 				return fmt.Errorf("coping file: %w", err)

--- a/cmd/release/minor/main.go
+++ b/cmd/release/minor/main.go
@@ -29,14 +29,14 @@ func main() {
 	// Adds project files new release branch
 	projectFilesAddedCount, err := projects.CreateFilesAndDirectories(prevReleaseBranch, nextReleaseBranch)
 	if err != nil {
-		log.Fatalf("at the end: %v", err)
+		log.Fatalf("creating project files and directories: %v", err)
 	}
 	log.Printf("Generated %d project files", projectFilesAddedCount)
 
 	// Adds release directory and sets RELEASE values to "0"
 	err = createReleaseDirectoryAndFiles(nextReleaseBranch)
 	if err != nil {
-		log.Fatalf("at the end: %v", err)
+		log.Fatalf("creating RELEASE files: %v", err)
 	}
 	log.Printf("Generated RELEASE files")
 }

--- a/cmd/release/minor/main.go
+++ b/cmd/release/minor/main.go
@@ -1,16 +1,12 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 
+	"github.com/aws/eks-distro/cmd/release/minor/projects"
 	"github.com/aws/eks-distro/cmd/release/utils/changetype"
 	"github.com/aws/eks-distro/cmd/release/utils/values"
 )
@@ -20,55 +16,33 @@ func main() {
 	if err != nil {
 		log.Fatalf("getting the latest supported release branch to create new minor release: %v", err)
 	}
-	newReleaseBranch, err := getNewReleaseBranch(string(latestSupportedReleaseBranch))
+
+	// Adds new release branch to SUPPORTED_RELEASE_BRANCHES
+	addedReleaseBranch, err := values.AddNextReleaseBranch()
 	if err != nil {
 		log.Fatalf("getting the new release branch: %v", err)
 	}
+	log.Printf("Added %v to SUPPORTED_RELEASE_BRANCHES", addedReleaseBranch)
 
-	// Adds new release branch to SUPPORTED_RELEASE_BRANCHES
-	err = addSupportedReleaseBranch([]byte(newReleaseBranch))
-	if err != nil {
-		log.Fatalf("adding %v as new supported release branch: %v", newReleaseBranch, err)
-	}
+	prevReleaseBranch, nextReleaseBranch := string(latestSupportedReleaseBranch), string(addedReleaseBranch)
 
 	// Adds project files new release branch
-	err = createProjectFilesAndDirectories(latestSupportedReleaseBranch, newReleaseBranch)
+	projectFilesAddedCount, err := projects.CreateFilesAndDirectories(prevReleaseBranch, nextReleaseBranch)
 	if err != nil {
 		log.Fatalf("at the end: %v", err)
 	}
+	log.Printf("Generated %d project files", projectFilesAddedCount)
 
 	// Adds release directory and sets RELEASE values to "0"
-	err = createReleaseDirectoryAndFiles(newReleaseBranch)
+	err = createReleaseDirectoryAndFiles(nextReleaseBranch)
 	if err != nil {
 		log.Fatalf("at the end: %v", err)
 	}
+	log.Printf("Generated RELEASE files")
 }
 
-func getNewReleaseBranch(latestSupportedReleaseBranch string) (string, error) {
-	// latestSupportedReleaseBranch format expected to be 1-XX, e.g. 1-26
-	prefix := latestSupportedReleaseBranch[:2]
-	suffix := latestSupportedReleaseBranch[2:]
-
-	latestMinorNum, err := strconv.Atoi(suffix)
-	if err != nil {
-		return "", fmt.Errorf("converting the minor release number %v to int: %w\n\n\n", latestMinorNum, err)
-	}
-	nextMinorNum := latestMinorNum + 1
-	foo := prefix + strconv.Itoa(nextMinorNum)
-	return foo, nil
-}
-
-func addSupportedReleaseBranch(newSupportedReleaseBranch []byte) error {
-	releaseBranches, err := values.GetSupportedReleaseBranches()
-	if err != nil {
-		return fmt.Errorf("getting supported release branches to add %v: %w", newSupportedReleaseBranch, err)
-	}
-	releaseBranches = append(releaseBranches, newSupportedReleaseBranch)
-	return os.WriteFile(values.SupportedReleaseBranchesPath, append(bytes.Join(releaseBranches, []byte("\n")), []byte("\n")...), 0644)
-}
-
-func createReleaseDirectoryAndFiles(newReleaseBranch string) error {
-	newRBReleasePath := filepath.Join(values.GetGitRootDirectory(), "release", newReleaseBranch)
+func createReleaseDirectoryAndFiles(nextReleaseBranch string) error {
+	newRBReleasePath := filepath.Join(values.GetGitRootDirectory(), "release", nextReleaseBranch)
 	if err := os.Mkdir(newRBReleasePath, 0755); err != nil {
 		return fmt.Errorf("creating new directory for release: %w", err)
 	}
@@ -80,94 +54,6 @@ func createReleaseDirectoryAndFiles(newReleaseBranch string) error {
 		}
 		if err := os.WriteFile(filepath.Join(ctDirPath, "RELEASE"), []byte("0\n"), 0744); err != nil {
 			return fmt.Errorf("writing to RELEASE file: %w", err)
-		}
-	}
-	return nil
-}
-
-func createProjectFilesAndDirectories(rbToDuplicateBytes []byte, rbToCreateBytes string) error {
-	rbToDuplicate := string(rbToDuplicateBytes)
-	rbToCreate := rbToCreateBytes
-
-	projects, err := values.GetProjects()
-	if err != nil {
-		return fmt.Errorf("getting projects: %w", err)
-	}
-	for _, project := range projects {
-		projectPath := project.GetFilePath()
-		repoRBToDuplicate := filepath.Join(projectPath, rbToDuplicate)
-		if _, err = os.Stat(repoRBToDuplicate); os.IsNotExist(err) {
-			return fmt.Errorf("expected %s to exist but it does not", repoRBToDuplicate)
-		}
-		// Create new release branch directory at projects/<org>/<repo>/<release_branch>
-		rbToCreatePath := filepath.Join(projectPath, rbToCreate)
-		if err = os.Mkdir(rbToCreatePath, 0755); err != nil {
-			return fmt.Errorf("crearing new directory %s", rbToCreatePath)
-		}
-		// Copy all files and directories from the latest release branch to new one
-		if err = copyDir(repoRBToDuplicate, rbToCreatePath, rbToDuplicate, rbToCreate); err != nil {
-			return fmt.Errorf("copying directories and files: %w", err)
-		}
-
-	}
-	return nil
-}
-
-func copyDir(existingBRPath, newRBPath, existingReleaseBranch, newReleaseBranch string) error {
-	existingBRDirs, err := os.ReadDir(existingBRPath)
-	if err != nil {
-		return fmt.Errorf("reading directory at path %s: %w", existingBRPath, err)
-	} else if len(existingBRPath) == 0 {
-		return nil
-	}
-
-	for _, existingChildDir := range existingBRDirs {
-		existingChildDirName := existingChildDir.Name()
-		existingChildPath := filepath.Join(existingBRPath, existingChildDirName)
-		newRBDirPath := filepath.Join(newRBPath, existingChildDirName)
-		if existingChildDir.IsDir() {
-			if err = os.Mkdir(newRBDirPath, 0755); err != nil {
-				return fmt.Errorf("creating new directory to copy %s", newRBDirPath)
-			}
-			if err = copyDir(existingChildPath, newRBDirPath, existingReleaseBranch, newReleaseBranch); err != nil {
-				return fmt.Errorf("copying child directory %s", existingChildPath)
-			}
-		} else {
-			if err := copyFile(existingChildPath, newRBDirPath, existingReleaseBranch, newReleaseBranch); err != nil {
-				return fmt.Errorf("coping file: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-func copyFile(existingFilePath, newFilePath, existingReleaseBranch, newReleaseBranch string) error {
-	existingFile, err := os.Open(existingFilePath)
-	if err != nil {
-		return err
-	}
-	defer existingFile.Close()
-
-	newFile, err := os.Create(newFilePath)
-	if err != nil {
-		return err
-	}
-	defer newFile.Close()
-
-	if filepath.Base(existingFile.Name()) == "CHECKSUMS" {
-		scanner := bufio.NewScanner(existingFile)
-		for scanner.Scan() {
-			updatedLine := strings.ReplaceAll(scanner.Text(), existingReleaseBranch, newReleaseBranch)
-			if _, err = fmt.Fprintln(newFile, updatedLine); err != nil {
-				return fmt.Errorf("modifying CHECKSUM file: %w", err)
-			}
-		}
-		if err = scanner.Err(); err != nil {
-			return fmt.Errorf("scanning CHECKSUMS: %w", err)
-		}
-	} else {
-		if _, err = io.Copy(newFile, existingFile); err != nil {
-			return fmt.Errorf("copying files: %w", err)
 		}
 	}
 	return nil

--- a/cmd/release/minor/projects/projects.go
+++ b/cmd/release/minor/projects/projects.go
@@ -1,0 +1,126 @@
+package projects
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/aws/eks-distro/cmd/release/utils/values"
+)
+
+var (
+	prevReleaseBranch string
+	nextReleaseBranch string
+)
+
+// CreateFilesAndDirectories returns the number of files generated. If there was an error, returns -1
+func CreateFilesAndDirectories(prevReleaseBranchInput string, nextReleaseBranchInput string) (int, error) {
+	prevReleaseBranch, nextReleaseBranch = prevReleaseBranchInput, nextReleaseBranchInput
+
+	projects, err := values.GetProjects()
+	if err != nil {
+		return -1, fmt.Errorf("getting projects: %w", err)
+	}
+	for _, project := range projects {
+		projectPath := project.GetFilePath()
+		prevReleaseBranchRepoPath := filepath.Join(projectPath, prevReleaseBranch)
+		if _, err = os.Stat(prevReleaseBranchRepoPath); os.IsNotExist(err) {
+			return -1, fmt.Errorf("expected %s to exist but it does not", prevReleaseBranchRepoPath)
+		}
+		// Create new release branch directory at projects/<org>/<repo>/<release_branch>
+		nextReleaseBranchRepoPath := filepath.Join(projectPath, nextReleaseBranch)
+		if err = os.Mkdir(nextReleaseBranchRepoPath, 0755); err != nil {
+			return -1, fmt.Errorf("creating new directory %s", nextReleaseBranchRepoPath)
+		}
+		// Copy all files and directories from the latest release branch to new one
+		err = copyDir(prevReleaseBranchRepoPath, nextReleaseBranchRepoPath)
+		if err != nil {
+			return -1, fmt.Errorf("copying directories and files: %w", err)
+		}
+	}
+
+	prevReleaseBranchFileCount, _ := getFileCount(prevReleaseBranch)
+	nextReleaseBranchFileCount, _ := getFileCount(nextReleaseBranch)
+	if prevReleaseBranchFileCount != nextReleaseBranchFileCount {
+		return -1, fmt.Errorf("expected previous release branch file count (%d) to match next release branch file count (%d)",
+			prevReleaseBranchFileCount, nextReleaseBranchFileCount)
+	}
+	return nextReleaseBranchFileCount, nil
+}
+
+func copyDir(prevReleaseBranchPath, nextReleaseBranchPath string) error {
+	prevReleaseBranchDirs, err := os.ReadDir(prevReleaseBranchPath)
+	if err != nil {
+		return fmt.Errorf("reading directory at path %s: %w", prevReleaseBranchPath, err)
+	} else if len(prevReleaseBranchDirs) == 0 {
+		return nil
+	}
+
+	for _, prevReleaseBranchChildDir := range prevReleaseBranchDirs {
+		prevReleaseBranchChildPath := filepath.Join(prevReleaseBranchPath, prevReleaseBranchChildDir.Name())
+		nextReleaseBranchDirPath := filepath.Join(nextReleaseBranchPath, prevReleaseBranchChildDir.Name())
+		if prevReleaseBranchChildDir.IsDir() {
+			if err = os.Mkdir(nextReleaseBranchDirPath, 0755); err != nil {
+				return fmt.Errorf("creating new directory to copy %s", nextReleaseBranchDirPath)
+			}
+			if err = copyDir(prevReleaseBranchChildPath, nextReleaseBranchDirPath); err != nil {
+				return fmt.Errorf("copying child directory %s", prevReleaseBranchChildPath)
+			}
+		} else {
+			if err = copyFile(prevReleaseBranchChildPath, nextReleaseBranchDirPath); err != nil {
+				return fmt.Errorf("coping file: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func copyFile(prevReleaseBranchFilePath, nextReleaseBranchFilePath string) error {
+	existingFile, err := os.Open(prevReleaseBranchFilePath)
+	if err != nil {
+		return err
+	}
+	defer existingFile.Close()
+
+	newFile, err := os.Create(nextReleaseBranchFilePath)
+	if err != nil {
+		return err
+	}
+	defer newFile.Close()
+
+	if filepath.Base(existingFile.Name()) == "CHECKSUMS" {
+		scanner := bufio.NewScanner(existingFile)
+		for scanner.Scan() {
+			updatedLine := strings.ReplaceAll(scanner.Text(), prevReleaseBranch, nextReleaseBranch)
+			if _, err = fmt.Fprintln(newFile, updatedLine); err != nil {
+				return fmt.Errorf("modifying CHECKSUM file: %w", err)
+			}
+		}
+		if err = scanner.Err(); err != nil {
+			return fmt.Errorf("scanning CHECKSUMS: %w", err)
+		}
+	} else {
+		if _, err = io.Copy(newFile, existingFile); err != nil {
+			return fmt.Errorf("copying files: %w", err)
+		}
+	}
+	return nil
+}
+
+func getFileCount(releaseBranch string) (int, error) {
+	pathPattern := filepath.Join(values.GetProjectPathRoot(), "*", "*", releaseBranch, "*")
+	out, err := exec.Command("find", pathPattern, "-type", "f", "|", "wc", "-l").Output()
+	if err != nil {
+		return -1, fmt.Errorf("getting file count for %s: %w", releaseBranch, err)
+	}
+	count, err := strconv.Atoi(string(out))
+	if err != nil {
+		return -1, fmt.Errorf("converting file count %v to int: %w", out, err)
+	}
+	return count, nil
+}

--- a/cmd/release/minor/projects/projects.go
+++ b/cmd/release/minor/projects/projects.go
@@ -90,13 +90,13 @@ func copyDir(prevReleaseBranchPath, nextReleaseBranchPath string) error {
 func copyFile(prevReleaseBranchFilePath, nextReleaseBranchFilePath string) error {
 	existingFile, err := os.Open(prevReleaseBranchFilePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("opening file %s to copy: %w", prevReleaseBranchFilePath, err)
 	}
 	defer existingFile.Close()
 
 	newFile, err := os.Create(nextReleaseBranchFilePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("creating file %s to write to as a copy: %w", nextReleaseBranchFilePath, err)
 	}
 	defer newFile.Close()
 

--- a/cmd/release/utils/values/filepaths.go
+++ b/cmd/release/utils/values/filepaths.go
@@ -8,9 +8,6 @@ import (
 var (
 	IndexPath  = getAbsolutePath("docs", "contents", IndexFileName)
 	ReadmePath = getAbsolutePath("README.md")
-
-	defaultReleaseBranchPath     = getAbsolutePath("release", "DEFAULT_RELEASE_BRANCH")
-	supportedReleaseBranchesPath = getAbsolutePath("release", "SUPPORTED_RELEASE_BRANCHES")
 )
 
 type PathValues interface {

--- a/cmd/release/utils/values/local.go
+++ b/cmd/release/utils/values/local.go
@@ -31,28 +31,3 @@ func GetGitTag(projectOrg, projectName, releaseBranch string) ([]byte, error) {
 	}
 	return bytes.TrimSpace(fileOutput), nil
 }
-
-func IsDefaultReleaseBranch(providedReleaseBranch string) (bool, error) {
-	fileOutput, err := os.ReadFile(defaultReleaseBranchPath.String())
-	if err != nil {
-		return false, fmt.Errorf("getting default release branch at %s path:%w", defaultReleaseBranchPath, err)
-	}
-	defaultReleaseBranch := strings.TrimSpace(string(fileOutput))
-	return strings.Compare(providedReleaseBranch, defaultReleaseBranch) == 0, nil
-}
-
-func IsSupportedReleaseBranch(rb string) (bool, error) {
-	fileOutput, err := os.ReadFile(supportedReleaseBranchesPath.String())
-	if err != nil {
-		return false, fmt.Errorf("getting supported release branches at %s path:%w", supportedReleaseBranchesPath, err)
-	}
-
-	providedReleaseBranch := []byte(rb)
-	splitData := bytes.Split(bytes.TrimSpace(fileOutput), []byte("\n"))
-	for _, supportedReleaseBranch := range splitData {
-		if bytes.Equal(supportedReleaseBranch, providedReleaseBranch) {
-			return true, nil
-		}
-	}
-	return false, nil
-}

--- a/cmd/release/utils/values/projects.go
+++ b/cmd/release/utils/values/projects.go
@@ -1,0 +1,44 @@
+package values
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var projectPath = filepath.Join(GetGitRootDirectory(), "projects")
+
+type Project struct {
+	org  string
+	repo string
+}
+
+func GetProjects() ([]Project, error) {
+	orgDirs, err := os.ReadDir(projectPath)
+	if err != nil {
+		return []Project{}, fmt.Errorf("reading projects path: %w", err)
+	}
+
+	var projects []Project
+	// Iterate through projects/<org>
+	for _, orgDir := range orgDirs {
+		if !orgDir.IsDir() {
+			continue
+		}
+		repoDirs, err := os.ReadDir(filepath.Join(projectPath, orgDir.Name()))
+		if err != nil {
+			return []Project{}, fmt.Errorf("reading repos paths: %w", err)
+		}
+		// Iterate through projects/<org>/<repo>
+		for _, repoDir := range repoDirs {
+			if repoDir.IsDir() {
+				projects = append(projects, Project{org: orgDir.Name(), repo: repoDir.Name()})
+			}
+		}
+	}
+	return projects, nil
+}
+
+func (p *Project) GetFilePath() string {
+	return filepath.Join(projectPath, p.org, p.repo)
+}

--- a/cmd/release/utils/values/projects.go
+++ b/cmd/release/utils/values/projects.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 )
 
-var projectPath = filepath.Join(GetGitRootDirectory(), "projects")
+var projectPathRoot = filepath.Join(GetGitRootDirectory(), "projects")
 
 type Project struct {
 	org  string
@@ -14,7 +14,7 @@ type Project struct {
 }
 
 func GetProjects() ([]Project, error) {
-	orgDirs, err := os.ReadDir(projectPath)
+	orgDirs, err := os.ReadDir(projectPathRoot)
 	if err != nil {
 		return []Project{}, fmt.Errorf("reading projects path: %w", err)
 	}
@@ -25,7 +25,7 @@ func GetProjects() ([]Project, error) {
 		if !orgDir.IsDir() {
 			continue
 		}
-		repoDirs, err := os.ReadDir(filepath.Join(projectPath, orgDir.Name()))
+		repoDirs, err := os.ReadDir(filepath.Join(projectPathRoot, orgDir.Name()))
 		if err != nil {
 			return []Project{}, fmt.Errorf("reading repos paths: %w", err)
 		}
@@ -40,5 +40,9 @@ func GetProjects() ([]Project, error) {
 }
 
 func (p *Project) GetFilePath() string {
-	return filepath.Join(projectPath, p.org, p.repo)
+	return filepath.Join(projectPathRoot, p.org, p.repo)
+}
+
+func GetProjectPathRoot() string {
+	return projectPathRoot
 }

--- a/cmd/release/utils/values/releasebranch.go
+++ b/cmd/release/utils/values/releasebranch.go
@@ -1,0 +1,53 @@
+package values
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var (
+	SupportedReleaseBranchesPath = getAbsolutePath("release", "SUPPORTED_RELEASE_BRANCHES").String()
+	defaultReleaseBranchPath     = getAbsolutePath("release", "DEFAULT_RELEASE_BRANCH").String()
+)
+
+func IsDefaultReleaseBranch(providedReleaseBranch string) (bool, error) {
+	fileOutput, err := os.ReadFile(defaultReleaseBranchPath)
+	if err != nil {
+		return false, fmt.Errorf("getting default release branch at %s path:%w", defaultReleaseBranchPath, err)
+	}
+	defaultReleaseBranch := strings.TrimSpace(string(fileOutput))
+	return strings.Compare(providedReleaseBranch, defaultReleaseBranch) == 0, nil
+}
+
+func IsSupportedReleaseBranch(rb string) (bool, error) {
+	supportedReleaseBranches, err := GetSupportedReleaseBranches()
+	if err != nil {
+		return false, fmt.Errorf("getting release branches to check if %s is supported: %w", rb, err)
+	}
+
+	providedReleaseBranch := []byte(rb)
+	for _, supportedReleaseBranch := range supportedReleaseBranches {
+		if bytes.Equal(supportedReleaseBranch, providedReleaseBranch) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func GetSupportedReleaseBranches() ([][]byte, error) {
+	fileOutput, err := os.ReadFile(SupportedReleaseBranchesPath)
+	if err != nil {
+		return [][]byte{}, fmt.Errorf("getting supported release branches at %s path:%w", SupportedReleaseBranchesPath, err)
+	}
+	return bytes.Split(bytes.TrimSpace(fileOutput), []byte("\n")), nil
+}
+
+func GetLatestSupportedReleaseBranch() ([]byte, error) {
+	supportedReleaseBranches, err := GetSupportedReleaseBranches()
+	if err != nil {
+		return []byte{}, fmt.Errorf("getting release branches to find lastest supported release branches: %w", err)
+	}
+	return supportedReleaseBranches[len(supportedReleaseBranches)-1], nil
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Added make command to generate everything needed to start a minor release. After running `make minor-release-foundation`, a PR can be opened
* Refactor releasebranch code into its own file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
