### PR TITLE
Retrigger 1-24 announcement postsubmit

### DIFF
--- a/docs/contents/releases/1-24/8/release-announcement.txt
+++ b/docs/contents/releases/1-24/8/release-announcement.txt
@@ -1,2 +1,3 @@
 Amazon EKS Distro v1-24-eks-8 is now available. Builds are available through ECR Public Gallery (https://gallery.ecr.aws/eks-distro). The changelog and release manifest are available on GitHub (https://github.com/aws/eks-distro/releases).
 	
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add extra space to trigger the sns message for 1-24, since the original docs PR didn't trigger.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
