### PR TITLE
Deprecate Go 1.15 and 1.16

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -215,6 +215,11 @@ function build::common::get_go_path() {
 function build::common::use_go_version() {
   local -r version=$1
 
+  if (( "${version#*.}" < 16 )); then
+    echo "Building with GO version $version is no longer supported!  Please update the build to use a newer version."
+    exit 1
+  fi
+
   local -r gobinarypath=$(build::common::get_go_path $version)
   echo "Adding $gobinarypath to PATH"
   # Adding to the beginning of PATH to allow for builds on specific version if it exists

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -86,19 +86,8 @@ function build::gather_licenses() {
   export GOOS=linux 
   export GOARCH=amd64 
 
-  # the version of go used here must be the version go-licenses was installed with
-  # by default we use 1.16, but due to changes in 1.17, there are some changes that require using 1.17
-  if [ "$golang_version" == "1.20" ]; then
-    build::common::use_go_version 1.20
-  elif [ "$golang_version" == "1.19" ]; then
-    build::common::use_go_version 1.19
-  elif [ "$golang_version" == "1.18" ]; then
-    build::common::use_go_version 1.18
-  elif [ "$golang_version" == "1.17" ]; then
-    build::common::use_go_version 1.17
-  else
-    build::common::use_go_version 1.16
-  fi
+  # the version of go used here must be the version go-licenses was installed with corresponding go versions
+  build::common::use_go_version $golang_version
 
   if ! command -v go-licenses &> /dev/null
   then

--- a/build/lib/install_go_versions.sh
+++ b/build/lib/install_go_versions.sh
@@ -34,20 +34,13 @@ setupgo() {
     ln -sf ${HOME}/sdk/go${version}/bin/gofmt ${GOPATH}/go${majorversion}/bin/gofmt
 }
 
-setupgo "${GOLANG113_VERSION:-1.13.15}"
-setupgo "${GOLANG114_VERSION:-1.14.15}"
-setupgo "${GOLANG115_VERSION:-1.15.15}"
-setupgo "${GOLANG116_VERSION:-1.16.15}"
 setupgo "${GOLANG117_VERSION:-1.17.13}"
 setupgo "${GOLANG118_VERSION:-1.18.10}"
 setupgo "${GOLANG119_VERSION:-1.19.9}"
 
-# use 1.16 or 1.17 when installing and running go-licenses
+# use 1.17 when installing and running go-licenses
 # go-licenses needs to be installed by the same version of go that is being used
 # to generate the deps list during the attribution generation process
-build::common::use_go_version "1.16"
-GOBIN=${GOPATH}/go1.16/bin go install github.com/google/go-licenses@v1.2.1
-
 build::common::use_go_version "1.17"
 GOBIN=${GOPATH}/go1.17/bin go install github.com/google/go-licenses@v1.2.1
 

--- a/build/lib/install_go_versions.sh
+++ b/build/lib/install_go_versions.sh
@@ -37,6 +37,7 @@ setupgo() {
 setupgo "${GOLANG117_VERSION:-1.17.13}"
 setupgo "${GOLANG118_VERSION:-1.18.10}"
 setupgo "${GOLANG119_VERSION:-1.19.9}"
+setupgo "${GOLANG120_VERSION:-1.20.4}"
 
 # use 1.17 when installing and running go-licenses
 # go-licenses needs to be installed by the same version of go that is being used
@@ -50,5 +51,8 @@ GOBIN=${GOPATH}/go1.18/bin go install github.com/google/go-licenses@v1.2.1
 build::common::use_go_version "1.19"
 GOBIN=${GOPATH}/go1.19/bin go install github.com/google/go-licenses@v1.2.1
 
-# 1.16 is the default so symlink it to /go/bin
-ln -sf ${GOPATH}/go1.16/bin/go-licenses ${GOPATH}/bin
+build::common::use_go_version "1.20"
+GOBIN=${GOPATH}/go1.20/bin go install github.com/google/go-licenses@v1.2.1
+
+# 1.17 is the default so symlink it to /go/bin
+ln -sf ${GOPATH}/go1.17/bin/go-licenses ${GOPATH}/bin


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
After EKS-D started supporting K8 1.27, EKS-D has stopped supporting [k8 1.22](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar). All our projects supporting k8 1.23-1.27 are build from EKS-Go 1.17-1.20. Thus, we are moving forward with deprecating EKS-Go 1.15 and 1.16 (will not update or backport new CVE'ss). All our Golang artifacts from EKS-Go 1.15 and 1.16 are still will be available in our Public ECR.

**As this poses immediate risk to users of EKS-Go 1.15 and 1.16, we advise them it is HIGHLY recommended that users of EKS-GO v1.15 - v1.16 update to a supported version of EKS-Go (v1.17+) as soon as possible.**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
