### PR TITLE
Bump kops to 1.28.0-alpha.1 for k8s v1.28

### DIFF
--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -24,7 +24,11 @@ export NODE_INSTANCE_TYPE=${NODE_INSTANCE_TYPE:-t3.medium}
 export NODE_ARCHITECTURE=${NODE_ARCHITECTURE:-amd64}
 export UBUNTU_RELEASE=${UBUNTU_RELEASE:-focal-20.04}
 export IPV6=${IPV6:-false}
-export KOPS_VERSION="1.27.0"
+if [ "$RELEASE_BRANCH" == "1-28" ]; then
+    export KOPS_VERSION="1.28.0-alpha.1"
+else
+    export KOPS_VERSION="1.27.0"
+fi
 
 if [ -n "$ARTIFACT_BUCKET" ]; then
     export ARTIFACT_BASE_URL="https://$ARTIFACT_BUCKET.s3.amazonaws.com"


### PR DESCRIPTION
*Issue #, if available:*
Update kops to use v1.28.0-alpha.1  for Release branch v1.28

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
