### PR TITLE
Bump gopkg.in/yaml.v3 to v3.0.1 to fix CVE-2022-28948

### DIFF
--- a/projects/coredns/coredns/1-23/CHECKSUMS
+++ b/projects/coredns/coredns/1-23/CHECKSUMS
@@ -1,2 +1,2 @@
-a9dac1e30746ac0072471dc656ae7711242fb7f40ffa23690c5b2b1db97ac359  _output/1-23/bin/coredns/linux-amd64/coredns
-41af9545c25df2511de1b8b47c7e4f5c1ec5dc90b45aa3eefe8873c213c1f5b7  _output/1-23/bin/coredns/linux-arm64/coredns
+c94d740b966203d97a2c8d8ab06718e947bb6c4b1e7749e5557ea579d0e89ec1  _output/1-23/bin/coredns/linux-amd64/coredns
+73145d4a299abe0111a34254eb98dccda74716ee34662c40ff70b449898b10ce  _output/1-23/bin/coredns/linux-arm64/coredns

--- a/projects/coredns/coredns/1-23/patches/0002-Bump-gopkg.in-yaml.v3-to-v3.0.1-to-fix-CVE-2022-2894.patch
+++ b/projects/coredns/coredns/1-23/patches/0002-Bump-gopkg.in-yaml.v3-to-v3.0.1-to-fix-CVE-2022-2894.patch
@@ -1,7 +1,7 @@
-From ba1652623e3c4b6a651c2bdd1c1074e62c16a0e9 Mon Sep 17 00:00:00 2001
+From 17987e9b73d1af18f6087274ffaedf0a2e52c815 Mon Sep 17 00:00:00 2001
 From: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
-Date: Mon, 11 Sep 2023 15:23:19 -0700
-Subject: [PATCH] Bump gopkg.in/yaml.v3 to v3.0.0 to fix CVE-2022-28948
+Date: Wed, 13 Sep 2023 11:20:18 -0700
+Subject: [PATCH] Bump gopkg.in/yaml.v3 to v3.0.1 to fix CVE-2022-28948
 
 Signed-off-by: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/go.mod b/go.mod
-index 38db0091..ddc0413b 100644
+index 38db0091..d7e716f9 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -102,7 +102,7 @@ require (
@@ -18,12 +18,12 @@ index 38db0091..ddc0413b 100644
  	gopkg.in/inf.v0 v0.9.1 // indirect
  	gopkg.in/yaml.v2 v2.4.0 // indirect
 -	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-+	gopkg.in/yaml.v3 v3.0.0 // indirect
++	gopkg.in/yaml.v3 v3.0.1 // indirect
  	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
  	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect
  	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 diff --git a/go.sum b/go.sum
-index d313e729..ad0fa3e5 100644
+index d313e729..53fbe067 100644
 --- a/go.sum
 +++ b/go.sum
 @@ -883,8 +883,9 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
@@ -32,8 +32,8 @@ index d313e729..ad0fa3e5 100644
  gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 -gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
  gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-+gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
-+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
++gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
++gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
  honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes [CVE-2022-28948](https://github.com/advisories/GHSA-hp87-p4gw-j4gq), but we bumping to v3.0.1 to follow EKS changes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
