### PR TITLE
Have go mod & go sum generate correctly

### DIFF
--- a/build/update-attribution-files/make_attribution.sh
+++ b/build/update-attribution-files/make_attribution.sh
@@ -55,7 +55,7 @@ else
         export RELEASE_BRANCH="$release"
 
         GIT_TAG="$(cat $PROJECT_ROOT/$release/GIT_TAG)"
-        if [ "$GIT_TAG" != "$LAST_GIT_TAG" ]; then
+        if [ "$GIT_TAG" != "$LAST_GIT_TAG" ] || [ $TARGET == "update-go-mods" ]; then
             # clean before regenerating to ensure there are no intermediate files left around
             make -C $PROJECT_ROOT clean clean-go-cache
             build::attribution::generate $release

--- a/projects/etcd-io/etcd/Makefile
+++ b/projects/etcd-io/etcd/Makefile
@@ -5,7 +5,7 @@ GOLANG_VERSION?=$(shell cat $(RELEASE_BRANCH)/GOLANG_VERSION)
 REPO=etcd
 REPO_OWNER=etcd-io
 
-BINARY_TARGET_FILES=server etcdctl
+BINARY_TARGET_FILES=etcd etcdctl
 SOURCE_PATTERNS=go.etcd.io/etcd ./etcdctl
 EXTRA_GOBUILD_FLAGS=-installsuffix cgo
 
@@ -31,6 +31,8 @@ release: validate-cli-version
 .PHONY: validate-cli-version
 validate-cli-version: CLI=$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$(REPO)
 validate-cli-version:
+	echo "What is release branch" $(RELEASE_BRANCH)
+	echo "What is binary target files" $(BINARY_TARGET_FILES)
 	$(MAKE) $(CLI) BINARY_PLATFORMS=$(BUILDER_PLATFORM)
 	$(CLI) --version
 	@if [[ "$$($(CLI) --version)" != *"etcd Version: $(GIT_TAG:v%=%)"* ]]; then \

--- a/projects/etcd-io/etcd/Makefile
+++ b/projects/etcd-io/etcd/Makefile
@@ -31,8 +31,6 @@ release: validate-cli-version
 .PHONY: validate-cli-version
 validate-cli-version: CLI=$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/$(REPO)
 validate-cli-version:
-	echo "What is release branch" $(RELEASE_BRANCH)
-	echo "What is binary target files" $(BINARY_TARGET_FILES)
 	$(MAKE) $(CLI) BINARY_PLATFORMS=$(BUILDER_PLATFORM)
 	$(CLI) --version
 	@if [[ "$$($(CLI) --version)" != *"etcd Version: $(GIT_TAG:v%=%)"* ]]; then \

--- a/projects/etcd-io/etcd/Makefile
+++ b/projects/etcd-io/etcd/Makefile
@@ -5,7 +5,7 @@ GOLANG_VERSION?=$(shell cat $(RELEASE_BRANCH)/GOLANG_VERSION)
 REPO=etcd
 REPO_OWNER=etcd-io
 
-BINARY_TARGET_FILES=etcd etcdctl
+BINARY_TARGET_FILES=server etcdctl
 SOURCE_PATTERNS=go.etcd.io/etcd ./etcdctl
 EXTRA_GOBUILD_FLAGS=-installsuffix cgo
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently we don't copy over go.mod/sum if that version is the same because we never checked on the make target (update-go-mods) and it bails out since it doesn't match "checksums" or "attributions". 

Doing this will pull in the files correctly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
