### PR TITLE
Fixes Kubernetes builds when there are no patches directory

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -500,7 +500,7 @@ $(GIT_CHECKOUT_TARGET): | $(REPO)
 $(GIT_PATCH_TARGET): $(GIT_CHECKOUT_TARGET)
 	git -C $(REPO) config user.email prow@amazonaws.com
 	git -C $(REPO) config user.name "Prow Bot"
-	git -C $(REPO) am --committer-date-is-author-date $(PATCHES_DIR)/*
+	if [ -n "$(PATCHES_DIR)" ]; then git -C $(REPO) am --committer-date-is-author-date $(PATCHES_DIR)/*; fi
 	@touch $@
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Common.mk is smart about applying patches only when there are some.  Kuberntees is the one odd ball project that because it knows there will "always" be patches, there are targets that depend on the specifically on [GIT_PATCH_TARGET](https://github.com/aws/eks-distro/blob/main/projects/kubernetes/kubernetes/Makefile#L86).  This becomes a problem as is when there are no patches because make tries to apply an non-existent folder of patches.

This PR adds a check before running `git am` to make sure there actually are patches. Another (better) approach would be to tweak the def of GIT_PATCH_TARGET, or introduce a different one that either points to GIT_CHECKOUT_TARGET GIT_PATCH_TARGET depending on the existence of the patches folder.  Similar to the [check-repo ](https://github.com/aws/eks-distro/blob/main/Common.mk#L554)target.  I would use that target directly in the kube makefile isntead, but that breaks make's caching ability since its a phony target. Since this is the only place we run into, I am going to punt on this solution until we can do some more thinking since its not as straight forward.

This also fixes docker run on linux machines by passing the current user_id to avoid git getting mad about folder permissions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
