### PR TITLE
Remove ubuntu 22 conformance run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,7 @@ kops-codebuild: kops-amd kops-arm
 
 .PHONY: kops-prow
 kops-prow: KOPS_ENTRYPOINT=development/kops/prow.sh
-# kops-prow: kops-amd kops-arm
-kops-prow: kops-arm-ubuntu-22
+kops-prow: kops-amd kops-arm
 	@echo 'Done kops-prow'
 
 .PHONY: kops-amd


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Revert ubuntu 22 conformance run. We tested and saw the failures in 1.24 that we expected but not in the other versions. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
