### PR TITLE
Add ubuntu 22 and new make target for nft test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ kops-arm-ubuntu-22: export NODE_ARCHITECTURE=arm64
 kops-arm-ubuntu-22: export UBUNTU_RELEASE=jammy-22.04
 kops-arm-ubuntu-22: export UBUNTU_RELEASE_DATE=20230115
 kops-arm-ubuntu-22: kops-prereqs
-	export IPV6=true;
+	export IPV6=true; \
 	sleep 10m; \
 	RELEASE=$(RELEASE) development/kops/prow.sh;
 

--- a/Makefile
+++ b/Makefile
@@ -73,22 +73,33 @@ postsubmit-build: setup
 .PHONY: kops-prow-arm
 kops-prow-arm: export NODE_INSTANCE_TYPE=t4g.medium
 kops-prow-arm: export NODE_ARCHITECTURE=arm64
+kops-prow-arm: export UBUNTU_RELEASE=focal-20.04
+kops-prow-arm: export UBUNTU_RELEASE_DATE=20221018
 kops-prow-arm: kops-prereqs
 	$(eval MINOR_VERSION=$(subst 1-,,$(RELEASE_BRANCH)))
 	if [[ $(MINOR_VERSION) -ge 22 ]]; then \
 		export IPV6=true; \
 	fi; \
-	if [[ $(MINOR_VERSION) -ge 21 ]]; then \
-		sleep 5m; \
-		RELEASE=$(RELEASE) development/kops/prow.sh; \
-	fi;
+	sleep 5m; \
+	RELEASE=$(RELEASE) development/kops/prow.sh;
 
 .PHONY: kops-prow-amd
+kops-prow-amd: export UBUNTU_RELEASE=focal-20.04
+kops-prow-amd: export UBUNTU_RELEASE_DATE=20221018
 kops-prow-amd: kops-prereqs
 	RELEASE=$(RELEASE) development/kops/prow.sh
 
+.PHONY: kops-arm-ubuntu-22
+kops-arm-ubuntu-22: export NODE_INSTANCE_TYPE=t4g.medium
+kops-arm-ubuntu-22: export NODE_ARCHITECTURE=arm64
+kops-arm-ubuntu-22: export UBUNTU_RELEASE=jammy-22.04
+kops-arm-ubuntu-22: export UBUNTU_RELEASE_DATE=20230115
+kops-arm-ubuntu-22: kops-prereqs
+	export IPV6=true; \
+	RELEASE=$(RELEASE) development/kops/prow.sh;
+
 .PHONY: kops-prow
-kops-prow: kops-prow-amd kops-prow-arm
+kops-prow: kops-arm-ubuntu-22
 	@echo 'Done kops-prow'
 
 .PHONY: kops-prereqs

--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,9 @@ kops-prow-amd: kops-prereqs
 	RELEASE=$(RELEASE) development/kops/prow.sh
 
 .PHONY: kops-arm-ubuntu-22
-kops-arm-ubuntu-22: export NODE_INSTANCE_TYPE=t4g.medium
-kops-arm-ubuntu-22: export NODE_ARCHITECTURE=arm64
 kops-arm-ubuntu-22: export UBUNTU_RELEASE=jammy-22.04
 kops-arm-ubuntu-22: export UBUNTU_RELEASE_DATE=20230115
 kops-arm-ubuntu-22: kops-prereqs
-	export IPV6=true; \
 	sleep 10m; \
 	RELEASE=$(RELEASE) development/kops/prow.sh;
 

--- a/Makefile
+++ b/Makefile
@@ -95,11 +95,12 @@ kops-arm-ubuntu-22: export NODE_ARCHITECTURE=arm64
 kops-arm-ubuntu-22: export UBUNTU_RELEASE=jammy-22.04
 kops-arm-ubuntu-22: export UBUNTU_RELEASE_DATE=20230115
 kops-arm-ubuntu-22: kops-prereqs
-	export IPV6=true; \
+	export IPV6=true;
+	sleep 10m; \
 	RELEASE=$(RELEASE) development/kops/prow.sh;
 
 .PHONY: kops-prow
-kops-prow: kops-arm-ubuntu-22
+kops-prow: kops-prow-amd kops-prow-arm kops-arm-ubuntu-22
 	@echo 'Done kops-prow'
 
 .PHONY: kops-prereqs

--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -73,6 +73,8 @@ controlPlaneInstanceProfileArn: $CONTROL_PLANE_INSTANCE_PROFILE
 nodeInstanceProfileArn: $NODE_INSTANCE_PROFILE
 instanceType: $NODE_INSTANCE_TYPE
 architecture: $NODE_ARCHITECTURE
+ubuntuRelease: $UBUNTU_RELEASE
+ubuntuReleaseDate: $UBUNTU_RELEASE_DATE
 ipv6: $IPV6
 pause:
 $(get_container_yaml kubernetes/pause $RELEASE)

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -127,7 +127,7 @@ spec:
   iam:
     profile: {{ .controlPlaneInstanceProfileArn }}
   {{- end }}
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-{{ .architecture }}-server-20221018
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-{{ .ubuntuRelease }}-{{ .architecture }}-server-{{ .ubuntuReleaseDate }}
   instanceMetadata:
     httpTokens: required
   machineType: {{ .instanceType }}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-distro/issues/1729

*Description of changes:*
Adds a new prow conformance test run using ubuntu 22 to test if ipv6 fails when the host is using iptables nft rules vs the legacy rules that our kube-proxy image is using.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
