### PR TITLE
use default value for `gitRoot` flag in `main_postsubmit`

### DIFF
--- a/cmd/main_postsubmit.go
+++ b/cmd/main_postsubmit.go
@@ -93,7 +93,7 @@ func main() {
 		fmt.Sprintf("IMAGE_REPO=%s", *imageRepo),
 	}
 
-	cmd := exec.Command("git", "-C", *gitRoot, "diff", "--name-only", "HEAD^", "HEAD")
+	cmd := exec.Command("git", "-C", c.gitRoot, "diff", "--name-only", "HEAD^", "HEAD")
 	log.Printf("Executing command: %s", strings.Join(cmd.Args, " "))
 	gitDiffOutput, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
this was pointing to the pointer, which is ALWAYS empty, rather than the default value that is set if the pointer is empty....

what's weird is that the prow command seems to work (search `--name-only` [here](https://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm.s3.us-west-2.amazonaws.com/logs/build-1-24-postsubmit/1616509820435697664/build-container-build-log.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAUTLHWUYSLXME4LPI%2F20230120%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230120T224719Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEC4aCXVzLXdlc3QtMiJHMEUCICNIX5EI3Xg8twXrv5LXLrvNaebA9IfTY8q5VOX1DiFTAiEApiIlNlAI8oM%2BRGdkSQWOOGgQtjyiUANjQOTkLBnxLJgq%2BQQIl%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARABGgwzMTY0MzQ0NTgxNDgiDDpvdR6K4%2BceDfwlnSrNBDmbdrrgu85s%2Fg5Vm5Y7sPZLo4yfiE7C1NN2nzbX8p%2F%2FxRhgaqkVWY0XrW4%2F1Rf4Wjkj%2FKDMOnn4Yr8zsLlbah2HXwYuwNmOJWSIZzYG6cvfx6XYHO9gI84Qmx46isN%2BNXZVtOz85eXZ18qGXCEvSl4H2A8EKcEwBaR3f5IGHmtTKQV4IvYOrqMt9Qu78mDymg23x90CEnyCzFEL6Goowlp4cS7xtFMxFR5zRSF3yDrsBChiYSgGnBWR5YVTSdrL5kKVfbBUQWXLHE0LZS7Cg0GmO5oHvAbaDkZTaZllHbt5CuIShkr%2FkIzCDPlgZHv14IpBm8EkepHm5bABRdFHB7f2eC5UGwLrjQgfFT642Ln4w4lvcjgbNennhZNR9pjV0Yc4%2FV7fPmx9JAp6lBeSSYRmaoNd6bwx535hmE19NYESGdZFcPpRSYv1t1bwCJyyzxZ8zy8Vy%2B3v8qJYb4gZecY%2Bw9qUgGKJZXCjEAN5pT6peqbU5j6x0uIpYJFCOsCBASWjPyt9eHlRSEAfMj5tuETWNrwKOPsvgbTFvWwZZV0rvzPcEjf%2BmoGsX1r7lFJ58%2F3DF7A%2BV1x1AEytw7QJsZD5ACzPBxWj0qzjrc0XQpM4Dr2CRmlS%2B0BpGyvwl5LMLBhicagTYSRALQnBIBUDIV6kmHRyTr0%2BwWfq1pBgDk6ELgLlDzaq5QcOA%2FfzOmEKj0UNuqWmvfVeFXMcIwq0bKcbKxjcyGXBqgvcItEiuT7xBaNJhvZlTtu%2FQLrp1faUN4OUMX7AYcv18sNnzoMw9Z2sngY6mgGKdsXwUJ6EPVd61GlawNFVHcAkPvuTMFzvc5euXb%2Fw6F7ctuBtMG%2B4Jv%2B%2BE0hmglVsYvUNjjK2SHzWndlqB3z4WIOvmwfbsJX3pxK482YySNq1amqotWPmvltiBKV5HA%2F7JMVteKnSNwYUO%2FQEO88jLjhN6VaWiopWmwNX9YSgJkSLD8%2FDYhF2IhiwG5vUFQiVkSWNH5CpOxkX&X-Amz-SignedHeaders=host&X-Amz-Signature=c5877d6851e41da33feb1c342fe0157f10dfa12c4613aa9c8d7f55562fb6e840)), and if you run `git -C "" diff --name-only HEAD^ HEAD` (note the literal empty qutoes there -- `""`) it WORKS and runs the diff for the cwd...it's treated like `.` or `$(pwd)`. Which ends up being the same result if it were defaulted by the code to `git rev-parse --show-toplevel`, since we're executing it from the root of the repo anyway every time we run it (except for now, when I'm running it in codebuild and invoking the main post-submit from somewhere else).

So we end seem to end up with a correct value in the code even if the code is incorrect.

However, this behavior is causing errors when running the EKS Go test pipeline, which invokes the `main_postsubmit` in EKS D repo from a root which is itself a different git repo (build tooling). I'd like to actually set this value to the 'right' value (the struct field that has been defaulted, not the pointer) and see how it affects the build, if at all.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
