### PR TITLE
Bump kops to 1.26.2

### DIFF
--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -25,7 +25,7 @@ export NODE_ARCHITECTURE=${NODE_ARCHITECTURE:-amd64}
 export UBUNTU_RELEASE=${UBUNTU_RELEASE:-focal-20.04}
 export UBUNTU_RELEASE_DATE=${UBUNTU_RELEASE_DATE:-server-20221018}
 export IPV6=${IPV6:-false}
-export KOPS_VERSION="1.26.0-beta.2"
+export KOPS_VERSION="1.26..2"
 
 if [ -n "$ARTIFACT_BUCKET" ]; then
     export ARTIFACT_BASE_URL="https://$ARTIFACT_BUCKET.s3.amazonaws.com"

--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -25,7 +25,7 @@ export NODE_ARCHITECTURE=${NODE_ARCHITECTURE:-amd64}
 export UBUNTU_RELEASE=${UBUNTU_RELEASE:-focal-20.04}
 export UBUNTU_RELEASE_DATE=${UBUNTU_RELEASE_DATE:-server-20221018}
 export IPV6=${IPV6:-false}
-export KOPS_VERSION="1.26..2"
+export KOPS_VERSION="1.26.2"
 
 if [ -n "$ARTIFACT_BUCKET" ]; then
     export ARTIFACT_BASE_URL="https://$ARTIFACT_BUCKET.s3.amazonaws.com"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump kops from using 1.26 beta to 1.26.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
