### PR TITLE
Add ub 22 to worker node group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ kops-arm-ubuntu-22: kops-prereqs
 	RELEASE=$(RELEASE) development/kops/prow.sh;
 
 .PHONY: kops-prow
-kops-prow: kops-prow-amd kops-prow-arm kops-arm-ubuntu-22
+kops-prow: kops-arm-ubuntu-22
 	@echo 'Done kops-prow'
 
 .PHONY: kops-prereqs

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -159,7 +159,7 @@ spec:
   iam:
     profile: {{ .nodeInstanceProfileArn }}
   {{- end }}
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-{{ .architecture }}-server-20221018
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-{{ .ubuntuRelease }}-{{ .architecture }}-{{ .ubuntuReleaseDate }}
   instanceMetadata:
     httpTokens: required
   machineType: {{ .instanceType }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds new ubuntu image to worker node group in addition to cp node to test for kube-proxy/iptables failures. 

It also turns off the other conformance test runs. We will reenable after testing. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
