### PR TITLE
Require imdsv2 on kops cp and worker nodes

### DIFF
--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -128,6 +128,8 @@ spec:
     profile: {{ .controlPlaneInstanceProfileArn }}
   {{- end }}
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-{{ .architecture }}-server-20221018
+  instanceMetadata:
+    httpTokens: required
   machineType: {{ .instanceType }}
   maxSize: 1
   minSize: 1
@@ -158,6 +160,8 @@ spec:
     profile: {{ .nodeInstanceProfileArn }}
   {{- end }}
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-{{ .architecture }}-server-20221018
+  instanceMetadata:
+    httpTokens: required
   machineType: {{ .instanceType }}
   maxSize: 3
   minSize: 3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

As a best practice we should require httpTokens to force v2 of the imds service

ref: https://kops.sigs.k8s.io/instance_groups/#instancemetadata

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
