### PR TITLE
Change iam-authenticator version to 0.5.12

### DIFF
--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-21/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-21/CHECKSUMS
@@ -1,4 +1,4 @@
-0a3316b54d4bbc8be545f1dbcb873b40ee71b971675e0a2c3b82611780ed79f3  _output/1-21/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-321ad9e4bdc2feb7417e90bb7db87609bf7edc7e7b10a27831579dc30d7981c1  _output/1-21/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-2f55b977c520514867f9ffa3d0799fd8e9202679735de2c4f596e5993241723c  _output/1-21/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-830128f223d16d44256ed37aaaf6a52f02e356a26fd6cb7a74cb0a788598c4cd  _output/1-21/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+eef55a2b347a55bb7c449089a34b1a1f25257c52fc2dfca44ac20ddf7e891bc0  _output/1-21/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+0b21f46f17fb740a91f251142a51e5108c2249eaeb846daa0043b352ac93fe8b  _output/1-21/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+df77c308310ce83732f9c6f1cf148be290e894b9b4697bbc5103a4746e2b2c9d  _output/1-21/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+689fd0872961c3f6994b204e2edf1d1ccfd293313292c1c86168116707b59b2a  _output/1-21/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-22/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-22/CHECKSUMS
@@ -1,4 +1,4 @@
-0a3316b54d4bbc8be545f1dbcb873b40ee71b971675e0a2c3b82611780ed79f3  _output/1-22/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-321ad9e4bdc2feb7417e90bb7db87609bf7edc7e7b10a27831579dc30d7981c1  _output/1-22/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-2f55b977c520514867f9ffa3d0799fd8e9202679735de2c4f596e5993241723c  _output/1-22/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-830128f223d16d44256ed37aaaf6a52f02e356a26fd6cb7a74cb0a788598c4cd  _output/1-22/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+eef55a2b347a55bb7c449089a34b1a1f25257c52fc2dfca44ac20ddf7e891bc0  _output/1-22/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+0b21f46f17fb740a91f251142a51e5108c2249eaeb846daa0043b352ac93fe8b  _output/1-22/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+df77c308310ce83732f9c6f1cf148be290e894b9b4697bbc5103a4746e2b2c9d  _output/1-22/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+689fd0872961c3f6994b204e2edf1d1ccfd293313292c1c86168116707b59b2a  _output/1-22/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-23/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-23/CHECKSUMS
@@ -1,4 +1,4 @@
-0a3316b54d4bbc8be545f1dbcb873b40ee71b971675e0a2c3b82611780ed79f3  _output/1-23/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-321ad9e4bdc2feb7417e90bb7db87609bf7edc7e7b10a27831579dc30d7981c1  _output/1-23/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-2f55b977c520514867f9ffa3d0799fd8e9202679735de2c4f596e5993241723c  _output/1-23/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-830128f223d16d44256ed37aaaf6a52f02e356a26fd6cb7a74cb0a788598c4cd  _output/1-23/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+eef55a2b347a55bb7c449089a34b1a1f25257c52fc2dfca44ac20ddf7e891bc0  _output/1-23/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+0b21f46f17fb740a91f251142a51e5108c2249eaeb846daa0043b352ac93fe8b  _output/1-23/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+df77c308310ce83732f9c6f1cf148be290e894b9b4697bbc5103a4746e2b2c9d  _output/1-23/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+689fd0872961c3f6994b204e2edf1d1ccfd293313292c1c86168116707b59b2a  _output/1-23/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe

--- a/projects/kubernetes-sigs/aws-iam-authenticator/1-24/CHECKSUMS
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/1-24/CHECKSUMS
@@ -1,4 +1,4 @@
-0a3316b54d4bbc8be545f1dbcb873b40ee71b971675e0a2c3b82611780ed79f3  _output/1-24/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
-321ad9e4bdc2feb7417e90bb7db87609bf7edc7e7b10a27831579dc30d7981c1  _output/1-24/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
-2f55b977c520514867f9ffa3d0799fd8e9202679735de2c4f596e5993241723c  _output/1-24/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
-830128f223d16d44256ed37aaaf6a52f02e356a26fd6cb7a74cb0a788598c4cd  _output/1-24/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe
+eef55a2b347a55bb7c449089a34b1a1f25257c52fc2dfca44ac20ddf7e891bc0  _output/1-24/bin/aws-iam-authenticator/darwin-amd64/aws-iam-authenticator
+0b21f46f17fb740a91f251142a51e5108c2249eaeb846daa0043b352ac93fe8b  _output/1-24/bin/aws-iam-authenticator/linux-amd64/aws-iam-authenticator
+df77c308310ce83732f9c6f1cf148be290e894b9b4697bbc5103a4746e2b2c9d  _output/1-24/bin/aws-iam-authenticator/linux-arm64/aws-iam-authenticator
+689fd0872961c3f6994b204e2edf1d1ccfd293313292c1c86168116707b59b2a  _output/1-24/bin/aws-iam-authenticator/windows-amd64/aws-iam-authenticator.exe


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Revert aws-iam-authenticator to v0.5.12 in 1-21, 1-22, 1-23, 1-24
Update README accordingly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
