### PR TITLE
Fix gomod attribution issue

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -921,7 +921,7 @@ update-go-mods: checkout-repo
 	for gomod in $(GO_MOD_PATHS); do \
 		mkdir -p $(DEST_PATH); \
 		cp $(REPO)/$$gomod/go.{mod,sum} $(DEST_PATH); \
-		sed -i '' -e "s,go 1.*,go 1.19," $(DEST_PATH)/go.mod; \
+		sed -i $(DEST_PATH)/go.mod "s,go 1.*,go 1.19,"; \
 		go mod tidy; \
 	done
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently no file is found because it uses macOS sed vs linux sed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
