### PR TITLE
Replace legacy k8s GCR registry with community-owned registry

### DIFF
--- a/development/kops/run_sonobuoy.sh
+++ b/development/kops/run_sonobuoy.sh
@@ -19,7 +19,7 @@ BASEDIR=$(dirname "$0")
 source ${BASEDIR}/set_environment.sh
 $PREFLIGHT_CHECK_PASSED || exit 1
 
-CONFORMANCE_IMAGE=k8s.gcr.io/conformance:${KUBERNETES_VERSION}
+CONFORMANCE_IMAGE=registry.k8s.io/conformance:${KUBERNETES_VERSION}
 echo "Testing cluster ${KOPS_CLUSTER_NAME}"
 
 COUNT=0

--- a/development/kops/tests/csi/deploy/csi-mock-driver-deployment.yaml.tpl
+++ b/development/kops/tests/csi/deploy/csi-mock-driver-deployment.yaml.tpl
@@ -94,7 +94,7 @@ spec:
           - mountPath: /csi
             name: socket-dir
         - name: mock-driver
-          image: k8s.gcr.io/sig-storage/mock-driver:v4.1.0
+          image: registry.k8s.io/sig-storage/mock-driver:v4.1.0
           args:
             - "--attach-limit=50"
             # Required for e2e test log parsing


### PR DESCRIPTION
Replace legacy `k8s.gcr.io` endpoint with community-owned `registry.k8s.io` registry endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
