### PR TITLE
Custom user agent for EKS D dev script `curl` calls

### DIFF
--- a/development/kops/install_requirements.sh
+++ b/development/kops/install_requirements.sh
@@ -20,23 +20,6 @@ BASEDIR=$(dirname "$0")
 source ${BASEDIR}/set_environment.sh
 # Ignoring preflight check failures since we only need the env vars set
 
-
-if [ "$(uname)" == "Darwin" ]
-then
-    OS="darwin"
-    ARCH="amd64"
-else
-    OS="linux"
-    ARCH="amd64"
-fi
-
-# Set customer user-agent for curl to ensure we can track requests against the CloudFront distribution
-UA_SYSTEM_INFO="${OS}/${ARCH};"
-if [[ -z "prowJobId:${PROW_JOB_ID}" ]]; then
-  UA_SYSTEM_INFO+=" prowJobId:${PROW_JOB_ID}"
-fi
-USERAGENT="EksDistro-${BASENAME}/${RELEASE_BRANCH} ($UA_SYSTEM_INFO)"
-
 mkdir -p ${BASEDIR}/bin
 
 if [ ! -x ${KOPS} ]

--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -99,8 +99,8 @@ else
 fi
 
 # Set customer user-agent for curl to ensure we can track requests against the CloudFront distribution
-UA_SYSTEM_INFO="${OS}/${ARCH};"
-if [[ -z "prowJobId:${PROW_JOB_ID}" ]]; then
+UA_SYSTEM_INFO="${OS}/${ARCH}; "
+if [[ -z "${PROW_JOB_ID}" ]]; then
   UA_SYSTEM_INFO+="prowJobId:${PROW_JOB_ID}; "
 fi
 export USERAGENT="EksDistro-${BASENAME}/${RELEASE_BRANCH} ($UA_SYSTEM_INFO)"

--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -99,8 +99,8 @@ else
 fi
 
 # Set customer user-agent for curl to ensure we can track requests against the CloudFront distribution
-UA_SYSTEM_INFO="${OS}/${ARCH}; "
-if [[ -z "${PROW_JOB_ID}" ]]; then
-  UA_SYSTEM_INFO+="prowJobId:${PROW_JOB_ID}; "
+UA_SYSTEM_INFO="${OS}/${ARCH};"
+if [[ -n "${PROW_JOB_ID}" ]]; then
+  UA_SYSTEM_INFO+=" prowJobId:${PROW_JOB_ID};"
 fi
 export USERAGENT="EksDistro-${BASENAME}/${RELEASE_BRANCH} ($UA_SYSTEM_INFO)"

--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -87,3 +87,20 @@ export KOPS_BASE_URL=https://eks-d-postsubmit-artifacts.s3.amazonaws.com/kops/$K
 export KOPS=bin/kops
 mkdir -p bin
 export PATH=`pwd`/bin:${PATH}
+
+# Set OS and ARCH env vars
+if [ "$(uname)" == "Darwin" ]
+then
+    export OS="darwin"
+    export ARCH="amd64"
+else
+    export OS="linux"
+    export ARCH="amd64"
+fi
+
+# Set customer user-agent for curl to ensure we can track requests against the CloudFront distribution
+UA_SYSTEM_INFO="${OS}/${ARCH};"
+if [[ -z "prowJobId:${PROW_JOB_ID}" ]]; then
+  UA_SYSTEM_INFO+="prowJobId:${PROW_JOB_ID}; "
+fi
+export USERAGENT="EksDistro-${BASENAME}/${RELEASE_BRANCH} ($UA_SYSTEM_INFO)"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set up a custom user-agent for EKS-A kOps scripts.

`set_environment.sh` will now make a custom user-agent available, of the form `EksDistro-${SCRIPT_NAME}/${RELASE_BRANCH} (${OS}/${ARCH}; prowjobId:${PROWJOB_ID})`, like `EksDistro-InstallRequierments.sh/1.27 (darwin/amd64; prowjobsId:123123124124124124;)`.

This will make it much easier to track the calls made by our dev scripts to the cloudfront distribution and debug issues like failure to pull artifacts due to eventual consistency. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
