### PR TITLE
Fix minor release docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ release-docs-no-git-no-announcement:
 	go vet ./cmd/release/docs
 	go run ./cmd/release/docs/main.go \
 		--branch=$(RELEASE_BRANCH) \
-		--generateChangelogChanges=true \
+		--generateChangelogChanges=false \
 		--openPR=false \
 		--releaseAnnouncement=false
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SUPPORTED_RELEASE_BRANCHES?=$(shell cat $(BASE_DIRECTORY)/release/SUPPORTED_RELE
 RELEASE_ENVIRONMENT?=development
 RELEASE?=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/$(RELEASE_ENVIRONMENT)/RELEASE)
 PROD_RELEASE=$(shell cat $(BASE_DIRECTORY)/release/$(RELEASE_BRANCH)/production/RELEASE)
-OVERRIDE_NUMBER?=""
+OVERRIDE_NUMBER?=-1
 ARTIFACT_BUCKET?=my-s3-bucket
 
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)

--- a/Makefile
+++ b/Makefile
@@ -239,8 +239,8 @@ release-docs:
 	go run ./cmd/release/docs/main.go \
 		--branch=$(RELEASE_BRANCH)
 
-.PHONY: release-docs-no-git-no-announcement
-release-docs-no-git-no-announcement:
+.PHONY: release-docs-limited
+release-docs-limited:
 	go vet ./cmd/release/docs
 	go run ./cmd/release/docs/main.go \
 		--branch=$(RELEASE_BRANCH) \

--- a/Makefile
+++ b/Makefile
@@ -245,8 +245,9 @@ release-docs-limited:
 	go run ./cmd/release/docs/main.go \
 		--branch=$(RELEASE_BRANCH) \
 		--generateChangelogChanges=false \
-		--openPR=false \
-		--releaseAnnouncement=false
+		--manageGitAndOpenPR=false \
+		--releaseAnnouncement=false \
+		--optionalOverrideNumber=$(OVERRIDE_NUMBER)
 
 .PHONY: github-release
 github-release:

--- a/cmd/release/docs/main.go
+++ b/cmd/release/docs/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"log"
+	"strconv"
 
 	"github.com/aws/eks-distro/cmd/release/docs/existingdocs"
 	"github.com/aws/eks-distro/cmd/release/docs/newdocs"
@@ -13,9 +14,7 @@ import (
 )
 
 const (
-	changeType              = changetype.Docs
-	minNumber               = 0
-	invalidNumberUpperLimit = minNumber - 1
+	changeType = changetype.Docs
 )
 
 // Generates docs for release. The release MUST already be out, and all upstream changes MUST be pulled down locally.
@@ -27,19 +26,19 @@ func main() {
 	hasChangelogChanges := flag.Bool("generateChangelogChanges", true, "If changes in changelog should be generated")
 	hasManageGitAndPR := flag.Bool("manageGitAndOpenPR", true, "If PR and all git should be done")
 	hasReleaseAnnouncement := flag.Bool("releaseAnnouncement", true, "If changes in changelog should be generated")
-	overrideNumber := flag.Int("optionalOverrideNumber", invalidNumberUpperLimit,
+	overrideNumber := flag.Int("optionalOverrideNumber", release.InvalidNumberUpperLimit,
 		"USE WITH CAUTION! Value to force override for number. Any value less than or equal to "+
-			string(rune(invalidNumberUpperLimit))+" is considered an indication that the number should not be overridden.")
+			strconv.Itoa(release.InvalidNumberUpperLimit)+" is considered an indication that the number should not be overridden.")
 	flag.Parse()
 
 	////////////	Create Release		////////////////////////////////////
 
 	// The actual release MUST already be out, and all upstream changes MUST be pulled down locally.
 	r, err := func(overrideNum int, branch *string) (*release.Release, error) {
-		if overrideNum > invalidNumberUpperLimit {
-			return release.NewRelease(*branch, changeType)
+		if overrideNum > release.InvalidNumberUpperLimit {
+			return release.NewReleaseOverrideNumber(*branch, strconv.Itoa(overrideNum))
 		} else {
-			return release.NewReleaseOverrideNumber(*branch, string(rune(overrideNum)))
+			return release.NewRelease(*branch, changeType)
 		}
 	}(*overrideNumber, branch)
 

--- a/cmd/release/docs/main.go
+++ b/cmd/release/docs/main.go
@@ -13,9 +13,7 @@ import (
 	"github.com/aws/eks-distro/cmd/release/utils/values"
 )
 
-const (
-	changeType = changetype.Docs
-)
+const changeType = changetype.Docs
 
 // Generates docs for release. The release MUST already be out, and all upstream changes MUST be pulled down locally.
 // Value for 'branch' flag must be provided. Value for 'hasChangelogChanges' flag should be 'false' if auto-

--- a/cmd/release/gh-release/main.go
+++ b/cmd/release/gh-release/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 
 	"github.com/aws/eks-distro/cmd/release/utils/changetype"
 	"github.com/aws/eks-distro/cmd/release/utils/release"
@@ -23,22 +24,21 @@ var (
 
 // Generates a release on GitHub. IMPORTANT! Only run after the prod release is out, you've pulled down the latest
 // changes, and the git tag for the release is on GitHub.
-// TODO: implement number override for release
 func main() {
 	branch := flag.String("branch", "", "Release branch, e.g. 1-22")
-	overrideNumber := flag.String("overrideNumber", "", "Optional override number, e.g. 1")
+	overrideNumber := flag.Int("overrideNumber", release.InvalidNumberUpperLimit, "Optional override number, e.g. 1")
 
 	flag.Parse()
 
 	var err error
 	var r = &release.Release{}
-	if len(*overrideNumber) == 0 {
+	if *overrideNumber <= release.InvalidNumberUpperLimit {
 		r, err = release.NewRelease(*branch, changetype.GHRelease)
 		if err != nil {
 			log.Fatalf("creating release values: %v", err)
 		}
 	} else {
-		r, err = release.NewReleaseOverrideNumber(*branch, *overrideNumber)
+		r, err = release.NewReleaseOverrideNumber(*branch, strconv.Itoa(*overrideNumber))
 		if err != nil {
 			log.Fatalf("creating release values with override number: %v", err)
 		}

--- a/cmd/release/utils/release/release.go
+++ b/cmd/release/utils/release/release.go
@@ -6,6 +6,11 @@ import (
 	"github.com/aws/eks-distro/cmd/release/utils/changetype"
 )
 
+const (
+	MinNumber               = 0
+	InvalidNumberUpperLimit = MinNumber - 1
+)
+
 type Release struct {
 	branch string
 	number string

--- a/cmd/release/utils/release/releaseinput.go
+++ b/cmd/release/utils/release/releaseinput.go
@@ -2,16 +2,14 @@ package release
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/aws/eks-distro/cmd/release/utils/changetype"
 	"github.com/aws/eks-distro/cmd/release/utils/values"
 )
 
-const (
-	minOverrideNumber = "0"
-	defaultReleaseEnv = changetype.Prod
-)
+const defaultReleaseEnv = changetype.Prod
 
 func newRelease(releaseBranchInput string, overrideNumInput string, hasOverrideNum bool) (*Release, error) {
 	rb, num, err := generateReleaseInput(releaseBranchInput, overrideNumInput, hasOverrideNum)
@@ -65,9 +63,9 @@ func generateReleaseInput(releaseBranchInput string, overrideNumInput string, ha
 		return "", "", fmt.Errorf("determining number: %w", err)
 	}
 	if hasOverrideNum {
-		if strings.Compare(minOverrideNumber, overrideNum) == 1 || strings.Compare(overrideNum, localNum) == 1 {
-			return "", "", fmt.Errorf("override number %s must between min number %s and local number %s (inclusive)",
-				overrideNum, minOverrideNumber, localNum)
+		if strings.Compare(strconv.Itoa(MinNumber), overrideNum) == 1 || strings.Compare(overrideNum, localNum) == 1 {
+			return "", "", fmt.Errorf("override number %s must between min number %d and local number %s (inclusive)",
+				overrideNum, MinNumber, localNum)
 		}
 		number = overrideNum
 	} else {


### PR DESCRIPTION
#### ⚠️⚠️⚠️ IMPORTANT: You still have to make [these changes](https://github.com/aws/eks-distro/pull/1906/files) before you run this make command ⚠️⚠️⚠️ 

---

*Description of changes:*
* Fixed bug in generation (`--generateChangelogChanges` should have been `false`)
* Added override number ability for generating docs
  * Changed github-release used the same logic as ^ this, as it already had this functionality
* Renamed variables to better fit what they were, though I don't particularly like any of the names

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
