### PR TITLE
Revert "Update 1.28 to use kops 1.28.0-beta.1 (#2336)"

### DIFF
--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -25,7 +25,7 @@ export NODE_ARCHITECTURE=${NODE_ARCHITECTURE:-amd64}
 export UBUNTU_RELEASE=${UBUNTU_RELEASE:-focal-20.04}
 export IPV6=${IPV6:-false}
 if [ "$RELEASE_BRANCH" == "1-28" ]; then
-    export KOPS_VERSION="1.28.0-beta.1"
+    export KOPS_VERSION="1.28.0-alpha.1"
 else
     export KOPS_VERSION="1.27.0"
 fi


### PR DESCRIPTION
This reverts commit d3406b85e2965214309e39d045676ed7be0c114e.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
