### PR TITLE
Docs: Fixing truncated code in numbered lists

### DIFF
--- a/docs/contents/users/install/kubeadm-onsite.md
+++ b/docs/contents/users/install/kubeadm-onsite.md
@@ -24,18 +24,22 @@ following prerequisites on each control plane and worker node:
 
 1. Make sure SELinux is disabled by setting *SELINUX=disabled* in the */etc/sysconfig/selinux* file. To turn it off immediately, type:
 
+        :::bash
         sudo setenforce 0
 
 1. Make sure that swap is disabled and that no swap areas are reinstated on reboot. For example, type:
 
+        :::bash
         sudo swapoff -a
 
     Then permanently disable swap by commenting out or deleting any swap areas in */etc/fstab*. On a Fedora system, remove the zram-generator package.
 
 1. Depending on the exact Linux system you installed, you may need to install additional packages. For example, with an RPM-based (Amazon Linux, CentOS, RHEL or Fedora), ensure that the iproute-tc, socat, and conntrack-tools packages are installed.
 
-1. Install a runtime. Docker was tested with this procedure. You could use some other container runtime service, although extra steps might be needed:
+1. Install a runtime. Docker was tested with this procedure.
+   You could use some other container runtime service, although extra steps might be needed:
 
+        :::bash
         sudo yum install docker -y
         sudo systemctl start docker
         sudo systemctl enable docker
@@ -43,6 +47,7 @@ following prerequisites on each control plane and worker node:
 1. Add the RPM repository to Google cloud RPM packages for Kubernetes by
 creating the following */etc/yum.repos.d/kubernetes.repo* file:
 
+        :::bash
         [kubernetes]
         name=Kubernetes
         baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$basearch
@@ -54,12 +59,14 @@ creating the following */etc/yum.repos.d/kubernetes.repo* file:
 
 1. Install the following Kubernetes packages:
 
+        :::bash
         sudo yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
 
 1. Get compatible binaries for *kubeadm*, *kubelet*, and *kubectl*.
 You can skip getting *kubectl* for now if you want to work with the
 cluster from your laptop:
 
+        :::bash
         cd /usr/bin
         sudo rm kubelet kubeadm kubectl
         sudo wget https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/kubernetes/v1.19.8/bin/linux/amd64/kubelet; \
@@ -69,10 +76,12 @@ cluster from your laptop:
 
 1. To enable the *kubelet* service, type the following:
 
+        :::bash
         sudo systemctl enable kubelet
 
 1. Create the */var/lib/kubelet/kubeadm-flags.env* file so it appears as shown below:
 
+        :::bash
         KUBELET_KUBEADM_ARGS="--cgroup-driver=systemd —network-plugin=cni —pod-infra-container-image=public.ecr.aws/eks-distro/kubernetes/pause:3.2"
 
 ## Set up a control plane node
@@ -90,6 +99,7 @@ or use a command such as *netstat -tlpn* to see which addresses *kube-apiserver*
 opening ports required by Kubernetes as described in
 [Check required ports](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#check-required-ports):
 
+        :::bash
         sudo yum install firewalld -y
         sudo systemctl start firewalld
         sudo systemctl enable firewalld
@@ -100,6 +110,7 @@ See [Working with security groups](https://docs.aws.amazon.com/vpc/latest/usergu
 
 1. Pull and retag the *pause*, *coredns*, and *etcd* containers (copy and paste as one line):
 
+        :::bash
         sudo docker pull public.ecr.aws/eks-distro/kubernetes/pause:v1.19.8-eks-1-19-4;\
         sudo docker pull public.ecr.aws/eks-distro/coredns/coredns:v1.8.0-eks-1-19-4;\
         sudo docker pull public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14-eks-1-19-4;\
@@ -109,10 +120,12 @@ See [Working with security groups](https://docs.aws.amazon.com/vpc/latest/usergu
 
 1. Create */etc/modules-load.d/k8s.conf* so it appears as follows:
 
+        :::bash
         br_netfilter
 
 1. Create */etc/sysctl.d/99-k8s.conf* file that contains the following:
 
+        :::bash
         net.bridge.bridge-nf-call-iptables = 1
 
     Then run *systemctl -p /etc/sysctl.d/99-k8s.conf* to load that value.
@@ -120,10 +133,12 @@ See [Working with security groups](https://docs.aws.amazon.com/vpc/latest/usergu
 
 1. Run the *kubeadm init* command, identifying the eks-distro image repository and Kubernetes version. Make any corrections requested for *kubeadm init* to complete successfully:
 
+        :::bash
         sudo kubeadm init --image-repository public.ecr.aws/eks-distro/kubernetes --kubernetes-version v1.19.8-eks-1-19-4
 
     The output should include something like the following:
 
+        :::bash
         [init] Using Kubernetes version: v1.19.8-eks-1-19-4
         [preflight] Running pre-flight checks
         ...
@@ -131,22 +146,24 @@ See [Working with security groups](https://docs.aws.amazon.com/vpc/latest/usergu
         [addons] Applied essential addon: CoreDNS
         [addons] Applied essential addon: kube-proxy
         
-        Your Kubernetes control-plane has initialized successfully!
+    Your Kubernetes control-plane has initialized successfully!
 
     Your Kubernetes cluster should now be up and running. The kubeadm output shows the exact commands to use to add nodes to the cluster. If something goes wrong, correct the problem and run *kubeadm reset* to prepare your system to run *kubeadm init* again:
 
 1. Follow the instructions for configuring the client. To configure the client locally, type:
 
+        :::bash
         mkdir -p $HOME/.kube
         sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
         sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
 1. Deploy a pod network to the cluster. See [Installing Addons](https://kubernetes.io/docs/concepts/cluster-administration/addons) for information on available Kubernetes pod networks. For example, to deploy a Weaveworks network, type:
-
+        :::bash
         kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=v1.19.8-eks-1-19-4"
 
     The output should appear similar to the following:
 
+        :::bash
         serviceaccount/weave-net created
         clusterrole.rbac.authorization.k8s.io/weave-net (http://clusterrole.rbac.authorization.k8s.io/weave-net) created
         clusterrolebinding.rbac.authorization.k8s.io/weave-net (http://clusterrolebinding.rbac.authorization.k8s.io/weave-net) created
@@ -158,8 +175,8 @@ See [Working with security groups](https://docs.aws.amazon.com/vpc/latest/usergu
 
 1. Optional: By default, you cannot deploy applications to a control plane node. So, you have to either add a node (as described later) or untaint the master node to allow pods to be scheduled, as follows:
 
+        :::bash
         kubectl taint nodes --all node-role.kubernetes.io/master-
-
 
 ## Configure the client
 
@@ -167,12 +184,15 @@ If you want to use the *kubectl* client from a system other than your control pl
 
 1. Log into your laptop and copy your credentials and the *kubectl* command and there. On a Linux system, you would do the following:
 
+        :::bash
         cd /usr/bin/
         sudo wget https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/kubernetes/v1.19.8/bin/linux/amd64/kubectl
         sudo chmod +x kubectl
 
+
 1. Copy the *admin.conf* file to your home directory:
 
+        :::bash
         mkdir -p $HOME/.kube
         scp <user>@<host>:/etc/kubernetes/admin.conf $HOME/.kube/config
         sudo chown $(id -u):$(id -g) $HOME/.kube/config 
@@ -185,11 +205,14 @@ Join any number of worker nodes to the control plane, using the IP address, toke
 
 1. Pull and re-tag the *pause* container (copy and paste as one line):
 
+        :::bash
         sudo docker pull public.ecr.aws/eks-distro/kubernetes/pause:v1.19.8-eks-1-19-4;\
         sudo docker tag public.ecr.aws/eks-distro/kubernetes/pause:v1.19.8-eks-1-19-4 public.ecr.aws/eks-distro/kubernetes/pause:3.2;\
 
 1. Run the kubeadm command to join the worker node to the cluster, using the *kubeadm init* output when you installed the control plane node:
 
-        sudo kubeadm join <IPaddress>:6443  --token <xxxx.xxxxxxxxxxxxxxxx>  --discovery-token-ca-cert-hash sha256:<xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>
+        :::bash
+        sudo kubeadm join <IPaddress>:6443  --token <xxxx.xxxxxxxxxxxxxxxx>  \
+            --discovery-token-ca-cert-hash sha256:<xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>
 
 You should now have a working cluster that is able to schedule workloads on the nodes you configured.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -57,3 +57,4 @@ markdown_extensions:
 - admonition
 - codehilite:
     linenums: true
+    use_pygments: False


### PR DESCRIPTION
*Issue #, if available:* [Issue #1717](https://github.com/aws/eks-distro/issues/1717): code fenced areas in docs getting clipped/truncated

*Description of changes:* Long code blocks inside of numbered lists in the [Install with kubeadm (bare metal or VM)](https://distro.eks.amazonaws.com/users/install/kubeadm-onsite/) instructions were being truncated. They were also missing the "copy to clipboard" icon. This PR seeks to fix those things.

