### PR TITLE
Changes kops version back to 1.26.2 for all versions

### DIFF
--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -24,13 +24,7 @@ export NODE_INSTANCE_TYPE=${NODE_INSTANCE_TYPE:-t3.medium}
 export NODE_ARCHITECTURE=${NODE_ARCHITECTURE:-amd64}
 export UBUNTU_RELEASE=${UBUNTU_RELEASE:-focal-20.04}
 export IPV6=${IPV6:-false}
-
-# Remove once kops 1.27 is stable and working for all versions
-if [ "$RELEASE_BRANCH" == "1-27" ]; then
-    export KOPS_VERSION="995bdda1588b7225dca29543ae73d09ae27f767d"
-else
-    export KOPS_VERSION="1.26.2"
-fi
+export KOPS_VERSION="1.26.2"
 
 if [ -n "$ARTIFACT_BUCKET" ]; then
     export ARTIFACT_BASE_URL="https://$ARTIFACT_BUCKET.s3.amazonaws.com"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
related to https://github.com/aws/eks-distro-build-tooling/pull/970

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
