### PR TITLE
Improve build log out but still allow full debug log

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -221,7 +221,7 @@ trimap = $(and $(strip $2),$(strip $3),$(strip $4),$(call \
 
 _pos = $(if $(filter $1,$2),$(call _pos,$1,\
        $(call list-rem,$2),x $3),$3)
-pos = $(words $(call _pos,$1,$2))
+pos = $(words $(call _pos,$1,$2,))
 
 # TODO: this exist in the gmsl, https://gmsl.sourceforge.io/
 # look into introducting gmsl for things like this
@@ -425,6 +425,13 @@ SKIP_CHECKSUM_VALIDATION?=false
 IN_DOCKER_TARGETS=all-attributions all-attributions-checksums all-checksums attribution attribution-checksums binaries checksums clean clean-go-cache
 ####################################################
 
+#################### LOGGING #######################
+DATE_CMD=TZ=utc $(shell if [ "$$(uname -s)" = "Darwin" ] && command -v gdate &> /dev/null; then echo gdate; else echo date; fi)
+DATE_NANO=$(shell if [ "$$(uname -s)" = "Linux" ] || command -v gdate &> /dev/null; then echo %3N; fi)
+TARGET_START_LOG?=$(eval _START_TIME:=$(shell $(DATE_CMD) +%s.$(DATE_NANO)))\\n------------------- $(shell $(DATE_CMD) +"%Y-%m-%dT%H:%M:%S.$(DATE_NANO)%z") Starting $@ target ------------------- 
+TARGET_END_LOG?="------------------- `$(DATE_CMD) +'%Y-%m-%dT%H:%M:%S.$(DATE_NANO)%z'` Finished $@ target (duration `echo $$($(DATE_CMD) +%s.$(DATE_NANO)) - $(_START_TIME) | bc` seconds) -------------------\\n"
+####################################################
+
 #################### TARGETS FOR OVERRIDING ########
 BUILD_TARGETS?=validate-checksums attribution $(if $(IMAGE_NAMES),local-images,) $(if $(filter true,$(HAS_HELM_CHART)),helm/build,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,) attribution-pr
 RELEASE_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),images,) $(if $(filter true,$(HAS_HELM_CHART)),helm/push,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,)
@@ -483,32 +490,40 @@ endif
 #### Source repo + binary Targets
 ifneq ($(REPO_NO_CLONE),true)
 $(REPO):
+	@echo -e $(call TARGET_START_LOG)
 ifneq ($(REPO_SPARSE_CHECKOUT),)
 	source $(BUILD_LIB)/common.sh && retry git clone --depth 1 --filter=blob:none --sparse -b $(GIT_TAG) $(CLONE_URL) $(REPO)
 	git -C $(REPO) sparse-checkout set $(REPO_SPARSE_CHECKOUT) --cone --skip-checks
 else
 	source $(BUILD_LIB)/common.sh && retry git clone $(CLONE_URL) $(REPO)
 endif
+	@echo -e $(call TARGET_END_LOG)
 endif
 
 $(GIT_CHECKOUT_TARGET): | $(REPO)
+	@echo -e $(call TARGET_START_LOG)
 	@rm -f $(REPO)/eks-distro-*
 	(cd $(REPO) && $(BASE_DIRECTORY)/build/lib/wait_for_tag.sh $(GIT_TAG))
-	git -C $(REPO) checkout -f $(GIT_TAG)
-	touch $@
+	git -C $(REPO) checkout --quiet -f $(GIT_TAG)
+	@touch $@
+	@echo -e $(call TARGET_END_LOG)
 
 $(GIT_PATCH_TARGET): $(GIT_CHECKOUT_TARGET)
+	@echo -e $(call TARGET_START_LOG)
 	git -C $(REPO) config user.email prow@amazonaws.com
 	git -C $(REPO) config user.name "Prow Bot"
 	if [ -n "$(PATCHES_DIR)" ]; then git -C $(REPO) am --committer-date-is-author-date $(PATCHES_DIR)/*; fi
 	@touch $@
+	@echo -e $(call TARGET_END_LOG)
 
 
 ## GO mod download targets
 $(REPO)/%ks-distro-go-mod-download: REPO_SUBPATH=$(if $(filter e,$*),,$(*:%/e=%))
 $(REPO)/%ks-distro-go-mod-download: $(if $(PATCHES_DIR),$(GIT_PATCH_TARGET),$(GIT_CHECKOUT_TARGET))
+	@echo -e $(call TARGET_START_LOG)
 	$(BASE_DIRECTORY)/build/lib/go_mod_download.sh $(MAKE_ROOT) $(REPO) $(GIT_TAG) $(GOLANG_VERSION) "$(REPO_SUBPATH)"
 	@touch $@
+	@echo -e $(call TARGET_END_LOG)
 
 ifneq ($(REPO),$(HELM_SOURCE_REPOSITORY))
 $(HELM_SOURCE_REPOSITORY):
@@ -538,7 +553,9 @@ $(OUTPUT_BIN_DIR)/%: SOURCE_PATTERN=$(if $(filter $(BINARY_TARGET),$(BINARY_TARG
 $(OUTPUT_BIN_DIR)/%: OUTPUT_PATH=$(if $(and $(if $(filter false,$(call IS_ONE_WORD,$(BINARY_TARGET_FILES_BUILD_TOGETHER))),$(filter $(BINARY_TARGET),$(BINARY_TARGET_FILES_BUILD_TOGETHER)))),$(@D)/,$@)
 $(OUTPUT_BIN_DIR)/%: GO_MOD_PATH=$($(call GO_MOD_TARGET_FOR_BINARY_VAR_NAME,$(BINARY_TARGET)))
 $(OUTPUT_BIN_DIR)/%: $$(call GO_MOD_DOWNLOAD_TARGET_FROM_GO_MOD_PATH,$$(GO_MOD_PATH))
+	@echo -e $(call TARGET_START_LOG)
 	$(if $(filter true,$(call needs-cgo-builder,$(PLATFORM))),$(call CGO_CREATE_BINARIES_SHELL,$@,$(*D)),$(call SIMPLE_CREATE_BINARIES_SHELL))
+	@echo -e $(call TARGET_END_LOG)
 endif
 
 .PHONY: binaries
@@ -575,8 +592,10 @@ $(OUTPUT_DIR)/%TTRIBUTION.txt:
 $(OUTPUT_DIR)/%ttribution/go-license.csv: BINARY_TARGET=$(if $(filter .,$(*D)),,$(*D))
 $(OUTPUT_DIR)/%ttribution/go-license.csv: GO_MOD_PATH=$(if $(BINARY_TARGET),$(GO_MOD_TARGET_FOR_BINARY_$(call TO_UPPER,$(BINARY_TARGET))),$(word 1,$(UNIQ_GO_MOD_PATHS)))
 $(OUTPUT_DIR)/%ttribution/go-license.csv: LICENSE_PACKAGE_FILTER=$(GO_MOD_$(subst /,_,$(GO_MOD_PATH))_LICENSE_PACKAGE_FILTER)
-$(OUTPUT_DIR)/%ttribution/go-license.csv: $$(call GO_MOD_DOWNLOAD_TARGET_FROM_GO_MOD_PATH,$$(GO_MOD_PATH))	
+$(OUTPUT_DIR)/%ttribution/go-license.csv: $$(call GO_MOD_DOWNLOAD_TARGET_FROM_GO_MOD_PATH,$$(GO_MOD_PATH))
+	@echo -e $(call TARGET_START_LOG)
 	$(BASE_DIRECTORY)/build/lib/gather_licenses.sh $(REPO) $(MAKE_ROOT)/$(OUTPUT_DIR)/$(BINARY_TARGET) "$(LICENSE_PACKAGE_FILTER)" $(GO_MOD_PATH) $(GOLANG_VERSION)
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: gather-licenses
 gather-licenses: $(GATHER_LICENSES_TARGETS)
@@ -586,15 +605,19 @@ gather-licenses: $(GATHER_LICENSES_TARGETS)
 # if multiple attributions are being generated, the file will be <binary>_ATTRIBUTION.txt and licenses will be stored in _output/<binary>, `%` will equal `<BINARY>_A`
 %TTRIBUTION.txt: LICENSE_OUTPUT_PATH=$(OUTPUT_DIR)$(if $(filter A,$(*F)),,/$(call TO_LOWER,$(*F:%_A=%)))
 %TTRIBUTION.txt: $$(LICENSE_OUTPUT_PATH)/attribution/go-license.csv
+	@echo -e $(call TARGET_START_LOG)
 	@rm -f $(@F)
 	$(BASE_DIRECTORY)/build/lib/create_attribution.sh $(MAKE_ROOT) $(GOLANG_VERSION) $(MAKE_ROOT)/$(LICENSE_OUTPUT_PATH) $(@F) $(RELEASE_BRANCH)
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: attribution
 attribution: $(and $(filter true,$(HAS_LICENSES)),$(ATTRIBUTION_TARGETS))
 
 .PHONY: attribution-pr
 attribution-pr: attribution
+	@echo -e $(call TARGET_START_LOG)
 	$(BASE_DIRECTORY)/build/update-attribution-files/create_pr.sh
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: all-attributions
 all-attributions:
@@ -606,16 +629,22 @@ all-attributions:
 .PHONY: tarballs
 tarballs: $(LICENSES_TARGETS_FOR_PREREQ)
 ifeq ($(SIMPLE_CREATE_TARBALLS),true)
+	@echo -e $(call TARGET_START_LOG)
 	$(BASE_DIRECTORY)/build/lib/simple_create_tarballs.sh $(TAR_FILE_PREFIX) $(MAKE_ROOT)/$(OUTPUT_DIR) $(MAKE_ROOT)/$(OUTPUT_BIN_DIR) $(GIT_TAG) "$(BINARY_PLATFORMS)" $(ARTIFACTS_PATH) $(GIT_HASH)
+	@echo -e $(call TARGET_END_LOG)
 endif
 
 .PHONY: upload-artifacts
 upload-artifacts: s3-artifacts
+	@echo -e $(call TARGET_START_LOG)
 	$(BASE_DIRECTORY)/release/s3_sync.sh $(RELEASE_BRANCH) $(RELEASE) $(ARTIFACTS_BUCKET) false $(UPLOAD_DRY_RUN)
+	@echo -e $(call TARGET_END_LOG)
 
+# Images (oci tarballs) always go to the kubernetes bin directly to match upstream. Beacuse of this we copy/sync artifacts from both the $(REPO) artifacts dir and the kubernetes artifacts dir
+# if both folders exists
 .PHONY: s3-artifacts
 s3-artifacts: tarballs
-# Images (oci tarballs) always go to the kubernetes bin directly to match upstream. That's why kubernetes is passed as the first arg below instead of $(REPO) like when copying other artifacts
+	@echo -e $(call TARGET_START_LOG)
 	if [ -d $(ARTIFACTS_PATH) ]; then \
 		$(BASE_DIRECTORY)/release/copy_artifacts.sh $(REPO) $(ARTIFACTS_PATH) $(RELEASE_BRANCH) $(RELEASE) $(GIT_TAG); \
 		$(BUILD_LIB)/validate_artifacts.sh $(MAKE_ROOT) $(ARTIFACTS_PATH) $(GIT_TAG) $(FAKE_ARM_BINARIES_FOR_VALIDATION); \
@@ -624,19 +653,24 @@ s3-artifacts: tarballs
 		$(BASE_DIRECTORY)/release/copy_artifacts.sh kubernetes $(MAKE_ROOT)/$(OUTPUT_DIR)/images $(RELEASE_BRANCH) $(RELEASE) $(GIT_TAG); \
 		$(BUILD_LIB)/validate_artifacts.sh $(MAKE_ROOT) $(MAKE_ROOT)/$(OUTPUT_DIR)/images $(GIT_TAG) $(FAKE_ARM_IMAGES_FOR_VALIDATION); \
 	fi
+	@echo -e $(call TARGET_END_LOG)
 
 ### Checksum Targets
 
 .PHONY: checksums
 checksums: $(BINARY_TARGETS)
 ifneq ($(strip $(BINARY_TARGETS)),)
+	@echo -e $(call TARGET_START_LOG)
 	$(BASE_DIRECTORY)/build/lib/update_checksums.sh $(MAKE_ROOT) $(PROJECT_ROOT) $(MAKE_ROOT)/$(OUTPUT_BIN_DIR)
+	@echo -e $(call TARGET_END_LOG)
 endif
 
 .PHONY: validate-checksums
 validate-checksums: $(BINARY_TARGETS)
 ifneq ($(and $(strip $(BINARY_TARGETS)), $(filter false, $(SKIP_CHECKSUM_VALIDATION))),)
+	@echo -e $(call TARGET_START_LOG)
 	$(BASE_DIRECTORY)/build/lib/validate_checksums.sh $(MAKE_ROOT) $(PROJECT_ROOT) $(MAKE_ROOT)/$(OUTPUT_BIN_DIR) $(FAKE_ARM_BINARIES_FOR_VALIDATION)
+	@echo -e $(call TARGET_END_LOG)
 endif
 
 .PHONY: attribution-checksums
@@ -685,20 +719,26 @@ endif
 %/images/amd64 %/images/arm64: IMAGE_OUTPUT?=dest=$(IMAGE_OUTPUT_DIR)/$(IMAGE_OUTPUT_NAME).tar
 
 %/images/push: $(BINARY_TARGETS) $(LICENSES_TARGETS_FOR_PREREQ) $(HANDLE_DEPENDENCIES_TARGET) $$(WINDOWS_IMAGE_BUILD_TARGETS_FOR_IMAGE)
+	@echo -e $(call TARGET_START_LOG)
 	$(BUILDCTL)
 	@if [ -n "$(WINDOWS_IMAGE_BUILD_TARGETS_FOR_IMAGE)" ]; then \
 		$(BUILD_LIB)/create_windows_manifest_list.sh $(IMAGE_NAME) $(IMAGE) $(LATEST_IMAGE) "$(WINDOWS_IMAGE_VERSIONS)"; \
 	fi
+	@echo -e $(call TARGET_END_LOG)
 
 %/images/amd64: $(BINARY_TARGETS) $(LICENSES_TARGETS_FOR_PREREQ) $(HANDLE_DEPENDENCIES_TARGET)
+	@echo -e $(call TARGET_START_LOG)
 	@mkdir -p $(IMAGE_OUTPUT_DIR)
 	$(BUILDCTL)
 	$(WRITE_LOCAL_IMAGE_TAG)
+	@echo -e $(call TARGET_END_LOG)
 
 %/images/arm64: $(BINARY_TARGETS) $(LICENSES_TARGETS_FOR_PREREQ) $(HANDLE_DEPENDENCIES_TARGET)
+	@echo -e $(call TARGET_START_LOG)
 	@mkdir -p $(IMAGE_OUTPUT_DIR)
 	$(BUILDCTL)
 	$(WRITE_LOCAL_IMAGE_TAG)
+	@echo -e $(call TARGET_END_LOG)
 
 %/windows/images/push: IMAGE_NAME=$(word 1,$(subst ., ,$*))
 %/windows/images/push: WINDOWS_OS_VERSION=$(word 2,$(subst ., ,$*))
@@ -708,7 +748,9 @@ endif
 %/windows/images/push: IMAGE_PLATFORMS=windows/amd64
 %/windows/images/push: IMAGE_METADATA_FILE=/tmp/$(IMAGE_NAME)-$(WINDOWS_OS_VERSION)-metadata.json
 %/windows/images/push: $(BINARY_TARGETS) $(LICENSES_TARGETS_FOR_PREREQ) $(HANDLE_DEPENDENCIES_TARGET)
+	@echo -e $(call TARGET_START_LOG)
 	$(BUILDCTL)
+	@echo -e $(call TARGET_END_LOG)
 
 ## CGO Targets
 .PHONY: %/cgo/amd64 %/cgo/arm64 prepare-cgo-folder
@@ -803,6 +845,7 @@ release: $(RELEASE_TARGETS)
 
 .PHONY: clean-go-cache
 clean-go-cache:
+	@echo -e $(call TARGET_START_LOG)
 # When go downloads pkg to the module cache, GOPATH/pkg/mod, it removes the write permissions
 # prevent accident modifications since files/checksums are tightly controlled
 # adding the perms necessary to perform the delete
@@ -816,6 +859,7 @@ clean-go-cache:
 # to the go_mod_cache directory. If we clear the go_mod_cache we need to delete the go_mod_download sentinel file
 # so the next time we run build go mods will be redownloaded
 	$(foreach file,$(GO_MOD_DOWNLOAD_TARGETS),$(if $(wildcard $(file)),rm -f $(file);,))
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: clean-repo
 clean-repo:

--- a/build/lib/go_mod_download.sh
+++ b/build/lib/go_mod_download.sh
@@ -31,4 +31,4 @@ cd $REPO/$REPO_SUBPATH
 CACHE_KEY=$(echo $PROJECT_ROOT | sed 's/\(.*\)\//\1-/' | xargs basename)
 build::common::use_go_version $GOLANG_VERSION
 build::common::set_go_cache $CACHE_KEY $TAG
-go mod vendor
+build::common::echo_and_run go mod vendor

--- a/build/lib/simple_create_tarballs.sh
+++ b/build/lib/simple_create_tarballs.sh
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -40,8 +39,8 @@ function build::simple::tarball() {
     ARCH="$(cut -d '/' -f2 <<< ${platform})"
     TAR_FILE="${TAR_FILE_PREFIX}-${OS}-${ARCH}-${TAG}.tar.gz"
 
-    cp -rf $LICENSES_PATH ${OUTPUT_BIN_DIR}/${OS}-${ARCH}/ 
-    cp $ATTRIBUTION_PATH ${OUTPUT_BIN_DIR}/${OS}-${ARCH}/ 
+    build::common::echo_and_run cp -rf $LICENSES_PATH ${OUTPUT_BIN_DIR}/${OS}-${ARCH}/ 
+    build::common::echo_and_run cp $ATTRIBUTION_PATH ${OUTPUT_BIN_DIR}/${OS}-${ARCH}/ 
     build::common::create_tarball ${TAR_PATH}/${TAR_FILE} ${OUTPUT_BIN_DIR}/${OS}-${ARCH} .
   done
 }

--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -62,7 +62,9 @@ s3-artifacts: cleanup-artifacts
 # Do not pass down overrides we add in common makefile
 $(BINARY_TARGETS): MAKEFLAGS=
 $(BINARY_TARGETS): $(KUBE_GIT_VERSION_FILE) | $(GIT_PATCH_TARGET)
+	@echo -e $(call TARGET_START_LOG)
 	build/create_binaries.sh $(REPO) $(GOLANG_VERSION) $(GIT_TAG) $(RELEASE_BRANCH)
+	@echo -e $(call TARGET_END_LOG)
 
 # There are a couple of fixes needed to the licenses and root-module name before running gather licenses
 $(GATHER_LICENSES_TARGETS): fix-licenses
@@ -87,8 +89,10 @@ $(PAUSE_DST): $(GIT_PATCH_TARGET)
 	@mkdir -p $(dir $(PAUSE_DST))
 	cp $(PAUSE_SRC_DIR)/linux/pause.c $(PAUSE_DST) || cp $(PAUSE_SRC_DIR)/pause.c $(PAUSE_DST)
 
-tarballs: $(KUBE_GIT_VERSION_FILE) 
+tarballs: $(KUBE_GIT_VERSION_FILE)
+	@echo -e $(call TARGET_START_LOG)
 	build/create_tarballs.sh $(REPO) $(GIT_TAG) $(RELEASE_BRANCH)
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: cleanup-artifacts
 cleanup-artifacts:

--- a/release/copy_artifacts.sh
+++ b/release/copy_artifacts.sh
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
 set -o errexit
 set -o nounset
 set -o pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+BASE_DIRECTORY="$(cd "${SCRIPT_ROOT}/.." && pwd -P)"
+source ${BASE_DIRECTORY}/build/lib/common.sh
 
 PROJECT="${1?First required argument is project}"
 SOURCE_ARTIFACT_DIR="${2?Second required argument is source artifact directory}"
@@ -24,9 +27,6 @@ RELEASE_BRANCH="${3?Third required argument is release branch for example 1-18}"
 RELEASE="${4?Fourth required argument is release for example 1}"
 GIT_TAG="${5:-}"
 
-SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-
-BASE_DIRECTORY=$(git rev-parse --show-toplevel)
 DEST_DIR=${BASE_DIRECTORY}/kubernetes-${RELEASE_BRANCH}/releases/${RELEASE}/artifacts
 
 # For when calling from projects other than kubernetes
@@ -36,8 +36,8 @@ fi
 
 ARTIFACT_DIR=${DEST_DIR}/${PROJECT}/${GIT_TAG}
 mkdir -p $ARTIFACT_DIR
-cp -r $SOURCE_ARTIFACT_DIR/* $ARTIFACT_DIR
+build::common::echo_and_run cp -r $SOURCE_ARTIFACT_DIR/* $ARTIFACT_DIR
 
 # create checksums in source output since we validate artifacts from that folder
-$SCRIPT_ROOT/create_release_checksums.sh $SOURCE_ARTIFACT_DIR
-$SCRIPT_ROOT/create_release_checksums.sh $ARTIFACT_DIR
+build::common::echo_and_run $SCRIPT_ROOT/create_release_checksums.sh $SOURCE_ARTIFACT_DIR
+build::common::echo_and_run $SCRIPT_ROOT/create_release_checksums.sh $ARTIFACT_DIR

--- a/release/create_release_checksums.sh
+++ b/release/create_release_checksums.sh
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
 set -o errexit
 set -o nounset
 set -o pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+BASE_DIRECTORY="$(cd "${SCRIPT_ROOT}/.." && pwd -P)"
+source ${BASE_DIRECTORY}/build/lib/common.sh
 
 ASSET_ROOT="$1"
 
@@ -31,7 +34,7 @@ SHA256SUM=$(dirname ${ASSET_ROOT})/SHA256SUM
 SHA512SUM=$(dirname ${ASSET_ROOT})/SHA512SUM
 rm -f $SHA256SUM
 rm -f $SHA512SUM
-echo "Writing artifact hashes to SHA256SUM/SHA512SUM files..."
+echo "Writing artifact hashes to SHA256SUM/SHA512SUM files in folder: $ASSET_ROOT"
 cd $ASSET_ROOT
 for file in $(find ${ASSET_ROOT} -type f -not -path '*\.sha[25][51][62]' -not -path '*\.docker_*' \( -path '*bin/linux*' -o -path '*bin/windows*' -o -path '*bin/darwin*' -o -name '*tar\.gz' \) ); do
     filepath=$(realpath --relative-base=${ASSET_ROOT} $file )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This builds on something weve in [build-tooling](https://github.com/aws/eks-distro-build-tooling/blob/main/eks-distro-base/scripts/eks-d-common#L53) to limit the output when building the minimal images, but still allow an override via the `OUTPUT_DEBUG_LOG` env var to see it all if you want.

This PR introduces `build::common::echo_and_run` along with start and end log message for key targets in Common.mk.  echo_and_run was added to a few key places in our common scripts and the `set -x` were removed.  The resulting output, imo, is easier to read and follow and should still provide key data points for when scripts fail. That said, I do expect to see failures in the future that we want to add more logging for. In those case, we can temporary set the `OUTPUT_DEBUG_LOG` env var to see the full debug log.

IMO, set -x is nice because it gives you all the output, but if you are not intimately familiar with and have a strong understanding of what these scripts are doing, its too overwhelming and introduces tons of red herrings.  

Please review the output from some of the presubmit jobs to see what you think and lets discuss!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
