### PR TITLE
Change time to match coreDNS 1.9.3 patches

### DIFF
--- a/projects/coredns/coredns/1-25/CHECKSUMS
+++ b/projects/coredns/coredns/1-25/CHECKSUMS
@@ -1,2 +1,2 @@
-7da4b72e3bffda8049dc0ac57f24f4febc73ad1542bbd6ad9a7de044c631609c  _output/1-25/bin/coredns/linux-amd64/coredns
-d3af2678d5a2472190305cebe00eecbfca1cc50308c5d1173ab37e6dc8994b35  _output/1-25/bin/coredns/linux-arm64/coredns
+4c45f64ac73e75f1733b1bf8d54d7219a12af4791b8c9d0dd92010f85f376ff4  _output/1-25/bin/coredns/linux-amd64/coredns
+0ca7b427233e7b871d4ffb61bbb59f44dd80dbc8d8eb4b61033996ce9ddb32f3  _output/1-25/bin/coredns/linux-arm64/coredns

--- a/projects/coredns/coredns/1-25/patches/0002-Bump-go-restful-to-2.16.0-incompatible-to-address-CV.patch
+++ b/projects/coredns/coredns/1-25/patches/0002-Bump-go-restful-to-2.16.0-incompatible-to-address-CV.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
-Date: Wed, 13 Sep 2023 12:31:57 -0700
+Date: Wed, 13 Sep 2023 12:19:43 -0700
 Subject: [PATCH] Bump go-restful to 2.16.0+incompatible to address
  CVE-2022-1996
 

--- a/projects/coredns/coredns/1-26/CHECKSUMS
+++ b/projects/coredns/coredns/1-26/CHECKSUMS
@@ -1,2 +1,2 @@
-fbf9705011f461f7df3c18fff7661476d772ead7601049395bfad503b2b99ed2  _output/1-26/bin/coredns/linux-amd64/coredns
-0ab937e1ee1d225b1b0f3b9c453cb7c16aee69410c2a36631bd7a79e2a884b0f  _output/1-26/bin/coredns/linux-arm64/coredns
+4c45f64ac73e75f1733b1bf8d54d7219a12af4791b8c9d0dd92010f85f376ff4  _output/1-26/bin/coredns/linux-amd64/coredns
+0ca7b427233e7b871d4ffb61bbb59f44dd80dbc8d8eb4b61033996ce9ddb32f3  _output/1-26/bin/coredns/linux-arm64/coredns

--- a/projects/coredns/coredns/1-26/patches/0002-Bump-go-restful-to-2.16.0-incompatible-to-address-CV.patch
+++ b/projects/coredns/coredns/1-26/patches/0002-Bump-go-restful-to-2.16.0-incompatible-to-address-CV.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
-Date: Wed, 13 Sep 2023 12:36:24 -0700
+Date: Wed, 13 Sep 2023 12:19:43 -0700
 Subject: [PATCH] Bump go-restful to 2.16.0+incompatible to address
  CVE-2022-1996
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The coreDNS 1.9.3 patch checksums for K8 version 1.25 and 1.26 is failing because the patches have different times, so matching all patches. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
