### PR TITLE
Added make print-versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,3 +237,8 @@ github-release:
 minor-release-foundation:
 	go vet ./cmd/release/minor
 	go run ./cmd/release/minor/main.go
+
+.PHONY: print-versions
+print-versions:
+	go vet ./cmd/print-versions
+	go run ./cmd/print-versions/main.go

--- a/cmd/print-versions/main.go
+++ b/cmd/print-versions/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/eks-distro/cmd/release/utils/projects"
+	"github.com/aws/eks-distro/cmd/release/utils/values"
+)
+
+// Prints GitTag and Golang versions for each project and release branch.
+// Uses local values, which may differ from what's in the upstream EKS-D repo
+// or the versions in the current releases.
+func main() {
+	eksdProjects, err := projects.GetProjects()
+	if err != nil {
+		log.Fatalf("getting projects: %v", err)
+	}
+
+	releaseBranches, err := values.GetSupportedReleaseBranchesStrings()
+	if err != nil {
+		log.Fatalf("getting suppoerted release branches: %v", err)
+	}
+
+	for _, project := range eksdProjects {
+		fmt.Printf("\n%s / %s\n", project.GetOrg(), project.GetRepo())
+		for _, rb := range releaseBranches {
+			version, err := project.GetVersion(rb)
+			if err != nil {
+				log.Fatalf("getting %s/%s versions for %s: %v", project.GetOrg(), project.GetRepo(), rb, err)
+			}
+			fmt.Printf("  ◦ %s  ➜  %-10s%s\n", rb, version.GetGitTag(), version.GetGolang())
+		}
+		fmt.Printf("  %s/tags\n", project.GetGitHubURL())
+	}
+	println()
+}

--- a/cmd/release/minor/projects/projects.go
+++ b/cmd/release/minor/projects/projects.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/eks-distro/cmd/release/utils/values"
+	"github.com/aws/eks-distro/cmd/release/utils/projects"
 )
 
 var (
@@ -22,11 +22,11 @@ var (
 func CreateFilesAndDirectories(prevReleaseBranchInput string, nextReleaseBranchInput string) (int, error) {
 	prevReleaseBranch, nextReleaseBranch = prevReleaseBranchInput, nextReleaseBranchInput
 
-	projects, err := values.GetProjects()
+	eksdProjects, err := projects.GetProjects()
 	if err != nil {
 		return -1, fmt.Errorf("getting projects: %w", err)
 	}
-	for _, project := range projects {
+	for _, project := range eksdProjects {
 		projectPath := project.GetFilePath()
 		prevReleaseBranchRepoPath := filepath.Join(projectPath, prevReleaseBranch)
 		if _, err = os.Stat(prevReleaseBranchRepoPath); os.IsNotExist(err) {
@@ -120,7 +120,7 @@ func copyFile(prevReleaseBranchFilePath, nextReleaseBranchFilePath string) error
 }
 
 func getFileCount(releaseBranch string) (int, error) {
-	pathPattern := filepath.Join(values.GetProjectPathRoot(), "*", "*", releaseBranch, "*")
+	pathPattern := filepath.Join(projects.GetProjectPathRoot(), "*", "*", releaseBranch, "*")
 	out, err := exec.Command("bash", "-c", fmt.Sprintf("find %s -type f | wc -l", pathPattern)).Output()
 	if err != nil {
 		return -1, fmt.Errorf("getting file count for %s: %w", releaseBranch, err)

--- a/cmd/release/utils/projects/projects.go
+++ b/cmd/release/utils/projects/projects.go
@@ -1,12 +1,14 @@
-package values
+package projects
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/aws/eks-distro/cmd/release/utils/values"
 )
 
-var projectPathRoot = filepath.Join(GetGitRootDirectory(), "projects")
+var projectPathRoot = filepath.Join(values.GetGitRootDirectory(), "projects")
 
 type Project struct {
 	org  string
@@ -41,6 +43,34 @@ func GetProjects() ([]Project, error) {
 
 func (p *Project) GetFilePath() string {
 	return filepath.Join(projectPathRoot, p.org, p.repo)
+}
+
+func (p *Project) GetRepo() string {
+	return p.repo
+}
+
+func (p *Project) GetOrg() string {
+	return p.org
+}
+
+func (p *Project) GetGitHubURL() string {
+	return fmt.Sprintf("https://github.com/%s/%s", p.GetOrg(), p.GetRepo())
+}
+
+func (p *Project) GetVersion(releaseBranch string) (Version, error) {
+	releaseBranchPath := filepath.Join(p.GetFilePath(), releaseBranch)
+	gitTagVersion, err := readGitTagVersionFile(releaseBranchPath)
+	if err != nil {
+		return Version{}, fmt.Errorf("getting GitTag version: %w", err)
+	}
+	golangVersion, err := readGolangVersionFile(releaseBranchPath)
+	if err != nil {
+		return Version{}, fmt.Errorf("getting Golang version: %w", err)
+	}
+	return Version{
+		gitTag: string(gitTagVersion),
+		golang: string(golangVersion),
+	}, nil
 }
 
 func GetProjectPathRoot() string {

--- a/cmd/release/utils/projects/versions.go
+++ b/cmd/release/utils/projects/versions.go
@@ -1,0 +1,42 @@
+package projects
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	gitTagFilename = "GIT_TAG"
+	golangFilename = "GOLANG_VERSION"
+)
+
+type Version struct {
+	gitTag string
+	golang string
+}
+
+func (v *Version) GetGitTag() string {
+	return v.gitTag
+}
+
+func (v *Version) GetGolang() string {
+	return v.golang
+}
+
+func readGitTagVersionFile(parentPath string) ([]byte, error) {
+	return readVersionFile(filepath.Join(parentPath, gitTagFilename))
+}
+
+func readGolangVersionFile(parentPath string) ([]byte, error) {
+	return readVersionFile(filepath.Join(parentPath, golangFilename))
+}
+
+func readVersionFile(versionFilepath string) ([]byte, error) {
+	fileOutput, err := os.ReadFile(versionFilepath)
+	if err != nil {
+		return []byte{}, fmt.Errorf("reading version at %s path:%w", versionFilepath, err)
+	}
+	return bytes.TrimSpace(fileOutput), nil
+}

--- a/cmd/release/utils/values/releasebranch.go
+++ b/cmd/release/utils/values/releasebranch.go
@@ -45,6 +45,18 @@ func GetSupportedReleaseBranches() ([][]byte, error) {
 	return bytes.Split(bytes.TrimSpace(fileOutput), []byte("\n")), nil
 }
 
+func GetSupportedReleaseBranchesStrings() ([]string, error) {
+	rbs, err := GetSupportedReleaseBranches()
+	if err != nil {
+		return []string{}, fmt.Errorf("getting supported release before converting to string:%w", err)
+	}
+	var rbsStrings []string
+	for _, rb := range rbs {
+		rbsStrings = append(rbsStrings, string(rb))
+	}
+	return rbsStrings, nil
+}
+
 func GetLatestSupportedReleaseBranch() ([]byte, error) {
 	supportedReleaseBranches, err := GetSupportedReleaseBranches()
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
produces this:
````
➜ make print-versions
go vet ./cmd/print-versions
go run ./cmd/print-versions/main.go

containernetworking / plugins
  ◦ 1-21  ➜  v0.9.0    1.15
  ◦ 1-22  ➜  v0.9.0    1.15
  ◦ 1-23  ➜  v1.1.1    1.17
  ◦ 1-24  ➜  v1.1.1    1.17
  ◦ 1-25  ➜  v1.1.1    1.17
  ◦ 1-26  ➜  v1.1.1    1.17
  https://github.com/containernetworking/plugins/tags

coredns / coredns
  ◦ 1-21  ➜  v1.8.4    1.16
  ◦ 1-22  ➜  v1.8.7    1.17
  ◦ 1-23  ➜  v1.8.7    1.17
  ◦ 1-24  ➜  v1.8.7    1.17
  ◦ 1-25  ➜  v1.9.3    1.17
  ◦ 1-26  ➜  v1.9.3    1.17
  https://github.com/coredns/coredns/tags

etcd-io / etcd
  ◦ 1-21  ➜  v3.4.21   1.16
  ◦ 1-22  ➜  v3.5.6    1.16
  ◦ 1-23  ➜  v3.5.6    1.16
  ◦ 1-24  ➜  v3.5.6    1.16
  ◦ 1-25  ➜  v3.5.6    1.16
  ◦ 1-26  ➜  v3.5.6    1.16
  https://github.com/etcd-io/etcd/tags

kubernetes / cloud-provider-aws
  ◦ 1-21  ➜  v1.21.6   1.18
  ◦ 1-22  ➜  v1.22.7   1.18
  ◦ 1-23  ➜  v1.23.6   1.17
  ◦ 1-24  ➜  v1.24.4   1.19
  ◦ 1-25  ➜  v1.25.2   1.19
  ◦ 1-26  ➜  v1.26.0   1.19
  https://github.com/kubernetes/cloud-provider-aws/tags

kubernetes / kubernetes
  ◦ 1-21  ➜  v1.21.14  1.16
  ◦ 1-22  ➜  v1.22.17  1.16
  ◦ 1-23  ➜  v1.23.15  1.17
  ◦ 1-24  ➜  v1.24.9   1.18
  ◦ 1-25  ➜  v1.25.5   1.19
  ◦ 1-26  ➜  v1.26.0   1.19
  https://github.com/kubernetes/kubernetes/tags

kubernetes / release
  ◦ 1-21  ➜  v0.9.0    1.16
  ◦ 1-22  ➜  v0.12.0   1.16
  ◦ 1-23  ➜  v0.13.0   1.17
  ◦ 1-24  ➜  v0.14.0   1.18
  ◦ 1-25  ➜  v0.14.0   1.18
  ◦ 1-26  ➜  v0.14.0   1.18
  https://github.com/kubernetes/release/tags

kubernetes-csi / external-attacher
  ◦ 1-21  ➜  v4.1.0    1.19
  ◦ 1-22  ➜  v4.1.0    1.19
  ◦ 1-23  ➜  v4.1.0    1.19
  ◦ 1-24  ➜  v4.1.0    1.19
  ◦ 1-25  ➜  v4.1.0    1.19
  ◦ 1-26  ➜  v4.1.0    1.19
  https://github.com/kubernetes-csi/external-attacher/tags

kubernetes-csi / external-provisioner
  ◦ 1-21  ➜  v3.4.0    1.19
  ◦ 1-22  ➜  v3.4.0    1.19
  ◦ 1-23  ➜  v3.4.0    1.19
  ◦ 1-24  ➜  v3.4.0    1.19
  ◦ 1-25  ➜  v3.4.0    1.19
  ◦ 1-26  ➜  v3.4.0    1.19
  https://github.com/kubernetes-csi/external-provisioner/tags

kubernetes-csi / external-resizer
  ◦ 1-21  ➜  v1.7.0    1.19
  ◦ 1-22  ➜  v1.7.0    1.19
  ◦ 1-23  ➜  v1.7.0    1.19
  ◦ 1-24  ➜  v1.7.0    1.19
  ◦ 1-25  ➜  v1.7.0    1.19
  ◦ 1-26  ➜  v1.7.0    1.19
  https://github.com/kubernetes-csi/external-resizer/tags

kubernetes-csi / external-snapshotter
  ◦ 1-21  ➜  v6.2.1    1.19
  ◦ 1-22  ➜  v6.2.1    1.19
  ◦ 1-23  ➜  v6.2.1    1.19
  ◦ 1-24  ➜  v6.2.1    1.19
  ◦ 1-25  ➜  v6.2.1    1.19
  ◦ 1-26  ➜  v6.2.1    1.19
  https://github.com/kubernetes-csi/external-snapshotter/tags

kubernetes-csi / livenessprobe
  ◦ 1-21  ➜  v2.9.0    1.19
  ◦ 1-22  ➜  v2.9.0    1.19
  ◦ 1-23  ➜  v2.9.0    1.19
  ◦ 1-24  ➜  v2.9.0    1.19
  ◦ 1-25  ➜  v2.9.0    1.19
  ◦ 1-26  ➜  v2.9.0    1.19
  https://github.com/kubernetes-csi/livenessprobe/tags

kubernetes-csi / node-driver-registrar
  ◦ 1-21  ➜  v2.7.0    1.19
  ◦ 1-22  ➜  v2.7.0    1.19
  ◦ 1-23  ➜  v2.7.0    1.19
  ◦ 1-24  ➜  v2.7.0    1.19
  ◦ 1-25  ➜  v2.7.0    1.19
  ◦ 1-26  ➜  v2.7.0    1.19
  https://github.com/kubernetes-csi/node-driver-registrar/tags

kubernetes-sigs / aws-iam-authenticator
  ◦ 1-21  ➜  v0.6.3    1.19
  ◦ 1-22  ➜  v0.6.3    1.19
  ◦ 1-23  ➜  v0.6.3    1.19
  ◦ 1-24  ➜  v0.6.3    1.19
  ◦ 1-25  ➜  v0.6.3    1.19
  ◦ 1-26  ➜  v0.6.3    1.19
  https://github.com/kubernetes-sigs/aws-iam-authenticator/tags

kubernetes-sigs / metrics-server
  ◦ 1-21  ➜  v0.6.2    1.17
  ◦ 1-22  ➜  v0.6.2    1.17
  ◦ 1-23  ➜  v0.6.2    1.17
  ◦ 1-24  ➜  v0.6.2    1.17
  ◦ 1-25  ➜  v0.6.2    1.17
  ◦ 1-26  ➜  v0.6.2    1.17
  https://github.com/kubernetes-sigs/metrics-server/tags
````

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
