### PR TITLE
Switch kube-proxy-base to using iptables-wrapper

### DIFF
--- a/projects/kubernetes/release/docker/kube-proxy-base/Dockerfile
+++ b/projects/kubernetes/release/docker/kube-proxy-base/Dockerfile
@@ -22,4 +22,6 @@ COPY bin/release-src/$TARGETOS-$TARGETARCH/go-runner /go-runner
 COPY LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
 
+RUN ["update-alternatives", "--set", "iptables", "/usr/sbin/iptables-wrapper"]
+
 ENTRYPOINT ["/go-runner"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This switches kube-proxy-base to use the new golang iptables-wrapper alternative. Should fix #1729 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
