### PR TITLE
Add ubuntu to worker node group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ kops: $(if $(CODEBUILD_BUILD_ID),kops-codebuild,kops-prow)
 
 .PHONY: kops-codebuild
 kops-codebuild: KOPS_ENTRYPOINT=development/kops/codebuild.sh
-kops-codebuild: kops-amd kops-arm
+# kops-codebuild: kops-amd kops-arm
+kops-codebuild: kops-arm-ubuntu-22
 	@echo 'Done kops-codebuild'
 
 .PHONY: kops-prow

--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,13 @@ kops: $(if $(CODEBUILD_BUILD_ID),kops-codebuild,kops-prow)
 
 .PHONY: kops-codebuild
 kops-codebuild: KOPS_ENTRYPOINT=development/kops/codebuild.sh
-# kops-codebuild: kops-amd kops-arm
-kops-codebuild: kops-arm-ubuntu-22
+kops-codebuild: kops-amd kops-arm
 	@echo 'Done kops-codebuild'
 
 .PHONY: kops-prow
 kops-prow: KOPS_ENTRYPOINT=development/kops/prow.sh
-kops-prow: kops-amd kops-arm
+# kops-prow: kops-amd kops-arm
+kops-prow: kops-arm-ubuntu-22
 	@echo 'Done kops-prow'
 
 .PHONY: kops-amd

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -159,7 +159,7 @@ spec:
   iam:
     profile: {{ .nodeInstanceProfileArn }}
   {{- end }}
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-{{ .architecture }}-server-20221018
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-{{ .ubuntuRelease }}-{{ .architecture }}-{{ .ubuntuReleaseDate }}
   instanceMetadata:
     httpTokens: required
   machineType: {{ .instanceType }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds ubuntu 22 to worker node group. Turns off regular ubuntu arm and amd runs. Will reenable after testing. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
