### PR TITLE
Pull latest ubuntu ami from ec2 for us when creating a kops cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ postsubmit-build: setup
 
 .PHONY: kops
 kops: export UBUNTU_RELEASE=focal-20.04
-kops: export UBUNTU_RELEASE_DATE=server-20221018
 kops: $(if $(CODEBUILD_BUILD_ID),kops-codebuild,kops-prow)
 
 .PHONY: kops-codebuild
@@ -102,7 +101,6 @@ kops-arm: kops-prereqs
 
 .PHONY: kops-arm-ubuntu-22
 kops-arm-ubuntu-22: export UBUNTU_RELEASE=jammy-22.04
-kops-arm-ubuntu-22: export UBUNTU_RELEASE_DATE=server-20230115
 kops-arm-ubuntu-22: kops-prereqs
 	sleep 10m; \
 	RELEASE=$(RELEASE) $(KOPS_ENTRYPOINT);

--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -62,6 +62,8 @@ function get_project_version(){
     echo $VERSION
 }
 
+# Get latest ubuntu ami based on desired release and arch
+UBUNTU_AMI=$(aws ec2 describe-images --owners 099720109477 --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-$UBUNTU_RELEASE-$NODE_ARCHITECTURE-server-*" --query 'sort_by(Images, &CreationDate)[-1].[Name]' --output text)
 
 echo "Creating ./${KOPS_CLUSTER_NAME}/values.yaml"
 cat << EOF > ./${KOPS_CLUSTER_NAME}/values.yaml
@@ -73,8 +75,7 @@ controlPlaneInstanceProfileArn: $CONTROL_PLANE_INSTANCE_PROFILE
 nodeInstanceProfileArn: $NODE_INSTANCE_PROFILE
 instanceType: $NODE_INSTANCE_TYPE
 architecture: $NODE_ARCHITECTURE
-ubuntuRelease: $UBUNTU_RELEASE
-ubuntuReleaseDate: $UBUNTU_RELEASE_DATE
+ubuntuAmi: $UBUNTU_AMI
 ipv6: $IPV6
 pause:
 $(get_container_yaml kubernetes/pause $RELEASE)

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -127,7 +127,7 @@ spec:
   iam:
     profile: {{ .controlPlaneInstanceProfileArn }}
   {{- end }}
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-{{ .ubuntuRelease }}-{{ .architecture }}-{{ .ubuntuReleaseDate }}
+  image: 099720109477/{{ .ubuntuAmi }}
   instanceMetadata:
     httpTokens: required
   machineType: {{ .instanceType }}
@@ -159,7 +159,7 @@ spec:
   iam:
     profile: {{ .nodeInstanceProfileArn }}
   {{- end }}
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-{{ .ubuntuRelease }}-{{ .architecture }}-{{ .ubuntuReleaseDate }}
+  image: 099720109477/{{ .ubuntuAmi }}
   instanceMetadata:
     httpTokens: required
   machineType: {{ .instanceType }}

--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -23,7 +23,6 @@ export ARTIFACT_BASE_URL="https://distro.eks.amazonaws.com"
 export NODE_INSTANCE_TYPE=${NODE_INSTANCE_TYPE:-t3.medium}
 export NODE_ARCHITECTURE=${NODE_ARCHITECTURE:-amd64}
 export UBUNTU_RELEASE=${UBUNTU_RELEASE:-focal-20.04}
-export UBUNTU_RELEASE_DATE=${UBUNTU_RELEASE_DATE:-server-20221018}
 export IPV6=${IPV6:-false}
 export KOPS_VERSION="1.26.0-beta.2"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This will allow us to avoid updating the ami version and help us stay as up to date as possible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
