### PR TITLE
Match hashes in patches for CoreDNS 1.9.3

### DIFF
--- a/projects/coredns/coredns/1-24/patches/0002-Bump-go-restful-to-2.16.0-incompatible-to-address-CV.patch
+++ b/projects/coredns/coredns/1-24/patches/0002-Bump-go-restful-to-2.16.0-incompatible-to-address-CV.patch
@@ -1,4 +1,4 @@
-From 7aa66745ca6c25ab68baa2cabfefbbb444b7598c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
 Date: Wed, 13 Sep 2023 12:19:43 -0700
 Subject: [PATCH] Bump go-restful to 2.16.0+incompatible to address

--- a/projects/coredns/coredns/1-25/patches/0002-Bump-go-restful-to-2.16.0-incompatible-to-address-CV.patch
+++ b/projects/coredns/coredns/1-25/patches/0002-Bump-go-restful-to-2.16.0-incompatible-to-address-CV.patch
@@ -1,4 +1,4 @@
-From bc18c5e4794580c3587c929d06642bec535dd1a5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
 Date: Wed, 13 Sep 2023 12:31:57 -0700
 Subject: [PATCH] Bump go-restful to 2.16.0+incompatible to address

--- a/projects/coredns/coredns/1-26/patches/0002-Bump-go-restful-to-2.16.0-incompatible-to-address-CV.patch
+++ b/projects/coredns/coredns/1-26/patches/0002-Bump-go-restful-to-2.16.0-incompatible-to-address-CV.patch
@@ -1,4 +1,4 @@
-From 45b5f40e4e9ba64dad611fe8da15e29c7a1204df Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
 Date: Wed, 13 Sep 2023 12:36:24 -0700
 Subject: [PATCH] Bump go-restful to 2.16.0+incompatible to address


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* To match hashes of CoreDNS 1.9.3, zeroed out all the hashes in CoreDNS 1.9.3, 0002 patches


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
