### PR TITLE
Go mod minimal go version updater

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -921,8 +921,8 @@ update-go-mods: checkout-repo
 	for gomod in $(GO_MOD_PATHS); do \
 		mkdir -p $(DEST_PATH); \
 		cp $(REPO)/$$gomod/go.{mod,sum} $(DEST_PATH); \
-		sed -i '' -e "s,go 1.*,go 1.19," go.mod
-		go mod tidy
+		sed -i '' -e "s,go 1.*,go 1.19," $(DEST_PATH)go.mod \
+		go mod tidy \
 	done
 
 .PHONY: all-update-go-mods

--- a/Common.mk
+++ b/Common.mk
@@ -921,6 +921,8 @@ update-go-mods: checkout-repo
 	for gomod in $(GO_MOD_PATHS); do \
 		mkdir -p $(DEST_PATH); \
 		cp $(REPO)/$$gomod/go.{mod,sum} $(DEST_PATH); \
+		sed -i '' -e "s,go 1.*,go 1.19," go.mod
+		go mod tidy
 	done
 
 .PHONY: all-update-go-mods

--- a/Common.mk
+++ b/Common.mk
@@ -921,7 +921,7 @@ update-go-mods: checkout-repo
 	for gomod in $(GO_MOD_PATHS); do \
 		mkdir -p $(DEST_PATH); \
 		cp $(REPO)/$$gomod/go.{mod,sum} $(DEST_PATH); \
-		sed -i '' -e "s,go 1.*,go 1.19," $(DEST_PATH)go.mod \
+		sed -i '' -e "s,go 1.*,go 1.19," $(DEST_PATH)/go.mod \
 		go mod tidy \
 	done
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
During the attributions prowjob, add the sed command to replace the current minimal go version to go 1.19, then run go mod tidy to cleanup the go.mod for easier required packages parsing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
