### PR TITLE
Add clean-go-cache target like eks-a build tooling

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -655,9 +655,15 @@ all-attributions-checksums:
 
 ifneq ($(IMAGE_NAMES),)
 .PHONY: local-images images
-local-images: $(LOCAL_IMAGE_TARGETS)
+local-images: clean-job-caches $(LOCAL_IMAGE_TARGETS)
 images: $(IMAGE_TARGETS)
 endif
+
+.PHONY: clean-job-caches
+# space is very limited in presubmit jobs, the image builds can push the total used space over the limit.
+# go-build cache and pkg mod cache handled by target above
+# prune is handled by buildkit.sh
+clean-job-caches: $(and $(findstring presubmit,$(JOB_TYPE)),$(filter true,$(PRUNE_BUILDCTL)),clean-go-cache)
 
 .PHONY: %/images/push %/images/amd64 %/images/arm64
 %/images/push %/images/amd64 %/images/arm64: IMAGE_NAME=$*


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Duplicate the changes from https://github.com/aws/eks-anywhere-build-tooling/pull/1825 to Common.mk

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
