### PR TITLE
Patch kubernenetes to fix CVE-2023-2253

### DIFF
--- a/projects/kubernetes/kubernetes/1-23/patches/0021-Bump-docker-distribution-to-2.8.2.patch
+++ b/projects/kubernetes/kubernetes/1-23/patches/0021-Bump-docker-distribution-to-2.8.2.patch
@@ -3,10 +3,29 @@ From: Stephen Kitt <skitt@redhat.com>
 Date: Tue, 16 May 2023 09:17:51 +0200
 Subject: [PATCH] Bump docker/distribution to 2.8.2
 
+Description:
 k/k doesn't use much code from docker/distribution so this doesn't
 change anything that's actually relevant, but 2.8.1 is identified as
-affected by CVE-2022-28391 and CVE-2023-2253; bumping to 2.8.2 avoids
+affected by CVE-2023-2253; bumping docker/distribution to 2.8.2 avoids
 k/k triggering scanners on those CVEs.
+
+Upstream PR, Issue, KEP, etc. links:
+* https://github.com/kubernetes/kubernetes/pull/118036/commits/3680a5230c386602ebc82700fe3031960d0479fd
+
+If this patch is based on an upstream commit, how (if at all) do this patch and the upstream source differ?
+* No difference
+
+If this patch's changes have not been added by upstream, why not?
+* N/A
+
+Other patches related to this patch:
+* None
+
+Changes made to this patch after its initial creation and reasons for these changes:
+* None
+
+Kubernetes version this patch can be dropped:
+* N/A
 
 Signed-off-by: Stephen Kitt <skitt@redhat.com>
 ---

--- a/projects/kubernetes/kubernetes/1-23/patches/0021-Bump-docker-distribution-to-2.8.2.patch
+++ b/projects/kubernetes/kubernetes/1-23/patches/0021-Bump-docker-distribution-to-2.8.2.patch
@@ -1,0 +1,112 @@
+From 3680a5230c386602ebc82700fe3031960d0479fd Mon Sep 17 00:00:00 2001
+From: Stephen Kitt <skitt@redhat.com>
+Date: Tue, 16 May 2023 09:17:51 +0200
+Subject: [PATCH] Bump docker/distribution to 2.8.2
+
+k/k doesn't use much code from docker/distribution so this doesn't
+change anything that's actually relevant, but 2.8.1 is identified as
+affected by CVE-2022-28391 and CVE-2023-2253; bumping to 2.8.2 avoids
+k/k triggering scanners on those CVEs.
+
+Signed-off-by: Stephen Kitt <skitt@redhat.com>
+---
+ go.mod                                                       | 2 +-
+ go.sum                                                       | 3 ++-
+ staging/src/k8s.io/kubectl/go.mod                            | 2 +-
+ staging/src/k8s.io/kubectl/go.sum                            | 4 ++--
+ vendor/github.com/docker/distribution/reference/reference.go | 4 ++--
+ vendor/modules.txt                                           | 2 +-
+ 6 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 5e5fadbadd9..5996859b7d0 100644
+--- a/go.mod
++++ b/go.mod
+@@ -26,7 +26,7 @@ require (
+ 	github.com/coreos/go-systemd/v22 v22.5.0
+ 	github.com/cpuguy83/go-md2man/v2 v2.0.2
+ 	github.com/cyphar/filepath-securejoin v0.2.3
+-	github.com/docker/distribution v2.8.1+incompatible
++	github.com/docker/distribution v2.8.2+incompatible
+ 	github.com/docker/go-units v0.5.0
+ 	github.com/emicklei/go-restful/v3 v3.9.0
+ 	github.com/evanphx/json-patch v4.12.0+incompatible
+diff --git a/go.sum b/go.sum
+index 83a05e125f1..5ab37fd89dd 100644
+--- a/go.sum
++++ b/go.sum
+@@ -204,8 +204,9 @@ github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hR
+ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+ github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
+ github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
++github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
++github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docker/docker v20.10.21+incompatible h1:UTLdBmHk3bEY+w8qeO5KttOhy6OmXWsl/FEet9Uswog=
+ github.com/docker/docker v20.10.21+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+diff --git a/staging/src/k8s.io/kubectl/go.mod b/staging/src/k8s.io/kubectl/go.mod
+index 0d2c2f02bcc..6954cfd154f 100644
+--- a/staging/src/k8s.io/kubectl/go.mod
++++ b/staging/src/k8s.io/kubectl/go.mod
+@@ -8,7 +8,7 @@ require (
+ 	github.com/MakeNowJust/heredoc v1.0.0
+ 	github.com/chai2010/gettext-go v1.0.2
+ 	github.com/daviddengcn/go-colortext v1.0.0
+-	github.com/docker/distribution v2.8.1+incompatible
++	github.com/docker/distribution v2.8.2+incompatible
+ 	github.com/evanphx/json-patch v4.12.0+incompatible
+ 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+ 	github.com/fatih/camelcase v1.0.0
+diff --git a/staging/src/k8s.io/kubectl/go.sum b/staging/src/k8s.io/kubectl/go.sum
+index 46da47d6f5b..4c43c3dc0fd 100644
+--- a/staging/src/k8s.io/kubectl/go.sum
++++ b/staging/src/k8s.io/kubectl/go.sum
+@@ -54,8 +54,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
+ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+ github.com/daviddengcn/go-colortext v1.0.0 h1:ANqDyC0ys6qCSvuEK7l3g5RaehL/Xck9EX8ATG8oKsE=
+ github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hRnmkD5G4Pmri9+m4c=
+-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
+-github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
++github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
++github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+ github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
+ github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+diff --git a/vendor/github.com/docker/distribution/reference/reference.go b/vendor/github.com/docker/distribution/reference/reference.go
+index 8c0c23b2fe1..b7cd00b0d68 100644
+--- a/vendor/github.com/docker/distribution/reference/reference.go
++++ b/vendor/github.com/docker/distribution/reference/reference.go
+@@ -3,13 +3,13 @@
+ //
+ // Grammar
+ //
+-// 	reference                       := name [ ":" tag ] [ "@" digest ]
++//	reference                       := name [ ":" tag ] [ "@" digest ]
+ //	name                            := [domain '/'] path-component ['/' path-component]*
+ //	domain                          := domain-component ['.' domain-component]* [':' port-number]
+ //	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+ //	port-number                     := /[0-9]+/
+ //	path-component                  := alpha-numeric [separator alpha-numeric]*
+-// 	alpha-numeric                   := /[a-z0-9]+/
++//	alpha-numeric                   := /[a-z0-9]+/
+ //	separator                       := /[_.]|__|[-]*/
+ //
+ //	tag                             := /[\w][\w.-]{0,127}/
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 4ca6a9b0c1e..d9ddb8f59b3 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -181,7 +181,7 @@ github.com/davecgh/go-spew/spew
+ # github.com/daviddengcn/go-colortext v1.0.0
+ ## explicit; go 1.14
+ github.com/daviddengcn/go-colortext
+-# github.com/docker/distribution v2.8.1+incompatible
++# github.com/docker/distribution v2.8.2+incompatible
+ ## explicit
+ github.com/docker/distribution/digestset
+ github.com/docker/distribution/reference
+-- 
+2.39.1
+

--- a/projects/kubernetes/kubernetes/1-24/patches/0016-Bump-docker-distribution-to-2.8.2.patch
+++ b/projects/kubernetes/kubernetes/1-24/patches/0016-Bump-docker-distribution-to-2.8.2.patch
@@ -3,10 +3,29 @@ From: Stephen Kitt <skitt@redhat.com>
 Date: Tue, 16 May 2023 09:17:51 +0200
 Subject: [PATCH] Bump docker/distribution to 2.8.2
 
+Description:
 k/k doesn't use much code from docker/distribution so this doesn't
 change anything that's actually relevant, but 2.8.1 is identified as
-affected by CVE-2022-28391 and CVE-2023-2253; bumping to 2.8.2 avoids
+affected by CVE-2023-2253; bumping docker/distribution to 2.8.2 avoids
 k/k triggering scanners on those CVEs.
+
+Upstream PR, Issue, KEP, etc. links:
+* https://github.com/kubernetes/kubernetes/pull/118036/commits/3680a5230c386602ebc82700fe3031960d0479fd
+
+If this patch is based on an upstream commit, how (if at all) do this patch and the upstream source differ?
+* No difference
+
+If this patch's changes have not been added by upstream, why not?
+* N/A
+
+Other patches related to this patch:
+* None
+
+Changes made to this patch after its initial creation and reasons for these changes:
+* None
+
+Kubernetes version this patch can be dropped:
+* N/A
 
 Signed-off-by: Stephen Kitt <skitt@redhat.com>
 ---

--- a/projects/kubernetes/kubernetes/1-24/patches/0016-Bump-docker-distribution-to-2.8.2.patch
+++ b/projects/kubernetes/kubernetes/1-24/patches/0016-Bump-docker-distribution-to-2.8.2.patch
@@ -1,0 +1,112 @@
+From 3680a5230c386602ebc82700fe3031960d0479fd Mon Sep 17 00:00:00 2001
+From: Stephen Kitt <skitt@redhat.com>
+Date: Tue, 16 May 2023 09:17:51 +0200
+Subject: [PATCH] Bump docker/distribution to 2.8.2
+
+k/k doesn't use much code from docker/distribution so this doesn't
+change anything that's actually relevant, but 2.8.1 is identified as
+affected by CVE-2022-28391 and CVE-2023-2253; bumping to 2.8.2 avoids
+k/k triggering scanners on those CVEs.
+
+Signed-off-by: Stephen Kitt <skitt@redhat.com>
+---
+ go.mod                                                       | 2 +-
+ go.sum                                                       | 3 ++-
+ staging/src/k8s.io/kubectl/go.mod                            | 2 +-
+ staging/src/k8s.io/kubectl/go.sum                            | 4 ++--
+ vendor/github.com/docker/distribution/reference/reference.go | 4 ++--
+ vendor/modules.txt                                           | 2 +-
+ 6 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 5e5fadbadd9..5996859b7d0 100644
+--- a/go.mod
++++ b/go.mod
+@@ -26,7 +26,7 @@ require (
+ 	github.com/coreos/go-systemd/v22 v22.5.0
+ 	github.com/cpuguy83/go-md2man/v2 v2.0.2
+ 	github.com/cyphar/filepath-securejoin v0.2.3
+-	github.com/docker/distribution v2.8.1+incompatible
++	github.com/docker/distribution v2.8.2+incompatible
+ 	github.com/docker/go-units v0.5.0
+ 	github.com/emicklei/go-restful/v3 v3.9.0
+ 	github.com/evanphx/json-patch v4.12.0+incompatible
+diff --git a/go.sum b/go.sum
+index 83a05e125f1..5ab37fd89dd 100644
+--- a/go.sum
++++ b/go.sum
+@@ -204,8 +204,9 @@ github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hR
+ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+ github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
+ github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
++github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
++github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docker/docker v20.10.21+incompatible h1:UTLdBmHk3bEY+w8qeO5KttOhy6OmXWsl/FEet9Uswog=
+ github.com/docker/docker v20.10.21+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+diff --git a/staging/src/k8s.io/kubectl/go.mod b/staging/src/k8s.io/kubectl/go.mod
+index 0d2c2f02bcc..6954cfd154f 100644
+--- a/staging/src/k8s.io/kubectl/go.mod
++++ b/staging/src/k8s.io/kubectl/go.mod
+@@ -8,7 +8,7 @@ require (
+ 	github.com/MakeNowJust/heredoc v1.0.0
+ 	github.com/chai2010/gettext-go v1.0.2
+ 	github.com/daviddengcn/go-colortext v1.0.0
+-	github.com/docker/distribution v2.8.1+incompatible
++	github.com/docker/distribution v2.8.2+incompatible
+ 	github.com/evanphx/json-patch v4.12.0+incompatible
+ 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+ 	github.com/fatih/camelcase v1.0.0
+diff --git a/staging/src/k8s.io/kubectl/go.sum b/staging/src/k8s.io/kubectl/go.sum
+index 46da47d6f5b..4c43c3dc0fd 100644
+--- a/staging/src/k8s.io/kubectl/go.sum
++++ b/staging/src/k8s.io/kubectl/go.sum
+@@ -54,8 +54,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
+ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+ github.com/daviddengcn/go-colortext v1.0.0 h1:ANqDyC0ys6qCSvuEK7l3g5RaehL/Xck9EX8ATG8oKsE=
+ github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hRnmkD5G4Pmri9+m4c=
+-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
+-github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
++github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
++github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+ github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
+ github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+diff --git a/vendor/github.com/docker/distribution/reference/reference.go b/vendor/github.com/docker/distribution/reference/reference.go
+index 8c0c23b2fe1..b7cd00b0d68 100644
+--- a/vendor/github.com/docker/distribution/reference/reference.go
++++ b/vendor/github.com/docker/distribution/reference/reference.go
+@@ -3,13 +3,13 @@
+ //
+ // Grammar
+ //
+-// 	reference                       := name [ ":" tag ] [ "@" digest ]
++//	reference                       := name [ ":" tag ] [ "@" digest ]
+ //	name                            := [domain '/'] path-component ['/' path-component]*
+ //	domain                          := domain-component ['.' domain-component]* [':' port-number]
+ //	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+ //	port-number                     := /[0-9]+/
+ //	path-component                  := alpha-numeric [separator alpha-numeric]*
+-// 	alpha-numeric                   := /[a-z0-9]+/
++//	alpha-numeric                   := /[a-z0-9]+/
+ //	separator                       := /[_.]|__|[-]*/
+ //
+ //	tag                             := /[\w][\w.-]{0,127}/
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 4ca6a9b0c1e..d9ddb8f59b3 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -181,7 +181,7 @@ github.com/davecgh/go-spew/spew
+ # github.com/daviddengcn/go-colortext v1.0.0
+ ## explicit; go 1.14
+ github.com/daviddengcn/go-colortext
+-# github.com/docker/distribution v2.8.1+incompatible
++# github.com/docker/distribution v2.8.2+incompatible
+ ## explicit
+ github.com/docker/distribution/digestset
+ github.com/docker/distribution/reference
+-- 
+2.39.1
+

--- a/projects/kubernetes/kubernetes/1-25/patches/0010-Bump-docker-distribution-to-2.8.2.patch
+++ b/projects/kubernetes/kubernetes/1-25/patches/0010-Bump-docker-distribution-to-2.8.2.patch
@@ -3,10 +3,29 @@ From: Stephen Kitt <skitt@redhat.com>
 Date: Tue, 16 May 2023 09:17:51 +0200
 Subject: [PATCH] Bump docker/distribution to 2.8.2
 
+Description:
 k/k doesn't use much code from docker/distribution so this doesn't
 change anything that's actually relevant, but 2.8.1 is identified as
-affected by CVE-2022-28391 and CVE-2023-2253; bumping to 2.8.2 avoids
+affected by CVE-2023-2253; bumping docker/distribution to 2.8.2 avoids
 k/k triggering scanners on those CVEs.
+
+Upstream PR, Issue, KEP, etc. links:
+* https://github.com/kubernetes/kubernetes/pull/118036/commits/3680a5230c386602ebc82700fe3031960d0479fd
+
+If this patch is based on an upstream commit, how (if at all) do this patch and the upstream source differ?
+* No difference
+
+If this patch's changes have not been added by upstream, why not?
+* N/A
+
+Other patches related to this patch:
+* None
+
+Changes made to this patch after its initial creation and reasons for these changes:
+* None
+
+Kubernetes version this patch can be dropped:
+* N/A
 
 Signed-off-by: Stephen Kitt <skitt@redhat.com>
 ---

--- a/projects/kubernetes/kubernetes/1-25/patches/0010-Bump-docker-distribution-to-2.8.2.patch
+++ b/projects/kubernetes/kubernetes/1-25/patches/0010-Bump-docker-distribution-to-2.8.2.patch
@@ -1,0 +1,112 @@
+From 3680a5230c386602ebc82700fe3031960d0479fd Mon Sep 17 00:00:00 2001
+From: Stephen Kitt <skitt@redhat.com>
+Date: Tue, 16 May 2023 09:17:51 +0200
+Subject: [PATCH] Bump docker/distribution to 2.8.2
+
+k/k doesn't use much code from docker/distribution so this doesn't
+change anything that's actually relevant, but 2.8.1 is identified as
+affected by CVE-2022-28391 and CVE-2023-2253; bumping to 2.8.2 avoids
+k/k triggering scanners on those CVEs.
+
+Signed-off-by: Stephen Kitt <skitt@redhat.com>
+---
+ go.mod                                                       | 2 +-
+ go.sum                                                       | 3 ++-
+ staging/src/k8s.io/kubectl/go.mod                            | 2 +-
+ staging/src/k8s.io/kubectl/go.sum                            | 4 ++--
+ vendor/github.com/docker/distribution/reference/reference.go | 4 ++--
+ vendor/modules.txt                                           | 2 +-
+ 6 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 5e5fadbadd9..5996859b7d0 100644
+--- a/go.mod
++++ b/go.mod
+@@ -26,7 +26,7 @@ require (
+ 	github.com/coreos/go-systemd/v22 v22.5.0
+ 	github.com/cpuguy83/go-md2man/v2 v2.0.2
+ 	github.com/cyphar/filepath-securejoin v0.2.3
+-	github.com/docker/distribution v2.8.1+incompatible
++	github.com/docker/distribution v2.8.2+incompatible
+ 	github.com/docker/go-units v0.5.0
+ 	github.com/emicklei/go-restful/v3 v3.9.0
+ 	github.com/evanphx/json-patch v4.12.0+incompatible
+diff --git a/go.sum b/go.sum
+index 83a05e125f1..5ab37fd89dd 100644
+--- a/go.sum
++++ b/go.sum
+@@ -204,8 +204,9 @@ github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hR
+ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+ github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
+ github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
++github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
++github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docker/docker v20.10.21+incompatible h1:UTLdBmHk3bEY+w8qeO5KttOhy6OmXWsl/FEet9Uswog=
+ github.com/docker/docker v20.10.21+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+diff --git a/staging/src/k8s.io/kubectl/go.mod b/staging/src/k8s.io/kubectl/go.mod
+index 0d2c2f02bcc..6954cfd154f 100644
+--- a/staging/src/k8s.io/kubectl/go.mod
++++ b/staging/src/k8s.io/kubectl/go.mod
+@@ -8,7 +8,7 @@ require (
+ 	github.com/MakeNowJust/heredoc v1.0.0
+ 	github.com/chai2010/gettext-go v1.0.2
+ 	github.com/daviddengcn/go-colortext v1.0.0
+-	github.com/docker/distribution v2.8.1+incompatible
++	github.com/docker/distribution v2.8.2+incompatible
+ 	github.com/evanphx/json-patch v4.12.0+incompatible
+ 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+ 	github.com/fatih/camelcase v1.0.0
+diff --git a/staging/src/k8s.io/kubectl/go.sum b/staging/src/k8s.io/kubectl/go.sum
+index 46da47d6f5b..4c43c3dc0fd 100644
+--- a/staging/src/k8s.io/kubectl/go.sum
++++ b/staging/src/k8s.io/kubectl/go.sum
+@@ -54,8 +54,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
+ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+ github.com/daviddengcn/go-colortext v1.0.0 h1:ANqDyC0ys6qCSvuEK7l3g5RaehL/Xck9EX8ATG8oKsE=
+ github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hRnmkD5G4Pmri9+m4c=
+-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
+-github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
++github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
++github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+ github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
+ github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+diff --git a/vendor/github.com/docker/distribution/reference/reference.go b/vendor/github.com/docker/distribution/reference/reference.go
+index 8c0c23b2fe1..b7cd00b0d68 100644
+--- a/vendor/github.com/docker/distribution/reference/reference.go
++++ b/vendor/github.com/docker/distribution/reference/reference.go
+@@ -3,13 +3,13 @@
+ //
+ // Grammar
+ //
+-// 	reference                       := name [ ":" tag ] [ "@" digest ]
++//	reference                       := name [ ":" tag ] [ "@" digest ]
+ //	name                            := [domain '/'] path-component ['/' path-component]*
+ //	domain                          := domain-component ['.' domain-component]* [':' port-number]
+ //	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+ //	port-number                     := /[0-9]+/
+ //	path-component                  := alpha-numeric [separator alpha-numeric]*
+-// 	alpha-numeric                   := /[a-z0-9]+/
++//	alpha-numeric                   := /[a-z0-9]+/
+ //	separator                       := /[_.]|__|[-]*/
+ //
+ //	tag                             := /[\w][\w.-]{0,127}/
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 4ca6a9b0c1e..d9ddb8f59b3 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -181,7 +181,7 @@ github.com/davecgh/go-spew/spew
+ # github.com/daviddengcn/go-colortext v1.0.0
+ ## explicit; go 1.14
+ github.com/daviddengcn/go-colortext
+-# github.com/docker/distribution v2.8.1+incompatible
++# github.com/docker/distribution v2.8.2+incompatible
+ ## explicit
+ github.com/docker/distribution/digestset
+ github.com/docker/distribution/reference
+-- 
+2.39.1
+

--- a/projects/kubernetes/kubernetes/1-26/patches/0007-Bump-docker-distribution-to-2.8.2.patch
+++ b/projects/kubernetes/kubernetes/1-26/patches/0007-Bump-docker-distribution-to-2.8.2.patch
@@ -3,10 +3,29 @@ From: Stephen Kitt <skitt@redhat.com>
 Date: Tue, 16 May 2023 09:17:51 +0200
 Subject: [PATCH] Bump docker/distribution to 2.8.2
 
+Description:
 k/k doesn't use much code from docker/distribution so this doesn't
 change anything that's actually relevant, but 2.8.1 is identified as
-affected by CVE-2022-28391 and CVE-2023-2253; bumping to 2.8.2 avoids
+affected by CVE-2023-2253; bumping docker/distribution to 2.8.2 avoids
 k/k triggering scanners on those CVEs.
+
+Upstream PR, Issue, KEP, etc. links:
+* https://github.com/kubernetes/kubernetes/pull/118036/commits/3680a5230c386602ebc82700fe3031960d0479fd
+
+If this patch is based on an upstream commit, how (if at all) do this patch and the upstream source differ?
+* No difference
+
+If this patch's changes have not been added by upstream, why not?
+* N/A
+
+Other patches related to this patch:
+* None
+
+Changes made to this patch after its initial creation and reasons for these changes:
+* None
+
+Kubernetes version this patch can be dropped:
+* N/A
 
 Signed-off-by: Stephen Kitt <skitt@redhat.com>
 ---

--- a/projects/kubernetes/kubernetes/1-26/patches/0007-Bump-docker-distribution-to-2.8.2.patch
+++ b/projects/kubernetes/kubernetes/1-26/patches/0007-Bump-docker-distribution-to-2.8.2.patch
@@ -1,0 +1,112 @@
+From 3680a5230c386602ebc82700fe3031960d0479fd Mon Sep 17 00:00:00 2001
+From: Stephen Kitt <skitt@redhat.com>
+Date: Tue, 16 May 2023 09:17:51 +0200
+Subject: [PATCH] Bump docker/distribution to 2.8.2
+
+k/k doesn't use much code from docker/distribution so this doesn't
+change anything that's actually relevant, but 2.8.1 is identified as
+affected by CVE-2022-28391 and CVE-2023-2253; bumping to 2.8.2 avoids
+k/k triggering scanners on those CVEs.
+
+Signed-off-by: Stephen Kitt <skitt@redhat.com>
+---
+ go.mod                                                       | 2 +-
+ go.sum                                                       | 3 ++-
+ staging/src/k8s.io/kubectl/go.mod                            | 2 +-
+ staging/src/k8s.io/kubectl/go.sum                            | 4 ++--
+ vendor/github.com/docker/distribution/reference/reference.go | 4 ++--
+ vendor/modules.txt                                           | 2 +-
+ 6 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 5e5fadbadd9..5996859b7d0 100644
+--- a/go.mod
++++ b/go.mod
+@@ -26,7 +26,7 @@ require (
+ 	github.com/coreos/go-systemd/v22 v22.5.0
+ 	github.com/cpuguy83/go-md2man/v2 v2.0.2
+ 	github.com/cyphar/filepath-securejoin v0.2.3
+-	github.com/docker/distribution v2.8.1+incompatible
++	github.com/docker/distribution v2.8.2+incompatible
+ 	github.com/docker/go-units v0.5.0
+ 	github.com/emicklei/go-restful/v3 v3.9.0
+ 	github.com/evanphx/json-patch v4.12.0+incompatible
+diff --git a/go.sum b/go.sum
+index 83a05e125f1..5ab37fd89dd 100644
+--- a/go.sum
++++ b/go.sum
+@@ -204,8 +204,9 @@ github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hR
+ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+ github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
+ github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
++github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
++github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docker/docker v20.10.21+incompatible h1:UTLdBmHk3bEY+w8qeO5KttOhy6OmXWsl/FEet9Uswog=
+ github.com/docker/docker v20.10.21+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+diff --git a/staging/src/k8s.io/kubectl/go.mod b/staging/src/k8s.io/kubectl/go.mod
+index 0d2c2f02bcc..6954cfd154f 100644
+--- a/staging/src/k8s.io/kubectl/go.mod
++++ b/staging/src/k8s.io/kubectl/go.mod
+@@ -8,7 +8,7 @@ require (
+ 	github.com/MakeNowJust/heredoc v1.0.0
+ 	github.com/chai2010/gettext-go v1.0.2
+ 	github.com/daviddengcn/go-colortext v1.0.0
+-	github.com/docker/distribution v2.8.1+incompatible
++	github.com/docker/distribution v2.8.2+incompatible
+ 	github.com/evanphx/json-patch v4.12.0+incompatible
+ 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+ 	github.com/fatih/camelcase v1.0.0
+diff --git a/staging/src/k8s.io/kubectl/go.sum b/staging/src/k8s.io/kubectl/go.sum
+index 46da47d6f5b..4c43c3dc0fd 100644
+--- a/staging/src/k8s.io/kubectl/go.sum
++++ b/staging/src/k8s.io/kubectl/go.sum
+@@ -54,8 +54,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
+ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+ github.com/daviddengcn/go-colortext v1.0.0 h1:ANqDyC0ys6qCSvuEK7l3g5RaehL/Xck9EX8ATG8oKsE=
+ github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hRnmkD5G4Pmri9+m4c=
+-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
+-github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
++github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
++github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+ github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
+ github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+diff --git a/vendor/github.com/docker/distribution/reference/reference.go b/vendor/github.com/docker/distribution/reference/reference.go
+index 8c0c23b2fe1..b7cd00b0d68 100644
+--- a/vendor/github.com/docker/distribution/reference/reference.go
++++ b/vendor/github.com/docker/distribution/reference/reference.go
+@@ -3,13 +3,13 @@
+ //
+ // Grammar
+ //
+-// 	reference                       := name [ ":" tag ] [ "@" digest ]
++//	reference                       := name [ ":" tag ] [ "@" digest ]
+ //	name                            := [domain '/'] path-component ['/' path-component]*
+ //	domain                          := domain-component ['.' domain-component]* [':' port-number]
+ //	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+ //	port-number                     := /[0-9]+/
+ //	path-component                  := alpha-numeric [separator alpha-numeric]*
+-// 	alpha-numeric                   := /[a-z0-9]+/
++//	alpha-numeric                   := /[a-z0-9]+/
+ //	separator                       := /[_.]|__|[-]*/
+ //
+ //	tag                             := /[\w][\w.-]{0,127}/
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 4ca6a9b0c1e..d9ddb8f59b3 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -181,7 +181,7 @@ github.com/davecgh/go-spew/spew
+ # github.com/daviddengcn/go-colortext v1.0.0
+ ## explicit; go 1.14
+ github.com/daviddengcn/go-colortext
+-# github.com/docker/distribution v2.8.1+incompatible
++# github.com/docker/distribution v2.8.2+incompatible
+ ## explicit
+ github.com/docker/distribution/digestset
+ github.com/docker/distribution/reference
+-- 
+2.39.1
+

--- a/projects/kubernetes/kubernetes/1-27/patches/0003-Bump-docker-distribution-to-2.8.2.patch
+++ b/projects/kubernetes/kubernetes/1-27/patches/0003-Bump-docker-distribution-to-2.8.2.patch
@@ -3,10 +3,29 @@ From: Stephen Kitt <skitt@redhat.com>
 Date: Tue, 16 May 2023 09:17:51 +0200
 Subject: [PATCH] Bump docker/distribution to 2.8.2
 
+Description:
 k/k doesn't use much code from docker/distribution so this doesn't
 change anything that's actually relevant, but 2.8.1 is identified as
-affected by CVE-2022-28391 and CVE-2023-2253; bumping to 2.8.2 avoids
+affected by CVE-2023-2253; bumping docker/distribution to 2.8.2 avoids
 k/k triggering scanners on those CVEs.
+
+Upstream PR, Issue, KEP, etc. links:
+* https://github.com/kubernetes/kubernetes/pull/118036/commits/3680a5230c386602ebc82700fe3031960d0479fd
+
+If this patch is based on an upstream commit, how (if at all) do this patch and the upstream source differ?
+* No difference
+
+If this patch's changes have not been added by upstream, why not?
+* N/A
+
+Other patches related to this patch:
+* None
+
+Changes made to this patch after its initial creation and reasons for these changes:
+* None
+
+Kubernetes version this patch can be dropped:
+* N/A
 
 Signed-off-by: Stephen Kitt <skitt@redhat.com>
 ---

--- a/projects/kubernetes/kubernetes/1-27/patches/0003-Bump-docker-distribution-to-2.8.2.patch
+++ b/projects/kubernetes/kubernetes/1-27/patches/0003-Bump-docker-distribution-to-2.8.2.patch
@@ -1,0 +1,112 @@
+From 3680a5230c386602ebc82700fe3031960d0479fd Mon Sep 17 00:00:00 2001
+From: Stephen Kitt <skitt@redhat.com>
+Date: Tue, 16 May 2023 09:17:51 +0200
+Subject: [PATCH] Bump docker/distribution to 2.8.2
+
+k/k doesn't use much code from docker/distribution so this doesn't
+change anything that's actually relevant, but 2.8.1 is identified as
+affected by CVE-2022-28391 and CVE-2023-2253; bumping to 2.8.2 avoids
+k/k triggering scanners on those CVEs.
+
+Signed-off-by: Stephen Kitt <skitt@redhat.com>
+---
+ go.mod                                                       | 2 +-
+ go.sum                                                       | 3 ++-
+ staging/src/k8s.io/kubectl/go.mod                            | 2 +-
+ staging/src/k8s.io/kubectl/go.sum                            | 4 ++--
+ vendor/github.com/docker/distribution/reference/reference.go | 4 ++--
+ vendor/modules.txt                                           | 2 +-
+ 6 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 5e5fadbadd9..5996859b7d0 100644
+--- a/go.mod
++++ b/go.mod
+@@ -26,7 +26,7 @@ require (
+ 	github.com/coreos/go-systemd/v22 v22.5.0
+ 	github.com/cpuguy83/go-md2man/v2 v2.0.2
+ 	github.com/cyphar/filepath-securejoin v0.2.3
+-	github.com/docker/distribution v2.8.1+incompatible
++	github.com/docker/distribution v2.8.2+incompatible
+ 	github.com/docker/go-units v0.5.0
+ 	github.com/emicklei/go-restful/v3 v3.9.0
+ 	github.com/evanphx/json-patch v4.12.0+incompatible
+diff --git a/go.sum b/go.sum
+index 83a05e125f1..5ab37fd89dd 100644
+--- a/go.sum
++++ b/go.sum
+@@ -204,8 +204,9 @@ github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hR
+ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+ github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
+ github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
++github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
++github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docker/docker v20.10.21+incompatible h1:UTLdBmHk3bEY+w8qeO5KttOhy6OmXWsl/FEet9Uswog=
+ github.com/docker/docker v20.10.21+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+diff --git a/staging/src/k8s.io/kubectl/go.mod b/staging/src/k8s.io/kubectl/go.mod
+index 0d2c2f02bcc..6954cfd154f 100644
+--- a/staging/src/k8s.io/kubectl/go.mod
++++ b/staging/src/k8s.io/kubectl/go.mod
+@@ -8,7 +8,7 @@ require (
+ 	github.com/MakeNowJust/heredoc v1.0.0
+ 	github.com/chai2010/gettext-go v1.0.2
+ 	github.com/daviddengcn/go-colortext v1.0.0
+-	github.com/docker/distribution v2.8.1+incompatible
++	github.com/docker/distribution v2.8.2+incompatible
+ 	github.com/evanphx/json-patch v4.12.0+incompatible
+ 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
+ 	github.com/fatih/camelcase v1.0.0
+diff --git a/staging/src/k8s.io/kubectl/go.sum b/staging/src/k8s.io/kubectl/go.sum
+index 46da47d6f5b..4c43c3dc0fd 100644
+--- a/staging/src/k8s.io/kubectl/go.sum
++++ b/staging/src/k8s.io/kubectl/go.sum
+@@ -54,8 +54,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
+ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+ github.com/daviddengcn/go-colortext v1.0.0 h1:ANqDyC0ys6qCSvuEK7l3g5RaehL/Xck9EX8ATG8oKsE=
+ github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hRnmkD5G4Pmri9+m4c=
+-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
+-github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
++github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
++github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+ github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
+ github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+diff --git a/vendor/github.com/docker/distribution/reference/reference.go b/vendor/github.com/docker/distribution/reference/reference.go
+index 8c0c23b2fe1..b7cd00b0d68 100644
+--- a/vendor/github.com/docker/distribution/reference/reference.go
++++ b/vendor/github.com/docker/distribution/reference/reference.go
+@@ -3,13 +3,13 @@
+ //
+ // Grammar
+ //
+-// 	reference                       := name [ ":" tag ] [ "@" digest ]
++//	reference                       := name [ ":" tag ] [ "@" digest ]
+ //	name                            := [domain '/'] path-component ['/' path-component]*
+ //	domain                          := domain-component ['.' domain-component]* [':' port-number]
+ //	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+ //	port-number                     := /[0-9]+/
+ //	path-component                  := alpha-numeric [separator alpha-numeric]*
+-// 	alpha-numeric                   := /[a-z0-9]+/
++//	alpha-numeric                   := /[a-z0-9]+/
+ //	separator                       := /[_.]|__|[-]*/
+ //
+ //	tag                             := /[\w][\w.-]{0,127}/
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 4ca6a9b0c1e..d9ddb8f59b3 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -181,7 +181,7 @@ github.com/davecgh/go-spew/spew
+ # github.com/daviddengcn/go-colortext v1.0.0
+ ## explicit; go 1.14
+ github.com/daviddengcn/go-colortext
+-# github.com/docker/distribution v2.8.1+incompatible
++# github.com/docker/distribution v2.8.2+incompatible
+ ## explicit
+ github.com/docker/distribution/digestset
+ github.com/docker/distribution/reference
+-- 
+2.39.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To resolve dependabot alerts for CVE-2023-2253, patches are made from upstream [commit](https://github.com/kubernetes/kubernetes/pull/118036/commits/3680a5230c386602ebc82700fe3031960d0479fd) for Kubernetes version 1.23-1.127 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
