### PR TITLE
Move gomod to 1.18 in attribution job

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -921,7 +921,7 @@ update-go-mods: checkout-repo
 	for gomod in $(GO_MOD_PATHS); do \
 		mkdir -p $(DEST_PATH); \
 		cp $(REPO)/$$gomod/go.{mod,sum} $(DEST_PATH); \
-		sed -i -e "s,go 1.*,go 1.19," $(DEST_PATH)/go.mod; \
+		sed -i -e "s,go 1.*,go 1.18," $(DEST_PATH)/go.mod; \
 		go mod tidy; \
 	done
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1.19 isn't supported in the cluster yet to run go mod tidy on go.mod files with go 1.19. Bumping down to 1.18 which is the highest supported version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
