### PR TITLE
Patch livenessprobe to Fix CVE-2023-44487 and CVE-2023-39325

### DIFF
--- a/projects/kubernetes-csi/livenessprobe/1-24/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-24/CHECKSUMS
@@ -1,3 +1,3 @@
-76c4a0a6d54a987744cc1ee11a6a59c75c863db7088ac7a88b6a635ba871024a  _output/1-24/bin/livenessprobe/linux-amd64/livenessprobe
-61349ff8a583832aab8254c3c3ba90c03373324cc6eff7ef1c890811903cc726  _output/1-24/bin/livenessprobe/linux-arm64/livenessprobe
-059722d18e2b0d29632f4a6f760d331f0ba053d6a0dfd758582d2131164b1f0d  _output/1-24/bin/livenessprobe/windows-amd64/livenessprobe.exe
+069068a60fdf7739331586e4ad9f3258690ffe44d066514612dfcc0d8a6c2063  _output/1-24/bin/livenessprobe/linux-amd64/livenessprobe
+d3508a41fee454aea498b9b8841f2b299895a153594b89877a1dac7ed5a56812  _output/1-24/bin/livenessprobe/linux-arm64/livenessprobe
+7c2eda8690b52b3fdf51f1855a6c070afc8bceee41ef2fe8fbdb36b9f07acfc0  _output/1-24/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-24/patches/0001-Fix-CVE-2023-44487-and-CVE-2023-39325-bump-golang.or.patch
+++ b/projects/kubernetes-csi/livenessprobe/1-24/patches/0001-Fix-CVE-2023-44487-and-CVE-2023-39325-bump-golang.or.patch
@@ -1,0 +1,6786 @@
+From 0da68f237a1f971d899df26ee722ddf72905aa15 Mon Sep 17 00:00:00 2001
+From: Jonathan Dobson <jdobson@redhat.com>
+Date: Wed, 18 Oct 2023 14:27:39 -0600
+Subject: [PATCH] Fix CVE-2023-44487 and CVE-2023-39325: bump golang.org/x/net
+
+Signed-off-by: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
+---
+ go.mod                                        |  13 +-
+ go.sum                                        |  31 +-
+ vendor/golang.org/x/net/http2/Dockerfile      |  51 ----
+ vendor/golang.org/x/net/http2/Makefile        |   3 -
+ vendor/golang.org/x/net/http2/server.go       |  86 ++++--
+ vendor/golang.org/x/net/http2/transport.go    |   3 +-
+ .../sys/internal/unsafeheader/unsafeheader.go |  30 --
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |   1 +
+ vendor/golang.org/x/sys/unix/ptrace_darwin.go |   6 -
+ vendor/golang.org/x/sys/unix/ptrace_ios.go    |   6 -
+ vendor/golang.org/x/sys/unix/syscall_aix.go   |   2 -
+ .../golang.org/x/sys/unix/syscall_darwin.go   | 186 ------------
+ .../x/sys/unix/syscall_darwin_amd64.go        |   1 -
+ .../x/sys/unix/syscall_darwin_arm64.go        |   1 -
+ .../x/sys/unix/syscall_dragonfly.go           | 198 -------------
+ .../golang.org/x/sys/unix/syscall_freebsd.go  | 192 -------------
+ vendor/golang.org/x/sys/unix/syscall_linux.go |  77 ++++-
+ .../golang.org/x/sys/unix/syscall_netbsd.go   | 272 +-----------------
+ .../golang.org/x/sys/unix/syscall_openbsd.go  |  74 -----
+ .../golang.org/x/sys/unix/syscall_solaris.go  |  32 ---
+ vendor/golang.org/x/sys/unix/syscall_unix.go  |   3 +
+ .../x/sys/unix/syscall_zos_s390x.go           |   1 -
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  26 ++
+ .../x/sys/unix/zerrors_linux_386.go           |   2 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   2 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   4 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   2 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   2 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   2 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   2 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   2 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   2 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   2 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   2 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   2 +
+ .../golang.org/x/sys/unix/zsyscall_aix_ppc.go |  22 --
+ .../x/sys/unix/zsyscall_aix_ppc64.go          |  22 --
+ .../x/sys/unix/zsyscall_darwin_amd64.go       |  40 +--
+ .../x/sys/unix/zsyscall_darwin_amd64.s        | 149 ----------
+ .../x/sys/unix/zsyscall_darwin_arm64.go       |  40 +--
+ .../x/sys/unix/zsyscall_darwin_arm64.s        | 149 ----------
+ .../x/sys/unix/zsyscall_dragonfly_amd64.go    |  22 --
+ .../x/sys/unix/zsyscall_freebsd_386.go        |  22 --
+ .../x/sys/unix/zsyscall_freebsd_amd64.go      |  22 --
+ .../x/sys/unix/zsyscall_freebsd_arm.go        |  22 --
+ .../x/sys/unix/zsyscall_freebsd_arm64.go      |  22 --
+ .../x/sys/unix/zsyscall_freebsd_riscv64.go    |  22 --
+ .../x/sys/unix/zsyscall_illumos_amd64.go      |  10 +-
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  42 ++-
+ .../x/sys/unix/zsyscall_netbsd_386.go         |  22 --
+ .../x/sys/unix/zsyscall_netbsd_amd64.go       |  22 --
+ .../x/sys/unix/zsyscall_netbsd_arm.go         |  22 --
+ .../x/sys/unix/zsyscall_netbsd_arm64.go       |  22 --
+ .../x/sys/unix/zsyscall_openbsd_386.go        |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |  22 --
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |  32 +--
+ .../x/sys/unix/zsyscall_solaris_amd64.go      | 256 ++++++++---------
+ .../x/sys/unix/zsyscall_zos_s390x.go          |  11 -
+ .../x/sys/unix/zsysnum_linux_386.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   1 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   1 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   1 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   1 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  |  23 +-
+ .../x/sys/unix/ztypes_linux_riscv64.go        |  27 ++
+ .../golang.org/x/sys/windows/exec_windows.go  |  89 +++++-
+ .../x/sys/windows/security_windows.go         |  21 +-
+ .../x/sys/windows/syscall_windows.go          |  53 ++--
+ .../golang.org/x/sys/windows/types_windows.go |   7 +
+ .../x/sys/windows/zsyscall_windows.go         |  54 +++-
+ vendor/golang.org/x/text/unicode/norm/trie.go |   2 +-
+ vendor/modules.txt                            |  46 ++-
+ 89 files changed, 698 insertions(+), 2141 deletions(-)
+ delete mode 100644 vendor/golang.org/x/net/http2/Dockerfile
+ delete mode 100644 vendor/golang.org/x/net/http2/Makefile
+ delete mode 100644 vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
+
+diff --git a/go.mod b/go.mod
+index 3c87bf0..1d87210 100644
+--- a/go.mod
++++ b/go.mod
+@@ -23,9 +23,16 @@ require (
+ 	github.com/prometheus/common v0.44.0 // indirect
+ 	github.com/prometheus/procfs v0.10.1 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+-	golang.org/x/net v0.13.0 // indirect
+-	golang.org/x/sys v0.10.0 // indirect
+-	golang.org/x/text v0.11.0 // indirect
++	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.0 // indirect
++	go.opentelemetry.io/otel v1.15.0 // indirect
++	go.opentelemetry.io/otel/metric v0.38.0 // indirect
++	go.opentelemetry.io/otel/trace v1.15.0 // indirect
++	go.uber.org/atomic v1.10.0 // indirect
++	go.uber.org/multierr v1.11.0 // indirect
++	go.uber.org/zap v1.19.0 // indirect
++	golang.org/x/net v0.17.0 // indirect
++	golang.org/x/sys v0.13.0 // indirect
++	golang.org/x/text v0.13.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
+ 	google.golang.org/protobuf v1.31.0 // indirect
+ 	k8s.io/apimachinery v0.28.0 // indirect
+diff --git a/go.sum b/go.sum
+index 038cdf3..d4a9711 100644
+--- a/go.sum
++++ b/go.sum
+@@ -137,17 +137,9 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
+-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+-golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+-golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+-golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+-golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=
+-golang.org/x/net v0.13.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
+-golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+-golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
++golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
++golang.org/x/oauth2 v0.10.0 h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -168,23 +160,14 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220731174439-a90be440212d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
++golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+-golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
+-golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
++golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
++golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+diff --git a/vendor/golang.org/x/net/http2/Dockerfile b/vendor/golang.org/x/net/http2/Dockerfile
+deleted file mode 100644
+index 8512245..0000000
+--- a/vendor/golang.org/x/net/http2/Dockerfile
++++ /dev/null
+@@ -1,51 +0,0 @@
+-#
+-# This Dockerfile builds a recent curl with HTTP/2 client support, using
+-# a recent nghttp2 build.
+-#
+-# See the Makefile for how to tag it. If Docker and that image is found, the
+-# Go tests use this curl binary for integration tests.
+-#
+-
+-FROM ubuntu:trusty
+-
+-RUN apt-get update && \
+-    apt-get upgrade -y && \
+-    apt-get install -y git-core build-essential wget
+-
+-RUN apt-get install -y --no-install-recommends \
+-       autotools-dev libtool pkg-config zlib1g-dev \
+-       libcunit1-dev libssl-dev libxml2-dev libevent-dev \
+-       automake autoconf
+-
+-# The list of packages nghttp2 recommends for h2load:
+-RUN apt-get install -y --no-install-recommends make binutils \
+-        autoconf automake autotools-dev \
+-        libtool pkg-config zlib1g-dev libcunit1-dev libssl-dev libxml2-dev \
+-        libev-dev libevent-dev libjansson-dev libjemalloc-dev \
+-        cython python3.4-dev python-setuptools
+-
+-# Note: setting NGHTTP2_VER before the git clone, so an old git clone isn't cached:
+-ENV NGHTTP2_VER 895da9a
+-RUN cd /root && git clone https://github.com/tatsuhiro-t/nghttp2.git
+-
+-WORKDIR /root/nghttp2
+-RUN git reset --hard $NGHTTP2_VER
+-RUN autoreconf -i
+-RUN automake
+-RUN autoconf
+-RUN ./configure
+-RUN make
+-RUN make install
+-
+-WORKDIR /root
+-RUN wget https://curl.se/download/curl-7.45.0.tar.gz
+-RUN tar -zxvf curl-7.45.0.tar.gz
+-WORKDIR /root/curl-7.45.0
+-RUN ./configure --with-ssl --with-nghttp2=/usr/local
+-RUN make
+-RUN make install
+-RUN ldconfig
+-
+-CMD ["-h"]
+-ENTRYPOINT ["/usr/local/bin/curl"]
+-
+diff --git a/vendor/golang.org/x/net/http2/Makefile b/vendor/golang.org/x/net/http2/Makefile
+deleted file mode 100644
+index 55fd826..0000000
+--- a/vendor/golang.org/x/net/http2/Makefile
++++ /dev/null
+@@ -1,3 +0,0 @@
+-curlimage:
+-	docker build -t gohttp2/curl .
+-
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index 033b6e6..02c88b6 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -581,9 +581,11 @@ type serverConn struct {
+ 	advMaxStreams               uint32 // our SETTINGS_MAX_CONCURRENT_STREAMS advertised the client
+ 	curClientStreams            uint32 // number of open streams initiated by the client
+ 	curPushedStreams            uint32 // number of open streams initiated by server push
++	curHandlers                 uint32 // number of running handler goroutines
+ 	maxClientStreamID           uint32 // max ever seen from client (odd), or 0 if there have been no client requests
+ 	maxPushPromiseID            uint32 // ID of the last push promise (even), or 0 if there have been no pushes
+ 	streams                     map[uint32]*stream
++	unstartedHandlers           []unstartedHandler
+ 	initialStreamSendWindowSize int32
+ 	maxFrameSize                int32
+ 	peerMaxHeaderListSize       uint32            // zero means unknown (default)
+@@ -981,6 +983,8 @@ func (sc *serverConn) serve() {
+ 					return
+ 				case gracefulShutdownMsg:
+ 					sc.startGracefulShutdownInternal()
++				case handlerDoneMsg:
++					sc.handlerDone()
+ 				default:
+ 					panic("unknown timer")
+ 				}
+@@ -1012,14 +1016,6 @@ func (sc *serverConn) serve() {
+ 	}
+ }
+ 
+-func (sc *serverConn) awaitGracefulShutdown(sharedCh <-chan struct{}, privateCh chan struct{}) {
+-	select {
+-	case <-sc.doneServing:
+-	case <-sharedCh:
+-		close(privateCh)
+-	}
+-}
+-
+ type serverMessage int
+ 
+ // Message values sent to serveMsgCh.
+@@ -1028,6 +1024,7 @@ var (
+ 	idleTimerMsg        = new(serverMessage)
+ 	shutdownTimerMsg    = new(serverMessage)
+ 	gracefulShutdownMsg = new(serverMessage)
++	handlerDoneMsg      = new(serverMessage)
+ )
+ 
+ func (sc *serverConn) onSettingsTimer() { sc.sendServeMsg(settingsTimerMsg) }
+@@ -1900,9 +1897,11 @@ func (st *stream) copyTrailersToHandlerRequest() {
+ // onReadTimeout is run on its own goroutine (from time.AfterFunc)
+ // when the stream's ReadTimeout has fired.
+ func (st *stream) onReadTimeout() {
+-	// Wrap the ErrDeadlineExceeded to avoid callers depending on us
+-	// returning the bare error.
+-	st.body.CloseWithError(fmt.Errorf("%w", os.ErrDeadlineExceeded))
++	if st.body != nil {
++		// Wrap the ErrDeadlineExceeded to avoid callers depending on us
++		// returning the bare error.
++		st.body.CloseWithError(fmt.Errorf("%w", os.ErrDeadlineExceeded))
++	}
+ }
+ 
+ // onWriteTimeout is run on its own goroutine (from time.AfterFunc)
+@@ -2020,13 +2019,10 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+ 	if sc.hs.ReadTimeout != 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+-		if st.body != nil {
+-			st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+-		}
++		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+ 
+-	go sc.runHandler(rw, req, handler)
+-	return nil
++	return sc.scheduleHandler(id, rw, req, handler)
+ }
+ 
+ func (sc *serverConn) upgradeRequest(req *http.Request) {
+@@ -2046,6 +2042,10 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
++	// This is the first request on the connection,
++	// so start the handler directly rather than going
++	// through scheduleHandler.
++	sc.curHandlers++
+ 	go sc.runHandler(rw, req, sc.handler.ServeHTTP)
+ }
+ 
+@@ -2286,8 +2286,62 @@ func (sc *serverConn) newResponseWriter(st *stream, req *http.Request) *response
+ 	return &responseWriter{rws: rws}
+ }
+ 
++type unstartedHandler struct {
++	streamID uint32
++	rw       *responseWriter
++	req      *http.Request
++	handler  func(http.ResponseWriter, *http.Request)
++}
++
++// scheduleHandler starts a handler goroutine,
++// or schedules one to start as soon as an existing handler finishes.
++func (sc *serverConn) scheduleHandler(streamID uint32, rw *responseWriter, req *http.Request, handler func(http.ResponseWriter, *http.Request)) error {
++	sc.serveG.check()
++	maxHandlers := sc.advMaxStreams
++	if sc.curHandlers < maxHandlers {
++		sc.curHandlers++
++		go sc.runHandler(rw, req, handler)
++		return nil
++	}
++	if len(sc.unstartedHandlers) > int(4*sc.advMaxStreams) {
++		return sc.countError("too_many_early_resets", ConnectionError(ErrCodeEnhanceYourCalm))
++	}
++	sc.unstartedHandlers = append(sc.unstartedHandlers, unstartedHandler{
++		streamID: streamID,
++		rw:       rw,
++		req:      req,
++		handler:  handler,
++	})
++	return nil
++}
++
++func (sc *serverConn) handlerDone() {
++	sc.serveG.check()
++	sc.curHandlers--
++	i := 0
++	maxHandlers := sc.advMaxStreams
++	for ; i < len(sc.unstartedHandlers); i++ {
++		u := sc.unstartedHandlers[i]
++		if sc.streams[u.streamID] == nil {
++			// This stream was reset before its goroutine had a chance to start.
++			continue
++		}
++		if sc.curHandlers >= maxHandlers {
++			break
++		}
++		sc.curHandlers++
++		go sc.runHandler(u.rw, u.req, u.handler)
++		sc.unstartedHandlers[i] = unstartedHandler{} // don't retain references
++	}
++	sc.unstartedHandlers = sc.unstartedHandlers[i:]
++	if len(sc.unstartedHandlers) == 0 {
++		sc.unstartedHandlers = nil
++	}
++}
++
+ // Run on its own goroutine.
+ func (sc *serverConn) runHandler(rw *responseWriter, req *http.Request, handler func(http.ResponseWriter, *http.Request)) {
++	defer sc.sendServeMsg(handlerDoneMsg)
+ 	didPanic := true
+ 	defer func() {
+ 		rw.rws.stream.cancelCtx()
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index b20c749..7497f56 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -290,8 +290,7 @@ func (t *Transport) initConnPool() {
+ // HTTP/2 server.
+ type ClientConn struct {
+ 	t             *Transport
+-	tconn         net.Conn // usually *tls.Conn, except specialized impls
+-	tconnClosed   bool
++	tconn         net.Conn             // usually *tls.Conn, except specialized impls
+ 	tlsState      *tls.ConnectionState // nil only for specialized impls
+ 	reused        uint32               // whether conn is being reused; atomic
+ 	singleUse     bool                 // whether being used for a single http.Request
+diff --git a/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go b/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
+deleted file mode 100644
+index e07899b..0000000
+--- a/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
++++ /dev/null
+@@ -1,30 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-// Package unsafeheader contains header declarations for the Go runtime's
+-// slice and string implementations.
+-//
+-// This package allows x/sys to use types equivalent to
+-// reflect.SliceHeader and reflect.StringHeader without introducing
+-// a dependency on the (relatively heavy) "reflect" package.
+-package unsafeheader
+-
+-import (
+-	"unsafe"
+-)
+-
+-// Slice is the runtime representation of a slice.
+-// It cannot be used safely or portably and its representation may change in a later release.
+-type Slice struct {
+-	Data unsafe.Pointer
+-	Len  int
+-	Cap  int
+-}
+-
+-// String is the runtime representation of a string.
+-// It cannot be used safely or portably and its representation may change in a later release.
+-type String struct {
+-	Data unsafe.Pointer
+-	Len  int
+-}
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index 0c4d149..831f9e3 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -583,6 +583,7 @@ ccflags="$@"
+ 		$2 ~ /^PERF_/ ||
+ 		$2 ~ /^SECCOMP_MODE_/ ||
+ 		$2 ~ /^SEEK_/ ||
++		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+ 		$2 ~ /^SYNC_FILE_RANGE_/ ||
+ 		$2 !~ /IOC_MAGIC/ &&
+diff --git a/vendor/golang.org/x/sys/unix/ptrace_darwin.go b/vendor/golang.org/x/sys/unix/ptrace_darwin.go
+index 39dba6c..463c3ef 100644
+--- a/vendor/golang.org/x/sys/unix/ptrace_darwin.go
++++ b/vendor/golang.org/x/sys/unix/ptrace_darwin.go
+@@ -7,12 +7,6 @@
+ 
+ package unix
+ 
+-import "unsafe"
+-
+ func ptrace(request int, pid int, addr uintptr, data uintptr) error {
+ 	return ptrace1(request, pid, addr, data)
+ }
+-
+-func ptracePtr(request int, pid int, addr uintptr, data unsafe.Pointer) error {
+-	return ptrace1Ptr(request, pid, addr, data)
+-}
+diff --git a/vendor/golang.org/x/sys/unix/ptrace_ios.go b/vendor/golang.org/x/sys/unix/ptrace_ios.go
+index 9ea6633..ed0509a 100644
+--- a/vendor/golang.org/x/sys/unix/ptrace_ios.go
++++ b/vendor/golang.org/x/sys/unix/ptrace_ios.go
+@@ -7,12 +7,6 @@
+ 
+ package unix
+ 
+-import "unsafe"
+-
+ func ptrace(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return ENOTSUP
+ }
+-
+-func ptracePtr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	return ENOTSUP
+-}
+diff --git a/vendor/golang.org/x/sys/unix/syscall_aix.go b/vendor/golang.org/x/sys/unix/syscall_aix.go
+index c406ae0..6f77ff5 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_aix.go
++++ b/vendor/golang.org/x/sys/unix/syscall_aix.go
+@@ -487,8 +487,6 @@ func Fsync(fd int) error {
+ //sys	Unlinkat(dirfd int, path string, flags int) (err error)
+ //sys	Ustat(dev int, ubuf *Ustat_t) (err error)
+ //sys	write(fd int, p []byte) (n int, err error)
+-//sys	readlen(fd int, p *byte, np int) (n int, err error) = read
+-//sys	writelen(fd int, p *byte, np int) (n int, err error) = write
+ 
+ //sys	Dup2(oldfd int, newfd int) (err error)
+ //sys	Fadvise(fd int, offset int64, length int64, advice int) (err error) = posix_fadvise64
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin.go b/vendor/golang.org/x/sys/unix/syscall_darwin.go
+index 2069215..3b0bd2d 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin.go
+@@ -638,189 +638,3 @@ func SysctlKinfoProcSlice(name string, args ...int) ([]KinfoProc, error) {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+-
+-/*
+- * Unimplemented
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Ioctl
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// sendfile
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Poll_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go b/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
+index 9fa8798..b37310c 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
+@@ -47,6 +47,5 @@ func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr,
+ //sys	getfsstat(buf unsafe.Pointer, size uintptr, flags int) (n int, err error) = SYS_GETFSSTAT64
+ //sys	Lstat(path string, stat *Stat_t) (err error) = SYS_LSTAT64
+ //sys	ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) = SYS_ptrace
+-//sys	ptrace1Ptr(request int, pid int, addr unsafe.Pointer, data uintptr) (err error) = SYS_ptrace
+ //sys	Stat(path string, stat *Stat_t) (err error) = SYS_STAT64
+ //sys	Statfs(path string, stat *Statfs_t) (err error) = SYS_STATFS64
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go b/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
+index f17b8c5..d51ec99 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
+@@ -47,6 +47,5 @@ func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr,
+ //sys	getfsstat(buf unsafe.Pointer, size uintptr, flags int) (n int, err error) = SYS_GETFSSTAT
+ //sys	Lstat(path string, stat *Stat_t) (err error)
+ //sys	ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) = SYS_ptrace
+-//sys	ptrace1Ptr(request int, pid int, addr unsafe.Pointer, data uintptr) (err error) = SYS_ptrace
+ //sys	Stat(path string, stat *Stat_t) (err error)
+ //sys	Statfs(path string, stat *Statfs_t) (err error)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+index d4ce988..97cb916 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
++++ b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+@@ -343,203 +343,5 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error)
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- * TODO(jsing): Update this list for DragonFly.
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Mount
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Setattrlist
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Getxattr
+-// Fgetxattr
+-// Setxattr
+-// Fsetxattr
+-// Removexattr
+-// Fremovexattr
+-// Listxattr
+-// Flistxattr
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shmat
+-// Shmctl
+-// Shmdt
+-// Shmget
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index afb1010..64d1bb4 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -449,197 +449,5 @@ func Dup3(oldfd, newfd, flags int) error {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error)
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Ioctl
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Mount
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Setattrlist
+-// Getdents
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shmat
+-// Shmctl
+-// Shmdt
+-// Shmget
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Poll_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index 39de5f1..c905ec8 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -693,10 +693,10 @@ type SockaddrALG struct {
+ 
+ func (sa *SockaddrALG) sockaddr() (unsafe.Pointer, _Socklen, error) {
+ 	// Leave room for NUL byte terminator.
+-	if len(sa.Type) > 13 {
++	if len(sa.Type) > len(sa.raw.Type)-1 {
+ 		return nil, 0, EINVAL
+ 	}
+-	if len(sa.Name) > 63 {
++	if len(sa.Name) > len(sa.raw.Name)-1 {
+ 		return nil, 0, EINVAL
+ 	}
+ 
+@@ -704,17 +704,8 @@ func (sa *SockaddrALG) sockaddr() (unsafe.Pointer, _Socklen, error) {
+ 	sa.raw.Feat = sa.Feature
+ 	sa.raw.Mask = sa.Mask
+ 
+-	typ, err := ByteSliceFromString(sa.Type)
+-	if err != nil {
+-		return nil, 0, err
+-	}
+-	name, err := ByteSliceFromString(sa.Name)
+-	if err != nil {
+-		return nil, 0, err
+-	}
+-
+-	copy(sa.raw.Type[:], typ)
+-	copy(sa.raw.Name[:], name)
++	copy(sa.raw.Type[:], sa.Type)
++	copy(sa.raw.Name[:], sa.Name)
+ 
+ 	return unsafe.Pointer(&sa.raw), SizeofSockaddrALG, nil
+ }
+@@ -1988,8 +1979,6 @@ func Signalfd(fd int, sigmask *Sigset_t, flags int) (newfd int, err error) {
+ //sys	Unshare(flags int) (err error)
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	exitThread(code int) (err error) = SYS_EXIT
+-//sys	readlen(fd int, p *byte, np int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, p *byte, np int) (n int, err error) = SYS_WRITE
+ //sys	readv(fd int, iovs []Iovec) (n int, err error) = SYS_READV
+ //sys	writev(fd int, iovs []Iovec) (n int, err error) = SYS_WRITEV
+ //sys	preadv(fd int, iovs []Iovec, offs_l uintptr, offs_h uintptr) (n int, err error) = SYS_PREADV
+@@ -2454,6 +2443,7 @@ func Getresgid() (rgid, egid, sgid int) {
+ 	return int(r), int(e), int(s)
+ }
+ 
++<<<<<<< HEAD
+ /*
+  * Unimplemented
+  */
+@@ -2549,3 +2539,60 @@ func Getresgid() (rgid, egid, sgid int) {
+ // Vhangup
+ // Vserver
+ // _Sysctl
++=======
++// Pselect is a wrapper around the Linux pselect6 system call.
++// This version does not modify the timeout argument.
++func Pselect(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
++	// Per https://man7.org/linux/man-pages/man2/select.2.html#NOTES,
++	// The Linux pselect6() system call modifies its timeout argument.
++	// [Not modifying the argument] is the behavior required by POSIX.1-2001.
++	var mutableTimeout *Timespec
++	if timeout != nil {
++		mutableTimeout = new(Timespec)
++		*mutableTimeout = *timeout
++	}
++
++	// The final argument of the pselect6() system call is not a
++	// sigset_t * pointer, but is instead a structure
++	var kernelMask *sigset_argpack
++	if sigmask != nil {
++		wordBits := 32 << (^uintptr(0) >> 63) // see math.intSize
++
++		// A sigset stores one bit per signal,
++		// offset by 1 (because signal 0 does not exist).
++		// So the number of words needed is ⌈__C_NSIG - 1 / wordBits⌉.
++		sigsetWords := (_C__NSIG - 1 + wordBits - 1) / (wordBits)
++
++		sigsetBytes := uintptr(sigsetWords * (wordBits / 8))
++		kernelMask = &sigset_argpack{
++			ss:    sigmask,
++			ssLen: sigsetBytes,
++		}
++	}
++
++	return pselect6(nfd, r, w, e, mutableTimeout, kernelMask)
++}
++
++//sys	schedSetattr(pid int, attr *SchedAttr, flags uint) (err error)
++//sys	schedGetattr(pid int, attr *SchedAttr, size uint, flags uint) (err error)
++
++// SchedSetAttr is a wrapper for sched_setattr(2) syscall.
++// https://man7.org/linux/man-pages/man2/sched_setattr.2.html
++func SchedSetAttr(pid int, attr *SchedAttr, flags uint) error {
++	if attr == nil {
++		return EINVAL
++	}
++	attr.Size = SizeofSchedAttr
++	return schedSetattr(pid, attr, flags)
++}
++
++// SchedGetAttr is a wrapper for sched_getattr(2) syscall.
++// https://man7.org/linux/man-pages/man2/sched_getattr.2.html
++func SchedGetAttr(pid int, flags uint) (*SchedAttr, error) {
++	attr := &SchedAttr{}
++	if err := schedGetattr(pid, attr, SizeofSchedAttr, flags); err != nil {
++		return nil, err
++	}
++	return attr, nil
++}
++>>>>>>> 48ed37b (CVE-2023-44487: bump golang.org/x/net to v0.17.0)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_netbsd.go b/vendor/golang.org/x/sys/unix/syscall_netbsd.go
+index 018d7d4..8816209 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_netbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_netbsd.go
+@@ -356,266 +356,16 @@ func Statvfs(path string, buf *Statvfs_t) (err error) {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+ 
+-/*
+- * Unimplemented
+- */
+-// ____semctl13
+-// __clone
+-// __fhopen40
+-// __fhstat40
+-// __fhstatvfs140
+-// __fstat30
+-// __getcwd
+-// __getfh30
+-// __getlogin
+-// __lstat30
+-// __mount50
+-// __msgctl13
+-// __msync13
+-// __ntp_gettime30
+-// __posix_chown
+-// __posix_fchown
+-// __posix_lchown
+-// __posix_rename
+-// __setlogin
+-// __shmctl13
+-// __sigaction_sigtramp
+-// __sigaltstack14
+-// __sigpending14
+-// __sigprocmask14
+-// __sigsuspend14
+-// __sigtimedwait
+-// __stat30
+-// __syscall
+-// __vfork14
+-// _ksem_close
+-// _ksem_destroy
+-// _ksem_getvalue
+-// _ksem_init
+-// _ksem_open
+-// _ksem_post
+-// _ksem_trywait
+-// _ksem_unlink
+-// _ksem_wait
+-// _lwp_continue
+-// _lwp_create
+-// _lwp_ctl
+-// _lwp_detach
+-// _lwp_exit
+-// _lwp_getname
+-// _lwp_getprivate
+-// _lwp_kill
+-// _lwp_park
+-// _lwp_self
+-// _lwp_setname
+-// _lwp_setprivate
+-// _lwp_suspend
+-// _lwp_unpark
+-// _lwp_unpark_all
+-// _lwp_wait
+-// _lwp_wakeup
+-// _pset_bind
+-// _sched_getaffinity
+-// _sched_getparam
+-// _sched_setaffinity
+-// _sched_setparam
+-// acct
+-// aio_cancel
+-// aio_error
+-// aio_fsync
+-// aio_read
+-// aio_return
+-// aio_suspend
+-// aio_write
+-// break
+-// clock_getres
+-// clock_gettime
+-// clock_settime
+-// compat_09_ogetdomainname
+-// compat_09_osetdomainname
+-// compat_09_ouname
+-// compat_10_omsgsys
+-// compat_10_osemsys
+-// compat_10_oshmsys
+-// compat_12_fstat12
+-// compat_12_getdirentries
+-// compat_12_lstat12
+-// compat_12_msync
+-// compat_12_oreboot
+-// compat_12_oswapon
+-// compat_12_stat12
+-// compat_13_sigaction13
+-// compat_13_sigaltstack13
+-// compat_13_sigpending13
+-// compat_13_sigprocmask13
+-// compat_13_sigreturn13
+-// compat_13_sigsuspend13
+-// compat_14___semctl
+-// compat_14_msgctl
+-// compat_14_shmctl
+-// compat_16___sigaction14
+-// compat_16___sigreturn14
+-// compat_20_fhstatfs
+-// compat_20_fstatfs
+-// compat_20_getfsstat
+-// compat_20_statfs
+-// compat_30___fhstat30
+-// compat_30___fstat13
+-// compat_30___lstat13
+-// compat_30___stat13
+-// compat_30_fhopen
+-// compat_30_fhstat
+-// compat_30_fhstatvfs1
+-// compat_30_getdents
+-// compat_30_getfh
+-// compat_30_ntp_gettime
+-// compat_30_socket
+-// compat_40_mount
+-// compat_43_fstat43
+-// compat_43_lstat43
+-// compat_43_oaccept
+-// compat_43_ocreat
+-// compat_43_oftruncate
+-// compat_43_ogetdirentries
+-// compat_43_ogetdtablesize
+-// compat_43_ogethostid
+-// compat_43_ogethostname
+-// compat_43_ogetkerninfo
+-// compat_43_ogetpagesize
+-// compat_43_ogetpeername
+-// compat_43_ogetrlimit
+-// compat_43_ogetsockname
+-// compat_43_okillpg
+-// compat_43_olseek
+-// compat_43_ommap
+-// compat_43_oquota
+-// compat_43_orecv
+-// compat_43_orecvfrom
+-// compat_43_orecvmsg
+-// compat_43_osend
+-// compat_43_osendmsg
+-// compat_43_osethostid
+-// compat_43_osethostname
+-// compat_43_osigblock
+-// compat_43_osigsetmask
+-// compat_43_osigstack
+-// compat_43_osigvec
+-// compat_43_otruncate
+-// compat_43_owait
+-// compat_43_stat43
+-// execve
+-// extattr_delete_fd
+-// extattr_delete_file
+-// extattr_delete_link
+-// extattr_get_fd
+-// extattr_get_file
+-// extattr_get_link
+-// extattr_list_fd
+-// extattr_list_file
+-// extattr_list_link
+-// extattr_set_fd
+-// extattr_set_file
+-// extattr_set_link
+-// extattrctl
+-// fchroot
+-// fdatasync
+-// fgetxattr
+-// fktrace
+-// flistxattr
+-// fork
+-// fremovexattr
+-// fsetxattr
+-// fstatvfs1
+-// fsync_range
+-// getcontext
+-// getitimer
+-// getvfsstat
+-// getxattr
+-// ktrace
+-// lchflags
+-// lchmod
+-// lfs_bmapv
+-// lfs_markv
+-// lfs_segclean
+-// lfs_segwait
+-// lgetxattr
+-// lio_listio
+-// listxattr
+-// llistxattr
+-// lremovexattr
+-// lseek
+-// lsetxattr
+-// lutimes
+-// madvise
+-// mincore
+-// minherit
+-// modctl
+-// mq_close
+-// mq_getattr
+-// mq_notify
+-// mq_open
+-// mq_receive
+-// mq_send
+-// mq_setattr
+-// mq_timedreceive
+-// mq_timedsend
+-// mq_unlink
+-// mremap
+-// msgget
+-// msgrcv
+-// msgsnd
+-// nfssvc
+-// ntp_adjtime
+-// pmc_control
+-// pmc_get_info
+-// pollts
+-// preadv
+-// profil
+-// pselect
+-// pset_assign
+-// pset_create
+-// pset_destroy
+-// ptrace
+-// pwritev
+-// quotactl
+-// rasctl
+-// readv
+-// reboot
+-// removexattr
+-// sa_enable
+-// sa_preempt
+-// sa_register
+-// sa_setconcurrency
+-// sa_stacks
+-// sa_yield
+-// sbrk
+-// sched_yield
+-// semconfig
+-// semget
+-// semop
+-// setcontext
+-// setitimer
+-// setxattr
+-// shmat
+-// shmdt
+-// shmget
+-// sstk
+-// statvfs1
+-// swapctl
+-// sysarch
+-// syscall
+-// timer_create
+-// timer_delete
+-// timer_getoverrun
+-// timer_gettime
+-// timer_settime
+-// undelete
+-// utrace
+-// uuidgen
+-// vadvise
+-// vfork
+-// writev
++const (
++	mremapFixed     = MAP_FIXED
++	mremapDontunmap = 0
++	mremapMaymove   = 0
++)
++
++//sys	mremapNetBSD(oldp uintptr, oldsize uintptr, newp uintptr, newsize uintptr, flags int) (xaddr uintptr, err error) = SYS_MREMAP
++
++func mremap(oldaddr uintptr, oldlength uintptr, newlength uintptr, flags int, newaddr uintptr) (uintptr, error) {
++	return mremapNetBSD(oldaddr, oldlength, newaddr, newlength, flags)
++}
+diff --git a/vendor/golang.org/x/sys/unix/syscall_openbsd.go b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+index c5f166a..6f34479 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_openbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+@@ -326,78 +326,4 @@ func Uname(uname *Utsname) error {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- */
+-// __getcwd
+-// __semctl
+-// __syscall
+-// __sysctl
+-// adjfreq
+-// break
+-// clock_getres
+-// clock_gettime
+-// clock_settime
+-// closefrom
+-// execve
+-// fhopen
+-// fhstat
+-// fhstatfs
+-// fork
+-// futimens
+-// getfh
+-// getgid
+-// getitimer
+-// getlogin
+-// getthrid
+-// ktrace
+-// lfs_bmapv
+-// lfs_markv
+-// lfs_segclean
+-// lfs_segwait
+-// mincore
+-// minherit
+-// mount
+-// mquery
+-// msgctl
+-// msgget
+-// msgrcv
+-// msgsnd
+-// nfssvc
+-// nnpfspioctl
+-// preadv
+-// profil
+-// pwritev
+-// quotactl
+-// readv
+-// reboot
+-// renameat
+-// rfork
+-// sched_yield
+-// semget
+-// semop
+-// setgroups
+-// setitimer
+-// setsockopt
+-// shmat
+-// shmctl
+-// shmdt
+-// shmget
+-// sigaction
+-// sigaltstack
+-// sigpending
+-// sigprocmask
+-// sigreturn
+-// sigsuspend
+-// sysarch
+-// syscall
+-// threxit
+-// thrsigdivert
+-// thrsleep
+-// thrwakeup
+-// vfork
+-// writev
+diff --git a/vendor/golang.org/x/sys/unix/syscall_solaris.go b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+index b600a28..b99cfa1 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
++++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+@@ -698,38 +698,6 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ //sys	setsockopt(s int, level int, name int, val unsafe.Pointer, vallen uintptr) (err error) = libsocket.setsockopt
+ //sys	recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Socklen) (n int, err error) = libsocket.recvfrom
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procread)), 3, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf), 0, 0, 0)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = e1
+-	}
+-	return
+-}
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwrite)), 3, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf), 0, 0, 0)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = e1
+-	}
+-	return
+-}
+-
+-var mapper = &mmapper{
+-	active: make(map[*byte][]byte),
+-	mmap:   mmap,
+-	munmap: munmap,
+-}
+-
+-func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
+-	return mapper.Mmap(fd, offset, length, prot, flags)
+-}
+-
+-func Munmap(b []byte) (err error) {
+-	return mapper.Munmap(b)
+-}
+-
+ // Event Ports
+ 
+ type fileObjCookie struct {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_unix.go b/vendor/golang.org/x/sys/unix/syscall_unix.go
+index 8e48c29..a4b2c98 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_unix.go
++++ b/vendor/golang.org/x/sys/unix/syscall_unix.go
+@@ -541,6 +541,9 @@ func SetNonblock(fd int, nonblocking bool) (err error) {
+ 	if err != nil {
+ 		return err
+ 	}
++	if (flag&O_NONBLOCK != 0) == nonblocking {
++		return nil
++	}
+ 	if nonblocking {
+ 		flag |= O_NONBLOCK
+ 	} else {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+index d3d49ec..799302f 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+@@ -192,7 +192,6 @@ func (cmsg *Cmsghdr) SetLen(length int) {
+ 
+ //sys   fcntl(fd int, cmd int, arg int) (val int, err error)
+ //sys	read(fd int, p []byte) (n int, err error)
+-//sys   readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+ //sys	write(fd int, p []byte) (n int, err error)
+ 
+ //sys	accept(s int, rsa *RawSockaddrAny, addrlen *_Socklen) (fd int, err error) = SYS___ACCEPT_A
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index 3784f40..f9c7f47 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -2421,6 +2421,15 @@ const (
+ 	PR_PAC_GET_ENABLED_KEYS                     = 0x3d
+ 	PR_PAC_RESET_KEYS                           = 0x36
+ 	PR_PAC_SET_ENABLED_KEYS                     = 0x3c
++	PR_RISCV_V_GET_CONTROL                      = 0x46
++	PR_RISCV_V_SET_CONTROL                      = 0x45
++	PR_RISCV_V_VSTATE_CTRL_CUR_MASK             = 0x3
++	PR_RISCV_V_VSTATE_CTRL_DEFAULT              = 0x0
++	PR_RISCV_V_VSTATE_CTRL_INHERIT              = 0x10
++	PR_RISCV_V_VSTATE_CTRL_MASK                 = 0x1f
++	PR_RISCV_V_VSTATE_CTRL_NEXT_MASK            = 0xc
++	PR_RISCV_V_VSTATE_CTRL_OFF                  = 0x1
++	PR_RISCV_V_VSTATE_CTRL_ON                   = 0x2
+ 	PR_SCHED_CORE                               = 0x3e
+ 	PR_SCHED_CORE_CREATE                        = 0x1
+ 	PR_SCHED_CORE_GET                           = 0x0
+@@ -2821,6 +2830,23 @@ const (
+ 	RWF_SUPPORTED                               = 0x1f
+ 	RWF_SYNC                                    = 0x4
+ 	RWF_WRITE_LIFE_NOT_SET                      = 0x0
++	SCHED_BATCH                                 = 0x3
++	SCHED_DEADLINE                              = 0x6
++	SCHED_FIFO                                  = 0x1
++	SCHED_FLAG_ALL                              = 0x7f
++	SCHED_FLAG_DL_OVERRUN                       = 0x4
++	SCHED_FLAG_KEEP_ALL                         = 0x18
++	SCHED_FLAG_KEEP_PARAMS                      = 0x10
++	SCHED_FLAG_KEEP_POLICY                      = 0x8
++	SCHED_FLAG_RECLAIM                          = 0x2
++	SCHED_FLAG_RESET_ON_FORK                    = 0x1
++	SCHED_FLAG_UTIL_CLAMP                       = 0x60
++	SCHED_FLAG_UTIL_CLAMP_MAX                   = 0x40
++	SCHED_FLAG_UTIL_CLAMP_MIN                   = 0x20
++	SCHED_IDLE                                  = 0x5
++	SCHED_NORMAL                                = 0x0
++	SCHED_RESET_ON_FORK                         = 0x40000000
++	SCHED_RR                                    = 0x2
+ 	SCM_CREDENTIALS                             = 0x2
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index a46df0f..c5aeab3 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index 6cd4a3e..6b9fda9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -318,10 +318,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c7ebee2..f015600 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -324,10 +324,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 12a9a13..f760f2a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -314,10 +314,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index f26a164..12f266c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -109,6 +109,8 @@ const (
+ 	IUCLC                            = 0x200
+ 	IXOFF                            = 0x1000
+ 	IXON                             = 0x400
++	LASX_CTX_MAGIC                   = 0x41535801
++	LSX_CTX_MAGIC                    = 0x53580001
+ 	MAP_ANON                         = 0x20
+ 	MAP_ANONYMOUS                    = 0x20
+ 	MAP_DENYWRITE                    = 0x800
+@@ -308,10 +310,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 890bc3c..7fd3806 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 549f26a..c38d426 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index e0365e3..17a5f97 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index fdccce1..b73088d 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index b2205c8..80b8d52 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -372,10 +372,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 81aa5ad..8292e16 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -376,10 +376,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index 76807a1..bb1ebb8 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -376,10 +376,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index d4a5ab9..28006d4 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -305,10 +305,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 66e65db..75e263b 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -380,10 +380,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 4898420..5d2d76a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -419,10 +419,12 @@ const (
+ 	SO_NOFCS                         = 0x27
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x2
++	SO_PASSPIDFD                     = 0x55
+ 	SO_PASSSEC                       = 0x1f
+ 	SO_PEEK_OFF                      = 0x26
+ 	SO_PEERCRED                      = 0x40
+ 	SO_PEERGROUPS                    = 0x3d
++	SO_PEERPIDFD                     = 0x56
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x48
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
+index 9a25721..d1d1d23 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
+@@ -817,28 +817,6 @@ func write(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, er := C.read(C.int(fd), C.uintptr_t(uintptr(unsafe.Pointer(p))), C.size_t(np))
+-	n = int(r0)
+-	if r0 == -1 && er != nil {
+-		err = er
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, er := C.write(C.int(fd), C.uintptr_t(uintptr(unsafe.Pointer(p))), C.size_t(np))
+-	n = int(r0)
+-	if r0 == -1 && er != nil {
+-		err = er
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	r0, er := C.dup2(C.int(oldfd), C.int(newfd))
+ 	if r0 == -1 && er != nil {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
+index 6de80c2..f99a18a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
+@@ -762,28 +762,6 @@ func write(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, e1 := callread(fd, uintptr(unsafe.Pointer(p)), np)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, e1 := callwrite(fd, uintptr(unsafe.Pointer(p)), np)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	_, e1 := calldup2(oldfd, newfd)
+ 	if e1 != 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
+index 4037ccf..1cad561 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
+@@ -725,6 +725,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -733,10 +739,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2410,28 +2412,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_fstat64_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0)
+ 	if e1 != 0 {
+@@ -2521,14 +2501,6 @@ func ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return
+ }
+ 
+-func ptrace1Ptr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	_, _, e1 := syscall_syscall6(libc_ptrace_trampoline_addr, uintptr(request), uintptr(pid), addr, uintptr(data), 0, 0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+ var libc_ptrace_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_ptrace ptrace "/usr/lib/libSystem.B.dylib"
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
+index 4baaed0..8b8bb28 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
+@@ -5,703 +5,586 @@
+ 
+ TEXT libc_fdopendir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fdopendir(SB)
+-
+ GLOBL	·libc_fdopendir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fdopendir_trampoline_addr(SB)/8, $libc_fdopendir_trampoline<>(SB)
+ 
+ TEXT libc_getgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgroups(SB)
+-
+ GLOBL	·libc_getgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgroups_trampoline_addr(SB)/8, $libc_getgroups_trampoline<>(SB)
+ 
+ TEXT libc_setgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgroups(SB)
+-
+ GLOBL	·libc_setgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgroups_trampoline_addr(SB)/8, $libc_setgroups_trampoline<>(SB)
+ 
+ TEXT libc_wait4_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_wait4(SB)
+-
+ GLOBL	·libc_wait4_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_wait4_trampoline_addr(SB)/8, $libc_wait4_trampoline<>(SB)
+ 
+ TEXT libc_accept_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_accept(SB)
+-
+ GLOBL	·libc_accept_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_accept_trampoline_addr(SB)/8, $libc_accept_trampoline<>(SB)
+ 
+ TEXT libc_bind_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_bind(SB)
+-
+ GLOBL	·libc_bind_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_bind_trampoline_addr(SB)/8, $libc_bind_trampoline<>(SB)
+ 
+ TEXT libc_connect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_connect(SB)
+-
+ GLOBL	·libc_connect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_connect_trampoline_addr(SB)/8, $libc_connect_trampoline<>(SB)
+ 
+ TEXT libc_socket_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socket(SB)
+-
+ GLOBL	·libc_socket_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socket_trampoline_addr(SB)/8, $libc_socket_trampoline<>(SB)
+ 
+ TEXT libc_getsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockopt(SB)
+-
+ GLOBL	·libc_getsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockopt_trampoline_addr(SB)/8, $libc_getsockopt_trampoline<>(SB)
+ 
+ TEXT libc_setsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsockopt(SB)
+-
+ GLOBL	·libc_setsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsockopt_trampoline_addr(SB)/8, $libc_setsockopt_trampoline<>(SB)
+ 
+ TEXT libc_getpeername_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpeername(SB)
+-
+ GLOBL	·libc_getpeername_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpeername_trampoline_addr(SB)/8, $libc_getpeername_trampoline<>(SB)
+ 
+ TEXT libc_getsockname_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockname(SB)
+-
+ GLOBL	·libc_getsockname_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockname_trampoline_addr(SB)/8, $libc_getsockname_trampoline<>(SB)
+ 
+ TEXT libc_shutdown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shutdown(SB)
+-
+ GLOBL	·libc_shutdown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shutdown_trampoline_addr(SB)/8, $libc_shutdown_trampoline<>(SB)
+ 
+ TEXT libc_socketpair_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socketpair(SB)
+-
+ GLOBL	·libc_socketpair_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socketpair_trampoline_addr(SB)/8, $libc_socketpair_trampoline<>(SB)
+ 
+ TEXT libc_recvfrom_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvfrom(SB)
+-
+ GLOBL	·libc_recvfrom_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvfrom_trampoline_addr(SB)/8, $libc_recvfrom_trampoline<>(SB)
+ 
+ TEXT libc_sendto_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendto(SB)
+-
+ GLOBL	·libc_sendto_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendto_trampoline_addr(SB)/8, $libc_sendto_trampoline<>(SB)
+ 
+ TEXT libc_recvmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvmsg(SB)
+-
+ GLOBL	·libc_recvmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvmsg_trampoline_addr(SB)/8, $libc_recvmsg_trampoline<>(SB)
+ 
+ TEXT libc_sendmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendmsg(SB)
+-
+ GLOBL	·libc_sendmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendmsg_trampoline_addr(SB)/8, $libc_sendmsg_trampoline<>(SB)
+ 
+ TEXT libc_kevent_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kevent(SB)
+-
+ GLOBL	·libc_kevent_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kevent_trampoline_addr(SB)/8, $libc_kevent_trampoline<>(SB)
+ 
+ TEXT libc_utimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimes(SB)
+-
+ GLOBL	·libc_utimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimes_trampoline_addr(SB)/8, $libc_utimes_trampoline<>(SB)
+ 
+ TEXT libc_futimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_futimes(SB)
+-
+ GLOBL	·libc_futimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_futimes_trampoline_addr(SB)/8, $libc_futimes_trampoline<>(SB)
+ 
+ TEXT libc_poll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_poll(SB)
+-
+ GLOBL	·libc_poll_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_poll_trampoline_addr(SB)/8, $libc_poll_trampoline<>(SB)
+ 
+ TEXT libc_madvise_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_madvise(SB)
+-
+ GLOBL	·libc_madvise_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_madvise_trampoline_addr(SB)/8, $libc_madvise_trampoline<>(SB)
+ 
+ TEXT libc_mlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlock(SB)
+-
+ GLOBL	·libc_mlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlock_trampoline_addr(SB)/8, $libc_mlock_trampoline<>(SB)
+ 
+ TEXT libc_mlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlockall(SB)
+-
+ GLOBL	·libc_mlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlockall_trampoline_addr(SB)/8, $libc_mlockall_trampoline<>(SB)
+ 
+ TEXT libc_mprotect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mprotect(SB)
+-
+ GLOBL	·libc_mprotect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mprotect_trampoline_addr(SB)/8, $libc_mprotect_trampoline<>(SB)
+ 
+ TEXT libc_msync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_msync(SB)
+-
+ GLOBL	·libc_msync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_msync_trampoline_addr(SB)/8, $libc_msync_trampoline<>(SB)
+ 
+ TEXT libc_munlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlock(SB)
+-
+ GLOBL	·libc_munlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlock_trampoline_addr(SB)/8, $libc_munlock_trampoline<>(SB)
+ 
+ TEXT libc_munlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlockall(SB)
+-
+ GLOBL	·libc_munlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlockall_trampoline_addr(SB)/8, $libc_munlockall_trampoline<>(SB)
+ 
+ TEXT libc_closedir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_closedir(SB)
+-
+ GLOBL	·libc_closedir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_closedir_trampoline_addr(SB)/8, $libc_closedir_trampoline<>(SB)
+ 
+ TEXT libc_readdir_r_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readdir_r(SB)
+-
+ GLOBL	·libc_readdir_r_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readdir_r_trampoline_addr(SB)/8, $libc_readdir_r_trampoline<>(SB)
+ 
+ TEXT libc_pipe_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pipe(SB)
+-
+ GLOBL	·libc_pipe_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pipe_trampoline_addr(SB)/8, $libc_pipe_trampoline<>(SB)
+ 
+ TEXT libc_getxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getxattr(SB)
+-
+ GLOBL	·libc_getxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getxattr_trampoline_addr(SB)/8, $libc_getxattr_trampoline<>(SB)
+ 
+ TEXT libc_fgetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fgetxattr(SB)
+-
+ GLOBL	·libc_fgetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fgetxattr_trampoline_addr(SB)/8, $libc_fgetxattr_trampoline<>(SB)
+ 
+ TEXT libc_setxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setxattr(SB)
+-
+ GLOBL	·libc_setxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setxattr_trampoline_addr(SB)/8, $libc_setxattr_trampoline<>(SB)
+ 
+ TEXT libc_fsetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsetxattr(SB)
+-
+ GLOBL	·libc_fsetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsetxattr_trampoline_addr(SB)/8, $libc_fsetxattr_trampoline<>(SB)
+ 
+ TEXT libc_removexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_removexattr(SB)
+-
+ GLOBL	·libc_removexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_removexattr_trampoline_addr(SB)/8, $libc_removexattr_trampoline<>(SB)
+ 
+ TEXT libc_fremovexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fremovexattr(SB)
+-
+ GLOBL	·libc_fremovexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fremovexattr_trampoline_addr(SB)/8, $libc_fremovexattr_trampoline<>(SB)
+ 
+ TEXT libc_listxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listxattr(SB)
+-
+ GLOBL	·libc_listxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listxattr_trampoline_addr(SB)/8, $libc_listxattr_trampoline<>(SB)
+ 
+ TEXT libc_flistxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flistxattr(SB)
+-
+ GLOBL	·libc_flistxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flistxattr_trampoline_addr(SB)/8, $libc_flistxattr_trampoline<>(SB)
+ 
+ TEXT libc_utimensat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimensat(SB)
+-
+ GLOBL	·libc_utimensat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimensat_trampoline_addr(SB)/8, $libc_utimensat_trampoline<>(SB)
+ 
+ TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fcntl(SB)
+-
+ GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
+ 
+ TEXT libc_kill_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kill(SB)
+-
+ GLOBL	·libc_kill_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kill_trampoline_addr(SB)/8, $libc_kill_trampoline<>(SB)
+ 
+ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ioctl(SB)
+-
+ GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
+ 
+ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sysctl(SB)
+-
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
+ TEXT libc_sendfile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendfile(SB)
+-
+ GLOBL	·libc_sendfile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendfile_trampoline_addr(SB)/8, $libc_sendfile_trampoline<>(SB)
+ 
+ TEXT libc_shmat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmat(SB)
+-
+ GLOBL	·libc_shmat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmat_trampoline_addr(SB)/8, $libc_shmat_trampoline<>(SB)
+ 
+ TEXT libc_shmctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmctl(SB)
+-
+ GLOBL	·libc_shmctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmctl_trampoline_addr(SB)/8, $libc_shmctl_trampoline<>(SB)
+ 
+ TEXT libc_shmdt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmdt(SB)
+-
+ GLOBL	·libc_shmdt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmdt_trampoline_addr(SB)/8, $libc_shmdt_trampoline<>(SB)
+ 
+ TEXT libc_shmget_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmget(SB)
+-
+ GLOBL	·libc_shmget_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmget_trampoline_addr(SB)/8, $libc_shmget_trampoline<>(SB)
+ 
+ TEXT libc_access_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_access(SB)
+-
+ GLOBL	·libc_access_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_access_trampoline_addr(SB)/8, $libc_access_trampoline<>(SB)
+ 
+ TEXT libc_adjtime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_adjtime(SB)
+-
+ GLOBL	·libc_adjtime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_adjtime_trampoline_addr(SB)/8, $libc_adjtime_trampoline<>(SB)
+ 
+ TEXT libc_chdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chdir(SB)
+-
+ GLOBL	·libc_chdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chdir_trampoline_addr(SB)/8, $libc_chdir_trampoline<>(SB)
+ 
+ TEXT libc_chflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chflags(SB)
+-
+ GLOBL	·libc_chflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chflags_trampoline_addr(SB)/8, $libc_chflags_trampoline<>(SB)
+ 
+ TEXT libc_chmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chmod(SB)
+-
+ GLOBL	·libc_chmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chmod_trampoline_addr(SB)/8, $libc_chmod_trampoline<>(SB)
+ 
+ TEXT libc_chown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chown(SB)
+-
+ GLOBL	·libc_chown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chown_trampoline_addr(SB)/8, $libc_chown_trampoline<>(SB)
+ 
+ TEXT libc_chroot_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chroot(SB)
+-
+ GLOBL	·libc_chroot_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chroot_trampoline_addr(SB)/8, $libc_chroot_trampoline<>(SB)
+ 
+ TEXT libc_clock_gettime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clock_gettime(SB)
+-
+ GLOBL	·libc_clock_gettime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clock_gettime_trampoline_addr(SB)/8, $libc_clock_gettime_trampoline<>(SB)
+ 
+ TEXT libc_close_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_close(SB)
+-
+ GLOBL	·libc_close_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_close_trampoline_addr(SB)/8, $libc_close_trampoline<>(SB)
+ 
+ TEXT libc_clonefile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefile(SB)
+-
+ GLOBL	·libc_clonefile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefile_trampoline_addr(SB)/8, $libc_clonefile_trampoline<>(SB)
+ 
+ TEXT libc_clonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefileat(SB)
+-
+ GLOBL	·libc_clonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefileat_trampoline_addr(SB)/8, $libc_clonefileat_trampoline<>(SB)
+ 
+ TEXT libc_dup_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup(SB)
+-
+ GLOBL	·libc_dup_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup_trampoline_addr(SB)/8, $libc_dup_trampoline<>(SB)
+ 
+ TEXT libc_dup2_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup2(SB)
+-
+ GLOBL	·libc_dup2_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup2_trampoline_addr(SB)/8, $libc_dup2_trampoline<>(SB)
+ 
+ TEXT libc_exchangedata_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exchangedata(SB)
+-
+ GLOBL	·libc_exchangedata_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exchangedata_trampoline_addr(SB)/8, $libc_exchangedata_trampoline<>(SB)
+ 
+ TEXT libc_exit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exit(SB)
+-
+ GLOBL	·libc_exit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exit_trampoline_addr(SB)/8, $libc_exit_trampoline<>(SB)
+ 
+ TEXT libc_faccessat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_faccessat(SB)
+-
+ GLOBL	·libc_faccessat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_faccessat_trampoline_addr(SB)/8, $libc_faccessat_trampoline<>(SB)
+ 
+ TEXT libc_fchdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchdir(SB)
+-
+ GLOBL	·libc_fchdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchdir_trampoline_addr(SB)/8, $libc_fchdir_trampoline<>(SB)
+ 
+ TEXT libc_fchflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchflags(SB)
+-
+ GLOBL	·libc_fchflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchflags_trampoline_addr(SB)/8, $libc_fchflags_trampoline<>(SB)
+ 
+ TEXT libc_fchmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmod(SB)
+-
+ GLOBL	·libc_fchmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmod_trampoline_addr(SB)/8, $libc_fchmod_trampoline<>(SB)
+ 
+ TEXT libc_fchmodat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmodat(SB)
+-
+ GLOBL	·libc_fchmodat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmodat_trampoline_addr(SB)/8, $libc_fchmodat_trampoline<>(SB)
+ 
+ TEXT libc_fchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchown(SB)
+-
+ GLOBL	·libc_fchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchown_trampoline_addr(SB)/8, $libc_fchown_trampoline<>(SB)
+ 
+ TEXT libc_fchownat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchownat(SB)
+-
+ GLOBL	·libc_fchownat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchownat_trampoline_addr(SB)/8, $libc_fchownat_trampoline<>(SB)
+ 
+ TEXT libc_fclonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fclonefileat(SB)
+-
+ GLOBL	·libc_fclonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fclonefileat_trampoline_addr(SB)/8, $libc_fclonefileat_trampoline<>(SB)
+ 
+ TEXT libc_flock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flock(SB)
+-
+ GLOBL	·libc_flock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flock_trampoline_addr(SB)/8, $libc_flock_trampoline<>(SB)
+ 
+ TEXT libc_fpathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fpathconf(SB)
+-
+ GLOBL	·libc_fpathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fpathconf_trampoline_addr(SB)/8, $libc_fpathconf_trampoline<>(SB)
+ 
+ TEXT libc_fsync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsync(SB)
+-
+ GLOBL	·libc_fsync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsync_trampoline_addr(SB)/8, $libc_fsync_trampoline<>(SB)
+ 
+ TEXT libc_ftruncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ftruncate(SB)
+-
+ GLOBL	·libc_ftruncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ftruncate_trampoline_addr(SB)/8, $libc_ftruncate_trampoline<>(SB)
+ 
+ TEXT libc_getcwd_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getcwd(SB)
+-
+ GLOBL	·libc_getcwd_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getcwd_trampoline_addr(SB)/8, $libc_getcwd_trampoline<>(SB)
+ 
+ TEXT libc_getdtablesize_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getdtablesize(SB)
+-
+ GLOBL	·libc_getdtablesize_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getdtablesize_trampoline_addr(SB)/8, $libc_getdtablesize_trampoline<>(SB)
+ 
+ TEXT libc_getegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getegid(SB)
+-
+ GLOBL	·libc_getegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getegid_trampoline_addr(SB)/8, $libc_getegid_trampoline<>(SB)
+ 
+ TEXT libc_geteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_geteuid(SB)
+-
+ GLOBL	·libc_geteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_geteuid_trampoline_addr(SB)/8, $libc_geteuid_trampoline<>(SB)
+ 
+ TEXT libc_getgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgid(SB)
+-
+ GLOBL	·libc_getgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgid_trampoline_addr(SB)/8, $libc_getgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgid(SB)
+-
+ GLOBL	·libc_getpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgid_trampoline_addr(SB)/8, $libc_getpgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgrp_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgrp(SB)
+-
+ GLOBL	·libc_getpgrp_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgrp_trampoline_addr(SB)/8, $libc_getpgrp_trampoline<>(SB)
+ 
+ TEXT libc_getpid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpid(SB)
+-
+ GLOBL	·libc_getpid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpid_trampoline_addr(SB)/8, $libc_getpid_trampoline<>(SB)
+ 
+ TEXT libc_getppid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getppid(SB)
+-
+ GLOBL	·libc_getppid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getppid_trampoline_addr(SB)/8, $libc_getppid_trampoline<>(SB)
+ 
+ TEXT libc_getpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpriority(SB)
+-
+ GLOBL	·libc_getpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpriority_trampoline_addr(SB)/8, $libc_getpriority_trampoline<>(SB)
+ 
+ TEXT libc_getrlimit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrlimit(SB)
+-
+ GLOBL	·libc_getrlimit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrlimit_trampoline_addr(SB)/8, $libc_getrlimit_trampoline<>(SB)
+ 
+ TEXT libc_getrusage_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrusage(SB)
+-
+ GLOBL	·libc_getrusage_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrusage_trampoline_addr(SB)/8, $libc_getrusage_trampoline<>(SB)
+ 
+ TEXT libc_getsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsid(SB)
+-
+ GLOBL	·libc_getsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsid_trampoline_addr(SB)/8, $libc_getsid_trampoline<>(SB)
+ 
+ TEXT libc_gettimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_gettimeofday(SB)
+-
+ GLOBL	·libc_gettimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_gettimeofday_trampoline_addr(SB)/8, $libc_gettimeofday_trampoline<>(SB)
+ 
+ TEXT libc_getuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getuid(SB)
+-
+ GLOBL	·libc_getuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getuid_trampoline_addr(SB)/8, $libc_getuid_trampoline<>(SB)
+ 
+ TEXT libc_issetugid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_issetugid(SB)
+-
+ GLOBL	·libc_issetugid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_issetugid_trampoline_addr(SB)/8, $libc_issetugid_trampoline<>(SB)
+ 
+ TEXT libc_kqueue_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kqueue(SB)
+-
+ GLOBL	·libc_kqueue_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kqueue_trampoline_addr(SB)/8, $libc_kqueue_trampoline<>(SB)
+ 
+ TEXT libc_lchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lchown(SB)
+-
+ GLOBL	·libc_lchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lchown_trampoline_addr(SB)/8, $libc_lchown_trampoline<>(SB)
+ 
+ TEXT libc_link_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_link(SB)
+-
+ GLOBL	·libc_link_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_link_trampoline_addr(SB)/8, $libc_link_trampoline<>(SB)
+ 
+ TEXT libc_linkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_linkat(SB)
+-
+ GLOBL	·libc_linkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_linkat_trampoline_addr(SB)/8, $libc_linkat_trampoline<>(SB)
+ 
+ TEXT libc_listen_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listen(SB)
+-
+ GLOBL	·libc_listen_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listen_trampoline_addr(SB)/8, $libc_listen_trampoline<>(SB)
+ 
+ TEXT libc_mkdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdir(SB)
+-
+ GLOBL	·libc_mkdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdir_trampoline_addr(SB)/8, $libc_mkdir_trampoline<>(SB)
+ 
+ TEXT libc_mkdirat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdirat(SB)
+-
+ GLOBL	·libc_mkdirat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdirat_trampoline_addr(SB)/8, $libc_mkdirat_trampoline<>(SB)
+ 
+ TEXT libc_mkfifo_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkfifo(SB)
+-
+ GLOBL	·libc_mkfifo_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkfifo_trampoline_addr(SB)/8, $libc_mkfifo_trampoline<>(SB)
+ 
+ TEXT libc_mknod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mknod(SB)
+-
+ GLOBL	·libc_mknod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mknod_trampoline_addr(SB)/8, $libc_mknod_trampoline<>(SB)
+ 
+ TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mount(SB)
+-
+ GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mount_trampoline_addr(SB)/8, $libc_mount_trampoline<>(SB)
+ 
+ TEXT libc_open_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_open(SB)
+-
+ GLOBL	·libc_open_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_open_trampoline_addr(SB)/8, $libc_open_trampoline<>(SB)
+ 
+ TEXT libc_openat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_openat(SB)
+-
+ GLOBL	·libc_openat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_openat_trampoline_addr(SB)/8, $libc_openat_trampoline<>(SB)
+ 
+ TEXT libc_pathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pathconf(SB)
+-
+ GLOBL	·libc_pathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pathconf_trampoline_addr(SB)/8, $libc_pathconf_trampoline<>(SB)
+ 
+ TEXT libc_pread_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pread(SB)
+-
+ GLOBL	·libc_pread_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pread_trampoline_addr(SB)/8, $libc_pread_trampoline<>(SB)
+ 
+ TEXT libc_pwrite_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pwrite(SB)
+-
+ GLOBL	·libc_pwrite_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pwrite_trampoline_addr(SB)/8, $libc_pwrite_trampoline<>(SB)
+ 
+ TEXT libc_read_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_read(SB)
+-
+ GLOBL	·libc_read_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_read_trampoline_addr(SB)/8, $libc_read_trampoline<>(SB)
+ 
+ TEXT libc_readlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlink(SB)
+-
+ GLOBL	·libc_readlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlink_trampoline_addr(SB)/8, $libc_readlink_trampoline<>(SB)
+ 
+ TEXT libc_readlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlinkat(SB)
+-
+ GLOBL	·libc_readlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlinkat_trampoline_addr(SB)/8, $libc_readlinkat_trampoline<>(SB)
+ 
+ TEXT libc_rename_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rename(SB)
+-
+ GLOBL	·libc_rename_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rename_trampoline_addr(SB)/8, $libc_rename_trampoline<>(SB)
+ 
+ TEXT libc_renameat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_renameat(SB)
+-
+ GLOBL	·libc_renameat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_renameat_trampoline_addr(SB)/8, $libc_renameat_trampoline<>(SB)
+ 
+ TEXT libc_revoke_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_revoke(SB)
+-
+ GLOBL	·libc_revoke_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_revoke_trampoline_addr(SB)/8, $libc_revoke_trampoline<>(SB)
+ 
+ TEXT libc_rmdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rmdir(SB)
+-
+ GLOBL	·libc_rmdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rmdir_trampoline_addr(SB)/8, $libc_rmdir_trampoline<>(SB)
+ 
+ TEXT libc_lseek_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lseek(SB)
+-
+ GLOBL	·libc_lseek_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lseek_trampoline_addr(SB)/8, $libc_lseek_trampoline<>(SB)
+ 
+ TEXT libc_select_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_select(SB)
+-
+ GLOBL	·libc_select_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_select_trampoline_addr(SB)/8, $libc_select_trampoline<>(SB)
+ 
+@@ -712,192 +595,160 @@ DATA	·libc_setattrlist_trampoline_addr(SB)/8, $libc_setattrlist_trampoline<>(SB
+ 
+ TEXT libc_setegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setegid(SB)
+-
+ GLOBL	·libc_setegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setegid_trampoline_addr(SB)/8, $libc_setegid_trampoline<>(SB)
+ 
+ TEXT libc_seteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_seteuid(SB)
+-
+ GLOBL	·libc_seteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_seteuid_trampoline_addr(SB)/8, $libc_seteuid_trampoline<>(SB)
+ 
+ TEXT libc_setgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgid(SB)
+-
+ GLOBL	·libc_setgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgid_trampoline_addr(SB)/8, $libc_setgid_trampoline<>(SB)
+ 
+ TEXT libc_setlogin_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setlogin(SB)
+-
+ GLOBL	·libc_setlogin_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setlogin_trampoline_addr(SB)/8, $libc_setlogin_trampoline<>(SB)
+ 
+ TEXT libc_setpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpgid(SB)
+-
+ GLOBL	·libc_setpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpgid_trampoline_addr(SB)/8, $libc_setpgid_trampoline<>(SB)
+ 
+ TEXT libc_setpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpriority(SB)
+-
+ GLOBL	·libc_setpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpriority_trampoline_addr(SB)/8, $libc_setpriority_trampoline<>(SB)
+ 
+ TEXT libc_setprivexec_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setprivexec(SB)
+-
+ GLOBL	·libc_setprivexec_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setprivexec_trampoline_addr(SB)/8, $libc_setprivexec_trampoline<>(SB)
+ 
+ TEXT libc_setregid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setregid(SB)
+-
+ GLOBL	·libc_setregid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setregid_trampoline_addr(SB)/8, $libc_setregid_trampoline<>(SB)
+ 
+ TEXT libc_setreuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setreuid(SB)
+-
+ GLOBL	·libc_setreuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setreuid_trampoline_addr(SB)/8, $libc_setreuid_trampoline<>(SB)
+ 
+ TEXT libc_setsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsid(SB)
+-
+ GLOBL	·libc_setsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsid_trampoline_addr(SB)/8, $libc_setsid_trampoline<>(SB)
+ 
+ TEXT libc_settimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_settimeofday(SB)
+-
+ GLOBL	·libc_settimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_settimeofday_trampoline_addr(SB)/8, $libc_settimeofday_trampoline<>(SB)
+ 
+ TEXT libc_setuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setuid(SB)
+-
+ GLOBL	·libc_setuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setuid_trampoline_addr(SB)/8, $libc_setuid_trampoline<>(SB)
+ 
+ TEXT libc_symlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlink(SB)
+-
+ GLOBL	·libc_symlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlink_trampoline_addr(SB)/8, $libc_symlink_trampoline<>(SB)
+ 
+ TEXT libc_symlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlinkat(SB)
+-
+ GLOBL	·libc_symlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlinkat_trampoline_addr(SB)/8, $libc_symlinkat_trampoline<>(SB)
+ 
+ TEXT libc_sync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sync(SB)
+-
+ GLOBL	·libc_sync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sync_trampoline_addr(SB)/8, $libc_sync_trampoline<>(SB)
+ 
+ TEXT libc_truncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_truncate(SB)
+-
+ GLOBL	·libc_truncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_truncate_trampoline_addr(SB)/8, $libc_truncate_trampoline<>(SB)
+ 
+ TEXT libc_umask_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_umask(SB)
+-
+ GLOBL	·libc_umask_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_umask_trampoline_addr(SB)/8, $libc_umask_trampoline<>(SB)
+ 
+ TEXT libc_undelete_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_undelete(SB)
+-
+ GLOBL	·libc_undelete_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_undelete_trampoline_addr(SB)/8, $libc_undelete_trampoline<>(SB)
+ 
+ TEXT libc_unlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlink(SB)
+-
+ GLOBL	·libc_unlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlink_trampoline_addr(SB)/8, $libc_unlink_trampoline<>(SB)
+ 
+ TEXT libc_unlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlinkat(SB)
+-
+ GLOBL	·libc_unlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlinkat_trampoline_addr(SB)/8, $libc_unlinkat_trampoline<>(SB)
+ 
+ TEXT libc_unmount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unmount(SB)
+-
+ GLOBL	·libc_unmount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unmount_trampoline_addr(SB)/8, $libc_unmount_trampoline<>(SB)
+ 
+ TEXT libc_write_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_write(SB)
+-
+ GLOBL	·libc_write_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_write_trampoline_addr(SB)/8, $libc_write_trampoline<>(SB)
+ 
+ TEXT libc_mmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mmap(SB)
+-
+ GLOBL	·libc_mmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mmap_trampoline_addr(SB)/8, $libc_mmap_trampoline<>(SB)
+ 
+ TEXT libc_munmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munmap(SB)
+-
+ GLOBL	·libc_munmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munmap_trampoline_addr(SB)/8, $libc_munmap_trampoline<>(SB)
+ 
+ TEXT libc_fstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstat64(SB)
+-
+ GLOBL	·libc_fstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstat64_trampoline_addr(SB)/8, $libc_fstat64_trampoline<>(SB)
+ 
+ TEXT libc_fstatat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatat64(SB)
+-
+ GLOBL	·libc_fstatat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatat64_trampoline_addr(SB)/8, $libc_fstatat64_trampoline<>(SB)
+ 
+ TEXT libc_fstatfs64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatfs64(SB)
+-
+ GLOBL	·libc_fstatfs64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatfs64_trampoline_addr(SB)/8, $libc_fstatfs64_trampoline<>(SB)
+ 
+ TEXT libc_getfsstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getfsstat64(SB)
+-
+ GLOBL	·libc_getfsstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getfsstat64_trampoline_addr(SB)/8, $libc_getfsstat64_trampoline<>(SB)
+ 
+ TEXT libc_lstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lstat64(SB)
+-
+ GLOBL	·libc_lstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lstat64_trampoline_addr(SB)/8, $libc_lstat64_trampoline<>(SB)
+ 
+ TEXT libc_ptrace_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ptrace(SB)
+-
+ GLOBL	·libc_ptrace_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ptrace_trampoline_addr(SB)/8, $libc_ptrace_trampoline<>(SB)
+ 
+ TEXT libc_stat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_stat64(SB)
+-
+ GLOBL	·libc_stat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_stat64_trampoline_addr(SB)/8, $libc_stat64_trampoline<>(SB)
+ 
+ TEXT libc_statfs64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_statfs64(SB)
+-
+ GLOBL	·libc_statfs64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_statfs64_trampoline_addr(SB)/8, $libc_statfs64_trampoline<>(SB)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
+index 51d6f3f..b18edbd 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
+@@ -725,6 +725,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -733,10 +739,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2410,28 +2412,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_fstat_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0)
+ 	if e1 != 0 {
+@@ -2521,14 +2501,6 @@ func ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return
+ }
+ 
+-func ptrace1Ptr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	_, _, e1 := syscall_syscall6(libc_ptrace_trampoline_addr, uintptr(request), uintptr(pid), addr, uintptr(data), 0, 0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+ var libc_ptrace_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_ptrace ptrace "/usr/lib/libSystem.B.dylib"
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
+index c3b82c0..08362c1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
+@@ -5,703 +5,586 @@
+ 
+ TEXT libc_fdopendir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fdopendir(SB)
+-
+ GLOBL	·libc_fdopendir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fdopendir_trampoline_addr(SB)/8, $libc_fdopendir_trampoline<>(SB)
+ 
+ TEXT libc_getgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgroups(SB)
+-
+ GLOBL	·libc_getgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgroups_trampoline_addr(SB)/8, $libc_getgroups_trampoline<>(SB)
+ 
+ TEXT libc_setgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgroups(SB)
+-
+ GLOBL	·libc_setgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgroups_trampoline_addr(SB)/8, $libc_setgroups_trampoline<>(SB)
+ 
+ TEXT libc_wait4_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_wait4(SB)
+-
+ GLOBL	·libc_wait4_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_wait4_trampoline_addr(SB)/8, $libc_wait4_trampoline<>(SB)
+ 
+ TEXT libc_accept_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_accept(SB)
+-
+ GLOBL	·libc_accept_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_accept_trampoline_addr(SB)/8, $libc_accept_trampoline<>(SB)
+ 
+ TEXT libc_bind_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_bind(SB)
+-
+ GLOBL	·libc_bind_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_bind_trampoline_addr(SB)/8, $libc_bind_trampoline<>(SB)
+ 
+ TEXT libc_connect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_connect(SB)
+-
+ GLOBL	·libc_connect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_connect_trampoline_addr(SB)/8, $libc_connect_trampoline<>(SB)
+ 
+ TEXT libc_socket_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socket(SB)
+-
+ GLOBL	·libc_socket_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socket_trampoline_addr(SB)/8, $libc_socket_trampoline<>(SB)
+ 
+ TEXT libc_getsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockopt(SB)
+-
+ GLOBL	·libc_getsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockopt_trampoline_addr(SB)/8, $libc_getsockopt_trampoline<>(SB)
+ 
+ TEXT libc_setsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsockopt(SB)
+-
+ GLOBL	·libc_setsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsockopt_trampoline_addr(SB)/8, $libc_setsockopt_trampoline<>(SB)
+ 
+ TEXT libc_getpeername_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpeername(SB)
+-
+ GLOBL	·libc_getpeername_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpeername_trampoline_addr(SB)/8, $libc_getpeername_trampoline<>(SB)
+ 
+ TEXT libc_getsockname_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockname(SB)
+-
+ GLOBL	·libc_getsockname_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockname_trampoline_addr(SB)/8, $libc_getsockname_trampoline<>(SB)
+ 
+ TEXT libc_shutdown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shutdown(SB)
+-
+ GLOBL	·libc_shutdown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shutdown_trampoline_addr(SB)/8, $libc_shutdown_trampoline<>(SB)
+ 
+ TEXT libc_socketpair_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socketpair(SB)
+-
+ GLOBL	·libc_socketpair_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socketpair_trampoline_addr(SB)/8, $libc_socketpair_trampoline<>(SB)
+ 
+ TEXT libc_recvfrom_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvfrom(SB)
+-
+ GLOBL	·libc_recvfrom_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvfrom_trampoline_addr(SB)/8, $libc_recvfrom_trampoline<>(SB)
+ 
+ TEXT libc_sendto_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendto(SB)
+-
+ GLOBL	·libc_sendto_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendto_trampoline_addr(SB)/8, $libc_sendto_trampoline<>(SB)
+ 
+ TEXT libc_recvmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvmsg(SB)
+-
+ GLOBL	·libc_recvmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvmsg_trampoline_addr(SB)/8, $libc_recvmsg_trampoline<>(SB)
+ 
+ TEXT libc_sendmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendmsg(SB)
+-
+ GLOBL	·libc_sendmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendmsg_trampoline_addr(SB)/8, $libc_sendmsg_trampoline<>(SB)
+ 
+ TEXT libc_kevent_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kevent(SB)
+-
+ GLOBL	·libc_kevent_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kevent_trampoline_addr(SB)/8, $libc_kevent_trampoline<>(SB)
+ 
+ TEXT libc_utimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimes(SB)
+-
+ GLOBL	·libc_utimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimes_trampoline_addr(SB)/8, $libc_utimes_trampoline<>(SB)
+ 
+ TEXT libc_futimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_futimes(SB)
+-
+ GLOBL	·libc_futimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_futimes_trampoline_addr(SB)/8, $libc_futimes_trampoline<>(SB)
+ 
+ TEXT libc_poll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_poll(SB)
+-
+ GLOBL	·libc_poll_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_poll_trampoline_addr(SB)/8, $libc_poll_trampoline<>(SB)
+ 
+ TEXT libc_madvise_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_madvise(SB)
+-
+ GLOBL	·libc_madvise_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_madvise_trampoline_addr(SB)/8, $libc_madvise_trampoline<>(SB)
+ 
+ TEXT libc_mlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlock(SB)
+-
+ GLOBL	·libc_mlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlock_trampoline_addr(SB)/8, $libc_mlock_trampoline<>(SB)
+ 
+ TEXT libc_mlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlockall(SB)
+-
+ GLOBL	·libc_mlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlockall_trampoline_addr(SB)/8, $libc_mlockall_trampoline<>(SB)
+ 
+ TEXT libc_mprotect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mprotect(SB)
+-
+ GLOBL	·libc_mprotect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mprotect_trampoline_addr(SB)/8, $libc_mprotect_trampoline<>(SB)
+ 
+ TEXT libc_msync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_msync(SB)
+-
+ GLOBL	·libc_msync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_msync_trampoline_addr(SB)/8, $libc_msync_trampoline<>(SB)
+ 
+ TEXT libc_munlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlock(SB)
+-
+ GLOBL	·libc_munlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlock_trampoline_addr(SB)/8, $libc_munlock_trampoline<>(SB)
+ 
+ TEXT libc_munlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlockall(SB)
+-
+ GLOBL	·libc_munlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlockall_trampoline_addr(SB)/8, $libc_munlockall_trampoline<>(SB)
+ 
+ TEXT libc_closedir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_closedir(SB)
+-
+ GLOBL	·libc_closedir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_closedir_trampoline_addr(SB)/8, $libc_closedir_trampoline<>(SB)
+ 
+ TEXT libc_readdir_r_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readdir_r(SB)
+-
+ GLOBL	·libc_readdir_r_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readdir_r_trampoline_addr(SB)/8, $libc_readdir_r_trampoline<>(SB)
+ 
+ TEXT libc_pipe_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pipe(SB)
+-
+ GLOBL	·libc_pipe_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pipe_trampoline_addr(SB)/8, $libc_pipe_trampoline<>(SB)
+ 
+ TEXT libc_getxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getxattr(SB)
+-
+ GLOBL	·libc_getxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getxattr_trampoline_addr(SB)/8, $libc_getxattr_trampoline<>(SB)
+ 
+ TEXT libc_fgetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fgetxattr(SB)
+-
+ GLOBL	·libc_fgetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fgetxattr_trampoline_addr(SB)/8, $libc_fgetxattr_trampoline<>(SB)
+ 
+ TEXT libc_setxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setxattr(SB)
+-
+ GLOBL	·libc_setxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setxattr_trampoline_addr(SB)/8, $libc_setxattr_trampoline<>(SB)
+ 
+ TEXT libc_fsetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsetxattr(SB)
+-
+ GLOBL	·libc_fsetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsetxattr_trampoline_addr(SB)/8, $libc_fsetxattr_trampoline<>(SB)
+ 
+ TEXT libc_removexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_removexattr(SB)
+-
+ GLOBL	·libc_removexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_removexattr_trampoline_addr(SB)/8, $libc_removexattr_trampoline<>(SB)
+ 
+ TEXT libc_fremovexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fremovexattr(SB)
+-
+ GLOBL	·libc_fremovexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fremovexattr_trampoline_addr(SB)/8, $libc_fremovexattr_trampoline<>(SB)
+ 
+ TEXT libc_listxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listxattr(SB)
+-
+ GLOBL	·libc_listxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listxattr_trampoline_addr(SB)/8, $libc_listxattr_trampoline<>(SB)
+ 
+ TEXT libc_flistxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flistxattr(SB)
+-
+ GLOBL	·libc_flistxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flistxattr_trampoline_addr(SB)/8, $libc_flistxattr_trampoline<>(SB)
+ 
+ TEXT libc_utimensat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimensat(SB)
+-
+ GLOBL	·libc_utimensat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimensat_trampoline_addr(SB)/8, $libc_utimensat_trampoline<>(SB)
+ 
+ TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fcntl(SB)
+-
+ GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
+ 
+ TEXT libc_kill_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kill(SB)
+-
+ GLOBL	·libc_kill_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kill_trampoline_addr(SB)/8, $libc_kill_trampoline<>(SB)
+ 
+ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ioctl(SB)
+-
+ GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
+ 
+ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sysctl(SB)
+-
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
+ TEXT libc_sendfile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendfile(SB)
+-
+ GLOBL	·libc_sendfile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendfile_trampoline_addr(SB)/8, $libc_sendfile_trampoline<>(SB)
+ 
+ TEXT libc_shmat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmat(SB)
+-
+ GLOBL	·libc_shmat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmat_trampoline_addr(SB)/8, $libc_shmat_trampoline<>(SB)
+ 
+ TEXT libc_shmctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmctl(SB)
+-
+ GLOBL	·libc_shmctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmctl_trampoline_addr(SB)/8, $libc_shmctl_trampoline<>(SB)
+ 
+ TEXT libc_shmdt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmdt(SB)
+-
+ GLOBL	·libc_shmdt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmdt_trampoline_addr(SB)/8, $libc_shmdt_trampoline<>(SB)
+ 
+ TEXT libc_shmget_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmget(SB)
+-
+ GLOBL	·libc_shmget_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmget_trampoline_addr(SB)/8, $libc_shmget_trampoline<>(SB)
+ 
+ TEXT libc_access_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_access(SB)
+-
+ GLOBL	·libc_access_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_access_trampoline_addr(SB)/8, $libc_access_trampoline<>(SB)
+ 
+ TEXT libc_adjtime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_adjtime(SB)
+-
+ GLOBL	·libc_adjtime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_adjtime_trampoline_addr(SB)/8, $libc_adjtime_trampoline<>(SB)
+ 
+ TEXT libc_chdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chdir(SB)
+-
+ GLOBL	·libc_chdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chdir_trampoline_addr(SB)/8, $libc_chdir_trampoline<>(SB)
+ 
+ TEXT libc_chflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chflags(SB)
+-
+ GLOBL	·libc_chflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chflags_trampoline_addr(SB)/8, $libc_chflags_trampoline<>(SB)
+ 
+ TEXT libc_chmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chmod(SB)
+-
+ GLOBL	·libc_chmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chmod_trampoline_addr(SB)/8, $libc_chmod_trampoline<>(SB)
+ 
+ TEXT libc_chown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chown(SB)
+-
+ GLOBL	·libc_chown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chown_trampoline_addr(SB)/8, $libc_chown_trampoline<>(SB)
+ 
+ TEXT libc_chroot_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chroot(SB)
+-
+ GLOBL	·libc_chroot_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chroot_trampoline_addr(SB)/8, $libc_chroot_trampoline<>(SB)
+ 
+ TEXT libc_clock_gettime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clock_gettime(SB)
+-
+ GLOBL	·libc_clock_gettime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clock_gettime_trampoline_addr(SB)/8, $libc_clock_gettime_trampoline<>(SB)
+ 
+ TEXT libc_close_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_close(SB)
+-
+ GLOBL	·libc_close_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_close_trampoline_addr(SB)/8, $libc_close_trampoline<>(SB)
+ 
+ TEXT libc_clonefile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefile(SB)
+-
+ GLOBL	·libc_clonefile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefile_trampoline_addr(SB)/8, $libc_clonefile_trampoline<>(SB)
+ 
+ TEXT libc_clonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefileat(SB)
+-
+ GLOBL	·libc_clonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefileat_trampoline_addr(SB)/8, $libc_clonefileat_trampoline<>(SB)
+ 
+ TEXT libc_dup_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup(SB)
+-
+ GLOBL	·libc_dup_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup_trampoline_addr(SB)/8, $libc_dup_trampoline<>(SB)
+ 
+ TEXT libc_dup2_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup2(SB)
+-
+ GLOBL	·libc_dup2_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup2_trampoline_addr(SB)/8, $libc_dup2_trampoline<>(SB)
+ 
+ TEXT libc_exchangedata_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exchangedata(SB)
+-
+ GLOBL	·libc_exchangedata_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exchangedata_trampoline_addr(SB)/8, $libc_exchangedata_trampoline<>(SB)
+ 
+ TEXT libc_exit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exit(SB)
+-
+ GLOBL	·libc_exit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exit_trampoline_addr(SB)/8, $libc_exit_trampoline<>(SB)
+ 
+ TEXT libc_faccessat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_faccessat(SB)
+-
+ GLOBL	·libc_faccessat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_faccessat_trampoline_addr(SB)/8, $libc_faccessat_trampoline<>(SB)
+ 
+ TEXT libc_fchdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchdir(SB)
+-
+ GLOBL	·libc_fchdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchdir_trampoline_addr(SB)/8, $libc_fchdir_trampoline<>(SB)
+ 
+ TEXT libc_fchflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchflags(SB)
+-
+ GLOBL	·libc_fchflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchflags_trampoline_addr(SB)/8, $libc_fchflags_trampoline<>(SB)
+ 
+ TEXT libc_fchmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmod(SB)
+-
+ GLOBL	·libc_fchmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmod_trampoline_addr(SB)/8, $libc_fchmod_trampoline<>(SB)
+ 
+ TEXT libc_fchmodat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmodat(SB)
+-
+ GLOBL	·libc_fchmodat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmodat_trampoline_addr(SB)/8, $libc_fchmodat_trampoline<>(SB)
+ 
+ TEXT libc_fchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchown(SB)
+-
+ GLOBL	·libc_fchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchown_trampoline_addr(SB)/8, $libc_fchown_trampoline<>(SB)
+ 
+ TEXT libc_fchownat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchownat(SB)
+-
+ GLOBL	·libc_fchownat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchownat_trampoline_addr(SB)/8, $libc_fchownat_trampoline<>(SB)
+ 
+ TEXT libc_fclonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fclonefileat(SB)
+-
+ GLOBL	·libc_fclonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fclonefileat_trampoline_addr(SB)/8, $libc_fclonefileat_trampoline<>(SB)
+ 
+ TEXT libc_flock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flock(SB)
+-
+ GLOBL	·libc_flock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flock_trampoline_addr(SB)/8, $libc_flock_trampoline<>(SB)
+ 
+ TEXT libc_fpathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fpathconf(SB)
+-
+ GLOBL	·libc_fpathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fpathconf_trampoline_addr(SB)/8, $libc_fpathconf_trampoline<>(SB)
+ 
+ TEXT libc_fsync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsync(SB)
+-
+ GLOBL	·libc_fsync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsync_trampoline_addr(SB)/8, $libc_fsync_trampoline<>(SB)
+ 
+ TEXT libc_ftruncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ftruncate(SB)
+-
+ GLOBL	·libc_ftruncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ftruncate_trampoline_addr(SB)/8, $libc_ftruncate_trampoline<>(SB)
+ 
+ TEXT libc_getcwd_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getcwd(SB)
+-
+ GLOBL	·libc_getcwd_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getcwd_trampoline_addr(SB)/8, $libc_getcwd_trampoline<>(SB)
+ 
+ TEXT libc_getdtablesize_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getdtablesize(SB)
+-
+ GLOBL	·libc_getdtablesize_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getdtablesize_trampoline_addr(SB)/8, $libc_getdtablesize_trampoline<>(SB)
+ 
+ TEXT libc_getegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getegid(SB)
+-
+ GLOBL	·libc_getegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getegid_trampoline_addr(SB)/8, $libc_getegid_trampoline<>(SB)
+ 
+ TEXT libc_geteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_geteuid(SB)
+-
+ GLOBL	·libc_geteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_geteuid_trampoline_addr(SB)/8, $libc_geteuid_trampoline<>(SB)
+ 
+ TEXT libc_getgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgid(SB)
+-
+ GLOBL	·libc_getgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgid_trampoline_addr(SB)/8, $libc_getgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgid(SB)
+-
+ GLOBL	·libc_getpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgid_trampoline_addr(SB)/8, $libc_getpgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgrp_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgrp(SB)
+-
+ GLOBL	·libc_getpgrp_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgrp_trampoline_addr(SB)/8, $libc_getpgrp_trampoline<>(SB)
+ 
+ TEXT libc_getpid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpid(SB)
+-
+ GLOBL	·libc_getpid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpid_trampoline_addr(SB)/8, $libc_getpid_trampoline<>(SB)
+ 
+ TEXT libc_getppid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getppid(SB)
+-
+ GLOBL	·libc_getppid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getppid_trampoline_addr(SB)/8, $libc_getppid_trampoline<>(SB)
+ 
+ TEXT libc_getpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpriority(SB)
+-
+ GLOBL	·libc_getpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpriority_trampoline_addr(SB)/8, $libc_getpriority_trampoline<>(SB)
+ 
+ TEXT libc_getrlimit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrlimit(SB)
+-
+ GLOBL	·libc_getrlimit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrlimit_trampoline_addr(SB)/8, $libc_getrlimit_trampoline<>(SB)
+ 
+ TEXT libc_getrusage_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrusage(SB)
+-
+ GLOBL	·libc_getrusage_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrusage_trampoline_addr(SB)/8, $libc_getrusage_trampoline<>(SB)
+ 
+ TEXT libc_getsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsid(SB)
+-
+ GLOBL	·libc_getsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsid_trampoline_addr(SB)/8, $libc_getsid_trampoline<>(SB)
+ 
+ TEXT libc_gettimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_gettimeofday(SB)
+-
+ GLOBL	·libc_gettimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_gettimeofday_trampoline_addr(SB)/8, $libc_gettimeofday_trampoline<>(SB)
+ 
+ TEXT libc_getuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getuid(SB)
+-
+ GLOBL	·libc_getuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getuid_trampoline_addr(SB)/8, $libc_getuid_trampoline<>(SB)
+ 
+ TEXT libc_issetugid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_issetugid(SB)
+-
+ GLOBL	·libc_issetugid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_issetugid_trampoline_addr(SB)/8, $libc_issetugid_trampoline<>(SB)
+ 
+ TEXT libc_kqueue_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kqueue(SB)
+-
+ GLOBL	·libc_kqueue_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kqueue_trampoline_addr(SB)/8, $libc_kqueue_trampoline<>(SB)
+ 
+ TEXT libc_lchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lchown(SB)
+-
+ GLOBL	·libc_lchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lchown_trampoline_addr(SB)/8, $libc_lchown_trampoline<>(SB)
+ 
+ TEXT libc_link_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_link(SB)
+-
+ GLOBL	·libc_link_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_link_trampoline_addr(SB)/8, $libc_link_trampoline<>(SB)
+ 
+ TEXT libc_linkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_linkat(SB)
+-
+ GLOBL	·libc_linkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_linkat_trampoline_addr(SB)/8, $libc_linkat_trampoline<>(SB)
+ 
+ TEXT libc_listen_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listen(SB)
+-
+ GLOBL	·libc_listen_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listen_trampoline_addr(SB)/8, $libc_listen_trampoline<>(SB)
+ 
+ TEXT libc_mkdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdir(SB)
+-
+ GLOBL	·libc_mkdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdir_trampoline_addr(SB)/8, $libc_mkdir_trampoline<>(SB)
+ 
+ TEXT libc_mkdirat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdirat(SB)
+-
+ GLOBL	·libc_mkdirat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdirat_trampoline_addr(SB)/8, $libc_mkdirat_trampoline<>(SB)
+ 
+ TEXT libc_mkfifo_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkfifo(SB)
+-
+ GLOBL	·libc_mkfifo_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkfifo_trampoline_addr(SB)/8, $libc_mkfifo_trampoline<>(SB)
+ 
+ TEXT libc_mknod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mknod(SB)
+-
+ GLOBL	·libc_mknod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mknod_trampoline_addr(SB)/8, $libc_mknod_trampoline<>(SB)
+ 
+ TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mount(SB)
+-
+ GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mount_trampoline_addr(SB)/8, $libc_mount_trampoline<>(SB)
+ 
+ TEXT libc_open_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_open(SB)
+-
+ GLOBL	·libc_open_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_open_trampoline_addr(SB)/8, $libc_open_trampoline<>(SB)
+ 
+ TEXT libc_openat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_openat(SB)
+-
+ GLOBL	·libc_openat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_openat_trampoline_addr(SB)/8, $libc_openat_trampoline<>(SB)
+ 
+ TEXT libc_pathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pathconf(SB)
+-
+ GLOBL	·libc_pathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pathconf_trampoline_addr(SB)/8, $libc_pathconf_trampoline<>(SB)
+ 
+ TEXT libc_pread_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pread(SB)
+-
+ GLOBL	·libc_pread_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pread_trampoline_addr(SB)/8, $libc_pread_trampoline<>(SB)
+ 
+ TEXT libc_pwrite_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pwrite(SB)
+-
+ GLOBL	·libc_pwrite_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pwrite_trampoline_addr(SB)/8, $libc_pwrite_trampoline<>(SB)
+ 
+ TEXT libc_read_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_read(SB)
+-
+ GLOBL	·libc_read_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_read_trampoline_addr(SB)/8, $libc_read_trampoline<>(SB)
+ 
+ TEXT libc_readlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlink(SB)
+-
+ GLOBL	·libc_readlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlink_trampoline_addr(SB)/8, $libc_readlink_trampoline<>(SB)
+ 
+ TEXT libc_readlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlinkat(SB)
+-
+ GLOBL	·libc_readlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlinkat_trampoline_addr(SB)/8, $libc_readlinkat_trampoline<>(SB)
+ 
+ TEXT libc_rename_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rename(SB)
+-
+ GLOBL	·libc_rename_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rename_trampoline_addr(SB)/8, $libc_rename_trampoline<>(SB)
+ 
+ TEXT libc_renameat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_renameat(SB)
+-
+ GLOBL	·libc_renameat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_renameat_trampoline_addr(SB)/8, $libc_renameat_trampoline<>(SB)
+ 
+ TEXT libc_revoke_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_revoke(SB)
+-
+ GLOBL	·libc_revoke_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_revoke_trampoline_addr(SB)/8, $libc_revoke_trampoline<>(SB)
+ 
+ TEXT libc_rmdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rmdir(SB)
+-
+ GLOBL	·libc_rmdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rmdir_trampoline_addr(SB)/8, $libc_rmdir_trampoline<>(SB)
+ 
+ TEXT libc_lseek_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lseek(SB)
+-
+ GLOBL	·libc_lseek_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lseek_trampoline_addr(SB)/8, $libc_lseek_trampoline<>(SB)
+ 
+ TEXT libc_select_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_select(SB)
+-
+ GLOBL	·libc_select_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_select_trampoline_addr(SB)/8, $libc_select_trampoline<>(SB)
+ 
+@@ -712,192 +595,160 @@ DATA	·libc_setattrlist_trampoline_addr(SB)/8, $libc_setattrlist_trampoline<>(SB
+ 
+ TEXT libc_setegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setegid(SB)
+-
+ GLOBL	·libc_setegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setegid_trampoline_addr(SB)/8, $libc_setegid_trampoline<>(SB)
+ 
+ TEXT libc_seteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_seteuid(SB)
+-
+ GLOBL	·libc_seteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_seteuid_trampoline_addr(SB)/8, $libc_seteuid_trampoline<>(SB)
+ 
+ TEXT libc_setgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgid(SB)
+-
+ GLOBL	·libc_setgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgid_trampoline_addr(SB)/8, $libc_setgid_trampoline<>(SB)
+ 
+ TEXT libc_setlogin_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setlogin(SB)
+-
+ GLOBL	·libc_setlogin_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setlogin_trampoline_addr(SB)/8, $libc_setlogin_trampoline<>(SB)
+ 
+ TEXT libc_setpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpgid(SB)
+-
+ GLOBL	·libc_setpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpgid_trampoline_addr(SB)/8, $libc_setpgid_trampoline<>(SB)
+ 
+ TEXT libc_setpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpriority(SB)
+-
+ GLOBL	·libc_setpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpriority_trampoline_addr(SB)/8, $libc_setpriority_trampoline<>(SB)
+ 
+ TEXT libc_setprivexec_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setprivexec(SB)
+-
+ GLOBL	·libc_setprivexec_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setprivexec_trampoline_addr(SB)/8, $libc_setprivexec_trampoline<>(SB)
+ 
+ TEXT libc_setregid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setregid(SB)
+-
+ GLOBL	·libc_setregid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setregid_trampoline_addr(SB)/8, $libc_setregid_trampoline<>(SB)
+ 
+ TEXT libc_setreuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setreuid(SB)
+-
+ GLOBL	·libc_setreuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setreuid_trampoline_addr(SB)/8, $libc_setreuid_trampoline<>(SB)
+ 
+ TEXT libc_setsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsid(SB)
+-
+ GLOBL	·libc_setsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsid_trampoline_addr(SB)/8, $libc_setsid_trampoline<>(SB)
+ 
+ TEXT libc_settimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_settimeofday(SB)
+-
+ GLOBL	·libc_settimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_settimeofday_trampoline_addr(SB)/8, $libc_settimeofday_trampoline<>(SB)
+ 
+ TEXT libc_setuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setuid(SB)
+-
+ GLOBL	·libc_setuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setuid_trampoline_addr(SB)/8, $libc_setuid_trampoline<>(SB)
+ 
+ TEXT libc_symlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlink(SB)
+-
+ GLOBL	·libc_symlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlink_trampoline_addr(SB)/8, $libc_symlink_trampoline<>(SB)
+ 
+ TEXT libc_symlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlinkat(SB)
+-
+ GLOBL	·libc_symlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlinkat_trampoline_addr(SB)/8, $libc_symlinkat_trampoline<>(SB)
+ 
+ TEXT libc_sync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sync(SB)
+-
+ GLOBL	·libc_sync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sync_trampoline_addr(SB)/8, $libc_sync_trampoline<>(SB)
+ 
+ TEXT libc_truncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_truncate(SB)
+-
+ GLOBL	·libc_truncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_truncate_trampoline_addr(SB)/8, $libc_truncate_trampoline<>(SB)
+ 
+ TEXT libc_umask_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_umask(SB)
+-
+ GLOBL	·libc_umask_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_umask_trampoline_addr(SB)/8, $libc_umask_trampoline<>(SB)
+ 
+ TEXT libc_undelete_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_undelete(SB)
+-
+ GLOBL	·libc_undelete_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_undelete_trampoline_addr(SB)/8, $libc_undelete_trampoline<>(SB)
+ 
+ TEXT libc_unlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlink(SB)
+-
+ GLOBL	·libc_unlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlink_trampoline_addr(SB)/8, $libc_unlink_trampoline<>(SB)
+ 
+ TEXT libc_unlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlinkat(SB)
+-
+ GLOBL	·libc_unlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlinkat_trampoline_addr(SB)/8, $libc_unlinkat_trampoline<>(SB)
+ 
+ TEXT libc_unmount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unmount(SB)
+-
+ GLOBL	·libc_unmount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unmount_trampoline_addr(SB)/8, $libc_unmount_trampoline<>(SB)
+ 
+ TEXT libc_write_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_write(SB)
+-
+ GLOBL	·libc_write_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_write_trampoline_addr(SB)/8, $libc_write_trampoline<>(SB)
+ 
+ TEXT libc_mmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mmap(SB)
+-
+ GLOBL	·libc_mmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mmap_trampoline_addr(SB)/8, $libc_mmap_trampoline<>(SB)
+ 
+ TEXT libc_munmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munmap(SB)
+-
+ GLOBL	·libc_munmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munmap_trampoline_addr(SB)/8, $libc_munmap_trampoline<>(SB)
+ 
+ TEXT libc_fstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstat(SB)
+-
+ GLOBL	·libc_fstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstat_trampoline_addr(SB)/8, $libc_fstat_trampoline<>(SB)
+ 
+ TEXT libc_fstatat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatat(SB)
+-
+ GLOBL	·libc_fstatat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatat_trampoline_addr(SB)/8, $libc_fstatat_trampoline<>(SB)
+ 
+ TEXT libc_fstatfs_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatfs(SB)
+-
+ GLOBL	·libc_fstatfs_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatfs_trampoline_addr(SB)/8, $libc_fstatfs_trampoline<>(SB)
+ 
+ TEXT libc_getfsstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getfsstat(SB)
+-
+ GLOBL	·libc_getfsstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getfsstat_trampoline_addr(SB)/8, $libc_getfsstat_trampoline<>(SB)
+ 
+ TEXT libc_lstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lstat(SB)
+-
+ GLOBL	·libc_lstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lstat_trampoline_addr(SB)/8, $libc_lstat_trampoline<>(SB)
+ 
+ TEXT libc_ptrace_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ptrace(SB)
+-
+ GLOBL	·libc_ptrace_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ptrace_trampoline_addr(SB)/8, $libc_ptrace_trampoline<>(SB)
+ 
+ TEXT libc_stat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_stat(SB)
+-
+ GLOBL	·libc_stat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_stat_trampoline_addr(SB)/8, $libc_stat_trampoline<>(SB)
+ 
+ TEXT libc_statfs_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_statfs(SB)
+-
+ GLOBL	·libc_statfs_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_statfs_trampoline_addr(SB)/8, $libc_statfs_trampoline<>(SB)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
+index 0eabac7..0c67df6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
+@@ -1642,28 +1642,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
+index ee313eb..e6e05d1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
+index 4c986e4..7508acc 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
+index 5552169..7b56aea 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
+index 67a226f..cc623dc 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
+index f0b9dda..5818491 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
+index b57c705..6be25cd 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
+@@ -40,7 +40,7 @@ func readv(fd int, iovs []Iovec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procreadv)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -55,7 +55,7 @@ func preadv(fd int, iovs []Iovec, off int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpreadv)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), uintptr(off), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -70,7 +70,7 @@ func writev(fd int, iovs []Iovec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwritev)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -85,7 +85,7 @@ func pwritev(fd int, iovs []Iovec, off int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpwritev)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), uintptr(off), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -96,7 +96,7 @@ func accept4(s int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (fd int,
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procaccept4)), 4, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index 7ceec23..8e5cee2 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -1734,28 +1734,6 @@ func exitThread(code int) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(p)), uintptr(np))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(p)), uintptr(np))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func readv(fd int, iovs []Iovec) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(iovs) > 0 {
+@@ -2197,3 +2175,23 @@ func getresgid(rgid *_C_int, egid *_C_int, sgid *_C_int) {
+ 	RawSyscallNoError(SYS_GETRESGID, uintptr(unsafe.Pointer(rgid)), uintptr(unsafe.Pointer(egid)), uintptr(unsafe.Pointer(sgid)))
+ 	return
+ }
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func schedSetattr(pid int, attr *SchedAttr, flags uint) (err error) {
++	_, _, e1 := Syscall(SYS_SCHED_SETATTR, uintptr(pid), uintptr(unsafe.Pointer(attr)), uintptr(flags))
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func schedGetattr(pid int, attr *SchedAttr, size uint, flags uint) (err error) {
++	_, _, e1 := Syscall6(SYS_SCHED_GETATTR, uintptr(pid), uintptr(unsafe.Pointer(attr)), uintptr(size), uintptr(flags), 0, 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
+index cdb2af5..af06b23 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
+index 9d25f76..093fcf3 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
+index d3f8035..4a78567 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
+index 887188a..741d8be 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index 9ab9abf..66b3b64 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index 915761e..c5c4cc1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -2213,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index 8e87fdf..93bfbb3 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 12a7a21..a107b8f 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index b19e8aa..c427de5 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index fb99594..60c1a99 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index 32cbbbc..52eba36 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
+index 609d1c5..b401894 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
+@@ -436,7 +436,7 @@ func pipe(p *[2]_C_int) (n int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procpipe)), 1, uintptr(unsafe.Pointer(p)), 0, 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -446,7 +446,7 @@ func pipe(p *[2]_C_int) (n int, err error) {
+ func pipe2(p *[2]_C_int, flags int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procpipe2)), 2, uintptr(unsafe.Pointer(p)), uintptr(flags), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -456,7 +456,7 @@ func pipe2(p *[2]_C_int, flags int) (err error) {
+ func getsockname(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgetsockname)), 3, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -471,7 +471,7 @@ func Getcwd(buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetcwd)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -482,7 +482,7 @@ func getgroups(ngid int, gid *_Gid_t) (n int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procgetgroups)), 2, uintptr(ngid), uintptr(unsafe.Pointer(gid)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -492,7 +492,7 @@ func getgroups(ngid int, gid *_Gid_t) (n int, err error) {
+ func setgroups(ngid int, gid *_Gid_t) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procsetgroups)), 2, uintptr(ngid), uintptr(unsafe.Pointer(gid)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -503,7 +503,7 @@ func wait4(pid int32, statusp *_C_int, options int, rusage *Rusage) (wpid int32,
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwait4)), 4, uintptr(pid), uintptr(unsafe.Pointer(statusp)), uintptr(options), uintptr(unsafe.Pointer(rusage)), 0, 0)
+ 	wpid = int32(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -518,7 +518,7 @@ func gethostname(buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgethostname)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -533,7 +533,7 @@ func utimes(path string, times *[2]Timeval) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procutimes)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(times)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -548,7 +548,7 @@ func utimensat(fd int, path string, times *[2]Timespec, flag int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procutimensat)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(times)), uintptr(flag), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -559,7 +559,7 @@ func fcntl(fd int, cmd int, arg int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procfcntl)), 3, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -569,7 +569,7 @@ func fcntl(fd int, cmd int, arg int) (val int, err error) {
+ func futimesat(fildes int, path *byte, times *[2]Timeval) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procfutimesat)), 3, uintptr(fildes), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(times)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -580,7 +580,7 @@ func accept(s int, rsa *RawSockaddrAny, addrlen *_Socklen) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procaccept)), 3, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -591,7 +591,7 @@ func recvmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_recvmsg)), 3, uintptr(s), uintptr(unsafe.Pointer(msg)), uintptr(flags), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -602,7 +602,7 @@ func sendmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_sendmsg)), 3, uintptr(s), uintptr(unsafe.Pointer(msg)), uintptr(flags), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -612,7 +612,7 @@ func sendmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ func acct(path *byte) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procacct)), 1, uintptr(unsafe.Pointer(path)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -647,7 +647,7 @@ func ioctlRet(fd int, req int, arg uintptr) (ret int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, uintptr(fd), uintptr(req), uintptr(arg), 0, 0, 0)
+ 	ret = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -658,7 +658,7 @@ func ioctlPtrRet(fd int, req int, arg unsafe.Pointer) (ret int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, uintptr(fd), uintptr(req), uintptr(arg), 0, 0, 0)
+ 	ret = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -669,7 +669,7 @@ func poll(fds *PollFd, nfds int, timeout int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpoll)), 3, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(timeout), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -684,7 +684,7 @@ func Access(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procAccess)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -694,7 +694,7 @@ func Access(path string, mode uint32) (err error) {
+ func Adjtime(delta *Timeval, olddelta *Timeval) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procAdjtime)), 2, uintptr(unsafe.Pointer(delta)), uintptr(unsafe.Pointer(olddelta)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -709,7 +709,7 @@ func Chdir(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChdir)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -724,7 +724,7 @@ func Chmod(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChmod)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -739,7 +739,7 @@ func Chown(path string, uid int, gid int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChown)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -754,7 +754,7 @@ func Chroot(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChroot)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -764,7 +764,7 @@ func Chroot(path string) (err error) {
+ func ClockGettime(clockid int32, time *Timespec) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procClockGettime)), 2, uintptr(clockid), uintptr(unsafe.Pointer(time)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -774,7 +774,7 @@ func ClockGettime(clockid int32, time *Timespec) (err error) {
+ func Close(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procClose)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -790,7 +790,7 @@ func Creat(path string, mode uint32) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procCreat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -801,7 +801,7 @@ func Dup(fd int) (nfd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procDup)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	nfd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -811,7 +811,7 @@ func Dup(fd int) (nfd int, err error) {
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procDup2)), 2, uintptr(oldfd), uintptr(newfd), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -833,7 +833,7 @@ func Faccessat(dirfd int, path string, mode uint32, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFaccessat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -843,7 +843,7 @@ func Faccessat(dirfd int, path string, mode uint32, flags int) (err error) {
+ func Fchdir(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchdir)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -853,7 +853,7 @@ func Fchdir(fd int) (err error) {
+ func Fchmod(fd int, mode uint32) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchmod)), 2, uintptr(fd), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -868,7 +868,7 @@ func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchmodat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -878,7 +878,7 @@ func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+ func Fchown(fd int, uid int, gid int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchown)), 3, uintptr(fd), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -893,7 +893,7 @@ func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchownat)), 5, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), uintptr(flags), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -903,7 +903,7 @@ func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
+ func Fdatasync(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFdatasync)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -913,7 +913,7 @@ func Fdatasync(fd int) (err error) {
+ func Flock(fd int, how int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFlock)), 2, uintptr(fd), uintptr(how), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -924,7 +924,7 @@ func Fpathconf(fd int, name int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFpathconf)), 2, uintptr(fd), uintptr(name), 0, 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -934,7 +934,7 @@ func Fpathconf(fd int, name int) (val int, err error) {
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstat)), 2, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -949,7 +949,7 @@ func Fstatat(fd int, path string, stat *Stat_t, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstatat)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -959,7 +959,7 @@ func Fstatat(fd int, path string, stat *Stat_t, flags int) (err error) {
+ func Fstatvfs(fd int, vfsstat *Statvfs_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstatvfs)), 2, uintptr(fd), uintptr(unsafe.Pointer(vfsstat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -974,7 +974,7 @@ func Getdents(fd int, buf []byte, basep *uintptr) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetdents)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(basep)), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1001,7 +1001,7 @@ func Getpgid(pid int) (pgid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetpgid)), 1, uintptr(pid), 0, 0, 0, 0, 0)
+ 	pgid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1012,7 +1012,7 @@ func Getpgrp() (pgid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetpgrp)), 0, 0, 0, 0, 0, 0, 0)
+ 	pgid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1047,7 +1047,7 @@ func Getpriority(which int, who int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetpriority)), 2, uintptr(which), uintptr(who), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1057,7 +1057,7 @@ func Getpriority(which int, who int) (n int, err error) {
+ func Getrlimit(which int, lim *Rlimit) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetrlimit)), 2, uintptr(which), uintptr(unsafe.Pointer(lim)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1067,7 +1067,7 @@ func Getrlimit(which int, lim *Rlimit) (err error) {
+ func Getrusage(who int, rusage *Rusage) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetrusage)), 2, uintptr(who), uintptr(unsafe.Pointer(rusage)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1078,7 +1078,7 @@ func Getsid(pid int) (sid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetsid)), 1, uintptr(pid), 0, 0, 0, 0, 0)
+ 	sid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1088,7 +1088,7 @@ func Getsid(pid int) (sid int, err error) {
+ func Gettimeofday(tv *Timeval) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGettimeofday)), 1, uintptr(unsafe.Pointer(tv)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1106,7 +1106,7 @@ func Getuid() (uid int) {
+ func Kill(pid int, signum syscall.Signal) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procKill)), 2, uintptr(pid), uintptr(signum), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1121,7 +1121,7 @@ func Lchown(path string, uid int, gid int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLchown)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1141,7 +1141,7 @@ func Link(path string, link string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLink)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1151,7 +1151,7 @@ func Link(path string, link string) (err error) {
+ func Listen(s int, backlog int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_llisten)), 2, uintptr(s), uintptr(backlog), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1166,7 +1166,7 @@ func Lstat(path string, stat *Stat_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLstat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1180,7 +1180,7 @@ func Madvise(b []byte, advice int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMadvise)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(advice), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1195,7 +1195,7 @@ func Mkdir(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkdir)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1210,7 +1210,7 @@ func Mkdirat(dirfd int, path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkdirat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1225,7 +1225,7 @@ func Mkfifo(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkfifo)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1240,7 +1240,7 @@ func Mkfifoat(dirfd int, path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkfifoat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1255,7 +1255,7 @@ func Mknod(path string, mode uint32, dev int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMknod)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(dev), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1270,7 +1270,7 @@ func Mknodat(dirfd int, path string, mode uint32, dev int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMknodat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(dev), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1284,7 +1284,7 @@ func Mlock(b []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMlock)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1294,7 +1294,7 @@ func Mlock(b []byte) (err error) {
+ func Mlockall(flags int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMlockall)), 1, uintptr(flags), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1308,7 +1308,7 @@ func Mprotect(b []byte, prot int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMprotect)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(prot), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1322,7 +1322,7 @@ func Msync(b []byte, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMsync)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(flags), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1336,7 +1336,7 @@ func Munlock(b []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMunlock)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1346,7 +1346,7 @@ func Munlock(b []byte) (err error) {
+ func Munlockall() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMunlockall)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1356,7 +1356,7 @@ func Munlockall() (err error) {
+ func Nanosleep(time *Timespec, leftover *Timespec) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procNanosleep)), 2, uintptr(unsafe.Pointer(time)), uintptr(unsafe.Pointer(leftover)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1372,7 +1372,7 @@ func Open(path string, mode int, perm uint32) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procOpen)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(perm), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1388,7 +1388,7 @@ func Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error)
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procOpenat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(flags), uintptr(mode), 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1404,7 +1404,7 @@ func Pathconf(path string, name int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procPathconf)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(name), 0, 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1414,7 +1414,7 @@ func Pathconf(path string, name int) (val int, err error) {
+ func Pause() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procPause)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1429,7 +1429,7 @@ func pread(fd int, p []byte, offset int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpread)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(offset), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1444,7 +1444,7 @@ func pwrite(fd int, p []byte, offset int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpwrite)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(offset), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1459,7 +1459,7 @@ func read(fd int, p []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procread)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1479,7 +1479,7 @@ func Readlink(path string, buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procReadlink)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), uintptr(len(buf)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1499,7 +1499,7 @@ func Rename(from string, to string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRename)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1519,7 +1519,7 @@ func Renameat(olddirfd int, oldpath string, newdirfd int, newpath string) (err e
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRenameat)), 4, uintptr(olddirfd), uintptr(unsafe.Pointer(_p0)), uintptr(newdirfd), uintptr(unsafe.Pointer(_p1)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1534,7 +1534,7 @@ func Rmdir(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRmdir)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1545,7 +1545,7 @@ func Seek(fd int, offset int64, whence int) (newoffset int64, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proclseek)), 3, uintptr(fd), uintptr(offset), uintptr(whence), 0, 0, 0)
+ 	newoffset = int64(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1556,7 +1556,7 @@ func Select(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timeval) (n int, err
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSelect)), 5, uintptr(nfd), uintptr(unsafe.Pointer(r)), uintptr(unsafe.Pointer(w)), uintptr(unsafe.Pointer(e)), uintptr(unsafe.Pointer(timeout)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1566,7 +1566,7 @@ func Select(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timeval) (n int, err
+ func Setegid(egid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetegid)), 1, uintptr(egid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1576,7 +1576,7 @@ func Setegid(egid int) (err error) {
+ func Seteuid(euid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSeteuid)), 1, uintptr(euid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1586,7 +1586,7 @@ func Seteuid(euid int) (err error) {
+ func Setgid(gid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetgid)), 1, uintptr(gid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1600,7 +1600,7 @@ func Sethostname(p []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSethostname)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1610,7 +1610,7 @@ func Sethostname(p []byte) (err error) {
+ func Setpgid(pid int, pgid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetpgid)), 2, uintptr(pid), uintptr(pgid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1620,7 +1620,7 @@ func Setpgid(pid int, pgid int) (err error) {
+ func Setpriority(which int, who int, prio int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSetpriority)), 3, uintptr(which), uintptr(who), uintptr(prio), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1630,7 +1630,7 @@ func Setpriority(which int, who int, prio int) (err error) {
+ func Setregid(rgid int, egid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetregid)), 2, uintptr(rgid), uintptr(egid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1640,7 +1640,7 @@ func Setregid(rgid int, egid int) (err error) {
+ func Setreuid(ruid int, euid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetreuid)), 2, uintptr(ruid), uintptr(euid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1651,7 +1651,7 @@ func Setsid() (pid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetsid)), 0, 0, 0, 0, 0, 0, 0)
+ 	pid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1661,7 +1661,7 @@ func Setsid() (pid int, err error) {
+ func Setuid(uid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetuid)), 1, uintptr(uid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1671,7 +1671,7 @@ func Setuid(uid int) (err error) {
+ func Shutdown(s int, how int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procshutdown)), 2, uintptr(s), uintptr(how), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1686,7 +1686,7 @@ func Stat(path string, stat *Stat_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procStat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1701,7 +1701,7 @@ func Statvfs(path string, vfsstat *Statvfs_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procStatvfs)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(vfsstat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1721,7 +1721,7 @@ func Symlink(path string, link string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSymlink)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1731,7 +1731,7 @@ func Symlink(path string, link string) (err error) {
+ func Sync() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSync)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1742,7 +1742,7 @@ func Sysconf(which int) (n int64, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSysconf)), 1, uintptr(which), 0, 0, 0, 0, 0)
+ 	n = int64(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1753,7 +1753,7 @@ func Times(tms *Tms) (ticks uintptr, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procTimes)), 1, uintptr(unsafe.Pointer(tms)), 0, 0, 0, 0, 0)
+ 	ticks = uintptr(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1768,7 +1768,7 @@ func Truncate(path string, length int64) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procTruncate)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1778,7 +1778,7 @@ func Truncate(path string, length int64) (err error) {
+ func Fsync(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFsync)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1788,7 +1788,7 @@ func Fsync(fd int) (err error) {
+ func Ftruncate(fd int, length int64) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFtruncate)), 2, uintptr(fd), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1806,7 +1806,7 @@ func Umask(mask int) (oldmask int) {
+ func Uname(buf *Utsname) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procUname)), 1, uintptr(unsafe.Pointer(buf)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1821,7 +1821,7 @@ func Unmount(target string, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procumount)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(flags), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1836,7 +1836,7 @@ func Unlink(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUnlink)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1851,7 +1851,7 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUnlinkat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(flags), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1861,7 +1861,7 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
+ func Ustat(dev int, ubuf *Ustat_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUstat)), 2, uintptr(dev), uintptr(unsafe.Pointer(ubuf)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1876,7 +1876,7 @@ func Utime(path string, buf *Utimbuf) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUtime)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(buf)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1886,7 +1886,7 @@ func Utime(path string, buf *Utimbuf) (err error) {
+ func bind(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_bind)), 3, uintptr(s), uintptr(addr), uintptr(addrlen), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1896,7 +1896,7 @@ func bind(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ func connect(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_connect)), 3, uintptr(s), uintptr(addr), uintptr(addrlen), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1907,7 +1907,7 @@ func mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procmmap)), 6, uintptr(addr), uintptr(length), uintptr(prot), uintptr(flag), uintptr(fd), uintptr(pos))
+ 	ret = uintptr(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1917,7 +1917,7 @@ func mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (
+ func munmap(addr uintptr, length uintptr) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procmunmap)), 2, uintptr(addr), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1928,7 +1928,7 @@ func sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procsendfile)), 4, uintptr(outfd), uintptr(infd), uintptr(unsafe.Pointer(offset)), uintptr(count), 0, 0)
+ 	written = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1942,7 +1942,7 @@ func sendto(s int, buf []byte, flags int, to unsafe.Pointer, addrlen _Socklen) (
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_sendto)), 6, uintptr(s), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(flags), uintptr(to), uintptr(addrlen))
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1953,7 +1953,7 @@ func socket(domain int, typ int, proto int) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_socket)), 3, uintptr(domain), uintptr(typ), uintptr(proto), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1963,7 +1963,7 @@ func socket(domain int, typ int, proto int) (fd int, err error) {
+ func socketpair(domain int, typ int, proto int, fd *[2]int32) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&proc__xnet_socketpair)), 4, uintptr(domain), uintptr(typ), uintptr(proto), uintptr(unsafe.Pointer(fd)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1978,7 +1978,7 @@ func write(fd int, p []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwrite)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1988,7 +1988,7 @@ func write(fd int, p []byte) (n int, err error) {
+ func getsockopt(s int, level int, name int, val unsafe.Pointer, vallen *_Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_getsockopt)), 5, uintptr(s), uintptr(level), uintptr(name), uintptr(val), uintptr(unsafe.Pointer(vallen)), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1998,7 +1998,7 @@ func getsockopt(s int, level int, name int, val unsafe.Pointer, vallen *_Socklen
+ func getpeername(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procgetpeername)), 3, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2008,7 +2008,7 @@ func getpeername(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ func setsockopt(s int, level int, name int, val unsafe.Pointer, vallen uintptr) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procsetsockopt)), 5, uintptr(s), uintptr(level), uintptr(name), uintptr(val), uintptr(vallen), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2023,7 +2023,7 @@ func recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Sockl
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procrecvfrom)), 6, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(flags), uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(fromlen)))
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2034,7 +2034,7 @@ func port_create() (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_create)), 0, 0, 0, 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2045,7 +2045,7 @@ func port_associate(port int, source int, object uintptr, events int, user *byte
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_associate)), 5, uintptr(port), uintptr(source), uintptr(object), uintptr(events), uintptr(unsafe.Pointer(user)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2056,7 +2056,7 @@ func port_dissociate(port int, source int, object uintptr) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_dissociate)), 3, uintptr(port), uintptr(source), uintptr(object), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2067,7 +2067,7 @@ func port_get(port int, pe *portEvent, timeout *Timespec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_get)), 3, uintptr(port), uintptr(unsafe.Pointer(pe)), uintptr(unsafe.Pointer(timeout)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2078,7 +2078,7 @@ func port_getn(port int, pe *portEvent, max uint32, nget *uint32, timeout *Times
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_getn)), 5, uintptr(port), uintptr(unsafe.Pointer(pe)), uintptr(max), uintptr(unsafe.Pointer(nget)), uintptr(unsafe.Pointer(timeout)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2088,7 +2088,7 @@ func port_getn(port int, pe *portEvent, max uint32, nget *uint32, timeout *Times
+ func putmsg(fd int, clptr *strbuf, dataptr *strbuf, flags int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procputmsg)), 4, uintptr(fd), uintptr(unsafe.Pointer(clptr)), uintptr(unsafe.Pointer(dataptr)), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2098,7 +2098,7 @@ func putmsg(fd int, clptr *strbuf, dataptr *strbuf, flags int) (err error) {
+ func getmsg(fd int, clptr *strbuf, dataptr *strbuf, flags *int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgetmsg)), 4, uintptr(fd), uintptr(unsafe.Pointer(clptr)), uintptr(unsafe.Pointer(dataptr)), uintptr(unsafe.Pointer(flags)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
+index c316817..1d8fe1d 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
+@@ -40,17 +40,6 @@ func read(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func write(fd int, p []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(p) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index c9c4ad0..9862853 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -447,4 +447,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index 12ff341..8901f0f 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -369,4 +369,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index c3fb5e7..6902c37 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -411,4 +411,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 358c847..a6d3dff 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -314,4 +314,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index 81c4849..b18f3f7 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -308,4 +308,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 202a57e..0302e5e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -431,4 +431,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 4448
+ 	SYS_FUTEX_WAITV                  = 4449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
++	SYS_CACHESTAT                    = 4451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index 1fbceb5..6693ba4 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -361,4 +361,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 5448
+ 	SYS_FUTEX_WAITV             = 5449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
++	SYS_CACHESTAT               = 5451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index b4ffb7a..fd93f49 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -361,4 +361,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 5448
+ 	SYS_FUTEX_WAITV             = 5449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
++	SYS_CACHESTAT               = 5451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index 867985f..760ddca 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -431,4 +431,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 4448
+ 	SYS_FUTEX_WAITV                  = 4449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
++	SYS_CACHESTAT                    = 4451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index a8cce69..cff2b25 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -438,4 +438,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index d44c5b3..a4b2405 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -410,4 +410,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index 4214dd9..aca54b4 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -410,4 +410,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 3e594a8..676245e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -313,4 +313,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index e6ed7d6..022878d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -376,4 +376,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index 92f628e..4100a76 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -389,4 +389,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index 02e2462..2d93b09 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -1972,7 +1972,7 @@ const (
+ 	NFT_MSG_GETFLOWTABLE              = 0x17
+ 	NFT_MSG_DELFLOWTABLE              = 0x18
+ 	NFT_MSG_GETRULE_RESET             = 0x19
+-	NFT_MSG_MAX                       = 0x21
++	NFT_MSG_MAX                       = 0x22
+ 	NFTA_LIST_UNSPEC                  = 0x0
+ 	NFTA_LIST_ELEM                    = 0x1
+ 	NFTA_HOOK_UNSPEC                  = 0x0
+@@ -4494,7 +4494,7 @@ const (
+ 	NL80211_ATTR_MAC_HINT                                   = 0xc8
+ 	NL80211_ATTR_MAC_MASK                                   = 0xd7
+ 	NL80211_ATTR_MAX_AP_ASSOC_STA                           = 0xca
+-	NL80211_ATTR_MAX                                        = 0x145
++	NL80211_ATTR_MAX                                        = 0x146
+ 	NL80211_ATTR_MAX_CRIT_PROT_DURATION                     = 0xb4
+ 	NL80211_ATTR_MAX_CSA_COUNTERS                           = 0xce
+ 	NL80211_ATTR_MAX_MATCH_SETS                             = 0x85
+@@ -4864,7 +4864,7 @@ const (
+ 	NL80211_CMD_LEAVE_IBSS                                  = 0x2c
+ 	NL80211_CMD_LEAVE_MESH                                  = 0x45
+ 	NL80211_CMD_LEAVE_OCB                                   = 0x6d
+-	NL80211_CMD_MAX                                         = 0x99
++	NL80211_CMD_MAX                                         = 0x9a
+ 	NL80211_CMD_MICHAEL_MIC_FAILURE                         = 0x29
+ 	NL80211_CMD_MODIFY_LINK_STA                             = 0x97
+ 	NL80211_CMD_NAN_MATCH                                   = 0x78
+@@ -5498,7 +5498,7 @@ const (
+ 	NL80211_RATE_INFO_HE_RU_ALLOC_52                        = 0x1
+ 	NL80211_RATE_INFO_HE_RU_ALLOC_996                       = 0x5
+ 	NL80211_RATE_INFO_HE_RU_ALLOC                           = 0x11
+-	NL80211_RATE_INFO_MAX                                   = 0x16
++	NL80211_RATE_INFO_MAX                                   = 0x1d
+ 	NL80211_RATE_INFO_MCS                                   = 0x2
+ 	NL80211_RATE_INFO_SHORT_GI                              = 0x4
+ 	NL80211_RATE_INFO_VHT_MCS                               = 0x6
+@@ -5863,3 +5863,18 @@ const (
+ 	VIRTIO_NET_HDR_GSO_UDP_L4 = 0x5
+ 	VIRTIO_NET_HDR_GSO_ECN    = 0x80
+ )
++
++type SchedAttr struct {
++	Size     uint32
++	Policy   uint32
++	Flags    uint64
++	Nice     int32
++	Priority uint32
++	Runtime  uint64
++	Deadline uint64
++	Period   uint64
++	Util_min uint32
++	Util_max uint32
++}
++
++const SizeofSchedAttr = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+index 9ea54b7..1b4c97c 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+@@ -718,3 +718,30 @@ type SysvShmDesc struct {
+ 	_      uint64
+ 	_      uint64
+ }
++
++type RISCVHWProbePairs struct {
++	Key   int64
++	Value uint64
++}
++
++const (
++	RISCV_HWPROBE_KEY_MVENDORID          = 0x0
++	RISCV_HWPROBE_KEY_MARCHID            = 0x1
++	RISCV_HWPROBE_KEY_MIMPID             = 0x2
++	RISCV_HWPROBE_KEY_BASE_BEHAVIOR      = 0x3
++	RISCV_HWPROBE_BASE_BEHAVIOR_IMA      = 0x1
++	RISCV_HWPROBE_KEY_IMA_EXT_0          = 0x4
++	RISCV_HWPROBE_IMA_FD                 = 0x1
++	RISCV_HWPROBE_IMA_C                  = 0x2
++	RISCV_HWPROBE_IMA_V                  = 0x4
++	RISCV_HWPROBE_EXT_ZBA                = 0x8
++	RISCV_HWPROBE_EXT_ZBB                = 0x10
++	RISCV_HWPROBE_EXT_ZBS                = 0x20
++	RISCV_HWPROBE_KEY_CPUPERF_0          = 0x5
++	RISCV_HWPROBE_MISALIGNED_UNKNOWN     = 0x0
++	RISCV_HWPROBE_MISALIGNED_EMULATED    = 0x1
++	RISCV_HWPROBE_MISALIGNED_SLOW        = 0x2
++	RISCV_HWPROBE_MISALIGNED_FAST        = 0x3
++	RISCV_HWPROBE_MISALIGNED_UNSUPPORTED = 0x4
++	RISCV_HWPROBE_MISALIGNED_MASK        = 0x7
++)
+diff --git a/vendor/golang.org/x/sys/windows/exec_windows.go b/vendor/golang.org/x/sys/windows/exec_windows.go
+index a52e033..9cabbb6 100644
+--- a/vendor/golang.org/x/sys/windows/exec_windows.go
++++ b/vendor/golang.org/x/sys/windows/exec_windows.go
+@@ -22,7 +22,7 @@ import (
+ //     but only if there is space or tab inside s.
+ func EscapeArg(s string) string {
+ 	if len(s) == 0 {
+-		return "\"\""
++		return `""`
+ 	}
+ 	n := len(s)
+ 	hasSpace := false
+@@ -35,7 +35,7 @@ func EscapeArg(s string) string {
+ 		}
+ 	}
+ 	if hasSpace {
+-		n += 2
++		n += 2 // Reserve space for quotes.
+ 	}
+ 	if n == len(s) {
+ 		return s
+@@ -82,20 +82,68 @@ func EscapeArg(s string) string {
+ // in CreateProcess's CommandLine argument, CreateService/ChangeServiceConfig's BinaryPathName argument,
+ // or any program that uses CommandLineToArgv.
+ func ComposeCommandLine(args []string) string {
+-	var commandLine string
+-	for i := range args {
+-		if i > 0 {
+-			commandLine += " "
++	if len(args) == 0 {
++		return ""
++	}
++
++	// Per https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw:
++	// “This function accepts command lines that contain a program name; the
++	// program name can be enclosed in quotation marks or not.”
++	//
++	// Unfortunately, it provides no means of escaping interior quotation marks
++	// within that program name, and we have no way to report them here.
++	prog := args[0]
++	mustQuote := len(prog) == 0
++	for i := 0; i < len(prog); i++ {
++		c := prog[i]
++		if c <= ' ' || (c == '"' && i == 0) {
++			// Force quotes for not only the ASCII space and tab as described in the
++			// MSDN article, but also ASCII control characters.
++			// The documentation for CommandLineToArgvW doesn't say what happens when
++			// the first argument is not a valid program name, but it empirically
++			// seems to drop unquoted control characters.
++			mustQuote = true
++			break
++		}
++	}
++	var commandLine []byte
++	if mustQuote {
++		commandLine = make([]byte, 0, len(prog)+2)
++		commandLine = append(commandLine, '"')
++		for i := 0; i < len(prog); i++ {
++			c := prog[i]
++			if c == '"' {
++				// This quote would interfere with our surrounding quotes.
++				// We have no way to report an error, so just strip out
++				// the offending character instead.
++				continue
++			}
++			commandLine = append(commandLine, c)
+ 		}
+-		commandLine += EscapeArg(args[i])
++		commandLine = append(commandLine, '"')
++	} else {
++		if len(args) == 1 {
++			// args[0] is a valid command line representing itself.
++			// No need to allocate a new slice or string for it.
++			return prog
++		}
++		commandLine = []byte(prog)
+ 	}
+-	return commandLine
++
++	for _, arg := range args[1:] {
++		commandLine = append(commandLine, ' ')
++		// TODO(bcmills): since we're already appending to a slice, it would be nice
++		// to avoid the intermediate allocations of EscapeArg.
++		// Perhaps we can factor out an appendEscapedArg function.
++		commandLine = append(commandLine, EscapeArg(arg)...)
++	}
++	return string(commandLine)
+ }
+ 
+ // DecomposeCommandLine breaks apart its argument command line into unescaped parts using CommandLineToArgv,
+ // as gathered from GetCommandLine, QUERY_SERVICE_CONFIG's BinaryPathName argument, or elsewhere that
+ // command lines are passed around.
+-// DecomposeCommandLine returns error if commandLine contains NUL.
++// DecomposeCommandLine returns an error if commandLine contains NUL.
+ func DecomposeCommandLine(commandLine string) ([]string, error) {
+ 	if len(commandLine) == 0 {
+ 		return []string{}, nil
+@@ -105,18 +153,35 @@ func DecomposeCommandLine(commandLine string) ([]string, error) {
+ 		return nil, errorspkg.New("string with NUL passed to DecomposeCommandLine")
+ 	}
+ 	var argc int32
+-	argv, err := CommandLineToArgv(&utf16CommandLine[0], &argc)
++	argv, err := commandLineToArgv(&utf16CommandLine[0], &argc)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 	defer LocalFree(Handle(unsafe.Pointer(argv)))
++
+ 	var args []string
+-	for _, v := range (*argv)[:argc] {
+-		args = append(args, UTF16ToString((*v)[:]))
++	for _, p := range unsafe.Slice(argv, argc) {
++		args = append(args, UTF16PtrToString(p))
+ 	}
+ 	return args, nil
+ }
+ 
++// CommandLineToArgv parses a Unicode command line string and sets
++// argc to the number of parsed arguments.
++//
++// The returned memory should be freed using a single call to LocalFree.
++//
++// Note that although the return type of CommandLineToArgv indicates 8192
++// entries of up to 8192 characters each, the actual count of parsed arguments
++// may exceed 8192, and the documentation for CommandLineToArgvW does not mention
++// any bound on the lengths of the individual argument strings.
++// (See https://go.dev/issue/63236.)
++func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) {
++	argp, err := commandLineToArgv(cmd, argc)
++	argv = (*[8192]*[8192]uint16)(unsafe.Pointer(argp))
++	return argv, err
++}
++
+ func CloseOnExec(fd Handle) {
+ 	SetHandleInformation(Handle(fd), HANDLE_FLAG_INHERIT, 0)
+ }
+diff --git a/vendor/golang.org/x/sys/windows/security_windows.go b/vendor/golang.org/x/sys/windows/security_windows.go
+index d414ef1..26be94a 100644
+--- a/vendor/golang.org/x/sys/windows/security_windows.go
++++ b/vendor/golang.org/x/sys/windows/security_windows.go
+@@ -7,8 +7,6 @@ package windows
+ import (
+ 	"syscall"
+ 	"unsafe"
+-
+-	"golang.org/x/sys/internal/unsafeheader"
+ )
+ 
+ const (
+@@ -1341,21 +1339,14 @@ func (selfRelativeSD *SECURITY_DESCRIPTOR) copySelfRelativeSecurityDescriptor()
+ 		sdLen = min
+ 	}
+ 
+-	var src []byte
+-	h := (*unsafeheader.Slice)(unsafe.Pointer(&src))
+-	h.Data = unsafe.Pointer(selfRelativeSD)
+-	h.Len = sdLen
+-	h.Cap = sdLen
+-
++	src := unsafe.Slice((*byte)(unsafe.Pointer(selfRelativeSD)), sdLen)
++	// SECURITY_DESCRIPTOR has pointers in it, which means checkptr expects for it to
++	// be aligned properly. When we're copying a Windows-allocated struct to a
++	// Go-allocated one, make sure that the Go allocation is aligned to the
++	// pointer size.
+ 	const psize = int(unsafe.Sizeof(uintptr(0)))
+-
+-	var dst []byte
+-	h = (*unsafeheader.Slice)(unsafe.Pointer(&dst))
+ 	alloc := make([]uintptr, (sdLen+psize-1)/psize)
+-	h.Data = (*unsafeheader.Slice)(unsafe.Pointer(&alloc)).Data
+-	h.Len = sdLen
+-	h.Cap = sdLen
+-
++	dst := unsafe.Slice((*byte)(unsafe.Pointer(&alloc[0])), sdLen)
+ 	copy(dst, src)
+ 	return (*SECURITY_DESCRIPTOR)(unsafe.Pointer(&dst[0]))
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index 9645900..a3cf746 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -15,8 +15,6 @@ import (
+ 	"time"
+ 	"unicode/utf16"
+ 	"unsafe"
+-
+-	"golang.org/x/sys/internal/unsafeheader"
+ )
+ 
+ type Handle uintptr
+@@ -216,7 +214,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	shGetKnownFolderPath(id *KNOWNFOLDERID, flags uint32, token Token, path **uint16) (ret error) = shell32.SHGetKnownFolderPath
+ //sys	TerminateProcess(handle Handle, exitcode uint32) (err error)
+ //sys	GetExitCodeProcess(handle Handle, exitcode *uint32) (err error)
+-//sys	GetStartupInfo(startupInfo *StartupInfo) (err error) = GetStartupInfoW
++//sys	getStartupInfo(startupInfo *StartupInfo) = GetStartupInfoW
+ //sys	GetProcessTimes(handle Handle, creationTime *Filetime, exitTime *Filetime, kernelTime *Filetime, userTime *Filetime) (err error)
+ //sys	DuplicateHandle(hSourceProcessHandle Handle, hSourceHandle Handle, hTargetProcessHandle Handle, lpTargetHandle *Handle, dwDesiredAccess uint32, bInheritHandle bool, dwOptions uint32) (err error)
+ //sys	WaitForSingleObject(handle Handle, waitMilliseconds uint32) (event uint32, err error) [failretval==0xffffffff]
+@@ -240,7 +238,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	SetFileAttributes(name *uint16, attrs uint32) (err error) = kernel32.SetFileAttributesW
+ //sys	GetFileAttributesEx(name *uint16, level uint32, info *byte) (err error) = kernel32.GetFileAttributesExW
+ //sys	GetCommandLine() (cmd *uint16) = kernel32.GetCommandLineW
+-//sys	CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) [failretval==nil] = shell32.CommandLineToArgvW
++//sys	commandLineToArgv(cmd *uint16, argc *int32) (argv **uint16, err error) [failretval==nil] = shell32.CommandLineToArgvW
+ //sys	LocalFree(hmem Handle) (handle Handle, err error) [failretval!=0]
+ //sys	LocalAlloc(flags uint32, length uint32) (ptr uintptr, err error)
+ //sys	SetHandleInformation(handle Handle, mask uint32, flags uint32) (err error)
+@@ -299,12 +297,15 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	RegNotifyChangeKeyValue(key Handle, watchSubtree bool, notifyFilter uint32, event Handle, asynchronous bool) (regerrno error) = advapi32.RegNotifyChangeKeyValue
+ //sys	GetCurrentProcessId() (pid uint32) = kernel32.GetCurrentProcessId
+ //sys	ProcessIdToSessionId(pid uint32, sessionid *uint32) (err error) = kernel32.ProcessIdToSessionId
++//sys	ClosePseudoConsole(console Handle) = kernel32.ClosePseudoConsole
++//sys	createPseudoConsole(size uint32, in Handle, out Handle, flags uint32, pconsole *Handle) (hr error) = kernel32.CreatePseudoConsole
+ //sys	GetConsoleMode(console Handle, mode *uint32) (err error) = kernel32.GetConsoleMode
+ //sys	SetConsoleMode(console Handle, mode uint32) (err error) = kernel32.SetConsoleMode
+ //sys	GetConsoleScreenBufferInfo(console Handle, info *ConsoleScreenBufferInfo) (err error) = kernel32.GetConsoleScreenBufferInfo
+ //sys	setConsoleCursorPosition(console Handle, position uint32) (err error) = kernel32.SetConsoleCursorPosition
+ //sys	WriteConsole(console Handle, buf *uint16, towrite uint32, written *uint32, reserved *byte) (err error) = kernel32.WriteConsoleW
+ //sys	ReadConsole(console Handle, buf *uint16, toread uint32, read *uint32, inputControl *byte) (err error) = kernel32.ReadConsoleW
++//sys	resizePseudoConsole(pconsole Handle, size uint32) (hr error) = kernel32.ResizePseudoConsole
+ //sys	CreateToolhelp32Snapshot(flags uint32, processId uint32) (handle Handle, err error) [failretval==InvalidHandle] = kernel32.CreateToolhelp32Snapshot
+ //sys	Module32First(snapshot Handle, moduleEntry *ModuleEntry32) (err error) = kernel32.Module32FirstW
+ //sys	Module32Next(snapshot Handle, moduleEntry *ModuleEntry32) (err error) = kernel32.Module32NextW
+@@ -437,6 +438,10 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	DwmGetWindowAttribute(hwnd HWND, attribute uint32, value unsafe.Pointer, size uint32) (ret error) = dwmapi.DwmGetWindowAttribute
+ //sys	DwmSetWindowAttribute(hwnd HWND, attribute uint32, value unsafe.Pointer, size uint32) (ret error) = dwmapi.DwmSetWindowAttribute
+ 
++// Windows Multimedia API
++//sys TimeBeginPeriod (period uint32) (err error) [failretval != 0] = winmm.timeBeginPeriod
++//sys TimeEndPeriod (period uint32) (err error) [failretval != 0] = winmm.timeEndPeriod
++
+ // syscall interface implementation for other packages
+ 
+ // GetCurrentProcess returns the handle for the current process.
+@@ -1624,6 +1629,11 @@ func SetConsoleCursorPosition(console Handle, position Coord) error {
+ 	return setConsoleCursorPosition(console, *((*uint32)(unsafe.Pointer(&position))))
+ }
+ 
++func GetStartupInfo(startupInfo *StartupInfo) error {
++	getStartupInfo(startupInfo)
++	return nil
++}
++
+ func (s NTStatus) Errno() syscall.Errno {
+ 	return rtlNtStatusToDosErrorNoTeb(s)
+ }
+@@ -1658,12 +1668,8 @@ func NewNTUnicodeString(s string) (*NTUnicodeString, error) {
+ 
+ // Slice returns a uint16 slice that aliases the data in the NTUnicodeString.
+ func (s *NTUnicodeString) Slice() []uint16 {
+-	var slice []uint16
+-	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&slice))
+-	hdr.Data = unsafe.Pointer(s.Buffer)
+-	hdr.Len = int(s.Length)
+-	hdr.Cap = int(s.MaximumLength)
+-	return slice
++	slice := unsafe.Slice(s.Buffer, s.MaximumLength)
++	return slice[:s.Length]
+ }
+ 
+ func (s *NTUnicodeString) String() string {
+@@ -1686,12 +1692,8 @@ func NewNTString(s string) (*NTString, error) {
+ 
+ // Slice returns a byte slice that aliases the data in the NTString.
+ func (s *NTString) Slice() []byte {
+-	var slice []byte
+-	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&slice))
+-	hdr.Data = unsafe.Pointer(s.Buffer)
+-	hdr.Len = int(s.Length)
+-	hdr.Cap = int(s.MaximumLength)
+-	return slice
++	slice := unsafe.Slice(s.Buffer, s.MaximumLength)
++	return slice[:s.Length]
+ }
+ 
+ func (s *NTString) String() string {
+@@ -1743,10 +1745,7 @@ func LoadResourceData(module, resInfo Handle) (data []byte, err error) {
+ 	if err != nil {
+ 		return
+ 	}
+-	h := (*unsafeheader.Slice)(unsafe.Pointer(&data))
+-	h.Data = unsafe.Pointer(ptr)
+-	h.Len = int(size)
+-	h.Cap = int(size)
++	data = unsafe.Slice((*byte)(unsafe.Pointer(ptr)), size)
+ 	return
+ }
+ 
+@@ -1817,3 +1816,17 @@ type PSAPI_WORKING_SET_EX_INFORMATION struct {
+ 	// A PSAPI_WORKING_SET_EX_BLOCK union that indicates the attributes of the page at VirtualAddress.
+ 	VirtualAttributes PSAPI_WORKING_SET_EX_BLOCK
+ }
++
++// CreatePseudoConsole creates a windows pseudo console.
++func CreatePseudoConsole(size Coord, in Handle, out Handle, flags uint32, pconsole *Handle) error {
++	// We need this wrapper to manually cast Coord to uint32. The autogenerated wrappers only
++	// accept arguments that can be casted to uintptr, and Coord can't.
++	return createPseudoConsole(*((*uint32)(unsafe.Pointer(&size))), in, out, flags, pconsole)
++}
++
++// ResizePseudoConsole resizes the internal buffers of the pseudo console to the width and height specified in `size`.
++func ResizePseudoConsole(pconsole Handle, size Coord) error {
++	// We need this wrapper to manually cast Coord to uint32. The autogenerated wrappers only
++	// accept arguments that can be casted to uintptr, and Coord can't.
++	return resizePseudoConsole(pconsole, *((*uint32)(unsafe.Pointer(&size))))
++}
+diff --git a/vendor/golang.org/x/sys/windows/types_windows.go b/vendor/golang.org/x/sys/windows/types_windows.go
+index 88e62a6..b88dc7c 100644
+--- a/vendor/golang.org/x/sys/windows/types_windows.go
++++ b/vendor/golang.org/x/sys/windows/types_windows.go
+@@ -247,6 +247,7 @@ const (
+ 	PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY = 0x00020007
+ 	PROC_THREAD_ATTRIBUTE_UMS_THREAD        = 0x00030006
+ 	PROC_THREAD_ATTRIBUTE_PROTECTION_LEVEL  = 0x0002000b
++	PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE     = 0x00020016
+ )
+ 
+ const (
+@@ -2139,6 +2140,12 @@ const (
+ 	ENABLE_LVB_GRID_WORLDWIDE          = 0x10
+ )
+ 
++// Pseudo console related constants used for the flags parameter to
++// CreatePseudoConsole. See: https://learn.microsoft.com/en-us/windows/console/createpseudoconsole
++const (
++	PSEUDOCONSOLE_INHERIT_CURSOR = 0x1
++)
++
+ type Coord struct {
+ 	X int16
+ 	Y int16
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index 566dd3e..8b1688d 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -55,6 +55,7 @@ var (
+ 	moduser32   = NewLazySystemDLL("user32.dll")
+ 	moduserenv  = NewLazySystemDLL("userenv.dll")
+ 	modversion  = NewLazySystemDLL("version.dll")
++	modwinmm    = NewLazySystemDLL("winmm.dll")
+ 	modwintrust = NewLazySystemDLL("wintrust.dll")
+ 	modws2_32   = NewLazySystemDLL("ws2_32.dll")
+ 	modwtsapi32 = NewLazySystemDLL("wtsapi32.dll")
+@@ -187,6 +188,7 @@ var (
+ 	procCancelIo                                             = modkernel32.NewProc("CancelIo")
+ 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
+ 	procCloseHandle                                          = modkernel32.NewProc("CloseHandle")
++	procClosePseudoConsole                                   = modkernel32.NewProc("ClosePseudoConsole")
+ 	procConnectNamedPipe                                     = modkernel32.NewProc("ConnectNamedPipe")
+ 	procCreateDirectoryW                                     = modkernel32.NewProc("CreateDirectoryW")
+ 	procCreateEventExW                                       = modkernel32.NewProc("CreateEventExW")
+@@ -201,6 +203,7 @@ var (
+ 	procCreateNamedPipeW                                     = modkernel32.NewProc("CreateNamedPipeW")
+ 	procCreatePipe                                           = modkernel32.NewProc("CreatePipe")
+ 	procCreateProcessW                                       = modkernel32.NewProc("CreateProcessW")
++	procCreatePseudoConsole                                  = modkernel32.NewProc("CreatePseudoConsole")
+ 	procCreateSymbolicLinkW                                  = modkernel32.NewProc("CreateSymbolicLinkW")
+ 	procCreateToolhelp32Snapshot                             = modkernel32.NewProc("CreateToolhelp32Snapshot")
+ 	procDefineDosDeviceW                                     = modkernel32.NewProc("DefineDosDeviceW")
+@@ -327,6 +330,7 @@ var (
+ 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
+ 	procRemoveDirectoryW                                     = modkernel32.NewProc("RemoveDirectoryW")
+ 	procResetEvent                                           = modkernel32.NewProc("ResetEvent")
++	procResizePseudoConsole                                  = modkernel32.NewProc("ResizePseudoConsole")
+ 	procResumeThread                                         = modkernel32.NewProc("ResumeThread")
+ 	procSetCommTimeouts                                      = modkernel32.NewProc("SetCommTimeouts")
+ 	procSetConsoleCursorPosition                             = modkernel32.NewProc("SetConsoleCursorPosition")
+@@ -468,6 +472,8 @@ var (
+ 	procGetFileVersionInfoSizeW                              = modversion.NewProc("GetFileVersionInfoSizeW")
+ 	procGetFileVersionInfoW                                  = modversion.NewProc("GetFileVersionInfoW")
+ 	procVerQueryValueW                                       = modversion.NewProc("VerQueryValueW")
++	proctimeBeginPeriod                                      = modwinmm.NewProc("timeBeginPeriod")
++	proctimeEndPeriod                                        = modwinmm.NewProc("timeEndPeriod")
+ 	procWinVerifyTrustEx                                     = modwintrust.NewProc("WinVerifyTrustEx")
+ 	procFreeAddrInfoW                                        = modws2_32.NewProc("FreeAddrInfoW")
+ 	procGetAddrInfoW                                         = modws2_32.NewProc("GetAddrInfoW")
+@@ -1630,6 +1636,11 @@ func CloseHandle(handle Handle) (err error) {
+ 	return
+ }
+ 
++func ClosePseudoConsole(console Handle) {
++	syscall.Syscall(procClosePseudoConsole.Addr(), 1, uintptr(console), 0, 0)
++	return
++}
++
+ func ConnectNamedPipe(pipe Handle, overlapped *Overlapped) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procConnectNamedPipe.Addr(), 2, uintptr(pipe), uintptr(unsafe.Pointer(overlapped)), 0)
+ 	if r1 == 0 {
+@@ -1759,6 +1770,14 @@ func CreateProcess(appName *uint16, commandLine *uint16, procSecurity *SecurityA
+ 	return
+ }
+ 
++func createPseudoConsole(size uint32, in Handle, out Handle, flags uint32, pconsole *Handle) (hr error) {
++	r0, _, _ := syscall.Syscall6(procCreatePseudoConsole.Addr(), 5, uintptr(size), uintptr(in), uintptr(out), uintptr(flags), uintptr(unsafe.Pointer(pconsole)), 0)
++	if r0 != 0 {
++		hr = syscall.Errno(r0)
++	}
++	return
++}
++
+ func CreateSymbolicLink(symlinkfilename *uint16, targetfilename *uint16, flags uint32) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procCreateSymbolicLinkW.Addr(), 3, uintptr(unsafe.Pointer(symlinkfilename)), uintptr(unsafe.Pointer(targetfilename)), uintptr(flags))
+ 	if r1&0xff == 0 {
+@@ -2367,11 +2386,8 @@ func GetShortPathName(longpath *uint16, shortpath *uint16, buflen uint32) (n uin
+ 	return
+ }
+ 
+-func GetStartupInfo(startupInfo *StartupInfo) (err error) {
+-	r1, _, e1 := syscall.Syscall(procGetStartupInfoW.Addr(), 1, uintptr(unsafe.Pointer(startupInfo)), 0, 0)
+-	if r1 == 0 {
+-		err = errnoErr(e1)
+-	}
++func getStartupInfo(startupInfo *StartupInfo) {
++	syscall.Syscall(procGetStartupInfoW.Addr(), 1, uintptr(unsafe.Pointer(startupInfo)), 0, 0)
+ 	return
+ }
+ 
+@@ -2862,6 +2878,14 @@ func ResetEvent(event Handle) (err error) {
+ 	return
+ }
+ 
++func resizePseudoConsole(pconsole Handle, size uint32) (hr error) {
++	r0, _, _ := syscall.Syscall(procResizePseudoConsole.Addr(), 2, uintptr(pconsole), uintptr(size), 0)
++	if r0 != 0 {
++		hr = syscall.Errno(r0)
++	}
++	return
++}
++
+ func ResumeThread(thread Handle) (ret uint32, err error) {
+ 	r0, _, e1 := syscall.Syscall(procResumeThread.Addr(), 1, uintptr(thread), 0, 0)
+ 	ret = uint32(r0)
+@@ -3820,9 +3844,9 @@ func setupUninstallOEMInf(infFileName *uint16, flags SUOI, reserved uintptr) (er
+ 	return
+ }
+ 
+-func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) {
++func commandLineToArgv(cmd *uint16, argc *int32) (argv **uint16, err error) {
+ 	r0, _, e1 := syscall.Syscall(procCommandLineToArgvW.Addr(), 2, uintptr(unsafe.Pointer(cmd)), uintptr(unsafe.Pointer(argc)), 0)
+-	argv = (*[8192]*[8192]uint16)(unsafe.Pointer(r0))
++	argv = (**uint16)(unsafe.Pointer(r0))
+ 	if argv == nil {
+ 		err = errnoErr(e1)
+ 	}
+@@ -4017,6 +4041,22 @@ func _VerQueryValue(block unsafe.Pointer, subBlock *uint16, pointerToBufferPoint
+ 	return
+ }
+ 
++func TimeBeginPeriod(period uint32) (err error) {
++	r1, _, e1 := syscall.Syscall(proctimeBeginPeriod.Addr(), 1, uintptr(period), 0, 0)
++	if r1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++func TimeEndPeriod(period uint32) (err error) {
++	r1, _, e1 := syscall.Syscall(proctimeEndPeriod.Addr(), 1, uintptr(period), 0, 0)
++	if r1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func WinVerifyTrustEx(hwnd HWND, actionId *GUID, data *WinTrustData) (ret error) {
+ 	r0, _, _ := syscall.Syscall(procWinVerifyTrustEx.Addr(), 3, uintptr(hwnd), uintptr(unsafe.Pointer(actionId)), uintptr(unsafe.Pointer(data)))
+ 	if r0 != 0 {
+diff --git a/vendor/golang.org/x/text/unicode/norm/trie.go b/vendor/golang.org/x/text/unicode/norm/trie.go
+index 423386b..e4250ae 100644
+--- a/vendor/golang.org/x/text/unicode/norm/trie.go
++++ b/vendor/golang.org/x/text/unicode/norm/trie.go
+@@ -29,7 +29,7 @@ var (
+ 	nfkcData = newNfkcTrie(0)
+ )
+ 
+-// lookupValue determines the type of block n and looks up the value for b.
++// lookup determines the type of block n and looks up the value for b.
+ // For n < t.cutoff, the block is a simple lookup table. Otherwise, the block
+ // is a list of ranges with an accompanying value. Given a matching range r,
+ // the value for b is by r.value + (b - r.lo) * stride.
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 352cad7..a028c0a 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -61,7 +61,46 @@ github.com/prometheus/procfs/internal/util
+ # github.com/spf13/pflag v1.0.5
+ ## explicit; go 1.12
+ github.com/spf13/pflag
+-# golang.org/x/net v0.13.0
++# go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.0
++## explicit; go 1.19
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/internal
++# go.opentelemetry.io/otel v1.15.0
++## explicit; go 1.19
++go.opentelemetry.io/otel
++go.opentelemetry.io/otel/attribute
++go.opentelemetry.io/otel/baggage
++go.opentelemetry.io/otel/codes
++go.opentelemetry.io/otel/internal
++go.opentelemetry.io/otel/internal/attribute
++go.opentelemetry.io/otel/internal/baggage
++go.opentelemetry.io/otel/internal/global
++go.opentelemetry.io/otel/propagation
++go.opentelemetry.io/otel/semconv/v1.17.0
++# go.opentelemetry.io/otel/metric v0.38.0
++## explicit; go 1.19
++go.opentelemetry.io/otel/metric
++go.opentelemetry.io/otel/metric/embedded
++go.opentelemetry.io/otel/metric/global
++go.opentelemetry.io/otel/metric/internal/global
++# go.opentelemetry.io/otel/trace v1.15.0
++## explicit; go 1.19
++go.opentelemetry.io/otel/trace
++# go.uber.org/atomic v1.10.0
++## explicit; go 1.18
++go.uber.org/atomic
++# go.uber.org/multierr v1.11.0
++## explicit; go 1.19
++go.uber.org/multierr
++# go.uber.org/zap v1.19.0
++## explicit; go 1.13
++go.uber.org/zap
++go.uber.org/zap/buffer
++go.uber.org/zap/internal/bufferpool
++go.uber.org/zap/internal/color
++go.uber.org/zap/internal/exit
++go.uber.org/zap/zapcore
++# golang.org/x/net v0.17.0
+ ## explicit; go 1.17
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -69,12 +108,11 @@ golang.org/x/net/http2/hpack
+ golang.org/x/net/idna
+ golang.org/x/net/internal/timeseries
+ golang.org/x/net/trace
+-# golang.org/x/sys v0.10.0
++# golang.org/x/sys v0.13.0
+ ## explicit; go 1.17
+-golang.org/x/sys/internal/unsafeheader
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-# golang.org/x/text v0.11.0
++# golang.org/x/text v0.13.0
+ ## explicit; go 1.17
+ golang.org/x/text/secure/bidirule
+ golang.org/x/text/transform
+-- 
+2.39.1
+

--- a/projects/kubernetes-csi/livenessprobe/1-25/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-25/CHECKSUMS
@@ -1,3 +1,3 @@
-76c4a0a6d54a987744cc1ee11a6a59c75c863db7088ac7a88b6a635ba871024a  _output/1-25/bin/livenessprobe/linux-amd64/livenessprobe
-61349ff8a583832aab8254c3c3ba90c03373324cc6eff7ef1c890811903cc726  _output/1-25/bin/livenessprobe/linux-arm64/livenessprobe
-059722d18e2b0d29632f4a6f760d331f0ba053d6a0dfd758582d2131164b1f0d  _output/1-25/bin/livenessprobe/windows-amd64/livenessprobe.exe
+069068a60fdf7739331586e4ad9f3258690ffe44d066514612dfcc0d8a6c2063  _output/1-25/bin/livenessprobe/linux-amd64/livenessprobe
+d3508a41fee454aea498b9b8841f2b299895a153594b89877a1dac7ed5a56812  _output/1-25/bin/livenessprobe/linux-arm64/livenessprobe
+7c2eda8690b52b3fdf51f1855a6c070afc8bceee41ef2fe8fbdb36b9f07acfc0  _output/1-25/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-25/patches/0001-Fix-CVE-2023-44487-and-CVE-2023-39325-bump-golang.or.patch
+++ b/projects/kubernetes-csi/livenessprobe/1-25/patches/0001-Fix-CVE-2023-44487-and-CVE-2023-39325-bump-golang.or.patch
@@ -1,0 +1,6786 @@
+From 0da68f237a1f971d899df26ee722ddf72905aa15 Mon Sep 17 00:00:00 2001
+From: Jonathan Dobson <jdobson@redhat.com>
+Date: Wed, 18 Oct 2023 14:27:39 -0600
+Subject: [PATCH] Fix CVE-2023-44487 and CVE-2023-39325: bump golang.org/x/net
+
+Signed-off-by: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
+---
+ go.mod                                        |  13 +-
+ go.sum                                        |  31 +-
+ vendor/golang.org/x/net/http2/Dockerfile      |  51 ----
+ vendor/golang.org/x/net/http2/Makefile        |   3 -
+ vendor/golang.org/x/net/http2/server.go       |  86 ++++--
+ vendor/golang.org/x/net/http2/transport.go    |   3 +-
+ .../sys/internal/unsafeheader/unsafeheader.go |  30 --
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |   1 +
+ vendor/golang.org/x/sys/unix/ptrace_darwin.go |   6 -
+ vendor/golang.org/x/sys/unix/ptrace_ios.go    |   6 -
+ vendor/golang.org/x/sys/unix/syscall_aix.go   |   2 -
+ .../golang.org/x/sys/unix/syscall_darwin.go   | 186 ------------
+ .../x/sys/unix/syscall_darwin_amd64.go        |   1 -
+ .../x/sys/unix/syscall_darwin_arm64.go        |   1 -
+ .../x/sys/unix/syscall_dragonfly.go           | 198 -------------
+ .../golang.org/x/sys/unix/syscall_freebsd.go  | 192 -------------
+ vendor/golang.org/x/sys/unix/syscall_linux.go |  77 ++++-
+ .../golang.org/x/sys/unix/syscall_netbsd.go   | 272 +-----------------
+ .../golang.org/x/sys/unix/syscall_openbsd.go  |  74 -----
+ .../golang.org/x/sys/unix/syscall_solaris.go  |  32 ---
+ vendor/golang.org/x/sys/unix/syscall_unix.go  |   3 +
+ .../x/sys/unix/syscall_zos_s390x.go           |   1 -
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  26 ++
+ .../x/sys/unix/zerrors_linux_386.go           |   2 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   2 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   4 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   2 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   2 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   2 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   2 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   2 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   2 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   2 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   2 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   2 +
+ .../golang.org/x/sys/unix/zsyscall_aix_ppc.go |  22 --
+ .../x/sys/unix/zsyscall_aix_ppc64.go          |  22 --
+ .../x/sys/unix/zsyscall_darwin_amd64.go       |  40 +--
+ .../x/sys/unix/zsyscall_darwin_amd64.s        | 149 ----------
+ .../x/sys/unix/zsyscall_darwin_arm64.go       |  40 +--
+ .../x/sys/unix/zsyscall_darwin_arm64.s        | 149 ----------
+ .../x/sys/unix/zsyscall_dragonfly_amd64.go    |  22 --
+ .../x/sys/unix/zsyscall_freebsd_386.go        |  22 --
+ .../x/sys/unix/zsyscall_freebsd_amd64.go      |  22 --
+ .../x/sys/unix/zsyscall_freebsd_arm.go        |  22 --
+ .../x/sys/unix/zsyscall_freebsd_arm64.go      |  22 --
+ .../x/sys/unix/zsyscall_freebsd_riscv64.go    |  22 --
+ .../x/sys/unix/zsyscall_illumos_amd64.go      |  10 +-
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  42 ++-
+ .../x/sys/unix/zsyscall_netbsd_386.go         |  22 --
+ .../x/sys/unix/zsyscall_netbsd_amd64.go       |  22 --
+ .../x/sys/unix/zsyscall_netbsd_arm.go         |  22 --
+ .../x/sys/unix/zsyscall_netbsd_arm64.go       |  22 --
+ .../x/sys/unix/zsyscall_openbsd_386.go        |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |  22 --
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |  32 +--
+ .../x/sys/unix/zsyscall_solaris_amd64.go      | 256 ++++++++---------
+ .../x/sys/unix/zsyscall_zos_s390x.go          |  11 -
+ .../x/sys/unix/zsysnum_linux_386.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   1 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   1 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   1 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   1 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  |  23 +-
+ .../x/sys/unix/ztypes_linux_riscv64.go        |  27 ++
+ .../golang.org/x/sys/windows/exec_windows.go  |  89 +++++-
+ .../x/sys/windows/security_windows.go         |  21 +-
+ .../x/sys/windows/syscall_windows.go          |  53 ++--
+ .../golang.org/x/sys/windows/types_windows.go |   7 +
+ .../x/sys/windows/zsyscall_windows.go         |  54 +++-
+ vendor/golang.org/x/text/unicode/norm/trie.go |   2 +-
+ vendor/modules.txt                            |  46 ++-
+ 89 files changed, 698 insertions(+), 2141 deletions(-)
+ delete mode 100644 vendor/golang.org/x/net/http2/Dockerfile
+ delete mode 100644 vendor/golang.org/x/net/http2/Makefile
+ delete mode 100644 vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
+
+diff --git a/go.mod b/go.mod
+index 3c87bf0..1d87210 100644
+--- a/go.mod
++++ b/go.mod
+@@ -23,9 +23,16 @@ require (
+ 	github.com/prometheus/common v0.44.0 // indirect
+ 	github.com/prometheus/procfs v0.10.1 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+-	golang.org/x/net v0.13.0 // indirect
+-	golang.org/x/sys v0.10.0 // indirect
+-	golang.org/x/text v0.11.0 // indirect
++	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.0 // indirect
++	go.opentelemetry.io/otel v1.15.0 // indirect
++	go.opentelemetry.io/otel/metric v0.38.0 // indirect
++	go.opentelemetry.io/otel/trace v1.15.0 // indirect
++	go.uber.org/atomic v1.10.0 // indirect
++	go.uber.org/multierr v1.11.0 // indirect
++	go.uber.org/zap v1.19.0 // indirect
++	golang.org/x/net v0.17.0 // indirect
++	golang.org/x/sys v0.13.0 // indirect
++	golang.org/x/text v0.13.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
+ 	google.golang.org/protobuf v1.31.0 // indirect
+ 	k8s.io/apimachinery v0.28.0 // indirect
+diff --git a/go.sum b/go.sum
+index 038cdf3..d4a9711 100644
+--- a/go.sum
++++ b/go.sum
+@@ -137,17 +137,9 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
+-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+-golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+-golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+-golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+-golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=
+-golang.org/x/net v0.13.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
+-golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+-golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
++golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
++golang.org/x/oauth2 v0.10.0 h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -168,23 +160,14 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220731174439-a90be440212d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
++golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+-golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
+-golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
++golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
++golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+diff --git a/vendor/golang.org/x/net/http2/Dockerfile b/vendor/golang.org/x/net/http2/Dockerfile
+deleted file mode 100644
+index 8512245..0000000
+--- a/vendor/golang.org/x/net/http2/Dockerfile
++++ /dev/null
+@@ -1,51 +0,0 @@
+-#
+-# This Dockerfile builds a recent curl with HTTP/2 client support, using
+-# a recent nghttp2 build.
+-#
+-# See the Makefile for how to tag it. If Docker and that image is found, the
+-# Go tests use this curl binary for integration tests.
+-#
+-
+-FROM ubuntu:trusty
+-
+-RUN apt-get update && \
+-    apt-get upgrade -y && \
+-    apt-get install -y git-core build-essential wget
+-
+-RUN apt-get install -y --no-install-recommends \
+-       autotools-dev libtool pkg-config zlib1g-dev \
+-       libcunit1-dev libssl-dev libxml2-dev libevent-dev \
+-       automake autoconf
+-
+-# The list of packages nghttp2 recommends for h2load:
+-RUN apt-get install -y --no-install-recommends make binutils \
+-        autoconf automake autotools-dev \
+-        libtool pkg-config zlib1g-dev libcunit1-dev libssl-dev libxml2-dev \
+-        libev-dev libevent-dev libjansson-dev libjemalloc-dev \
+-        cython python3.4-dev python-setuptools
+-
+-# Note: setting NGHTTP2_VER before the git clone, so an old git clone isn't cached:
+-ENV NGHTTP2_VER 895da9a
+-RUN cd /root && git clone https://github.com/tatsuhiro-t/nghttp2.git
+-
+-WORKDIR /root/nghttp2
+-RUN git reset --hard $NGHTTP2_VER
+-RUN autoreconf -i
+-RUN automake
+-RUN autoconf
+-RUN ./configure
+-RUN make
+-RUN make install
+-
+-WORKDIR /root
+-RUN wget https://curl.se/download/curl-7.45.0.tar.gz
+-RUN tar -zxvf curl-7.45.0.tar.gz
+-WORKDIR /root/curl-7.45.0
+-RUN ./configure --with-ssl --with-nghttp2=/usr/local
+-RUN make
+-RUN make install
+-RUN ldconfig
+-
+-CMD ["-h"]
+-ENTRYPOINT ["/usr/local/bin/curl"]
+-
+diff --git a/vendor/golang.org/x/net/http2/Makefile b/vendor/golang.org/x/net/http2/Makefile
+deleted file mode 100644
+index 55fd826..0000000
+--- a/vendor/golang.org/x/net/http2/Makefile
++++ /dev/null
+@@ -1,3 +0,0 @@
+-curlimage:
+-	docker build -t gohttp2/curl .
+-
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index 033b6e6..02c88b6 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -581,9 +581,11 @@ type serverConn struct {
+ 	advMaxStreams               uint32 // our SETTINGS_MAX_CONCURRENT_STREAMS advertised the client
+ 	curClientStreams            uint32 // number of open streams initiated by the client
+ 	curPushedStreams            uint32 // number of open streams initiated by server push
++	curHandlers                 uint32 // number of running handler goroutines
+ 	maxClientStreamID           uint32 // max ever seen from client (odd), or 0 if there have been no client requests
+ 	maxPushPromiseID            uint32 // ID of the last push promise (even), or 0 if there have been no pushes
+ 	streams                     map[uint32]*stream
++	unstartedHandlers           []unstartedHandler
+ 	initialStreamSendWindowSize int32
+ 	maxFrameSize                int32
+ 	peerMaxHeaderListSize       uint32            // zero means unknown (default)
+@@ -981,6 +983,8 @@ func (sc *serverConn) serve() {
+ 					return
+ 				case gracefulShutdownMsg:
+ 					sc.startGracefulShutdownInternal()
++				case handlerDoneMsg:
++					sc.handlerDone()
+ 				default:
+ 					panic("unknown timer")
+ 				}
+@@ -1012,14 +1016,6 @@ func (sc *serverConn) serve() {
+ 	}
+ }
+ 
+-func (sc *serverConn) awaitGracefulShutdown(sharedCh <-chan struct{}, privateCh chan struct{}) {
+-	select {
+-	case <-sc.doneServing:
+-	case <-sharedCh:
+-		close(privateCh)
+-	}
+-}
+-
+ type serverMessage int
+ 
+ // Message values sent to serveMsgCh.
+@@ -1028,6 +1024,7 @@ var (
+ 	idleTimerMsg        = new(serverMessage)
+ 	shutdownTimerMsg    = new(serverMessage)
+ 	gracefulShutdownMsg = new(serverMessage)
++	handlerDoneMsg      = new(serverMessage)
+ )
+ 
+ func (sc *serverConn) onSettingsTimer() { sc.sendServeMsg(settingsTimerMsg) }
+@@ -1900,9 +1897,11 @@ func (st *stream) copyTrailersToHandlerRequest() {
+ // onReadTimeout is run on its own goroutine (from time.AfterFunc)
+ // when the stream's ReadTimeout has fired.
+ func (st *stream) onReadTimeout() {
+-	// Wrap the ErrDeadlineExceeded to avoid callers depending on us
+-	// returning the bare error.
+-	st.body.CloseWithError(fmt.Errorf("%w", os.ErrDeadlineExceeded))
++	if st.body != nil {
++		// Wrap the ErrDeadlineExceeded to avoid callers depending on us
++		// returning the bare error.
++		st.body.CloseWithError(fmt.Errorf("%w", os.ErrDeadlineExceeded))
++	}
+ }
+ 
+ // onWriteTimeout is run on its own goroutine (from time.AfterFunc)
+@@ -2020,13 +2019,10 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+ 	if sc.hs.ReadTimeout != 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+-		if st.body != nil {
+-			st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+-		}
++		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+ 
+-	go sc.runHandler(rw, req, handler)
+-	return nil
++	return sc.scheduleHandler(id, rw, req, handler)
+ }
+ 
+ func (sc *serverConn) upgradeRequest(req *http.Request) {
+@@ -2046,6 +2042,10 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
++	// This is the first request on the connection,
++	// so start the handler directly rather than going
++	// through scheduleHandler.
++	sc.curHandlers++
+ 	go sc.runHandler(rw, req, sc.handler.ServeHTTP)
+ }
+ 
+@@ -2286,8 +2286,62 @@ func (sc *serverConn) newResponseWriter(st *stream, req *http.Request) *response
+ 	return &responseWriter{rws: rws}
+ }
+ 
++type unstartedHandler struct {
++	streamID uint32
++	rw       *responseWriter
++	req      *http.Request
++	handler  func(http.ResponseWriter, *http.Request)
++}
++
++// scheduleHandler starts a handler goroutine,
++// or schedules one to start as soon as an existing handler finishes.
++func (sc *serverConn) scheduleHandler(streamID uint32, rw *responseWriter, req *http.Request, handler func(http.ResponseWriter, *http.Request)) error {
++	sc.serveG.check()
++	maxHandlers := sc.advMaxStreams
++	if sc.curHandlers < maxHandlers {
++		sc.curHandlers++
++		go sc.runHandler(rw, req, handler)
++		return nil
++	}
++	if len(sc.unstartedHandlers) > int(4*sc.advMaxStreams) {
++		return sc.countError("too_many_early_resets", ConnectionError(ErrCodeEnhanceYourCalm))
++	}
++	sc.unstartedHandlers = append(sc.unstartedHandlers, unstartedHandler{
++		streamID: streamID,
++		rw:       rw,
++		req:      req,
++		handler:  handler,
++	})
++	return nil
++}
++
++func (sc *serverConn) handlerDone() {
++	sc.serveG.check()
++	sc.curHandlers--
++	i := 0
++	maxHandlers := sc.advMaxStreams
++	for ; i < len(sc.unstartedHandlers); i++ {
++		u := sc.unstartedHandlers[i]
++		if sc.streams[u.streamID] == nil {
++			// This stream was reset before its goroutine had a chance to start.
++			continue
++		}
++		if sc.curHandlers >= maxHandlers {
++			break
++		}
++		sc.curHandlers++
++		go sc.runHandler(u.rw, u.req, u.handler)
++		sc.unstartedHandlers[i] = unstartedHandler{} // don't retain references
++	}
++	sc.unstartedHandlers = sc.unstartedHandlers[i:]
++	if len(sc.unstartedHandlers) == 0 {
++		sc.unstartedHandlers = nil
++	}
++}
++
+ // Run on its own goroutine.
+ func (sc *serverConn) runHandler(rw *responseWriter, req *http.Request, handler func(http.ResponseWriter, *http.Request)) {
++	defer sc.sendServeMsg(handlerDoneMsg)
+ 	didPanic := true
+ 	defer func() {
+ 		rw.rws.stream.cancelCtx()
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index b20c749..7497f56 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -290,8 +290,7 @@ func (t *Transport) initConnPool() {
+ // HTTP/2 server.
+ type ClientConn struct {
+ 	t             *Transport
+-	tconn         net.Conn // usually *tls.Conn, except specialized impls
+-	tconnClosed   bool
++	tconn         net.Conn             // usually *tls.Conn, except specialized impls
+ 	tlsState      *tls.ConnectionState // nil only for specialized impls
+ 	reused        uint32               // whether conn is being reused; atomic
+ 	singleUse     bool                 // whether being used for a single http.Request
+diff --git a/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go b/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
+deleted file mode 100644
+index e07899b..0000000
+--- a/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
++++ /dev/null
+@@ -1,30 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-// Package unsafeheader contains header declarations for the Go runtime's
+-// slice and string implementations.
+-//
+-// This package allows x/sys to use types equivalent to
+-// reflect.SliceHeader and reflect.StringHeader without introducing
+-// a dependency on the (relatively heavy) "reflect" package.
+-package unsafeheader
+-
+-import (
+-	"unsafe"
+-)
+-
+-// Slice is the runtime representation of a slice.
+-// It cannot be used safely or portably and its representation may change in a later release.
+-type Slice struct {
+-	Data unsafe.Pointer
+-	Len  int
+-	Cap  int
+-}
+-
+-// String is the runtime representation of a string.
+-// It cannot be used safely or portably and its representation may change in a later release.
+-type String struct {
+-	Data unsafe.Pointer
+-	Len  int
+-}
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index 0c4d149..831f9e3 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -583,6 +583,7 @@ ccflags="$@"
+ 		$2 ~ /^PERF_/ ||
+ 		$2 ~ /^SECCOMP_MODE_/ ||
+ 		$2 ~ /^SEEK_/ ||
++		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+ 		$2 ~ /^SYNC_FILE_RANGE_/ ||
+ 		$2 !~ /IOC_MAGIC/ &&
+diff --git a/vendor/golang.org/x/sys/unix/ptrace_darwin.go b/vendor/golang.org/x/sys/unix/ptrace_darwin.go
+index 39dba6c..463c3ef 100644
+--- a/vendor/golang.org/x/sys/unix/ptrace_darwin.go
++++ b/vendor/golang.org/x/sys/unix/ptrace_darwin.go
+@@ -7,12 +7,6 @@
+ 
+ package unix
+ 
+-import "unsafe"
+-
+ func ptrace(request int, pid int, addr uintptr, data uintptr) error {
+ 	return ptrace1(request, pid, addr, data)
+ }
+-
+-func ptracePtr(request int, pid int, addr uintptr, data unsafe.Pointer) error {
+-	return ptrace1Ptr(request, pid, addr, data)
+-}
+diff --git a/vendor/golang.org/x/sys/unix/ptrace_ios.go b/vendor/golang.org/x/sys/unix/ptrace_ios.go
+index 9ea6633..ed0509a 100644
+--- a/vendor/golang.org/x/sys/unix/ptrace_ios.go
++++ b/vendor/golang.org/x/sys/unix/ptrace_ios.go
+@@ -7,12 +7,6 @@
+ 
+ package unix
+ 
+-import "unsafe"
+-
+ func ptrace(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return ENOTSUP
+ }
+-
+-func ptracePtr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	return ENOTSUP
+-}
+diff --git a/vendor/golang.org/x/sys/unix/syscall_aix.go b/vendor/golang.org/x/sys/unix/syscall_aix.go
+index c406ae0..6f77ff5 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_aix.go
++++ b/vendor/golang.org/x/sys/unix/syscall_aix.go
+@@ -487,8 +487,6 @@ func Fsync(fd int) error {
+ //sys	Unlinkat(dirfd int, path string, flags int) (err error)
+ //sys	Ustat(dev int, ubuf *Ustat_t) (err error)
+ //sys	write(fd int, p []byte) (n int, err error)
+-//sys	readlen(fd int, p *byte, np int) (n int, err error) = read
+-//sys	writelen(fd int, p *byte, np int) (n int, err error) = write
+ 
+ //sys	Dup2(oldfd int, newfd int) (err error)
+ //sys	Fadvise(fd int, offset int64, length int64, advice int) (err error) = posix_fadvise64
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin.go b/vendor/golang.org/x/sys/unix/syscall_darwin.go
+index 2069215..3b0bd2d 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin.go
+@@ -638,189 +638,3 @@ func SysctlKinfoProcSlice(name string, args ...int) ([]KinfoProc, error) {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+-
+-/*
+- * Unimplemented
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Ioctl
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// sendfile
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Poll_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go b/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
+index 9fa8798..b37310c 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
+@@ -47,6 +47,5 @@ func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr,
+ //sys	getfsstat(buf unsafe.Pointer, size uintptr, flags int) (n int, err error) = SYS_GETFSSTAT64
+ //sys	Lstat(path string, stat *Stat_t) (err error) = SYS_LSTAT64
+ //sys	ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) = SYS_ptrace
+-//sys	ptrace1Ptr(request int, pid int, addr unsafe.Pointer, data uintptr) (err error) = SYS_ptrace
+ //sys	Stat(path string, stat *Stat_t) (err error) = SYS_STAT64
+ //sys	Statfs(path string, stat *Statfs_t) (err error) = SYS_STATFS64
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go b/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
+index f17b8c5..d51ec99 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
+@@ -47,6 +47,5 @@ func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr,
+ //sys	getfsstat(buf unsafe.Pointer, size uintptr, flags int) (n int, err error) = SYS_GETFSSTAT
+ //sys	Lstat(path string, stat *Stat_t) (err error)
+ //sys	ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) = SYS_ptrace
+-//sys	ptrace1Ptr(request int, pid int, addr unsafe.Pointer, data uintptr) (err error) = SYS_ptrace
+ //sys	Stat(path string, stat *Stat_t) (err error)
+ //sys	Statfs(path string, stat *Statfs_t) (err error)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+index d4ce988..97cb916 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
++++ b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+@@ -343,203 +343,5 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error)
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- * TODO(jsing): Update this list for DragonFly.
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Mount
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Setattrlist
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Getxattr
+-// Fgetxattr
+-// Setxattr
+-// Fsetxattr
+-// Removexattr
+-// Fremovexattr
+-// Listxattr
+-// Flistxattr
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shmat
+-// Shmctl
+-// Shmdt
+-// Shmget
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index afb1010..64d1bb4 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -449,197 +449,5 @@ func Dup3(oldfd, newfd, flags int) error {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error)
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Ioctl
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Mount
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Setattrlist
+-// Getdents
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shmat
+-// Shmctl
+-// Shmdt
+-// Shmget
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Poll_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index 39de5f1..c905ec8 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -693,10 +693,10 @@ type SockaddrALG struct {
+ 
+ func (sa *SockaddrALG) sockaddr() (unsafe.Pointer, _Socklen, error) {
+ 	// Leave room for NUL byte terminator.
+-	if len(sa.Type) > 13 {
++	if len(sa.Type) > len(sa.raw.Type)-1 {
+ 		return nil, 0, EINVAL
+ 	}
+-	if len(sa.Name) > 63 {
++	if len(sa.Name) > len(sa.raw.Name)-1 {
+ 		return nil, 0, EINVAL
+ 	}
+ 
+@@ -704,17 +704,8 @@ func (sa *SockaddrALG) sockaddr() (unsafe.Pointer, _Socklen, error) {
+ 	sa.raw.Feat = sa.Feature
+ 	sa.raw.Mask = sa.Mask
+ 
+-	typ, err := ByteSliceFromString(sa.Type)
+-	if err != nil {
+-		return nil, 0, err
+-	}
+-	name, err := ByteSliceFromString(sa.Name)
+-	if err != nil {
+-		return nil, 0, err
+-	}
+-
+-	copy(sa.raw.Type[:], typ)
+-	copy(sa.raw.Name[:], name)
++	copy(sa.raw.Type[:], sa.Type)
++	copy(sa.raw.Name[:], sa.Name)
+ 
+ 	return unsafe.Pointer(&sa.raw), SizeofSockaddrALG, nil
+ }
+@@ -1988,8 +1979,6 @@ func Signalfd(fd int, sigmask *Sigset_t, flags int) (newfd int, err error) {
+ //sys	Unshare(flags int) (err error)
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	exitThread(code int) (err error) = SYS_EXIT
+-//sys	readlen(fd int, p *byte, np int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, p *byte, np int) (n int, err error) = SYS_WRITE
+ //sys	readv(fd int, iovs []Iovec) (n int, err error) = SYS_READV
+ //sys	writev(fd int, iovs []Iovec) (n int, err error) = SYS_WRITEV
+ //sys	preadv(fd int, iovs []Iovec, offs_l uintptr, offs_h uintptr) (n int, err error) = SYS_PREADV
+@@ -2454,6 +2443,7 @@ func Getresgid() (rgid, egid, sgid int) {
+ 	return int(r), int(e), int(s)
+ }
+ 
++<<<<<<< HEAD
+ /*
+  * Unimplemented
+  */
+@@ -2549,3 +2539,60 @@ func Getresgid() (rgid, egid, sgid int) {
+ // Vhangup
+ // Vserver
+ // _Sysctl
++=======
++// Pselect is a wrapper around the Linux pselect6 system call.
++// This version does not modify the timeout argument.
++func Pselect(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
++	// Per https://man7.org/linux/man-pages/man2/select.2.html#NOTES,
++	// The Linux pselect6() system call modifies its timeout argument.
++	// [Not modifying the argument] is the behavior required by POSIX.1-2001.
++	var mutableTimeout *Timespec
++	if timeout != nil {
++		mutableTimeout = new(Timespec)
++		*mutableTimeout = *timeout
++	}
++
++	// The final argument of the pselect6() system call is not a
++	// sigset_t * pointer, but is instead a structure
++	var kernelMask *sigset_argpack
++	if sigmask != nil {
++		wordBits := 32 << (^uintptr(0) >> 63) // see math.intSize
++
++		// A sigset stores one bit per signal,
++		// offset by 1 (because signal 0 does not exist).
++		// So the number of words needed is ⌈__C_NSIG - 1 / wordBits⌉.
++		sigsetWords := (_C__NSIG - 1 + wordBits - 1) / (wordBits)
++
++		sigsetBytes := uintptr(sigsetWords * (wordBits / 8))
++		kernelMask = &sigset_argpack{
++			ss:    sigmask,
++			ssLen: sigsetBytes,
++		}
++	}
++
++	return pselect6(nfd, r, w, e, mutableTimeout, kernelMask)
++}
++
++//sys	schedSetattr(pid int, attr *SchedAttr, flags uint) (err error)
++//sys	schedGetattr(pid int, attr *SchedAttr, size uint, flags uint) (err error)
++
++// SchedSetAttr is a wrapper for sched_setattr(2) syscall.
++// https://man7.org/linux/man-pages/man2/sched_setattr.2.html
++func SchedSetAttr(pid int, attr *SchedAttr, flags uint) error {
++	if attr == nil {
++		return EINVAL
++	}
++	attr.Size = SizeofSchedAttr
++	return schedSetattr(pid, attr, flags)
++}
++
++// SchedGetAttr is a wrapper for sched_getattr(2) syscall.
++// https://man7.org/linux/man-pages/man2/sched_getattr.2.html
++func SchedGetAttr(pid int, flags uint) (*SchedAttr, error) {
++	attr := &SchedAttr{}
++	if err := schedGetattr(pid, attr, SizeofSchedAttr, flags); err != nil {
++		return nil, err
++	}
++	return attr, nil
++}
++>>>>>>> 48ed37b (CVE-2023-44487: bump golang.org/x/net to v0.17.0)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_netbsd.go b/vendor/golang.org/x/sys/unix/syscall_netbsd.go
+index 018d7d4..8816209 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_netbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_netbsd.go
+@@ -356,266 +356,16 @@ func Statvfs(path string, buf *Statvfs_t) (err error) {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+ 
+-/*
+- * Unimplemented
+- */
+-// ____semctl13
+-// __clone
+-// __fhopen40
+-// __fhstat40
+-// __fhstatvfs140
+-// __fstat30
+-// __getcwd
+-// __getfh30
+-// __getlogin
+-// __lstat30
+-// __mount50
+-// __msgctl13
+-// __msync13
+-// __ntp_gettime30
+-// __posix_chown
+-// __posix_fchown
+-// __posix_lchown
+-// __posix_rename
+-// __setlogin
+-// __shmctl13
+-// __sigaction_sigtramp
+-// __sigaltstack14
+-// __sigpending14
+-// __sigprocmask14
+-// __sigsuspend14
+-// __sigtimedwait
+-// __stat30
+-// __syscall
+-// __vfork14
+-// _ksem_close
+-// _ksem_destroy
+-// _ksem_getvalue
+-// _ksem_init
+-// _ksem_open
+-// _ksem_post
+-// _ksem_trywait
+-// _ksem_unlink
+-// _ksem_wait
+-// _lwp_continue
+-// _lwp_create
+-// _lwp_ctl
+-// _lwp_detach
+-// _lwp_exit
+-// _lwp_getname
+-// _lwp_getprivate
+-// _lwp_kill
+-// _lwp_park
+-// _lwp_self
+-// _lwp_setname
+-// _lwp_setprivate
+-// _lwp_suspend
+-// _lwp_unpark
+-// _lwp_unpark_all
+-// _lwp_wait
+-// _lwp_wakeup
+-// _pset_bind
+-// _sched_getaffinity
+-// _sched_getparam
+-// _sched_setaffinity
+-// _sched_setparam
+-// acct
+-// aio_cancel
+-// aio_error
+-// aio_fsync
+-// aio_read
+-// aio_return
+-// aio_suspend
+-// aio_write
+-// break
+-// clock_getres
+-// clock_gettime
+-// clock_settime
+-// compat_09_ogetdomainname
+-// compat_09_osetdomainname
+-// compat_09_ouname
+-// compat_10_omsgsys
+-// compat_10_osemsys
+-// compat_10_oshmsys
+-// compat_12_fstat12
+-// compat_12_getdirentries
+-// compat_12_lstat12
+-// compat_12_msync
+-// compat_12_oreboot
+-// compat_12_oswapon
+-// compat_12_stat12
+-// compat_13_sigaction13
+-// compat_13_sigaltstack13
+-// compat_13_sigpending13
+-// compat_13_sigprocmask13
+-// compat_13_sigreturn13
+-// compat_13_sigsuspend13
+-// compat_14___semctl
+-// compat_14_msgctl
+-// compat_14_shmctl
+-// compat_16___sigaction14
+-// compat_16___sigreturn14
+-// compat_20_fhstatfs
+-// compat_20_fstatfs
+-// compat_20_getfsstat
+-// compat_20_statfs
+-// compat_30___fhstat30
+-// compat_30___fstat13
+-// compat_30___lstat13
+-// compat_30___stat13
+-// compat_30_fhopen
+-// compat_30_fhstat
+-// compat_30_fhstatvfs1
+-// compat_30_getdents
+-// compat_30_getfh
+-// compat_30_ntp_gettime
+-// compat_30_socket
+-// compat_40_mount
+-// compat_43_fstat43
+-// compat_43_lstat43
+-// compat_43_oaccept
+-// compat_43_ocreat
+-// compat_43_oftruncate
+-// compat_43_ogetdirentries
+-// compat_43_ogetdtablesize
+-// compat_43_ogethostid
+-// compat_43_ogethostname
+-// compat_43_ogetkerninfo
+-// compat_43_ogetpagesize
+-// compat_43_ogetpeername
+-// compat_43_ogetrlimit
+-// compat_43_ogetsockname
+-// compat_43_okillpg
+-// compat_43_olseek
+-// compat_43_ommap
+-// compat_43_oquota
+-// compat_43_orecv
+-// compat_43_orecvfrom
+-// compat_43_orecvmsg
+-// compat_43_osend
+-// compat_43_osendmsg
+-// compat_43_osethostid
+-// compat_43_osethostname
+-// compat_43_osigblock
+-// compat_43_osigsetmask
+-// compat_43_osigstack
+-// compat_43_osigvec
+-// compat_43_otruncate
+-// compat_43_owait
+-// compat_43_stat43
+-// execve
+-// extattr_delete_fd
+-// extattr_delete_file
+-// extattr_delete_link
+-// extattr_get_fd
+-// extattr_get_file
+-// extattr_get_link
+-// extattr_list_fd
+-// extattr_list_file
+-// extattr_list_link
+-// extattr_set_fd
+-// extattr_set_file
+-// extattr_set_link
+-// extattrctl
+-// fchroot
+-// fdatasync
+-// fgetxattr
+-// fktrace
+-// flistxattr
+-// fork
+-// fremovexattr
+-// fsetxattr
+-// fstatvfs1
+-// fsync_range
+-// getcontext
+-// getitimer
+-// getvfsstat
+-// getxattr
+-// ktrace
+-// lchflags
+-// lchmod
+-// lfs_bmapv
+-// lfs_markv
+-// lfs_segclean
+-// lfs_segwait
+-// lgetxattr
+-// lio_listio
+-// listxattr
+-// llistxattr
+-// lremovexattr
+-// lseek
+-// lsetxattr
+-// lutimes
+-// madvise
+-// mincore
+-// minherit
+-// modctl
+-// mq_close
+-// mq_getattr
+-// mq_notify
+-// mq_open
+-// mq_receive
+-// mq_send
+-// mq_setattr
+-// mq_timedreceive
+-// mq_timedsend
+-// mq_unlink
+-// mremap
+-// msgget
+-// msgrcv
+-// msgsnd
+-// nfssvc
+-// ntp_adjtime
+-// pmc_control
+-// pmc_get_info
+-// pollts
+-// preadv
+-// profil
+-// pselect
+-// pset_assign
+-// pset_create
+-// pset_destroy
+-// ptrace
+-// pwritev
+-// quotactl
+-// rasctl
+-// readv
+-// reboot
+-// removexattr
+-// sa_enable
+-// sa_preempt
+-// sa_register
+-// sa_setconcurrency
+-// sa_stacks
+-// sa_yield
+-// sbrk
+-// sched_yield
+-// semconfig
+-// semget
+-// semop
+-// setcontext
+-// setitimer
+-// setxattr
+-// shmat
+-// shmdt
+-// shmget
+-// sstk
+-// statvfs1
+-// swapctl
+-// sysarch
+-// syscall
+-// timer_create
+-// timer_delete
+-// timer_getoverrun
+-// timer_gettime
+-// timer_settime
+-// undelete
+-// utrace
+-// uuidgen
+-// vadvise
+-// vfork
+-// writev
++const (
++	mremapFixed     = MAP_FIXED
++	mremapDontunmap = 0
++	mremapMaymove   = 0
++)
++
++//sys	mremapNetBSD(oldp uintptr, oldsize uintptr, newp uintptr, newsize uintptr, flags int) (xaddr uintptr, err error) = SYS_MREMAP
++
++func mremap(oldaddr uintptr, oldlength uintptr, newlength uintptr, flags int, newaddr uintptr) (uintptr, error) {
++	return mremapNetBSD(oldaddr, oldlength, newaddr, newlength, flags)
++}
+diff --git a/vendor/golang.org/x/sys/unix/syscall_openbsd.go b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+index c5f166a..6f34479 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_openbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+@@ -326,78 +326,4 @@ func Uname(uname *Utsname) error {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- */
+-// __getcwd
+-// __semctl
+-// __syscall
+-// __sysctl
+-// adjfreq
+-// break
+-// clock_getres
+-// clock_gettime
+-// clock_settime
+-// closefrom
+-// execve
+-// fhopen
+-// fhstat
+-// fhstatfs
+-// fork
+-// futimens
+-// getfh
+-// getgid
+-// getitimer
+-// getlogin
+-// getthrid
+-// ktrace
+-// lfs_bmapv
+-// lfs_markv
+-// lfs_segclean
+-// lfs_segwait
+-// mincore
+-// minherit
+-// mount
+-// mquery
+-// msgctl
+-// msgget
+-// msgrcv
+-// msgsnd
+-// nfssvc
+-// nnpfspioctl
+-// preadv
+-// profil
+-// pwritev
+-// quotactl
+-// readv
+-// reboot
+-// renameat
+-// rfork
+-// sched_yield
+-// semget
+-// semop
+-// setgroups
+-// setitimer
+-// setsockopt
+-// shmat
+-// shmctl
+-// shmdt
+-// shmget
+-// sigaction
+-// sigaltstack
+-// sigpending
+-// sigprocmask
+-// sigreturn
+-// sigsuspend
+-// sysarch
+-// syscall
+-// threxit
+-// thrsigdivert
+-// thrsleep
+-// thrwakeup
+-// vfork
+-// writev
+diff --git a/vendor/golang.org/x/sys/unix/syscall_solaris.go b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+index b600a28..b99cfa1 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
++++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+@@ -698,38 +698,6 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ //sys	setsockopt(s int, level int, name int, val unsafe.Pointer, vallen uintptr) (err error) = libsocket.setsockopt
+ //sys	recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Socklen) (n int, err error) = libsocket.recvfrom
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procread)), 3, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf), 0, 0, 0)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = e1
+-	}
+-	return
+-}
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwrite)), 3, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf), 0, 0, 0)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = e1
+-	}
+-	return
+-}
+-
+-var mapper = &mmapper{
+-	active: make(map[*byte][]byte),
+-	mmap:   mmap,
+-	munmap: munmap,
+-}
+-
+-func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
+-	return mapper.Mmap(fd, offset, length, prot, flags)
+-}
+-
+-func Munmap(b []byte) (err error) {
+-	return mapper.Munmap(b)
+-}
+-
+ // Event Ports
+ 
+ type fileObjCookie struct {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_unix.go b/vendor/golang.org/x/sys/unix/syscall_unix.go
+index 8e48c29..a4b2c98 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_unix.go
++++ b/vendor/golang.org/x/sys/unix/syscall_unix.go
+@@ -541,6 +541,9 @@ func SetNonblock(fd int, nonblocking bool) (err error) {
+ 	if err != nil {
+ 		return err
+ 	}
++	if (flag&O_NONBLOCK != 0) == nonblocking {
++		return nil
++	}
+ 	if nonblocking {
+ 		flag |= O_NONBLOCK
+ 	} else {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+index d3d49ec..799302f 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+@@ -192,7 +192,6 @@ func (cmsg *Cmsghdr) SetLen(length int) {
+ 
+ //sys   fcntl(fd int, cmd int, arg int) (val int, err error)
+ //sys	read(fd int, p []byte) (n int, err error)
+-//sys   readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+ //sys	write(fd int, p []byte) (n int, err error)
+ 
+ //sys	accept(s int, rsa *RawSockaddrAny, addrlen *_Socklen) (fd int, err error) = SYS___ACCEPT_A
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index 3784f40..f9c7f47 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -2421,6 +2421,15 @@ const (
+ 	PR_PAC_GET_ENABLED_KEYS                     = 0x3d
+ 	PR_PAC_RESET_KEYS                           = 0x36
+ 	PR_PAC_SET_ENABLED_KEYS                     = 0x3c
++	PR_RISCV_V_GET_CONTROL                      = 0x46
++	PR_RISCV_V_SET_CONTROL                      = 0x45
++	PR_RISCV_V_VSTATE_CTRL_CUR_MASK             = 0x3
++	PR_RISCV_V_VSTATE_CTRL_DEFAULT              = 0x0
++	PR_RISCV_V_VSTATE_CTRL_INHERIT              = 0x10
++	PR_RISCV_V_VSTATE_CTRL_MASK                 = 0x1f
++	PR_RISCV_V_VSTATE_CTRL_NEXT_MASK            = 0xc
++	PR_RISCV_V_VSTATE_CTRL_OFF                  = 0x1
++	PR_RISCV_V_VSTATE_CTRL_ON                   = 0x2
+ 	PR_SCHED_CORE                               = 0x3e
+ 	PR_SCHED_CORE_CREATE                        = 0x1
+ 	PR_SCHED_CORE_GET                           = 0x0
+@@ -2821,6 +2830,23 @@ const (
+ 	RWF_SUPPORTED                               = 0x1f
+ 	RWF_SYNC                                    = 0x4
+ 	RWF_WRITE_LIFE_NOT_SET                      = 0x0
++	SCHED_BATCH                                 = 0x3
++	SCHED_DEADLINE                              = 0x6
++	SCHED_FIFO                                  = 0x1
++	SCHED_FLAG_ALL                              = 0x7f
++	SCHED_FLAG_DL_OVERRUN                       = 0x4
++	SCHED_FLAG_KEEP_ALL                         = 0x18
++	SCHED_FLAG_KEEP_PARAMS                      = 0x10
++	SCHED_FLAG_KEEP_POLICY                      = 0x8
++	SCHED_FLAG_RECLAIM                          = 0x2
++	SCHED_FLAG_RESET_ON_FORK                    = 0x1
++	SCHED_FLAG_UTIL_CLAMP                       = 0x60
++	SCHED_FLAG_UTIL_CLAMP_MAX                   = 0x40
++	SCHED_FLAG_UTIL_CLAMP_MIN                   = 0x20
++	SCHED_IDLE                                  = 0x5
++	SCHED_NORMAL                                = 0x0
++	SCHED_RESET_ON_FORK                         = 0x40000000
++	SCHED_RR                                    = 0x2
+ 	SCM_CREDENTIALS                             = 0x2
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index a46df0f..c5aeab3 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index 6cd4a3e..6b9fda9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -318,10 +318,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c7ebee2..f015600 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -324,10 +324,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 12a9a13..f760f2a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -314,10 +314,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index f26a164..12f266c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -109,6 +109,8 @@ const (
+ 	IUCLC                            = 0x200
+ 	IXOFF                            = 0x1000
+ 	IXON                             = 0x400
++	LASX_CTX_MAGIC                   = 0x41535801
++	LSX_CTX_MAGIC                    = 0x53580001
+ 	MAP_ANON                         = 0x20
+ 	MAP_ANONYMOUS                    = 0x20
+ 	MAP_DENYWRITE                    = 0x800
+@@ -308,10 +310,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 890bc3c..7fd3806 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 549f26a..c38d426 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index e0365e3..17a5f97 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index fdccce1..b73088d 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index b2205c8..80b8d52 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -372,10 +372,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 81aa5ad..8292e16 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -376,10 +376,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index 76807a1..bb1ebb8 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -376,10 +376,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index d4a5ab9..28006d4 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -305,10 +305,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 66e65db..75e263b 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -380,10 +380,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 4898420..5d2d76a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -419,10 +419,12 @@ const (
+ 	SO_NOFCS                         = 0x27
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x2
++	SO_PASSPIDFD                     = 0x55
+ 	SO_PASSSEC                       = 0x1f
+ 	SO_PEEK_OFF                      = 0x26
+ 	SO_PEERCRED                      = 0x40
+ 	SO_PEERGROUPS                    = 0x3d
++	SO_PEERPIDFD                     = 0x56
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x48
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
+index 9a25721..d1d1d23 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
+@@ -817,28 +817,6 @@ func write(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, er := C.read(C.int(fd), C.uintptr_t(uintptr(unsafe.Pointer(p))), C.size_t(np))
+-	n = int(r0)
+-	if r0 == -1 && er != nil {
+-		err = er
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, er := C.write(C.int(fd), C.uintptr_t(uintptr(unsafe.Pointer(p))), C.size_t(np))
+-	n = int(r0)
+-	if r0 == -1 && er != nil {
+-		err = er
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	r0, er := C.dup2(C.int(oldfd), C.int(newfd))
+ 	if r0 == -1 && er != nil {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
+index 6de80c2..f99a18a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
+@@ -762,28 +762,6 @@ func write(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, e1 := callread(fd, uintptr(unsafe.Pointer(p)), np)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, e1 := callwrite(fd, uintptr(unsafe.Pointer(p)), np)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	_, e1 := calldup2(oldfd, newfd)
+ 	if e1 != 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
+index 4037ccf..1cad561 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
+@@ -725,6 +725,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -733,10 +739,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2410,28 +2412,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_fstat64_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0)
+ 	if e1 != 0 {
+@@ -2521,14 +2501,6 @@ func ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return
+ }
+ 
+-func ptrace1Ptr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	_, _, e1 := syscall_syscall6(libc_ptrace_trampoline_addr, uintptr(request), uintptr(pid), addr, uintptr(data), 0, 0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+ var libc_ptrace_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_ptrace ptrace "/usr/lib/libSystem.B.dylib"
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
+index 4baaed0..8b8bb28 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
+@@ -5,703 +5,586 @@
+ 
+ TEXT libc_fdopendir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fdopendir(SB)
+-
+ GLOBL	·libc_fdopendir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fdopendir_trampoline_addr(SB)/8, $libc_fdopendir_trampoline<>(SB)
+ 
+ TEXT libc_getgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgroups(SB)
+-
+ GLOBL	·libc_getgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgroups_trampoline_addr(SB)/8, $libc_getgroups_trampoline<>(SB)
+ 
+ TEXT libc_setgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgroups(SB)
+-
+ GLOBL	·libc_setgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgroups_trampoline_addr(SB)/8, $libc_setgroups_trampoline<>(SB)
+ 
+ TEXT libc_wait4_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_wait4(SB)
+-
+ GLOBL	·libc_wait4_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_wait4_trampoline_addr(SB)/8, $libc_wait4_trampoline<>(SB)
+ 
+ TEXT libc_accept_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_accept(SB)
+-
+ GLOBL	·libc_accept_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_accept_trampoline_addr(SB)/8, $libc_accept_trampoline<>(SB)
+ 
+ TEXT libc_bind_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_bind(SB)
+-
+ GLOBL	·libc_bind_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_bind_trampoline_addr(SB)/8, $libc_bind_trampoline<>(SB)
+ 
+ TEXT libc_connect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_connect(SB)
+-
+ GLOBL	·libc_connect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_connect_trampoline_addr(SB)/8, $libc_connect_trampoline<>(SB)
+ 
+ TEXT libc_socket_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socket(SB)
+-
+ GLOBL	·libc_socket_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socket_trampoline_addr(SB)/8, $libc_socket_trampoline<>(SB)
+ 
+ TEXT libc_getsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockopt(SB)
+-
+ GLOBL	·libc_getsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockopt_trampoline_addr(SB)/8, $libc_getsockopt_trampoline<>(SB)
+ 
+ TEXT libc_setsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsockopt(SB)
+-
+ GLOBL	·libc_setsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsockopt_trampoline_addr(SB)/8, $libc_setsockopt_trampoline<>(SB)
+ 
+ TEXT libc_getpeername_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpeername(SB)
+-
+ GLOBL	·libc_getpeername_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpeername_trampoline_addr(SB)/8, $libc_getpeername_trampoline<>(SB)
+ 
+ TEXT libc_getsockname_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockname(SB)
+-
+ GLOBL	·libc_getsockname_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockname_trampoline_addr(SB)/8, $libc_getsockname_trampoline<>(SB)
+ 
+ TEXT libc_shutdown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shutdown(SB)
+-
+ GLOBL	·libc_shutdown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shutdown_trampoline_addr(SB)/8, $libc_shutdown_trampoline<>(SB)
+ 
+ TEXT libc_socketpair_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socketpair(SB)
+-
+ GLOBL	·libc_socketpair_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socketpair_trampoline_addr(SB)/8, $libc_socketpair_trampoline<>(SB)
+ 
+ TEXT libc_recvfrom_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvfrom(SB)
+-
+ GLOBL	·libc_recvfrom_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvfrom_trampoline_addr(SB)/8, $libc_recvfrom_trampoline<>(SB)
+ 
+ TEXT libc_sendto_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendto(SB)
+-
+ GLOBL	·libc_sendto_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendto_trampoline_addr(SB)/8, $libc_sendto_trampoline<>(SB)
+ 
+ TEXT libc_recvmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvmsg(SB)
+-
+ GLOBL	·libc_recvmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvmsg_trampoline_addr(SB)/8, $libc_recvmsg_trampoline<>(SB)
+ 
+ TEXT libc_sendmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendmsg(SB)
+-
+ GLOBL	·libc_sendmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendmsg_trampoline_addr(SB)/8, $libc_sendmsg_trampoline<>(SB)
+ 
+ TEXT libc_kevent_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kevent(SB)
+-
+ GLOBL	·libc_kevent_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kevent_trampoline_addr(SB)/8, $libc_kevent_trampoline<>(SB)
+ 
+ TEXT libc_utimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimes(SB)
+-
+ GLOBL	·libc_utimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimes_trampoline_addr(SB)/8, $libc_utimes_trampoline<>(SB)
+ 
+ TEXT libc_futimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_futimes(SB)
+-
+ GLOBL	·libc_futimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_futimes_trampoline_addr(SB)/8, $libc_futimes_trampoline<>(SB)
+ 
+ TEXT libc_poll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_poll(SB)
+-
+ GLOBL	·libc_poll_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_poll_trampoline_addr(SB)/8, $libc_poll_trampoline<>(SB)
+ 
+ TEXT libc_madvise_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_madvise(SB)
+-
+ GLOBL	·libc_madvise_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_madvise_trampoline_addr(SB)/8, $libc_madvise_trampoline<>(SB)
+ 
+ TEXT libc_mlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlock(SB)
+-
+ GLOBL	·libc_mlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlock_trampoline_addr(SB)/8, $libc_mlock_trampoline<>(SB)
+ 
+ TEXT libc_mlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlockall(SB)
+-
+ GLOBL	·libc_mlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlockall_trampoline_addr(SB)/8, $libc_mlockall_trampoline<>(SB)
+ 
+ TEXT libc_mprotect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mprotect(SB)
+-
+ GLOBL	·libc_mprotect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mprotect_trampoline_addr(SB)/8, $libc_mprotect_trampoline<>(SB)
+ 
+ TEXT libc_msync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_msync(SB)
+-
+ GLOBL	·libc_msync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_msync_trampoline_addr(SB)/8, $libc_msync_trampoline<>(SB)
+ 
+ TEXT libc_munlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlock(SB)
+-
+ GLOBL	·libc_munlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlock_trampoline_addr(SB)/8, $libc_munlock_trampoline<>(SB)
+ 
+ TEXT libc_munlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlockall(SB)
+-
+ GLOBL	·libc_munlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlockall_trampoline_addr(SB)/8, $libc_munlockall_trampoline<>(SB)
+ 
+ TEXT libc_closedir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_closedir(SB)
+-
+ GLOBL	·libc_closedir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_closedir_trampoline_addr(SB)/8, $libc_closedir_trampoline<>(SB)
+ 
+ TEXT libc_readdir_r_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readdir_r(SB)
+-
+ GLOBL	·libc_readdir_r_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readdir_r_trampoline_addr(SB)/8, $libc_readdir_r_trampoline<>(SB)
+ 
+ TEXT libc_pipe_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pipe(SB)
+-
+ GLOBL	·libc_pipe_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pipe_trampoline_addr(SB)/8, $libc_pipe_trampoline<>(SB)
+ 
+ TEXT libc_getxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getxattr(SB)
+-
+ GLOBL	·libc_getxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getxattr_trampoline_addr(SB)/8, $libc_getxattr_trampoline<>(SB)
+ 
+ TEXT libc_fgetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fgetxattr(SB)
+-
+ GLOBL	·libc_fgetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fgetxattr_trampoline_addr(SB)/8, $libc_fgetxattr_trampoline<>(SB)
+ 
+ TEXT libc_setxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setxattr(SB)
+-
+ GLOBL	·libc_setxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setxattr_trampoline_addr(SB)/8, $libc_setxattr_trampoline<>(SB)
+ 
+ TEXT libc_fsetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsetxattr(SB)
+-
+ GLOBL	·libc_fsetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsetxattr_trampoline_addr(SB)/8, $libc_fsetxattr_trampoline<>(SB)
+ 
+ TEXT libc_removexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_removexattr(SB)
+-
+ GLOBL	·libc_removexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_removexattr_trampoline_addr(SB)/8, $libc_removexattr_trampoline<>(SB)
+ 
+ TEXT libc_fremovexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fremovexattr(SB)
+-
+ GLOBL	·libc_fremovexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fremovexattr_trampoline_addr(SB)/8, $libc_fremovexattr_trampoline<>(SB)
+ 
+ TEXT libc_listxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listxattr(SB)
+-
+ GLOBL	·libc_listxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listxattr_trampoline_addr(SB)/8, $libc_listxattr_trampoline<>(SB)
+ 
+ TEXT libc_flistxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flistxattr(SB)
+-
+ GLOBL	·libc_flistxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flistxattr_trampoline_addr(SB)/8, $libc_flistxattr_trampoline<>(SB)
+ 
+ TEXT libc_utimensat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimensat(SB)
+-
+ GLOBL	·libc_utimensat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimensat_trampoline_addr(SB)/8, $libc_utimensat_trampoline<>(SB)
+ 
+ TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fcntl(SB)
+-
+ GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
+ 
+ TEXT libc_kill_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kill(SB)
+-
+ GLOBL	·libc_kill_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kill_trampoline_addr(SB)/8, $libc_kill_trampoline<>(SB)
+ 
+ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ioctl(SB)
+-
+ GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
+ 
+ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sysctl(SB)
+-
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
+ TEXT libc_sendfile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendfile(SB)
+-
+ GLOBL	·libc_sendfile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendfile_trampoline_addr(SB)/8, $libc_sendfile_trampoline<>(SB)
+ 
+ TEXT libc_shmat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmat(SB)
+-
+ GLOBL	·libc_shmat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmat_trampoline_addr(SB)/8, $libc_shmat_trampoline<>(SB)
+ 
+ TEXT libc_shmctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmctl(SB)
+-
+ GLOBL	·libc_shmctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmctl_trampoline_addr(SB)/8, $libc_shmctl_trampoline<>(SB)
+ 
+ TEXT libc_shmdt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmdt(SB)
+-
+ GLOBL	·libc_shmdt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmdt_trampoline_addr(SB)/8, $libc_shmdt_trampoline<>(SB)
+ 
+ TEXT libc_shmget_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmget(SB)
+-
+ GLOBL	·libc_shmget_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmget_trampoline_addr(SB)/8, $libc_shmget_trampoline<>(SB)
+ 
+ TEXT libc_access_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_access(SB)
+-
+ GLOBL	·libc_access_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_access_trampoline_addr(SB)/8, $libc_access_trampoline<>(SB)
+ 
+ TEXT libc_adjtime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_adjtime(SB)
+-
+ GLOBL	·libc_adjtime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_adjtime_trampoline_addr(SB)/8, $libc_adjtime_trampoline<>(SB)
+ 
+ TEXT libc_chdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chdir(SB)
+-
+ GLOBL	·libc_chdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chdir_trampoline_addr(SB)/8, $libc_chdir_trampoline<>(SB)
+ 
+ TEXT libc_chflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chflags(SB)
+-
+ GLOBL	·libc_chflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chflags_trampoline_addr(SB)/8, $libc_chflags_trampoline<>(SB)
+ 
+ TEXT libc_chmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chmod(SB)
+-
+ GLOBL	·libc_chmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chmod_trampoline_addr(SB)/8, $libc_chmod_trampoline<>(SB)
+ 
+ TEXT libc_chown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chown(SB)
+-
+ GLOBL	·libc_chown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chown_trampoline_addr(SB)/8, $libc_chown_trampoline<>(SB)
+ 
+ TEXT libc_chroot_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chroot(SB)
+-
+ GLOBL	·libc_chroot_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chroot_trampoline_addr(SB)/8, $libc_chroot_trampoline<>(SB)
+ 
+ TEXT libc_clock_gettime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clock_gettime(SB)
+-
+ GLOBL	·libc_clock_gettime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clock_gettime_trampoline_addr(SB)/8, $libc_clock_gettime_trampoline<>(SB)
+ 
+ TEXT libc_close_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_close(SB)
+-
+ GLOBL	·libc_close_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_close_trampoline_addr(SB)/8, $libc_close_trampoline<>(SB)
+ 
+ TEXT libc_clonefile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefile(SB)
+-
+ GLOBL	·libc_clonefile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefile_trampoline_addr(SB)/8, $libc_clonefile_trampoline<>(SB)
+ 
+ TEXT libc_clonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefileat(SB)
+-
+ GLOBL	·libc_clonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefileat_trampoline_addr(SB)/8, $libc_clonefileat_trampoline<>(SB)
+ 
+ TEXT libc_dup_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup(SB)
+-
+ GLOBL	·libc_dup_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup_trampoline_addr(SB)/8, $libc_dup_trampoline<>(SB)
+ 
+ TEXT libc_dup2_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup2(SB)
+-
+ GLOBL	·libc_dup2_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup2_trampoline_addr(SB)/8, $libc_dup2_trampoline<>(SB)
+ 
+ TEXT libc_exchangedata_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exchangedata(SB)
+-
+ GLOBL	·libc_exchangedata_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exchangedata_trampoline_addr(SB)/8, $libc_exchangedata_trampoline<>(SB)
+ 
+ TEXT libc_exit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exit(SB)
+-
+ GLOBL	·libc_exit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exit_trampoline_addr(SB)/8, $libc_exit_trampoline<>(SB)
+ 
+ TEXT libc_faccessat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_faccessat(SB)
+-
+ GLOBL	·libc_faccessat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_faccessat_trampoline_addr(SB)/8, $libc_faccessat_trampoline<>(SB)
+ 
+ TEXT libc_fchdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchdir(SB)
+-
+ GLOBL	·libc_fchdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchdir_trampoline_addr(SB)/8, $libc_fchdir_trampoline<>(SB)
+ 
+ TEXT libc_fchflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchflags(SB)
+-
+ GLOBL	·libc_fchflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchflags_trampoline_addr(SB)/8, $libc_fchflags_trampoline<>(SB)
+ 
+ TEXT libc_fchmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmod(SB)
+-
+ GLOBL	·libc_fchmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmod_trampoline_addr(SB)/8, $libc_fchmod_trampoline<>(SB)
+ 
+ TEXT libc_fchmodat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmodat(SB)
+-
+ GLOBL	·libc_fchmodat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmodat_trampoline_addr(SB)/8, $libc_fchmodat_trampoline<>(SB)
+ 
+ TEXT libc_fchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchown(SB)
+-
+ GLOBL	·libc_fchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchown_trampoline_addr(SB)/8, $libc_fchown_trampoline<>(SB)
+ 
+ TEXT libc_fchownat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchownat(SB)
+-
+ GLOBL	·libc_fchownat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchownat_trampoline_addr(SB)/8, $libc_fchownat_trampoline<>(SB)
+ 
+ TEXT libc_fclonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fclonefileat(SB)
+-
+ GLOBL	·libc_fclonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fclonefileat_trampoline_addr(SB)/8, $libc_fclonefileat_trampoline<>(SB)
+ 
+ TEXT libc_flock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flock(SB)
+-
+ GLOBL	·libc_flock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flock_trampoline_addr(SB)/8, $libc_flock_trampoline<>(SB)
+ 
+ TEXT libc_fpathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fpathconf(SB)
+-
+ GLOBL	·libc_fpathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fpathconf_trampoline_addr(SB)/8, $libc_fpathconf_trampoline<>(SB)
+ 
+ TEXT libc_fsync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsync(SB)
+-
+ GLOBL	·libc_fsync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsync_trampoline_addr(SB)/8, $libc_fsync_trampoline<>(SB)
+ 
+ TEXT libc_ftruncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ftruncate(SB)
+-
+ GLOBL	·libc_ftruncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ftruncate_trampoline_addr(SB)/8, $libc_ftruncate_trampoline<>(SB)
+ 
+ TEXT libc_getcwd_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getcwd(SB)
+-
+ GLOBL	·libc_getcwd_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getcwd_trampoline_addr(SB)/8, $libc_getcwd_trampoline<>(SB)
+ 
+ TEXT libc_getdtablesize_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getdtablesize(SB)
+-
+ GLOBL	·libc_getdtablesize_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getdtablesize_trampoline_addr(SB)/8, $libc_getdtablesize_trampoline<>(SB)
+ 
+ TEXT libc_getegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getegid(SB)
+-
+ GLOBL	·libc_getegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getegid_trampoline_addr(SB)/8, $libc_getegid_trampoline<>(SB)
+ 
+ TEXT libc_geteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_geteuid(SB)
+-
+ GLOBL	·libc_geteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_geteuid_trampoline_addr(SB)/8, $libc_geteuid_trampoline<>(SB)
+ 
+ TEXT libc_getgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgid(SB)
+-
+ GLOBL	·libc_getgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgid_trampoline_addr(SB)/8, $libc_getgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgid(SB)
+-
+ GLOBL	·libc_getpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgid_trampoline_addr(SB)/8, $libc_getpgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgrp_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgrp(SB)
+-
+ GLOBL	·libc_getpgrp_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgrp_trampoline_addr(SB)/8, $libc_getpgrp_trampoline<>(SB)
+ 
+ TEXT libc_getpid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpid(SB)
+-
+ GLOBL	·libc_getpid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpid_trampoline_addr(SB)/8, $libc_getpid_trampoline<>(SB)
+ 
+ TEXT libc_getppid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getppid(SB)
+-
+ GLOBL	·libc_getppid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getppid_trampoline_addr(SB)/8, $libc_getppid_trampoline<>(SB)
+ 
+ TEXT libc_getpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpriority(SB)
+-
+ GLOBL	·libc_getpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpriority_trampoline_addr(SB)/8, $libc_getpriority_trampoline<>(SB)
+ 
+ TEXT libc_getrlimit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrlimit(SB)
+-
+ GLOBL	·libc_getrlimit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrlimit_trampoline_addr(SB)/8, $libc_getrlimit_trampoline<>(SB)
+ 
+ TEXT libc_getrusage_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrusage(SB)
+-
+ GLOBL	·libc_getrusage_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrusage_trampoline_addr(SB)/8, $libc_getrusage_trampoline<>(SB)
+ 
+ TEXT libc_getsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsid(SB)
+-
+ GLOBL	·libc_getsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsid_trampoline_addr(SB)/8, $libc_getsid_trampoline<>(SB)
+ 
+ TEXT libc_gettimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_gettimeofday(SB)
+-
+ GLOBL	·libc_gettimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_gettimeofday_trampoline_addr(SB)/8, $libc_gettimeofday_trampoline<>(SB)
+ 
+ TEXT libc_getuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getuid(SB)
+-
+ GLOBL	·libc_getuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getuid_trampoline_addr(SB)/8, $libc_getuid_trampoline<>(SB)
+ 
+ TEXT libc_issetugid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_issetugid(SB)
+-
+ GLOBL	·libc_issetugid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_issetugid_trampoline_addr(SB)/8, $libc_issetugid_trampoline<>(SB)
+ 
+ TEXT libc_kqueue_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kqueue(SB)
+-
+ GLOBL	·libc_kqueue_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kqueue_trampoline_addr(SB)/8, $libc_kqueue_trampoline<>(SB)
+ 
+ TEXT libc_lchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lchown(SB)
+-
+ GLOBL	·libc_lchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lchown_trampoline_addr(SB)/8, $libc_lchown_trampoline<>(SB)
+ 
+ TEXT libc_link_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_link(SB)
+-
+ GLOBL	·libc_link_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_link_trampoline_addr(SB)/8, $libc_link_trampoline<>(SB)
+ 
+ TEXT libc_linkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_linkat(SB)
+-
+ GLOBL	·libc_linkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_linkat_trampoline_addr(SB)/8, $libc_linkat_trampoline<>(SB)
+ 
+ TEXT libc_listen_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listen(SB)
+-
+ GLOBL	·libc_listen_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listen_trampoline_addr(SB)/8, $libc_listen_trampoline<>(SB)
+ 
+ TEXT libc_mkdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdir(SB)
+-
+ GLOBL	·libc_mkdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdir_trampoline_addr(SB)/8, $libc_mkdir_trampoline<>(SB)
+ 
+ TEXT libc_mkdirat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdirat(SB)
+-
+ GLOBL	·libc_mkdirat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdirat_trampoline_addr(SB)/8, $libc_mkdirat_trampoline<>(SB)
+ 
+ TEXT libc_mkfifo_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkfifo(SB)
+-
+ GLOBL	·libc_mkfifo_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkfifo_trampoline_addr(SB)/8, $libc_mkfifo_trampoline<>(SB)
+ 
+ TEXT libc_mknod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mknod(SB)
+-
+ GLOBL	·libc_mknod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mknod_trampoline_addr(SB)/8, $libc_mknod_trampoline<>(SB)
+ 
+ TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mount(SB)
+-
+ GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mount_trampoline_addr(SB)/8, $libc_mount_trampoline<>(SB)
+ 
+ TEXT libc_open_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_open(SB)
+-
+ GLOBL	·libc_open_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_open_trampoline_addr(SB)/8, $libc_open_trampoline<>(SB)
+ 
+ TEXT libc_openat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_openat(SB)
+-
+ GLOBL	·libc_openat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_openat_trampoline_addr(SB)/8, $libc_openat_trampoline<>(SB)
+ 
+ TEXT libc_pathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pathconf(SB)
+-
+ GLOBL	·libc_pathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pathconf_trampoline_addr(SB)/8, $libc_pathconf_trampoline<>(SB)
+ 
+ TEXT libc_pread_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pread(SB)
+-
+ GLOBL	·libc_pread_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pread_trampoline_addr(SB)/8, $libc_pread_trampoline<>(SB)
+ 
+ TEXT libc_pwrite_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pwrite(SB)
+-
+ GLOBL	·libc_pwrite_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pwrite_trampoline_addr(SB)/8, $libc_pwrite_trampoline<>(SB)
+ 
+ TEXT libc_read_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_read(SB)
+-
+ GLOBL	·libc_read_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_read_trampoline_addr(SB)/8, $libc_read_trampoline<>(SB)
+ 
+ TEXT libc_readlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlink(SB)
+-
+ GLOBL	·libc_readlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlink_trampoline_addr(SB)/8, $libc_readlink_trampoline<>(SB)
+ 
+ TEXT libc_readlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlinkat(SB)
+-
+ GLOBL	·libc_readlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlinkat_trampoline_addr(SB)/8, $libc_readlinkat_trampoline<>(SB)
+ 
+ TEXT libc_rename_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rename(SB)
+-
+ GLOBL	·libc_rename_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rename_trampoline_addr(SB)/8, $libc_rename_trampoline<>(SB)
+ 
+ TEXT libc_renameat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_renameat(SB)
+-
+ GLOBL	·libc_renameat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_renameat_trampoline_addr(SB)/8, $libc_renameat_trampoline<>(SB)
+ 
+ TEXT libc_revoke_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_revoke(SB)
+-
+ GLOBL	·libc_revoke_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_revoke_trampoline_addr(SB)/8, $libc_revoke_trampoline<>(SB)
+ 
+ TEXT libc_rmdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rmdir(SB)
+-
+ GLOBL	·libc_rmdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rmdir_trampoline_addr(SB)/8, $libc_rmdir_trampoline<>(SB)
+ 
+ TEXT libc_lseek_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lseek(SB)
+-
+ GLOBL	·libc_lseek_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lseek_trampoline_addr(SB)/8, $libc_lseek_trampoline<>(SB)
+ 
+ TEXT libc_select_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_select(SB)
+-
+ GLOBL	·libc_select_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_select_trampoline_addr(SB)/8, $libc_select_trampoline<>(SB)
+ 
+@@ -712,192 +595,160 @@ DATA	·libc_setattrlist_trampoline_addr(SB)/8, $libc_setattrlist_trampoline<>(SB
+ 
+ TEXT libc_setegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setegid(SB)
+-
+ GLOBL	·libc_setegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setegid_trampoline_addr(SB)/8, $libc_setegid_trampoline<>(SB)
+ 
+ TEXT libc_seteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_seteuid(SB)
+-
+ GLOBL	·libc_seteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_seteuid_trampoline_addr(SB)/8, $libc_seteuid_trampoline<>(SB)
+ 
+ TEXT libc_setgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgid(SB)
+-
+ GLOBL	·libc_setgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgid_trampoline_addr(SB)/8, $libc_setgid_trampoline<>(SB)
+ 
+ TEXT libc_setlogin_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setlogin(SB)
+-
+ GLOBL	·libc_setlogin_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setlogin_trampoline_addr(SB)/8, $libc_setlogin_trampoline<>(SB)
+ 
+ TEXT libc_setpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpgid(SB)
+-
+ GLOBL	·libc_setpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpgid_trampoline_addr(SB)/8, $libc_setpgid_trampoline<>(SB)
+ 
+ TEXT libc_setpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpriority(SB)
+-
+ GLOBL	·libc_setpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpriority_trampoline_addr(SB)/8, $libc_setpriority_trampoline<>(SB)
+ 
+ TEXT libc_setprivexec_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setprivexec(SB)
+-
+ GLOBL	·libc_setprivexec_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setprivexec_trampoline_addr(SB)/8, $libc_setprivexec_trampoline<>(SB)
+ 
+ TEXT libc_setregid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setregid(SB)
+-
+ GLOBL	·libc_setregid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setregid_trampoline_addr(SB)/8, $libc_setregid_trampoline<>(SB)
+ 
+ TEXT libc_setreuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setreuid(SB)
+-
+ GLOBL	·libc_setreuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setreuid_trampoline_addr(SB)/8, $libc_setreuid_trampoline<>(SB)
+ 
+ TEXT libc_setsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsid(SB)
+-
+ GLOBL	·libc_setsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsid_trampoline_addr(SB)/8, $libc_setsid_trampoline<>(SB)
+ 
+ TEXT libc_settimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_settimeofday(SB)
+-
+ GLOBL	·libc_settimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_settimeofday_trampoline_addr(SB)/8, $libc_settimeofday_trampoline<>(SB)
+ 
+ TEXT libc_setuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setuid(SB)
+-
+ GLOBL	·libc_setuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setuid_trampoline_addr(SB)/8, $libc_setuid_trampoline<>(SB)
+ 
+ TEXT libc_symlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlink(SB)
+-
+ GLOBL	·libc_symlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlink_trampoline_addr(SB)/8, $libc_symlink_trampoline<>(SB)
+ 
+ TEXT libc_symlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlinkat(SB)
+-
+ GLOBL	·libc_symlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlinkat_trampoline_addr(SB)/8, $libc_symlinkat_trampoline<>(SB)
+ 
+ TEXT libc_sync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sync(SB)
+-
+ GLOBL	·libc_sync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sync_trampoline_addr(SB)/8, $libc_sync_trampoline<>(SB)
+ 
+ TEXT libc_truncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_truncate(SB)
+-
+ GLOBL	·libc_truncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_truncate_trampoline_addr(SB)/8, $libc_truncate_trampoline<>(SB)
+ 
+ TEXT libc_umask_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_umask(SB)
+-
+ GLOBL	·libc_umask_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_umask_trampoline_addr(SB)/8, $libc_umask_trampoline<>(SB)
+ 
+ TEXT libc_undelete_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_undelete(SB)
+-
+ GLOBL	·libc_undelete_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_undelete_trampoline_addr(SB)/8, $libc_undelete_trampoline<>(SB)
+ 
+ TEXT libc_unlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlink(SB)
+-
+ GLOBL	·libc_unlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlink_trampoline_addr(SB)/8, $libc_unlink_trampoline<>(SB)
+ 
+ TEXT libc_unlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlinkat(SB)
+-
+ GLOBL	·libc_unlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlinkat_trampoline_addr(SB)/8, $libc_unlinkat_trampoline<>(SB)
+ 
+ TEXT libc_unmount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unmount(SB)
+-
+ GLOBL	·libc_unmount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unmount_trampoline_addr(SB)/8, $libc_unmount_trampoline<>(SB)
+ 
+ TEXT libc_write_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_write(SB)
+-
+ GLOBL	·libc_write_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_write_trampoline_addr(SB)/8, $libc_write_trampoline<>(SB)
+ 
+ TEXT libc_mmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mmap(SB)
+-
+ GLOBL	·libc_mmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mmap_trampoline_addr(SB)/8, $libc_mmap_trampoline<>(SB)
+ 
+ TEXT libc_munmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munmap(SB)
+-
+ GLOBL	·libc_munmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munmap_trampoline_addr(SB)/8, $libc_munmap_trampoline<>(SB)
+ 
+ TEXT libc_fstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstat64(SB)
+-
+ GLOBL	·libc_fstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstat64_trampoline_addr(SB)/8, $libc_fstat64_trampoline<>(SB)
+ 
+ TEXT libc_fstatat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatat64(SB)
+-
+ GLOBL	·libc_fstatat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatat64_trampoline_addr(SB)/8, $libc_fstatat64_trampoline<>(SB)
+ 
+ TEXT libc_fstatfs64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatfs64(SB)
+-
+ GLOBL	·libc_fstatfs64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatfs64_trampoline_addr(SB)/8, $libc_fstatfs64_trampoline<>(SB)
+ 
+ TEXT libc_getfsstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getfsstat64(SB)
+-
+ GLOBL	·libc_getfsstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getfsstat64_trampoline_addr(SB)/8, $libc_getfsstat64_trampoline<>(SB)
+ 
+ TEXT libc_lstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lstat64(SB)
+-
+ GLOBL	·libc_lstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lstat64_trampoline_addr(SB)/8, $libc_lstat64_trampoline<>(SB)
+ 
+ TEXT libc_ptrace_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ptrace(SB)
+-
+ GLOBL	·libc_ptrace_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ptrace_trampoline_addr(SB)/8, $libc_ptrace_trampoline<>(SB)
+ 
+ TEXT libc_stat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_stat64(SB)
+-
+ GLOBL	·libc_stat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_stat64_trampoline_addr(SB)/8, $libc_stat64_trampoline<>(SB)
+ 
+ TEXT libc_statfs64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_statfs64(SB)
+-
+ GLOBL	·libc_statfs64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_statfs64_trampoline_addr(SB)/8, $libc_statfs64_trampoline<>(SB)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
+index 51d6f3f..b18edbd 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
+@@ -725,6 +725,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -733,10 +739,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2410,28 +2412,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_fstat_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0)
+ 	if e1 != 0 {
+@@ -2521,14 +2501,6 @@ func ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return
+ }
+ 
+-func ptrace1Ptr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	_, _, e1 := syscall_syscall6(libc_ptrace_trampoline_addr, uintptr(request), uintptr(pid), addr, uintptr(data), 0, 0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+ var libc_ptrace_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_ptrace ptrace "/usr/lib/libSystem.B.dylib"
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
+index c3b82c0..08362c1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
+@@ -5,703 +5,586 @@
+ 
+ TEXT libc_fdopendir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fdopendir(SB)
+-
+ GLOBL	·libc_fdopendir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fdopendir_trampoline_addr(SB)/8, $libc_fdopendir_trampoline<>(SB)
+ 
+ TEXT libc_getgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgroups(SB)
+-
+ GLOBL	·libc_getgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgroups_trampoline_addr(SB)/8, $libc_getgroups_trampoline<>(SB)
+ 
+ TEXT libc_setgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgroups(SB)
+-
+ GLOBL	·libc_setgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgroups_trampoline_addr(SB)/8, $libc_setgroups_trampoline<>(SB)
+ 
+ TEXT libc_wait4_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_wait4(SB)
+-
+ GLOBL	·libc_wait4_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_wait4_trampoline_addr(SB)/8, $libc_wait4_trampoline<>(SB)
+ 
+ TEXT libc_accept_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_accept(SB)
+-
+ GLOBL	·libc_accept_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_accept_trampoline_addr(SB)/8, $libc_accept_trampoline<>(SB)
+ 
+ TEXT libc_bind_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_bind(SB)
+-
+ GLOBL	·libc_bind_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_bind_trampoline_addr(SB)/8, $libc_bind_trampoline<>(SB)
+ 
+ TEXT libc_connect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_connect(SB)
+-
+ GLOBL	·libc_connect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_connect_trampoline_addr(SB)/8, $libc_connect_trampoline<>(SB)
+ 
+ TEXT libc_socket_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socket(SB)
+-
+ GLOBL	·libc_socket_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socket_trampoline_addr(SB)/8, $libc_socket_trampoline<>(SB)
+ 
+ TEXT libc_getsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockopt(SB)
+-
+ GLOBL	·libc_getsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockopt_trampoline_addr(SB)/8, $libc_getsockopt_trampoline<>(SB)
+ 
+ TEXT libc_setsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsockopt(SB)
+-
+ GLOBL	·libc_setsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsockopt_trampoline_addr(SB)/8, $libc_setsockopt_trampoline<>(SB)
+ 
+ TEXT libc_getpeername_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpeername(SB)
+-
+ GLOBL	·libc_getpeername_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpeername_trampoline_addr(SB)/8, $libc_getpeername_trampoline<>(SB)
+ 
+ TEXT libc_getsockname_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockname(SB)
+-
+ GLOBL	·libc_getsockname_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockname_trampoline_addr(SB)/8, $libc_getsockname_trampoline<>(SB)
+ 
+ TEXT libc_shutdown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shutdown(SB)
+-
+ GLOBL	·libc_shutdown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shutdown_trampoline_addr(SB)/8, $libc_shutdown_trampoline<>(SB)
+ 
+ TEXT libc_socketpair_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socketpair(SB)
+-
+ GLOBL	·libc_socketpair_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socketpair_trampoline_addr(SB)/8, $libc_socketpair_trampoline<>(SB)
+ 
+ TEXT libc_recvfrom_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvfrom(SB)
+-
+ GLOBL	·libc_recvfrom_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvfrom_trampoline_addr(SB)/8, $libc_recvfrom_trampoline<>(SB)
+ 
+ TEXT libc_sendto_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendto(SB)
+-
+ GLOBL	·libc_sendto_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendto_trampoline_addr(SB)/8, $libc_sendto_trampoline<>(SB)
+ 
+ TEXT libc_recvmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvmsg(SB)
+-
+ GLOBL	·libc_recvmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvmsg_trampoline_addr(SB)/8, $libc_recvmsg_trampoline<>(SB)
+ 
+ TEXT libc_sendmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendmsg(SB)
+-
+ GLOBL	·libc_sendmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendmsg_trampoline_addr(SB)/8, $libc_sendmsg_trampoline<>(SB)
+ 
+ TEXT libc_kevent_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kevent(SB)
+-
+ GLOBL	·libc_kevent_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kevent_trampoline_addr(SB)/8, $libc_kevent_trampoline<>(SB)
+ 
+ TEXT libc_utimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimes(SB)
+-
+ GLOBL	·libc_utimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimes_trampoline_addr(SB)/8, $libc_utimes_trampoline<>(SB)
+ 
+ TEXT libc_futimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_futimes(SB)
+-
+ GLOBL	·libc_futimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_futimes_trampoline_addr(SB)/8, $libc_futimes_trampoline<>(SB)
+ 
+ TEXT libc_poll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_poll(SB)
+-
+ GLOBL	·libc_poll_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_poll_trampoline_addr(SB)/8, $libc_poll_trampoline<>(SB)
+ 
+ TEXT libc_madvise_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_madvise(SB)
+-
+ GLOBL	·libc_madvise_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_madvise_trampoline_addr(SB)/8, $libc_madvise_trampoline<>(SB)
+ 
+ TEXT libc_mlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlock(SB)
+-
+ GLOBL	·libc_mlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlock_trampoline_addr(SB)/8, $libc_mlock_trampoline<>(SB)
+ 
+ TEXT libc_mlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlockall(SB)
+-
+ GLOBL	·libc_mlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlockall_trampoline_addr(SB)/8, $libc_mlockall_trampoline<>(SB)
+ 
+ TEXT libc_mprotect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mprotect(SB)
+-
+ GLOBL	·libc_mprotect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mprotect_trampoline_addr(SB)/8, $libc_mprotect_trampoline<>(SB)
+ 
+ TEXT libc_msync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_msync(SB)
+-
+ GLOBL	·libc_msync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_msync_trampoline_addr(SB)/8, $libc_msync_trampoline<>(SB)
+ 
+ TEXT libc_munlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlock(SB)
+-
+ GLOBL	·libc_munlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlock_trampoline_addr(SB)/8, $libc_munlock_trampoline<>(SB)
+ 
+ TEXT libc_munlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlockall(SB)
+-
+ GLOBL	·libc_munlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlockall_trampoline_addr(SB)/8, $libc_munlockall_trampoline<>(SB)
+ 
+ TEXT libc_closedir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_closedir(SB)
+-
+ GLOBL	·libc_closedir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_closedir_trampoline_addr(SB)/8, $libc_closedir_trampoline<>(SB)
+ 
+ TEXT libc_readdir_r_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readdir_r(SB)
+-
+ GLOBL	·libc_readdir_r_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readdir_r_trampoline_addr(SB)/8, $libc_readdir_r_trampoline<>(SB)
+ 
+ TEXT libc_pipe_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pipe(SB)
+-
+ GLOBL	·libc_pipe_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pipe_trampoline_addr(SB)/8, $libc_pipe_trampoline<>(SB)
+ 
+ TEXT libc_getxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getxattr(SB)
+-
+ GLOBL	·libc_getxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getxattr_trampoline_addr(SB)/8, $libc_getxattr_trampoline<>(SB)
+ 
+ TEXT libc_fgetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fgetxattr(SB)
+-
+ GLOBL	·libc_fgetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fgetxattr_trampoline_addr(SB)/8, $libc_fgetxattr_trampoline<>(SB)
+ 
+ TEXT libc_setxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setxattr(SB)
+-
+ GLOBL	·libc_setxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setxattr_trampoline_addr(SB)/8, $libc_setxattr_trampoline<>(SB)
+ 
+ TEXT libc_fsetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsetxattr(SB)
+-
+ GLOBL	·libc_fsetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsetxattr_trampoline_addr(SB)/8, $libc_fsetxattr_trampoline<>(SB)
+ 
+ TEXT libc_removexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_removexattr(SB)
+-
+ GLOBL	·libc_removexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_removexattr_trampoline_addr(SB)/8, $libc_removexattr_trampoline<>(SB)
+ 
+ TEXT libc_fremovexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fremovexattr(SB)
+-
+ GLOBL	·libc_fremovexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fremovexattr_trampoline_addr(SB)/8, $libc_fremovexattr_trampoline<>(SB)
+ 
+ TEXT libc_listxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listxattr(SB)
+-
+ GLOBL	·libc_listxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listxattr_trampoline_addr(SB)/8, $libc_listxattr_trampoline<>(SB)
+ 
+ TEXT libc_flistxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flistxattr(SB)
+-
+ GLOBL	·libc_flistxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flistxattr_trampoline_addr(SB)/8, $libc_flistxattr_trampoline<>(SB)
+ 
+ TEXT libc_utimensat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimensat(SB)
+-
+ GLOBL	·libc_utimensat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimensat_trampoline_addr(SB)/8, $libc_utimensat_trampoline<>(SB)
+ 
+ TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fcntl(SB)
+-
+ GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
+ 
+ TEXT libc_kill_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kill(SB)
+-
+ GLOBL	·libc_kill_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kill_trampoline_addr(SB)/8, $libc_kill_trampoline<>(SB)
+ 
+ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ioctl(SB)
+-
+ GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
+ 
+ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sysctl(SB)
+-
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
+ TEXT libc_sendfile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendfile(SB)
+-
+ GLOBL	·libc_sendfile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendfile_trampoline_addr(SB)/8, $libc_sendfile_trampoline<>(SB)
+ 
+ TEXT libc_shmat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmat(SB)
+-
+ GLOBL	·libc_shmat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmat_trampoline_addr(SB)/8, $libc_shmat_trampoline<>(SB)
+ 
+ TEXT libc_shmctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmctl(SB)
+-
+ GLOBL	·libc_shmctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmctl_trampoline_addr(SB)/8, $libc_shmctl_trampoline<>(SB)
+ 
+ TEXT libc_shmdt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmdt(SB)
+-
+ GLOBL	·libc_shmdt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmdt_trampoline_addr(SB)/8, $libc_shmdt_trampoline<>(SB)
+ 
+ TEXT libc_shmget_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmget(SB)
+-
+ GLOBL	·libc_shmget_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmget_trampoline_addr(SB)/8, $libc_shmget_trampoline<>(SB)
+ 
+ TEXT libc_access_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_access(SB)
+-
+ GLOBL	·libc_access_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_access_trampoline_addr(SB)/8, $libc_access_trampoline<>(SB)
+ 
+ TEXT libc_adjtime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_adjtime(SB)
+-
+ GLOBL	·libc_adjtime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_adjtime_trampoline_addr(SB)/8, $libc_adjtime_trampoline<>(SB)
+ 
+ TEXT libc_chdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chdir(SB)
+-
+ GLOBL	·libc_chdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chdir_trampoline_addr(SB)/8, $libc_chdir_trampoline<>(SB)
+ 
+ TEXT libc_chflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chflags(SB)
+-
+ GLOBL	·libc_chflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chflags_trampoline_addr(SB)/8, $libc_chflags_trampoline<>(SB)
+ 
+ TEXT libc_chmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chmod(SB)
+-
+ GLOBL	·libc_chmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chmod_trampoline_addr(SB)/8, $libc_chmod_trampoline<>(SB)
+ 
+ TEXT libc_chown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chown(SB)
+-
+ GLOBL	·libc_chown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chown_trampoline_addr(SB)/8, $libc_chown_trampoline<>(SB)
+ 
+ TEXT libc_chroot_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chroot(SB)
+-
+ GLOBL	·libc_chroot_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chroot_trampoline_addr(SB)/8, $libc_chroot_trampoline<>(SB)
+ 
+ TEXT libc_clock_gettime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clock_gettime(SB)
+-
+ GLOBL	·libc_clock_gettime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clock_gettime_trampoline_addr(SB)/8, $libc_clock_gettime_trampoline<>(SB)
+ 
+ TEXT libc_close_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_close(SB)
+-
+ GLOBL	·libc_close_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_close_trampoline_addr(SB)/8, $libc_close_trampoline<>(SB)
+ 
+ TEXT libc_clonefile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefile(SB)
+-
+ GLOBL	·libc_clonefile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefile_trampoline_addr(SB)/8, $libc_clonefile_trampoline<>(SB)
+ 
+ TEXT libc_clonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefileat(SB)
+-
+ GLOBL	·libc_clonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefileat_trampoline_addr(SB)/8, $libc_clonefileat_trampoline<>(SB)
+ 
+ TEXT libc_dup_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup(SB)
+-
+ GLOBL	·libc_dup_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup_trampoline_addr(SB)/8, $libc_dup_trampoline<>(SB)
+ 
+ TEXT libc_dup2_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup2(SB)
+-
+ GLOBL	·libc_dup2_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup2_trampoline_addr(SB)/8, $libc_dup2_trampoline<>(SB)
+ 
+ TEXT libc_exchangedata_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exchangedata(SB)
+-
+ GLOBL	·libc_exchangedata_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exchangedata_trampoline_addr(SB)/8, $libc_exchangedata_trampoline<>(SB)
+ 
+ TEXT libc_exit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exit(SB)
+-
+ GLOBL	·libc_exit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exit_trampoline_addr(SB)/8, $libc_exit_trampoline<>(SB)
+ 
+ TEXT libc_faccessat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_faccessat(SB)
+-
+ GLOBL	·libc_faccessat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_faccessat_trampoline_addr(SB)/8, $libc_faccessat_trampoline<>(SB)
+ 
+ TEXT libc_fchdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchdir(SB)
+-
+ GLOBL	·libc_fchdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchdir_trampoline_addr(SB)/8, $libc_fchdir_trampoline<>(SB)
+ 
+ TEXT libc_fchflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchflags(SB)
+-
+ GLOBL	·libc_fchflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchflags_trampoline_addr(SB)/8, $libc_fchflags_trampoline<>(SB)
+ 
+ TEXT libc_fchmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmod(SB)
+-
+ GLOBL	·libc_fchmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmod_trampoline_addr(SB)/8, $libc_fchmod_trampoline<>(SB)
+ 
+ TEXT libc_fchmodat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmodat(SB)
+-
+ GLOBL	·libc_fchmodat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmodat_trampoline_addr(SB)/8, $libc_fchmodat_trampoline<>(SB)
+ 
+ TEXT libc_fchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchown(SB)
+-
+ GLOBL	·libc_fchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchown_trampoline_addr(SB)/8, $libc_fchown_trampoline<>(SB)
+ 
+ TEXT libc_fchownat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchownat(SB)
+-
+ GLOBL	·libc_fchownat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchownat_trampoline_addr(SB)/8, $libc_fchownat_trampoline<>(SB)
+ 
+ TEXT libc_fclonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fclonefileat(SB)
+-
+ GLOBL	·libc_fclonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fclonefileat_trampoline_addr(SB)/8, $libc_fclonefileat_trampoline<>(SB)
+ 
+ TEXT libc_flock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flock(SB)
+-
+ GLOBL	·libc_flock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flock_trampoline_addr(SB)/8, $libc_flock_trampoline<>(SB)
+ 
+ TEXT libc_fpathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fpathconf(SB)
+-
+ GLOBL	·libc_fpathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fpathconf_trampoline_addr(SB)/8, $libc_fpathconf_trampoline<>(SB)
+ 
+ TEXT libc_fsync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsync(SB)
+-
+ GLOBL	·libc_fsync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsync_trampoline_addr(SB)/8, $libc_fsync_trampoline<>(SB)
+ 
+ TEXT libc_ftruncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ftruncate(SB)
+-
+ GLOBL	·libc_ftruncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ftruncate_trampoline_addr(SB)/8, $libc_ftruncate_trampoline<>(SB)
+ 
+ TEXT libc_getcwd_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getcwd(SB)
+-
+ GLOBL	·libc_getcwd_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getcwd_trampoline_addr(SB)/8, $libc_getcwd_trampoline<>(SB)
+ 
+ TEXT libc_getdtablesize_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getdtablesize(SB)
+-
+ GLOBL	·libc_getdtablesize_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getdtablesize_trampoline_addr(SB)/8, $libc_getdtablesize_trampoline<>(SB)
+ 
+ TEXT libc_getegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getegid(SB)
+-
+ GLOBL	·libc_getegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getegid_trampoline_addr(SB)/8, $libc_getegid_trampoline<>(SB)
+ 
+ TEXT libc_geteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_geteuid(SB)
+-
+ GLOBL	·libc_geteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_geteuid_trampoline_addr(SB)/8, $libc_geteuid_trampoline<>(SB)
+ 
+ TEXT libc_getgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgid(SB)
+-
+ GLOBL	·libc_getgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgid_trampoline_addr(SB)/8, $libc_getgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgid(SB)
+-
+ GLOBL	·libc_getpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgid_trampoline_addr(SB)/8, $libc_getpgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgrp_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgrp(SB)
+-
+ GLOBL	·libc_getpgrp_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgrp_trampoline_addr(SB)/8, $libc_getpgrp_trampoline<>(SB)
+ 
+ TEXT libc_getpid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpid(SB)
+-
+ GLOBL	·libc_getpid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpid_trampoline_addr(SB)/8, $libc_getpid_trampoline<>(SB)
+ 
+ TEXT libc_getppid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getppid(SB)
+-
+ GLOBL	·libc_getppid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getppid_trampoline_addr(SB)/8, $libc_getppid_trampoline<>(SB)
+ 
+ TEXT libc_getpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpriority(SB)
+-
+ GLOBL	·libc_getpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpriority_trampoline_addr(SB)/8, $libc_getpriority_trampoline<>(SB)
+ 
+ TEXT libc_getrlimit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrlimit(SB)
+-
+ GLOBL	·libc_getrlimit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrlimit_trampoline_addr(SB)/8, $libc_getrlimit_trampoline<>(SB)
+ 
+ TEXT libc_getrusage_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrusage(SB)
+-
+ GLOBL	·libc_getrusage_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrusage_trampoline_addr(SB)/8, $libc_getrusage_trampoline<>(SB)
+ 
+ TEXT libc_getsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsid(SB)
+-
+ GLOBL	·libc_getsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsid_trampoline_addr(SB)/8, $libc_getsid_trampoline<>(SB)
+ 
+ TEXT libc_gettimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_gettimeofday(SB)
+-
+ GLOBL	·libc_gettimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_gettimeofday_trampoline_addr(SB)/8, $libc_gettimeofday_trampoline<>(SB)
+ 
+ TEXT libc_getuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getuid(SB)
+-
+ GLOBL	·libc_getuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getuid_trampoline_addr(SB)/8, $libc_getuid_trampoline<>(SB)
+ 
+ TEXT libc_issetugid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_issetugid(SB)
+-
+ GLOBL	·libc_issetugid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_issetugid_trampoline_addr(SB)/8, $libc_issetugid_trampoline<>(SB)
+ 
+ TEXT libc_kqueue_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kqueue(SB)
+-
+ GLOBL	·libc_kqueue_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kqueue_trampoline_addr(SB)/8, $libc_kqueue_trampoline<>(SB)
+ 
+ TEXT libc_lchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lchown(SB)
+-
+ GLOBL	·libc_lchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lchown_trampoline_addr(SB)/8, $libc_lchown_trampoline<>(SB)
+ 
+ TEXT libc_link_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_link(SB)
+-
+ GLOBL	·libc_link_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_link_trampoline_addr(SB)/8, $libc_link_trampoline<>(SB)
+ 
+ TEXT libc_linkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_linkat(SB)
+-
+ GLOBL	·libc_linkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_linkat_trampoline_addr(SB)/8, $libc_linkat_trampoline<>(SB)
+ 
+ TEXT libc_listen_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listen(SB)
+-
+ GLOBL	·libc_listen_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listen_trampoline_addr(SB)/8, $libc_listen_trampoline<>(SB)
+ 
+ TEXT libc_mkdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdir(SB)
+-
+ GLOBL	·libc_mkdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdir_trampoline_addr(SB)/8, $libc_mkdir_trampoline<>(SB)
+ 
+ TEXT libc_mkdirat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdirat(SB)
+-
+ GLOBL	·libc_mkdirat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdirat_trampoline_addr(SB)/8, $libc_mkdirat_trampoline<>(SB)
+ 
+ TEXT libc_mkfifo_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkfifo(SB)
+-
+ GLOBL	·libc_mkfifo_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkfifo_trampoline_addr(SB)/8, $libc_mkfifo_trampoline<>(SB)
+ 
+ TEXT libc_mknod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mknod(SB)
+-
+ GLOBL	·libc_mknod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mknod_trampoline_addr(SB)/8, $libc_mknod_trampoline<>(SB)
+ 
+ TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mount(SB)
+-
+ GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mount_trampoline_addr(SB)/8, $libc_mount_trampoline<>(SB)
+ 
+ TEXT libc_open_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_open(SB)
+-
+ GLOBL	·libc_open_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_open_trampoline_addr(SB)/8, $libc_open_trampoline<>(SB)
+ 
+ TEXT libc_openat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_openat(SB)
+-
+ GLOBL	·libc_openat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_openat_trampoline_addr(SB)/8, $libc_openat_trampoline<>(SB)
+ 
+ TEXT libc_pathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pathconf(SB)
+-
+ GLOBL	·libc_pathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pathconf_trampoline_addr(SB)/8, $libc_pathconf_trampoline<>(SB)
+ 
+ TEXT libc_pread_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pread(SB)
+-
+ GLOBL	·libc_pread_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pread_trampoline_addr(SB)/8, $libc_pread_trampoline<>(SB)
+ 
+ TEXT libc_pwrite_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pwrite(SB)
+-
+ GLOBL	·libc_pwrite_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pwrite_trampoline_addr(SB)/8, $libc_pwrite_trampoline<>(SB)
+ 
+ TEXT libc_read_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_read(SB)
+-
+ GLOBL	·libc_read_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_read_trampoline_addr(SB)/8, $libc_read_trampoline<>(SB)
+ 
+ TEXT libc_readlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlink(SB)
+-
+ GLOBL	·libc_readlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlink_trampoline_addr(SB)/8, $libc_readlink_trampoline<>(SB)
+ 
+ TEXT libc_readlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlinkat(SB)
+-
+ GLOBL	·libc_readlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlinkat_trampoline_addr(SB)/8, $libc_readlinkat_trampoline<>(SB)
+ 
+ TEXT libc_rename_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rename(SB)
+-
+ GLOBL	·libc_rename_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rename_trampoline_addr(SB)/8, $libc_rename_trampoline<>(SB)
+ 
+ TEXT libc_renameat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_renameat(SB)
+-
+ GLOBL	·libc_renameat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_renameat_trampoline_addr(SB)/8, $libc_renameat_trampoline<>(SB)
+ 
+ TEXT libc_revoke_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_revoke(SB)
+-
+ GLOBL	·libc_revoke_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_revoke_trampoline_addr(SB)/8, $libc_revoke_trampoline<>(SB)
+ 
+ TEXT libc_rmdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rmdir(SB)
+-
+ GLOBL	·libc_rmdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rmdir_trampoline_addr(SB)/8, $libc_rmdir_trampoline<>(SB)
+ 
+ TEXT libc_lseek_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lseek(SB)
+-
+ GLOBL	·libc_lseek_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lseek_trampoline_addr(SB)/8, $libc_lseek_trampoline<>(SB)
+ 
+ TEXT libc_select_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_select(SB)
+-
+ GLOBL	·libc_select_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_select_trampoline_addr(SB)/8, $libc_select_trampoline<>(SB)
+ 
+@@ -712,192 +595,160 @@ DATA	·libc_setattrlist_trampoline_addr(SB)/8, $libc_setattrlist_trampoline<>(SB
+ 
+ TEXT libc_setegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setegid(SB)
+-
+ GLOBL	·libc_setegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setegid_trampoline_addr(SB)/8, $libc_setegid_trampoline<>(SB)
+ 
+ TEXT libc_seteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_seteuid(SB)
+-
+ GLOBL	·libc_seteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_seteuid_trampoline_addr(SB)/8, $libc_seteuid_trampoline<>(SB)
+ 
+ TEXT libc_setgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgid(SB)
+-
+ GLOBL	·libc_setgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgid_trampoline_addr(SB)/8, $libc_setgid_trampoline<>(SB)
+ 
+ TEXT libc_setlogin_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setlogin(SB)
+-
+ GLOBL	·libc_setlogin_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setlogin_trampoline_addr(SB)/8, $libc_setlogin_trampoline<>(SB)
+ 
+ TEXT libc_setpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpgid(SB)
+-
+ GLOBL	·libc_setpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpgid_trampoline_addr(SB)/8, $libc_setpgid_trampoline<>(SB)
+ 
+ TEXT libc_setpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpriority(SB)
+-
+ GLOBL	·libc_setpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpriority_trampoline_addr(SB)/8, $libc_setpriority_trampoline<>(SB)
+ 
+ TEXT libc_setprivexec_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setprivexec(SB)
+-
+ GLOBL	·libc_setprivexec_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setprivexec_trampoline_addr(SB)/8, $libc_setprivexec_trampoline<>(SB)
+ 
+ TEXT libc_setregid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setregid(SB)
+-
+ GLOBL	·libc_setregid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setregid_trampoline_addr(SB)/8, $libc_setregid_trampoline<>(SB)
+ 
+ TEXT libc_setreuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setreuid(SB)
+-
+ GLOBL	·libc_setreuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setreuid_trampoline_addr(SB)/8, $libc_setreuid_trampoline<>(SB)
+ 
+ TEXT libc_setsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsid(SB)
+-
+ GLOBL	·libc_setsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsid_trampoline_addr(SB)/8, $libc_setsid_trampoline<>(SB)
+ 
+ TEXT libc_settimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_settimeofday(SB)
+-
+ GLOBL	·libc_settimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_settimeofday_trampoline_addr(SB)/8, $libc_settimeofday_trampoline<>(SB)
+ 
+ TEXT libc_setuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setuid(SB)
+-
+ GLOBL	·libc_setuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setuid_trampoline_addr(SB)/8, $libc_setuid_trampoline<>(SB)
+ 
+ TEXT libc_symlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlink(SB)
+-
+ GLOBL	·libc_symlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlink_trampoline_addr(SB)/8, $libc_symlink_trampoline<>(SB)
+ 
+ TEXT libc_symlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlinkat(SB)
+-
+ GLOBL	·libc_symlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlinkat_trampoline_addr(SB)/8, $libc_symlinkat_trampoline<>(SB)
+ 
+ TEXT libc_sync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sync(SB)
+-
+ GLOBL	·libc_sync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sync_trampoline_addr(SB)/8, $libc_sync_trampoline<>(SB)
+ 
+ TEXT libc_truncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_truncate(SB)
+-
+ GLOBL	·libc_truncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_truncate_trampoline_addr(SB)/8, $libc_truncate_trampoline<>(SB)
+ 
+ TEXT libc_umask_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_umask(SB)
+-
+ GLOBL	·libc_umask_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_umask_trampoline_addr(SB)/8, $libc_umask_trampoline<>(SB)
+ 
+ TEXT libc_undelete_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_undelete(SB)
+-
+ GLOBL	·libc_undelete_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_undelete_trampoline_addr(SB)/8, $libc_undelete_trampoline<>(SB)
+ 
+ TEXT libc_unlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlink(SB)
+-
+ GLOBL	·libc_unlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlink_trampoline_addr(SB)/8, $libc_unlink_trampoline<>(SB)
+ 
+ TEXT libc_unlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlinkat(SB)
+-
+ GLOBL	·libc_unlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlinkat_trampoline_addr(SB)/8, $libc_unlinkat_trampoline<>(SB)
+ 
+ TEXT libc_unmount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unmount(SB)
+-
+ GLOBL	·libc_unmount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unmount_trampoline_addr(SB)/8, $libc_unmount_trampoline<>(SB)
+ 
+ TEXT libc_write_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_write(SB)
+-
+ GLOBL	·libc_write_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_write_trampoline_addr(SB)/8, $libc_write_trampoline<>(SB)
+ 
+ TEXT libc_mmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mmap(SB)
+-
+ GLOBL	·libc_mmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mmap_trampoline_addr(SB)/8, $libc_mmap_trampoline<>(SB)
+ 
+ TEXT libc_munmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munmap(SB)
+-
+ GLOBL	·libc_munmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munmap_trampoline_addr(SB)/8, $libc_munmap_trampoline<>(SB)
+ 
+ TEXT libc_fstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstat(SB)
+-
+ GLOBL	·libc_fstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstat_trampoline_addr(SB)/8, $libc_fstat_trampoline<>(SB)
+ 
+ TEXT libc_fstatat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatat(SB)
+-
+ GLOBL	·libc_fstatat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatat_trampoline_addr(SB)/8, $libc_fstatat_trampoline<>(SB)
+ 
+ TEXT libc_fstatfs_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatfs(SB)
+-
+ GLOBL	·libc_fstatfs_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatfs_trampoline_addr(SB)/8, $libc_fstatfs_trampoline<>(SB)
+ 
+ TEXT libc_getfsstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getfsstat(SB)
+-
+ GLOBL	·libc_getfsstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getfsstat_trampoline_addr(SB)/8, $libc_getfsstat_trampoline<>(SB)
+ 
+ TEXT libc_lstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lstat(SB)
+-
+ GLOBL	·libc_lstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lstat_trampoline_addr(SB)/8, $libc_lstat_trampoline<>(SB)
+ 
+ TEXT libc_ptrace_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ptrace(SB)
+-
+ GLOBL	·libc_ptrace_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ptrace_trampoline_addr(SB)/8, $libc_ptrace_trampoline<>(SB)
+ 
+ TEXT libc_stat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_stat(SB)
+-
+ GLOBL	·libc_stat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_stat_trampoline_addr(SB)/8, $libc_stat_trampoline<>(SB)
+ 
+ TEXT libc_statfs_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_statfs(SB)
+-
+ GLOBL	·libc_statfs_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_statfs_trampoline_addr(SB)/8, $libc_statfs_trampoline<>(SB)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
+index 0eabac7..0c67df6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
+@@ -1642,28 +1642,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
+index ee313eb..e6e05d1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
+index 4c986e4..7508acc 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
+index 5552169..7b56aea 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
+index 67a226f..cc623dc 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
+index f0b9dda..5818491 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
+index b57c705..6be25cd 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
+@@ -40,7 +40,7 @@ func readv(fd int, iovs []Iovec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procreadv)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -55,7 +55,7 @@ func preadv(fd int, iovs []Iovec, off int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpreadv)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), uintptr(off), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -70,7 +70,7 @@ func writev(fd int, iovs []Iovec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwritev)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -85,7 +85,7 @@ func pwritev(fd int, iovs []Iovec, off int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpwritev)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), uintptr(off), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -96,7 +96,7 @@ func accept4(s int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (fd int,
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procaccept4)), 4, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index 7ceec23..8e5cee2 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -1734,28 +1734,6 @@ func exitThread(code int) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(p)), uintptr(np))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(p)), uintptr(np))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func readv(fd int, iovs []Iovec) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(iovs) > 0 {
+@@ -2197,3 +2175,23 @@ func getresgid(rgid *_C_int, egid *_C_int, sgid *_C_int) {
+ 	RawSyscallNoError(SYS_GETRESGID, uintptr(unsafe.Pointer(rgid)), uintptr(unsafe.Pointer(egid)), uintptr(unsafe.Pointer(sgid)))
+ 	return
+ }
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func schedSetattr(pid int, attr *SchedAttr, flags uint) (err error) {
++	_, _, e1 := Syscall(SYS_SCHED_SETATTR, uintptr(pid), uintptr(unsafe.Pointer(attr)), uintptr(flags))
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func schedGetattr(pid int, attr *SchedAttr, size uint, flags uint) (err error) {
++	_, _, e1 := Syscall6(SYS_SCHED_GETATTR, uintptr(pid), uintptr(unsafe.Pointer(attr)), uintptr(size), uintptr(flags), 0, 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
+index cdb2af5..af06b23 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
+index 9d25f76..093fcf3 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
+index d3f8035..4a78567 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
+index 887188a..741d8be 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index 9ab9abf..66b3b64 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index 915761e..c5c4cc1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -2213,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index 8e87fdf..93bfbb3 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 12a7a21..a107b8f 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index b19e8aa..c427de5 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index fb99594..60c1a99 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index 32cbbbc..52eba36 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
+index 609d1c5..b401894 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
+@@ -436,7 +436,7 @@ func pipe(p *[2]_C_int) (n int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procpipe)), 1, uintptr(unsafe.Pointer(p)), 0, 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -446,7 +446,7 @@ func pipe(p *[2]_C_int) (n int, err error) {
+ func pipe2(p *[2]_C_int, flags int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procpipe2)), 2, uintptr(unsafe.Pointer(p)), uintptr(flags), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -456,7 +456,7 @@ func pipe2(p *[2]_C_int, flags int) (err error) {
+ func getsockname(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgetsockname)), 3, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -471,7 +471,7 @@ func Getcwd(buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetcwd)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -482,7 +482,7 @@ func getgroups(ngid int, gid *_Gid_t) (n int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procgetgroups)), 2, uintptr(ngid), uintptr(unsafe.Pointer(gid)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -492,7 +492,7 @@ func getgroups(ngid int, gid *_Gid_t) (n int, err error) {
+ func setgroups(ngid int, gid *_Gid_t) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procsetgroups)), 2, uintptr(ngid), uintptr(unsafe.Pointer(gid)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -503,7 +503,7 @@ func wait4(pid int32, statusp *_C_int, options int, rusage *Rusage) (wpid int32,
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwait4)), 4, uintptr(pid), uintptr(unsafe.Pointer(statusp)), uintptr(options), uintptr(unsafe.Pointer(rusage)), 0, 0)
+ 	wpid = int32(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -518,7 +518,7 @@ func gethostname(buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgethostname)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -533,7 +533,7 @@ func utimes(path string, times *[2]Timeval) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procutimes)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(times)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -548,7 +548,7 @@ func utimensat(fd int, path string, times *[2]Timespec, flag int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procutimensat)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(times)), uintptr(flag), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -559,7 +559,7 @@ func fcntl(fd int, cmd int, arg int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procfcntl)), 3, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -569,7 +569,7 @@ func fcntl(fd int, cmd int, arg int) (val int, err error) {
+ func futimesat(fildes int, path *byte, times *[2]Timeval) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procfutimesat)), 3, uintptr(fildes), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(times)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -580,7 +580,7 @@ func accept(s int, rsa *RawSockaddrAny, addrlen *_Socklen) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procaccept)), 3, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -591,7 +591,7 @@ func recvmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_recvmsg)), 3, uintptr(s), uintptr(unsafe.Pointer(msg)), uintptr(flags), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -602,7 +602,7 @@ func sendmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_sendmsg)), 3, uintptr(s), uintptr(unsafe.Pointer(msg)), uintptr(flags), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -612,7 +612,7 @@ func sendmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ func acct(path *byte) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procacct)), 1, uintptr(unsafe.Pointer(path)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -647,7 +647,7 @@ func ioctlRet(fd int, req int, arg uintptr) (ret int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, uintptr(fd), uintptr(req), uintptr(arg), 0, 0, 0)
+ 	ret = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -658,7 +658,7 @@ func ioctlPtrRet(fd int, req int, arg unsafe.Pointer) (ret int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, uintptr(fd), uintptr(req), uintptr(arg), 0, 0, 0)
+ 	ret = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -669,7 +669,7 @@ func poll(fds *PollFd, nfds int, timeout int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpoll)), 3, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(timeout), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -684,7 +684,7 @@ func Access(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procAccess)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -694,7 +694,7 @@ func Access(path string, mode uint32) (err error) {
+ func Adjtime(delta *Timeval, olddelta *Timeval) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procAdjtime)), 2, uintptr(unsafe.Pointer(delta)), uintptr(unsafe.Pointer(olddelta)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -709,7 +709,7 @@ func Chdir(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChdir)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -724,7 +724,7 @@ func Chmod(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChmod)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -739,7 +739,7 @@ func Chown(path string, uid int, gid int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChown)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -754,7 +754,7 @@ func Chroot(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChroot)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -764,7 +764,7 @@ func Chroot(path string) (err error) {
+ func ClockGettime(clockid int32, time *Timespec) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procClockGettime)), 2, uintptr(clockid), uintptr(unsafe.Pointer(time)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -774,7 +774,7 @@ func ClockGettime(clockid int32, time *Timespec) (err error) {
+ func Close(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procClose)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -790,7 +790,7 @@ func Creat(path string, mode uint32) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procCreat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -801,7 +801,7 @@ func Dup(fd int) (nfd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procDup)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	nfd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -811,7 +811,7 @@ func Dup(fd int) (nfd int, err error) {
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procDup2)), 2, uintptr(oldfd), uintptr(newfd), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -833,7 +833,7 @@ func Faccessat(dirfd int, path string, mode uint32, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFaccessat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -843,7 +843,7 @@ func Faccessat(dirfd int, path string, mode uint32, flags int) (err error) {
+ func Fchdir(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchdir)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -853,7 +853,7 @@ func Fchdir(fd int) (err error) {
+ func Fchmod(fd int, mode uint32) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchmod)), 2, uintptr(fd), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -868,7 +868,7 @@ func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchmodat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -878,7 +878,7 @@ func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+ func Fchown(fd int, uid int, gid int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchown)), 3, uintptr(fd), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -893,7 +893,7 @@ func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchownat)), 5, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), uintptr(flags), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -903,7 +903,7 @@ func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
+ func Fdatasync(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFdatasync)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -913,7 +913,7 @@ func Fdatasync(fd int) (err error) {
+ func Flock(fd int, how int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFlock)), 2, uintptr(fd), uintptr(how), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -924,7 +924,7 @@ func Fpathconf(fd int, name int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFpathconf)), 2, uintptr(fd), uintptr(name), 0, 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -934,7 +934,7 @@ func Fpathconf(fd int, name int) (val int, err error) {
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstat)), 2, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -949,7 +949,7 @@ func Fstatat(fd int, path string, stat *Stat_t, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstatat)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -959,7 +959,7 @@ func Fstatat(fd int, path string, stat *Stat_t, flags int) (err error) {
+ func Fstatvfs(fd int, vfsstat *Statvfs_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstatvfs)), 2, uintptr(fd), uintptr(unsafe.Pointer(vfsstat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -974,7 +974,7 @@ func Getdents(fd int, buf []byte, basep *uintptr) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetdents)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(basep)), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1001,7 +1001,7 @@ func Getpgid(pid int) (pgid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetpgid)), 1, uintptr(pid), 0, 0, 0, 0, 0)
+ 	pgid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1012,7 +1012,7 @@ func Getpgrp() (pgid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetpgrp)), 0, 0, 0, 0, 0, 0, 0)
+ 	pgid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1047,7 +1047,7 @@ func Getpriority(which int, who int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetpriority)), 2, uintptr(which), uintptr(who), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1057,7 +1057,7 @@ func Getpriority(which int, who int) (n int, err error) {
+ func Getrlimit(which int, lim *Rlimit) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetrlimit)), 2, uintptr(which), uintptr(unsafe.Pointer(lim)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1067,7 +1067,7 @@ func Getrlimit(which int, lim *Rlimit) (err error) {
+ func Getrusage(who int, rusage *Rusage) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetrusage)), 2, uintptr(who), uintptr(unsafe.Pointer(rusage)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1078,7 +1078,7 @@ func Getsid(pid int) (sid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetsid)), 1, uintptr(pid), 0, 0, 0, 0, 0)
+ 	sid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1088,7 +1088,7 @@ func Getsid(pid int) (sid int, err error) {
+ func Gettimeofday(tv *Timeval) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGettimeofday)), 1, uintptr(unsafe.Pointer(tv)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1106,7 +1106,7 @@ func Getuid() (uid int) {
+ func Kill(pid int, signum syscall.Signal) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procKill)), 2, uintptr(pid), uintptr(signum), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1121,7 +1121,7 @@ func Lchown(path string, uid int, gid int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLchown)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1141,7 +1141,7 @@ func Link(path string, link string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLink)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1151,7 +1151,7 @@ func Link(path string, link string) (err error) {
+ func Listen(s int, backlog int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_llisten)), 2, uintptr(s), uintptr(backlog), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1166,7 +1166,7 @@ func Lstat(path string, stat *Stat_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLstat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1180,7 +1180,7 @@ func Madvise(b []byte, advice int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMadvise)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(advice), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1195,7 +1195,7 @@ func Mkdir(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkdir)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1210,7 +1210,7 @@ func Mkdirat(dirfd int, path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkdirat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1225,7 +1225,7 @@ func Mkfifo(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkfifo)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1240,7 +1240,7 @@ func Mkfifoat(dirfd int, path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkfifoat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1255,7 +1255,7 @@ func Mknod(path string, mode uint32, dev int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMknod)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(dev), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1270,7 +1270,7 @@ func Mknodat(dirfd int, path string, mode uint32, dev int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMknodat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(dev), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1284,7 +1284,7 @@ func Mlock(b []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMlock)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1294,7 +1294,7 @@ func Mlock(b []byte) (err error) {
+ func Mlockall(flags int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMlockall)), 1, uintptr(flags), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1308,7 +1308,7 @@ func Mprotect(b []byte, prot int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMprotect)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(prot), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1322,7 +1322,7 @@ func Msync(b []byte, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMsync)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(flags), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1336,7 +1336,7 @@ func Munlock(b []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMunlock)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1346,7 +1346,7 @@ func Munlock(b []byte) (err error) {
+ func Munlockall() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMunlockall)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1356,7 +1356,7 @@ func Munlockall() (err error) {
+ func Nanosleep(time *Timespec, leftover *Timespec) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procNanosleep)), 2, uintptr(unsafe.Pointer(time)), uintptr(unsafe.Pointer(leftover)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1372,7 +1372,7 @@ func Open(path string, mode int, perm uint32) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procOpen)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(perm), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1388,7 +1388,7 @@ func Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error)
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procOpenat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(flags), uintptr(mode), 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1404,7 +1404,7 @@ func Pathconf(path string, name int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procPathconf)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(name), 0, 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1414,7 +1414,7 @@ func Pathconf(path string, name int) (val int, err error) {
+ func Pause() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procPause)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1429,7 +1429,7 @@ func pread(fd int, p []byte, offset int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpread)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(offset), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1444,7 +1444,7 @@ func pwrite(fd int, p []byte, offset int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpwrite)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(offset), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1459,7 +1459,7 @@ func read(fd int, p []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procread)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1479,7 +1479,7 @@ func Readlink(path string, buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procReadlink)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), uintptr(len(buf)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1499,7 +1499,7 @@ func Rename(from string, to string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRename)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1519,7 +1519,7 @@ func Renameat(olddirfd int, oldpath string, newdirfd int, newpath string) (err e
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRenameat)), 4, uintptr(olddirfd), uintptr(unsafe.Pointer(_p0)), uintptr(newdirfd), uintptr(unsafe.Pointer(_p1)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1534,7 +1534,7 @@ func Rmdir(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRmdir)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1545,7 +1545,7 @@ func Seek(fd int, offset int64, whence int) (newoffset int64, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proclseek)), 3, uintptr(fd), uintptr(offset), uintptr(whence), 0, 0, 0)
+ 	newoffset = int64(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1556,7 +1556,7 @@ func Select(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timeval) (n int, err
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSelect)), 5, uintptr(nfd), uintptr(unsafe.Pointer(r)), uintptr(unsafe.Pointer(w)), uintptr(unsafe.Pointer(e)), uintptr(unsafe.Pointer(timeout)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1566,7 +1566,7 @@ func Select(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timeval) (n int, err
+ func Setegid(egid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetegid)), 1, uintptr(egid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1576,7 +1576,7 @@ func Setegid(egid int) (err error) {
+ func Seteuid(euid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSeteuid)), 1, uintptr(euid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1586,7 +1586,7 @@ func Seteuid(euid int) (err error) {
+ func Setgid(gid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetgid)), 1, uintptr(gid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1600,7 +1600,7 @@ func Sethostname(p []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSethostname)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1610,7 +1610,7 @@ func Sethostname(p []byte) (err error) {
+ func Setpgid(pid int, pgid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetpgid)), 2, uintptr(pid), uintptr(pgid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1620,7 +1620,7 @@ func Setpgid(pid int, pgid int) (err error) {
+ func Setpriority(which int, who int, prio int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSetpriority)), 3, uintptr(which), uintptr(who), uintptr(prio), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1630,7 +1630,7 @@ func Setpriority(which int, who int, prio int) (err error) {
+ func Setregid(rgid int, egid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetregid)), 2, uintptr(rgid), uintptr(egid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1640,7 +1640,7 @@ func Setregid(rgid int, egid int) (err error) {
+ func Setreuid(ruid int, euid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetreuid)), 2, uintptr(ruid), uintptr(euid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1651,7 +1651,7 @@ func Setsid() (pid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetsid)), 0, 0, 0, 0, 0, 0, 0)
+ 	pid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1661,7 +1661,7 @@ func Setsid() (pid int, err error) {
+ func Setuid(uid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetuid)), 1, uintptr(uid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1671,7 +1671,7 @@ func Setuid(uid int) (err error) {
+ func Shutdown(s int, how int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procshutdown)), 2, uintptr(s), uintptr(how), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1686,7 +1686,7 @@ func Stat(path string, stat *Stat_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procStat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1701,7 +1701,7 @@ func Statvfs(path string, vfsstat *Statvfs_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procStatvfs)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(vfsstat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1721,7 +1721,7 @@ func Symlink(path string, link string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSymlink)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1731,7 +1731,7 @@ func Symlink(path string, link string) (err error) {
+ func Sync() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSync)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1742,7 +1742,7 @@ func Sysconf(which int) (n int64, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSysconf)), 1, uintptr(which), 0, 0, 0, 0, 0)
+ 	n = int64(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1753,7 +1753,7 @@ func Times(tms *Tms) (ticks uintptr, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procTimes)), 1, uintptr(unsafe.Pointer(tms)), 0, 0, 0, 0, 0)
+ 	ticks = uintptr(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1768,7 +1768,7 @@ func Truncate(path string, length int64) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procTruncate)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1778,7 +1778,7 @@ func Truncate(path string, length int64) (err error) {
+ func Fsync(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFsync)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1788,7 +1788,7 @@ func Fsync(fd int) (err error) {
+ func Ftruncate(fd int, length int64) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFtruncate)), 2, uintptr(fd), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1806,7 +1806,7 @@ func Umask(mask int) (oldmask int) {
+ func Uname(buf *Utsname) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procUname)), 1, uintptr(unsafe.Pointer(buf)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1821,7 +1821,7 @@ func Unmount(target string, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procumount)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(flags), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1836,7 +1836,7 @@ func Unlink(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUnlink)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1851,7 +1851,7 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUnlinkat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(flags), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1861,7 +1861,7 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
+ func Ustat(dev int, ubuf *Ustat_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUstat)), 2, uintptr(dev), uintptr(unsafe.Pointer(ubuf)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1876,7 +1876,7 @@ func Utime(path string, buf *Utimbuf) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUtime)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(buf)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1886,7 +1886,7 @@ func Utime(path string, buf *Utimbuf) (err error) {
+ func bind(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_bind)), 3, uintptr(s), uintptr(addr), uintptr(addrlen), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1896,7 +1896,7 @@ func bind(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ func connect(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_connect)), 3, uintptr(s), uintptr(addr), uintptr(addrlen), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1907,7 +1907,7 @@ func mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procmmap)), 6, uintptr(addr), uintptr(length), uintptr(prot), uintptr(flag), uintptr(fd), uintptr(pos))
+ 	ret = uintptr(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1917,7 +1917,7 @@ func mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (
+ func munmap(addr uintptr, length uintptr) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procmunmap)), 2, uintptr(addr), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1928,7 +1928,7 @@ func sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procsendfile)), 4, uintptr(outfd), uintptr(infd), uintptr(unsafe.Pointer(offset)), uintptr(count), 0, 0)
+ 	written = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1942,7 +1942,7 @@ func sendto(s int, buf []byte, flags int, to unsafe.Pointer, addrlen _Socklen) (
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_sendto)), 6, uintptr(s), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(flags), uintptr(to), uintptr(addrlen))
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1953,7 +1953,7 @@ func socket(domain int, typ int, proto int) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_socket)), 3, uintptr(domain), uintptr(typ), uintptr(proto), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1963,7 +1963,7 @@ func socket(domain int, typ int, proto int) (fd int, err error) {
+ func socketpair(domain int, typ int, proto int, fd *[2]int32) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&proc__xnet_socketpair)), 4, uintptr(domain), uintptr(typ), uintptr(proto), uintptr(unsafe.Pointer(fd)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1978,7 +1978,7 @@ func write(fd int, p []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwrite)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1988,7 +1988,7 @@ func write(fd int, p []byte) (n int, err error) {
+ func getsockopt(s int, level int, name int, val unsafe.Pointer, vallen *_Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_getsockopt)), 5, uintptr(s), uintptr(level), uintptr(name), uintptr(val), uintptr(unsafe.Pointer(vallen)), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1998,7 +1998,7 @@ func getsockopt(s int, level int, name int, val unsafe.Pointer, vallen *_Socklen
+ func getpeername(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procgetpeername)), 3, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2008,7 +2008,7 @@ func getpeername(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ func setsockopt(s int, level int, name int, val unsafe.Pointer, vallen uintptr) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procsetsockopt)), 5, uintptr(s), uintptr(level), uintptr(name), uintptr(val), uintptr(vallen), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2023,7 +2023,7 @@ func recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Sockl
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procrecvfrom)), 6, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(flags), uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(fromlen)))
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2034,7 +2034,7 @@ func port_create() (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_create)), 0, 0, 0, 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2045,7 +2045,7 @@ func port_associate(port int, source int, object uintptr, events int, user *byte
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_associate)), 5, uintptr(port), uintptr(source), uintptr(object), uintptr(events), uintptr(unsafe.Pointer(user)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2056,7 +2056,7 @@ func port_dissociate(port int, source int, object uintptr) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_dissociate)), 3, uintptr(port), uintptr(source), uintptr(object), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2067,7 +2067,7 @@ func port_get(port int, pe *portEvent, timeout *Timespec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_get)), 3, uintptr(port), uintptr(unsafe.Pointer(pe)), uintptr(unsafe.Pointer(timeout)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2078,7 +2078,7 @@ func port_getn(port int, pe *portEvent, max uint32, nget *uint32, timeout *Times
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_getn)), 5, uintptr(port), uintptr(unsafe.Pointer(pe)), uintptr(max), uintptr(unsafe.Pointer(nget)), uintptr(unsafe.Pointer(timeout)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2088,7 +2088,7 @@ func port_getn(port int, pe *portEvent, max uint32, nget *uint32, timeout *Times
+ func putmsg(fd int, clptr *strbuf, dataptr *strbuf, flags int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procputmsg)), 4, uintptr(fd), uintptr(unsafe.Pointer(clptr)), uintptr(unsafe.Pointer(dataptr)), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2098,7 +2098,7 @@ func putmsg(fd int, clptr *strbuf, dataptr *strbuf, flags int) (err error) {
+ func getmsg(fd int, clptr *strbuf, dataptr *strbuf, flags *int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgetmsg)), 4, uintptr(fd), uintptr(unsafe.Pointer(clptr)), uintptr(unsafe.Pointer(dataptr)), uintptr(unsafe.Pointer(flags)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
+index c316817..1d8fe1d 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
+@@ -40,17 +40,6 @@ func read(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func write(fd int, p []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(p) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index c9c4ad0..9862853 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -447,4 +447,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index 12ff341..8901f0f 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -369,4 +369,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index c3fb5e7..6902c37 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -411,4 +411,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 358c847..a6d3dff 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -314,4 +314,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index 81c4849..b18f3f7 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -308,4 +308,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 202a57e..0302e5e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -431,4 +431,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 4448
+ 	SYS_FUTEX_WAITV                  = 4449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
++	SYS_CACHESTAT                    = 4451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index 1fbceb5..6693ba4 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -361,4 +361,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 5448
+ 	SYS_FUTEX_WAITV             = 5449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
++	SYS_CACHESTAT               = 5451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index b4ffb7a..fd93f49 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -361,4 +361,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 5448
+ 	SYS_FUTEX_WAITV             = 5449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
++	SYS_CACHESTAT               = 5451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index 867985f..760ddca 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -431,4 +431,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 4448
+ 	SYS_FUTEX_WAITV                  = 4449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
++	SYS_CACHESTAT                    = 4451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index a8cce69..cff2b25 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -438,4 +438,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index d44c5b3..a4b2405 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -410,4 +410,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index 4214dd9..aca54b4 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -410,4 +410,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 3e594a8..676245e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -313,4 +313,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index e6ed7d6..022878d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -376,4 +376,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index 92f628e..4100a76 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -389,4 +389,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index 02e2462..2d93b09 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -1972,7 +1972,7 @@ const (
+ 	NFT_MSG_GETFLOWTABLE              = 0x17
+ 	NFT_MSG_DELFLOWTABLE              = 0x18
+ 	NFT_MSG_GETRULE_RESET             = 0x19
+-	NFT_MSG_MAX                       = 0x21
++	NFT_MSG_MAX                       = 0x22
+ 	NFTA_LIST_UNSPEC                  = 0x0
+ 	NFTA_LIST_ELEM                    = 0x1
+ 	NFTA_HOOK_UNSPEC                  = 0x0
+@@ -4494,7 +4494,7 @@ const (
+ 	NL80211_ATTR_MAC_HINT                                   = 0xc8
+ 	NL80211_ATTR_MAC_MASK                                   = 0xd7
+ 	NL80211_ATTR_MAX_AP_ASSOC_STA                           = 0xca
+-	NL80211_ATTR_MAX                                        = 0x145
++	NL80211_ATTR_MAX                                        = 0x146
+ 	NL80211_ATTR_MAX_CRIT_PROT_DURATION                     = 0xb4
+ 	NL80211_ATTR_MAX_CSA_COUNTERS                           = 0xce
+ 	NL80211_ATTR_MAX_MATCH_SETS                             = 0x85
+@@ -4864,7 +4864,7 @@ const (
+ 	NL80211_CMD_LEAVE_IBSS                                  = 0x2c
+ 	NL80211_CMD_LEAVE_MESH                                  = 0x45
+ 	NL80211_CMD_LEAVE_OCB                                   = 0x6d
+-	NL80211_CMD_MAX                                         = 0x99
++	NL80211_CMD_MAX                                         = 0x9a
+ 	NL80211_CMD_MICHAEL_MIC_FAILURE                         = 0x29
+ 	NL80211_CMD_MODIFY_LINK_STA                             = 0x97
+ 	NL80211_CMD_NAN_MATCH                                   = 0x78
+@@ -5498,7 +5498,7 @@ const (
+ 	NL80211_RATE_INFO_HE_RU_ALLOC_52                        = 0x1
+ 	NL80211_RATE_INFO_HE_RU_ALLOC_996                       = 0x5
+ 	NL80211_RATE_INFO_HE_RU_ALLOC                           = 0x11
+-	NL80211_RATE_INFO_MAX                                   = 0x16
++	NL80211_RATE_INFO_MAX                                   = 0x1d
+ 	NL80211_RATE_INFO_MCS                                   = 0x2
+ 	NL80211_RATE_INFO_SHORT_GI                              = 0x4
+ 	NL80211_RATE_INFO_VHT_MCS                               = 0x6
+@@ -5863,3 +5863,18 @@ const (
+ 	VIRTIO_NET_HDR_GSO_UDP_L4 = 0x5
+ 	VIRTIO_NET_HDR_GSO_ECN    = 0x80
+ )
++
++type SchedAttr struct {
++	Size     uint32
++	Policy   uint32
++	Flags    uint64
++	Nice     int32
++	Priority uint32
++	Runtime  uint64
++	Deadline uint64
++	Period   uint64
++	Util_min uint32
++	Util_max uint32
++}
++
++const SizeofSchedAttr = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+index 9ea54b7..1b4c97c 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+@@ -718,3 +718,30 @@ type SysvShmDesc struct {
+ 	_      uint64
+ 	_      uint64
+ }
++
++type RISCVHWProbePairs struct {
++	Key   int64
++	Value uint64
++}
++
++const (
++	RISCV_HWPROBE_KEY_MVENDORID          = 0x0
++	RISCV_HWPROBE_KEY_MARCHID            = 0x1
++	RISCV_HWPROBE_KEY_MIMPID             = 0x2
++	RISCV_HWPROBE_KEY_BASE_BEHAVIOR      = 0x3
++	RISCV_HWPROBE_BASE_BEHAVIOR_IMA      = 0x1
++	RISCV_HWPROBE_KEY_IMA_EXT_0          = 0x4
++	RISCV_HWPROBE_IMA_FD                 = 0x1
++	RISCV_HWPROBE_IMA_C                  = 0x2
++	RISCV_HWPROBE_IMA_V                  = 0x4
++	RISCV_HWPROBE_EXT_ZBA                = 0x8
++	RISCV_HWPROBE_EXT_ZBB                = 0x10
++	RISCV_HWPROBE_EXT_ZBS                = 0x20
++	RISCV_HWPROBE_KEY_CPUPERF_0          = 0x5
++	RISCV_HWPROBE_MISALIGNED_UNKNOWN     = 0x0
++	RISCV_HWPROBE_MISALIGNED_EMULATED    = 0x1
++	RISCV_HWPROBE_MISALIGNED_SLOW        = 0x2
++	RISCV_HWPROBE_MISALIGNED_FAST        = 0x3
++	RISCV_HWPROBE_MISALIGNED_UNSUPPORTED = 0x4
++	RISCV_HWPROBE_MISALIGNED_MASK        = 0x7
++)
+diff --git a/vendor/golang.org/x/sys/windows/exec_windows.go b/vendor/golang.org/x/sys/windows/exec_windows.go
+index a52e033..9cabbb6 100644
+--- a/vendor/golang.org/x/sys/windows/exec_windows.go
++++ b/vendor/golang.org/x/sys/windows/exec_windows.go
+@@ -22,7 +22,7 @@ import (
+ //     but only if there is space or tab inside s.
+ func EscapeArg(s string) string {
+ 	if len(s) == 0 {
+-		return "\"\""
++		return `""`
+ 	}
+ 	n := len(s)
+ 	hasSpace := false
+@@ -35,7 +35,7 @@ func EscapeArg(s string) string {
+ 		}
+ 	}
+ 	if hasSpace {
+-		n += 2
++		n += 2 // Reserve space for quotes.
+ 	}
+ 	if n == len(s) {
+ 		return s
+@@ -82,20 +82,68 @@ func EscapeArg(s string) string {
+ // in CreateProcess's CommandLine argument, CreateService/ChangeServiceConfig's BinaryPathName argument,
+ // or any program that uses CommandLineToArgv.
+ func ComposeCommandLine(args []string) string {
+-	var commandLine string
+-	for i := range args {
+-		if i > 0 {
+-			commandLine += " "
++	if len(args) == 0 {
++		return ""
++	}
++
++	// Per https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw:
++	// “This function accepts command lines that contain a program name; the
++	// program name can be enclosed in quotation marks or not.”
++	//
++	// Unfortunately, it provides no means of escaping interior quotation marks
++	// within that program name, and we have no way to report them here.
++	prog := args[0]
++	mustQuote := len(prog) == 0
++	for i := 0; i < len(prog); i++ {
++		c := prog[i]
++		if c <= ' ' || (c == '"' && i == 0) {
++			// Force quotes for not only the ASCII space and tab as described in the
++			// MSDN article, but also ASCII control characters.
++			// The documentation for CommandLineToArgvW doesn't say what happens when
++			// the first argument is not a valid program name, but it empirically
++			// seems to drop unquoted control characters.
++			mustQuote = true
++			break
++		}
++	}
++	var commandLine []byte
++	if mustQuote {
++		commandLine = make([]byte, 0, len(prog)+2)
++		commandLine = append(commandLine, '"')
++		for i := 0; i < len(prog); i++ {
++			c := prog[i]
++			if c == '"' {
++				// This quote would interfere with our surrounding quotes.
++				// We have no way to report an error, so just strip out
++				// the offending character instead.
++				continue
++			}
++			commandLine = append(commandLine, c)
+ 		}
+-		commandLine += EscapeArg(args[i])
++		commandLine = append(commandLine, '"')
++	} else {
++		if len(args) == 1 {
++			// args[0] is a valid command line representing itself.
++			// No need to allocate a new slice or string for it.
++			return prog
++		}
++		commandLine = []byte(prog)
+ 	}
+-	return commandLine
++
++	for _, arg := range args[1:] {
++		commandLine = append(commandLine, ' ')
++		// TODO(bcmills): since we're already appending to a slice, it would be nice
++		// to avoid the intermediate allocations of EscapeArg.
++		// Perhaps we can factor out an appendEscapedArg function.
++		commandLine = append(commandLine, EscapeArg(arg)...)
++	}
++	return string(commandLine)
+ }
+ 
+ // DecomposeCommandLine breaks apart its argument command line into unescaped parts using CommandLineToArgv,
+ // as gathered from GetCommandLine, QUERY_SERVICE_CONFIG's BinaryPathName argument, or elsewhere that
+ // command lines are passed around.
+-// DecomposeCommandLine returns error if commandLine contains NUL.
++// DecomposeCommandLine returns an error if commandLine contains NUL.
+ func DecomposeCommandLine(commandLine string) ([]string, error) {
+ 	if len(commandLine) == 0 {
+ 		return []string{}, nil
+@@ -105,18 +153,35 @@ func DecomposeCommandLine(commandLine string) ([]string, error) {
+ 		return nil, errorspkg.New("string with NUL passed to DecomposeCommandLine")
+ 	}
+ 	var argc int32
+-	argv, err := CommandLineToArgv(&utf16CommandLine[0], &argc)
++	argv, err := commandLineToArgv(&utf16CommandLine[0], &argc)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 	defer LocalFree(Handle(unsafe.Pointer(argv)))
++
+ 	var args []string
+-	for _, v := range (*argv)[:argc] {
+-		args = append(args, UTF16ToString((*v)[:]))
++	for _, p := range unsafe.Slice(argv, argc) {
++		args = append(args, UTF16PtrToString(p))
+ 	}
+ 	return args, nil
+ }
+ 
++// CommandLineToArgv parses a Unicode command line string and sets
++// argc to the number of parsed arguments.
++//
++// The returned memory should be freed using a single call to LocalFree.
++//
++// Note that although the return type of CommandLineToArgv indicates 8192
++// entries of up to 8192 characters each, the actual count of parsed arguments
++// may exceed 8192, and the documentation for CommandLineToArgvW does not mention
++// any bound on the lengths of the individual argument strings.
++// (See https://go.dev/issue/63236.)
++func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) {
++	argp, err := commandLineToArgv(cmd, argc)
++	argv = (*[8192]*[8192]uint16)(unsafe.Pointer(argp))
++	return argv, err
++}
++
+ func CloseOnExec(fd Handle) {
+ 	SetHandleInformation(Handle(fd), HANDLE_FLAG_INHERIT, 0)
+ }
+diff --git a/vendor/golang.org/x/sys/windows/security_windows.go b/vendor/golang.org/x/sys/windows/security_windows.go
+index d414ef1..26be94a 100644
+--- a/vendor/golang.org/x/sys/windows/security_windows.go
++++ b/vendor/golang.org/x/sys/windows/security_windows.go
+@@ -7,8 +7,6 @@ package windows
+ import (
+ 	"syscall"
+ 	"unsafe"
+-
+-	"golang.org/x/sys/internal/unsafeheader"
+ )
+ 
+ const (
+@@ -1341,21 +1339,14 @@ func (selfRelativeSD *SECURITY_DESCRIPTOR) copySelfRelativeSecurityDescriptor()
+ 		sdLen = min
+ 	}
+ 
+-	var src []byte
+-	h := (*unsafeheader.Slice)(unsafe.Pointer(&src))
+-	h.Data = unsafe.Pointer(selfRelativeSD)
+-	h.Len = sdLen
+-	h.Cap = sdLen
+-
++	src := unsafe.Slice((*byte)(unsafe.Pointer(selfRelativeSD)), sdLen)
++	// SECURITY_DESCRIPTOR has pointers in it, which means checkptr expects for it to
++	// be aligned properly. When we're copying a Windows-allocated struct to a
++	// Go-allocated one, make sure that the Go allocation is aligned to the
++	// pointer size.
+ 	const psize = int(unsafe.Sizeof(uintptr(0)))
+-
+-	var dst []byte
+-	h = (*unsafeheader.Slice)(unsafe.Pointer(&dst))
+ 	alloc := make([]uintptr, (sdLen+psize-1)/psize)
+-	h.Data = (*unsafeheader.Slice)(unsafe.Pointer(&alloc)).Data
+-	h.Len = sdLen
+-	h.Cap = sdLen
+-
++	dst := unsafe.Slice((*byte)(unsafe.Pointer(&alloc[0])), sdLen)
+ 	copy(dst, src)
+ 	return (*SECURITY_DESCRIPTOR)(unsafe.Pointer(&dst[0]))
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index 9645900..a3cf746 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -15,8 +15,6 @@ import (
+ 	"time"
+ 	"unicode/utf16"
+ 	"unsafe"
+-
+-	"golang.org/x/sys/internal/unsafeheader"
+ )
+ 
+ type Handle uintptr
+@@ -216,7 +214,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	shGetKnownFolderPath(id *KNOWNFOLDERID, flags uint32, token Token, path **uint16) (ret error) = shell32.SHGetKnownFolderPath
+ //sys	TerminateProcess(handle Handle, exitcode uint32) (err error)
+ //sys	GetExitCodeProcess(handle Handle, exitcode *uint32) (err error)
+-//sys	GetStartupInfo(startupInfo *StartupInfo) (err error) = GetStartupInfoW
++//sys	getStartupInfo(startupInfo *StartupInfo) = GetStartupInfoW
+ //sys	GetProcessTimes(handle Handle, creationTime *Filetime, exitTime *Filetime, kernelTime *Filetime, userTime *Filetime) (err error)
+ //sys	DuplicateHandle(hSourceProcessHandle Handle, hSourceHandle Handle, hTargetProcessHandle Handle, lpTargetHandle *Handle, dwDesiredAccess uint32, bInheritHandle bool, dwOptions uint32) (err error)
+ //sys	WaitForSingleObject(handle Handle, waitMilliseconds uint32) (event uint32, err error) [failretval==0xffffffff]
+@@ -240,7 +238,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	SetFileAttributes(name *uint16, attrs uint32) (err error) = kernel32.SetFileAttributesW
+ //sys	GetFileAttributesEx(name *uint16, level uint32, info *byte) (err error) = kernel32.GetFileAttributesExW
+ //sys	GetCommandLine() (cmd *uint16) = kernel32.GetCommandLineW
+-//sys	CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) [failretval==nil] = shell32.CommandLineToArgvW
++//sys	commandLineToArgv(cmd *uint16, argc *int32) (argv **uint16, err error) [failretval==nil] = shell32.CommandLineToArgvW
+ //sys	LocalFree(hmem Handle) (handle Handle, err error) [failretval!=0]
+ //sys	LocalAlloc(flags uint32, length uint32) (ptr uintptr, err error)
+ //sys	SetHandleInformation(handle Handle, mask uint32, flags uint32) (err error)
+@@ -299,12 +297,15 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	RegNotifyChangeKeyValue(key Handle, watchSubtree bool, notifyFilter uint32, event Handle, asynchronous bool) (regerrno error) = advapi32.RegNotifyChangeKeyValue
+ //sys	GetCurrentProcessId() (pid uint32) = kernel32.GetCurrentProcessId
+ //sys	ProcessIdToSessionId(pid uint32, sessionid *uint32) (err error) = kernel32.ProcessIdToSessionId
++//sys	ClosePseudoConsole(console Handle) = kernel32.ClosePseudoConsole
++//sys	createPseudoConsole(size uint32, in Handle, out Handle, flags uint32, pconsole *Handle) (hr error) = kernel32.CreatePseudoConsole
+ //sys	GetConsoleMode(console Handle, mode *uint32) (err error) = kernel32.GetConsoleMode
+ //sys	SetConsoleMode(console Handle, mode uint32) (err error) = kernel32.SetConsoleMode
+ //sys	GetConsoleScreenBufferInfo(console Handle, info *ConsoleScreenBufferInfo) (err error) = kernel32.GetConsoleScreenBufferInfo
+ //sys	setConsoleCursorPosition(console Handle, position uint32) (err error) = kernel32.SetConsoleCursorPosition
+ //sys	WriteConsole(console Handle, buf *uint16, towrite uint32, written *uint32, reserved *byte) (err error) = kernel32.WriteConsoleW
+ //sys	ReadConsole(console Handle, buf *uint16, toread uint32, read *uint32, inputControl *byte) (err error) = kernel32.ReadConsoleW
++//sys	resizePseudoConsole(pconsole Handle, size uint32) (hr error) = kernel32.ResizePseudoConsole
+ //sys	CreateToolhelp32Snapshot(flags uint32, processId uint32) (handle Handle, err error) [failretval==InvalidHandle] = kernel32.CreateToolhelp32Snapshot
+ //sys	Module32First(snapshot Handle, moduleEntry *ModuleEntry32) (err error) = kernel32.Module32FirstW
+ //sys	Module32Next(snapshot Handle, moduleEntry *ModuleEntry32) (err error) = kernel32.Module32NextW
+@@ -437,6 +438,10 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	DwmGetWindowAttribute(hwnd HWND, attribute uint32, value unsafe.Pointer, size uint32) (ret error) = dwmapi.DwmGetWindowAttribute
+ //sys	DwmSetWindowAttribute(hwnd HWND, attribute uint32, value unsafe.Pointer, size uint32) (ret error) = dwmapi.DwmSetWindowAttribute
+ 
++// Windows Multimedia API
++//sys TimeBeginPeriod (period uint32) (err error) [failretval != 0] = winmm.timeBeginPeriod
++//sys TimeEndPeriod (period uint32) (err error) [failretval != 0] = winmm.timeEndPeriod
++
+ // syscall interface implementation for other packages
+ 
+ // GetCurrentProcess returns the handle for the current process.
+@@ -1624,6 +1629,11 @@ func SetConsoleCursorPosition(console Handle, position Coord) error {
+ 	return setConsoleCursorPosition(console, *((*uint32)(unsafe.Pointer(&position))))
+ }
+ 
++func GetStartupInfo(startupInfo *StartupInfo) error {
++	getStartupInfo(startupInfo)
++	return nil
++}
++
+ func (s NTStatus) Errno() syscall.Errno {
+ 	return rtlNtStatusToDosErrorNoTeb(s)
+ }
+@@ -1658,12 +1668,8 @@ func NewNTUnicodeString(s string) (*NTUnicodeString, error) {
+ 
+ // Slice returns a uint16 slice that aliases the data in the NTUnicodeString.
+ func (s *NTUnicodeString) Slice() []uint16 {
+-	var slice []uint16
+-	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&slice))
+-	hdr.Data = unsafe.Pointer(s.Buffer)
+-	hdr.Len = int(s.Length)
+-	hdr.Cap = int(s.MaximumLength)
+-	return slice
++	slice := unsafe.Slice(s.Buffer, s.MaximumLength)
++	return slice[:s.Length]
+ }
+ 
+ func (s *NTUnicodeString) String() string {
+@@ -1686,12 +1692,8 @@ func NewNTString(s string) (*NTString, error) {
+ 
+ // Slice returns a byte slice that aliases the data in the NTString.
+ func (s *NTString) Slice() []byte {
+-	var slice []byte
+-	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&slice))
+-	hdr.Data = unsafe.Pointer(s.Buffer)
+-	hdr.Len = int(s.Length)
+-	hdr.Cap = int(s.MaximumLength)
+-	return slice
++	slice := unsafe.Slice(s.Buffer, s.MaximumLength)
++	return slice[:s.Length]
+ }
+ 
+ func (s *NTString) String() string {
+@@ -1743,10 +1745,7 @@ func LoadResourceData(module, resInfo Handle) (data []byte, err error) {
+ 	if err != nil {
+ 		return
+ 	}
+-	h := (*unsafeheader.Slice)(unsafe.Pointer(&data))
+-	h.Data = unsafe.Pointer(ptr)
+-	h.Len = int(size)
+-	h.Cap = int(size)
++	data = unsafe.Slice((*byte)(unsafe.Pointer(ptr)), size)
+ 	return
+ }
+ 
+@@ -1817,3 +1816,17 @@ type PSAPI_WORKING_SET_EX_INFORMATION struct {
+ 	// A PSAPI_WORKING_SET_EX_BLOCK union that indicates the attributes of the page at VirtualAddress.
+ 	VirtualAttributes PSAPI_WORKING_SET_EX_BLOCK
+ }
++
++// CreatePseudoConsole creates a windows pseudo console.
++func CreatePseudoConsole(size Coord, in Handle, out Handle, flags uint32, pconsole *Handle) error {
++	// We need this wrapper to manually cast Coord to uint32. The autogenerated wrappers only
++	// accept arguments that can be casted to uintptr, and Coord can't.
++	return createPseudoConsole(*((*uint32)(unsafe.Pointer(&size))), in, out, flags, pconsole)
++}
++
++// ResizePseudoConsole resizes the internal buffers of the pseudo console to the width and height specified in `size`.
++func ResizePseudoConsole(pconsole Handle, size Coord) error {
++	// We need this wrapper to manually cast Coord to uint32. The autogenerated wrappers only
++	// accept arguments that can be casted to uintptr, and Coord can't.
++	return resizePseudoConsole(pconsole, *((*uint32)(unsafe.Pointer(&size))))
++}
+diff --git a/vendor/golang.org/x/sys/windows/types_windows.go b/vendor/golang.org/x/sys/windows/types_windows.go
+index 88e62a6..b88dc7c 100644
+--- a/vendor/golang.org/x/sys/windows/types_windows.go
++++ b/vendor/golang.org/x/sys/windows/types_windows.go
+@@ -247,6 +247,7 @@ const (
+ 	PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY = 0x00020007
+ 	PROC_THREAD_ATTRIBUTE_UMS_THREAD        = 0x00030006
+ 	PROC_THREAD_ATTRIBUTE_PROTECTION_LEVEL  = 0x0002000b
++	PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE     = 0x00020016
+ )
+ 
+ const (
+@@ -2139,6 +2140,12 @@ const (
+ 	ENABLE_LVB_GRID_WORLDWIDE          = 0x10
+ )
+ 
++// Pseudo console related constants used for the flags parameter to
++// CreatePseudoConsole. See: https://learn.microsoft.com/en-us/windows/console/createpseudoconsole
++const (
++	PSEUDOCONSOLE_INHERIT_CURSOR = 0x1
++)
++
+ type Coord struct {
+ 	X int16
+ 	Y int16
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index 566dd3e..8b1688d 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -55,6 +55,7 @@ var (
+ 	moduser32   = NewLazySystemDLL("user32.dll")
+ 	moduserenv  = NewLazySystemDLL("userenv.dll")
+ 	modversion  = NewLazySystemDLL("version.dll")
++	modwinmm    = NewLazySystemDLL("winmm.dll")
+ 	modwintrust = NewLazySystemDLL("wintrust.dll")
+ 	modws2_32   = NewLazySystemDLL("ws2_32.dll")
+ 	modwtsapi32 = NewLazySystemDLL("wtsapi32.dll")
+@@ -187,6 +188,7 @@ var (
+ 	procCancelIo                                             = modkernel32.NewProc("CancelIo")
+ 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
+ 	procCloseHandle                                          = modkernel32.NewProc("CloseHandle")
++	procClosePseudoConsole                                   = modkernel32.NewProc("ClosePseudoConsole")
+ 	procConnectNamedPipe                                     = modkernel32.NewProc("ConnectNamedPipe")
+ 	procCreateDirectoryW                                     = modkernel32.NewProc("CreateDirectoryW")
+ 	procCreateEventExW                                       = modkernel32.NewProc("CreateEventExW")
+@@ -201,6 +203,7 @@ var (
+ 	procCreateNamedPipeW                                     = modkernel32.NewProc("CreateNamedPipeW")
+ 	procCreatePipe                                           = modkernel32.NewProc("CreatePipe")
+ 	procCreateProcessW                                       = modkernel32.NewProc("CreateProcessW")
++	procCreatePseudoConsole                                  = modkernel32.NewProc("CreatePseudoConsole")
+ 	procCreateSymbolicLinkW                                  = modkernel32.NewProc("CreateSymbolicLinkW")
+ 	procCreateToolhelp32Snapshot                             = modkernel32.NewProc("CreateToolhelp32Snapshot")
+ 	procDefineDosDeviceW                                     = modkernel32.NewProc("DefineDosDeviceW")
+@@ -327,6 +330,7 @@ var (
+ 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
+ 	procRemoveDirectoryW                                     = modkernel32.NewProc("RemoveDirectoryW")
+ 	procResetEvent                                           = modkernel32.NewProc("ResetEvent")
++	procResizePseudoConsole                                  = modkernel32.NewProc("ResizePseudoConsole")
+ 	procResumeThread                                         = modkernel32.NewProc("ResumeThread")
+ 	procSetCommTimeouts                                      = modkernel32.NewProc("SetCommTimeouts")
+ 	procSetConsoleCursorPosition                             = modkernel32.NewProc("SetConsoleCursorPosition")
+@@ -468,6 +472,8 @@ var (
+ 	procGetFileVersionInfoSizeW                              = modversion.NewProc("GetFileVersionInfoSizeW")
+ 	procGetFileVersionInfoW                                  = modversion.NewProc("GetFileVersionInfoW")
+ 	procVerQueryValueW                                       = modversion.NewProc("VerQueryValueW")
++	proctimeBeginPeriod                                      = modwinmm.NewProc("timeBeginPeriod")
++	proctimeEndPeriod                                        = modwinmm.NewProc("timeEndPeriod")
+ 	procWinVerifyTrustEx                                     = modwintrust.NewProc("WinVerifyTrustEx")
+ 	procFreeAddrInfoW                                        = modws2_32.NewProc("FreeAddrInfoW")
+ 	procGetAddrInfoW                                         = modws2_32.NewProc("GetAddrInfoW")
+@@ -1630,6 +1636,11 @@ func CloseHandle(handle Handle) (err error) {
+ 	return
+ }
+ 
++func ClosePseudoConsole(console Handle) {
++	syscall.Syscall(procClosePseudoConsole.Addr(), 1, uintptr(console), 0, 0)
++	return
++}
++
+ func ConnectNamedPipe(pipe Handle, overlapped *Overlapped) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procConnectNamedPipe.Addr(), 2, uintptr(pipe), uintptr(unsafe.Pointer(overlapped)), 0)
+ 	if r1 == 0 {
+@@ -1759,6 +1770,14 @@ func CreateProcess(appName *uint16, commandLine *uint16, procSecurity *SecurityA
+ 	return
+ }
+ 
++func createPseudoConsole(size uint32, in Handle, out Handle, flags uint32, pconsole *Handle) (hr error) {
++	r0, _, _ := syscall.Syscall6(procCreatePseudoConsole.Addr(), 5, uintptr(size), uintptr(in), uintptr(out), uintptr(flags), uintptr(unsafe.Pointer(pconsole)), 0)
++	if r0 != 0 {
++		hr = syscall.Errno(r0)
++	}
++	return
++}
++
+ func CreateSymbolicLink(symlinkfilename *uint16, targetfilename *uint16, flags uint32) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procCreateSymbolicLinkW.Addr(), 3, uintptr(unsafe.Pointer(symlinkfilename)), uintptr(unsafe.Pointer(targetfilename)), uintptr(flags))
+ 	if r1&0xff == 0 {
+@@ -2367,11 +2386,8 @@ func GetShortPathName(longpath *uint16, shortpath *uint16, buflen uint32) (n uin
+ 	return
+ }
+ 
+-func GetStartupInfo(startupInfo *StartupInfo) (err error) {
+-	r1, _, e1 := syscall.Syscall(procGetStartupInfoW.Addr(), 1, uintptr(unsafe.Pointer(startupInfo)), 0, 0)
+-	if r1 == 0 {
+-		err = errnoErr(e1)
+-	}
++func getStartupInfo(startupInfo *StartupInfo) {
++	syscall.Syscall(procGetStartupInfoW.Addr(), 1, uintptr(unsafe.Pointer(startupInfo)), 0, 0)
+ 	return
+ }
+ 
+@@ -2862,6 +2878,14 @@ func ResetEvent(event Handle) (err error) {
+ 	return
+ }
+ 
++func resizePseudoConsole(pconsole Handle, size uint32) (hr error) {
++	r0, _, _ := syscall.Syscall(procResizePseudoConsole.Addr(), 2, uintptr(pconsole), uintptr(size), 0)
++	if r0 != 0 {
++		hr = syscall.Errno(r0)
++	}
++	return
++}
++
+ func ResumeThread(thread Handle) (ret uint32, err error) {
+ 	r0, _, e1 := syscall.Syscall(procResumeThread.Addr(), 1, uintptr(thread), 0, 0)
+ 	ret = uint32(r0)
+@@ -3820,9 +3844,9 @@ func setupUninstallOEMInf(infFileName *uint16, flags SUOI, reserved uintptr) (er
+ 	return
+ }
+ 
+-func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) {
++func commandLineToArgv(cmd *uint16, argc *int32) (argv **uint16, err error) {
+ 	r0, _, e1 := syscall.Syscall(procCommandLineToArgvW.Addr(), 2, uintptr(unsafe.Pointer(cmd)), uintptr(unsafe.Pointer(argc)), 0)
+-	argv = (*[8192]*[8192]uint16)(unsafe.Pointer(r0))
++	argv = (**uint16)(unsafe.Pointer(r0))
+ 	if argv == nil {
+ 		err = errnoErr(e1)
+ 	}
+@@ -4017,6 +4041,22 @@ func _VerQueryValue(block unsafe.Pointer, subBlock *uint16, pointerToBufferPoint
+ 	return
+ }
+ 
++func TimeBeginPeriod(period uint32) (err error) {
++	r1, _, e1 := syscall.Syscall(proctimeBeginPeriod.Addr(), 1, uintptr(period), 0, 0)
++	if r1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++func TimeEndPeriod(period uint32) (err error) {
++	r1, _, e1 := syscall.Syscall(proctimeEndPeriod.Addr(), 1, uintptr(period), 0, 0)
++	if r1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func WinVerifyTrustEx(hwnd HWND, actionId *GUID, data *WinTrustData) (ret error) {
+ 	r0, _, _ := syscall.Syscall(procWinVerifyTrustEx.Addr(), 3, uintptr(hwnd), uintptr(unsafe.Pointer(actionId)), uintptr(unsafe.Pointer(data)))
+ 	if r0 != 0 {
+diff --git a/vendor/golang.org/x/text/unicode/norm/trie.go b/vendor/golang.org/x/text/unicode/norm/trie.go
+index 423386b..e4250ae 100644
+--- a/vendor/golang.org/x/text/unicode/norm/trie.go
++++ b/vendor/golang.org/x/text/unicode/norm/trie.go
+@@ -29,7 +29,7 @@ var (
+ 	nfkcData = newNfkcTrie(0)
+ )
+ 
+-// lookupValue determines the type of block n and looks up the value for b.
++// lookup determines the type of block n and looks up the value for b.
+ // For n < t.cutoff, the block is a simple lookup table. Otherwise, the block
+ // is a list of ranges with an accompanying value. Given a matching range r,
+ // the value for b is by r.value + (b - r.lo) * stride.
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 352cad7..a028c0a 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -61,7 +61,46 @@ github.com/prometheus/procfs/internal/util
+ # github.com/spf13/pflag v1.0.5
+ ## explicit; go 1.12
+ github.com/spf13/pflag
+-# golang.org/x/net v0.13.0
++# go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.0
++## explicit; go 1.19
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/internal
++# go.opentelemetry.io/otel v1.15.0
++## explicit; go 1.19
++go.opentelemetry.io/otel
++go.opentelemetry.io/otel/attribute
++go.opentelemetry.io/otel/baggage
++go.opentelemetry.io/otel/codes
++go.opentelemetry.io/otel/internal
++go.opentelemetry.io/otel/internal/attribute
++go.opentelemetry.io/otel/internal/baggage
++go.opentelemetry.io/otel/internal/global
++go.opentelemetry.io/otel/propagation
++go.opentelemetry.io/otel/semconv/v1.17.0
++# go.opentelemetry.io/otel/metric v0.38.0
++## explicit; go 1.19
++go.opentelemetry.io/otel/metric
++go.opentelemetry.io/otel/metric/embedded
++go.opentelemetry.io/otel/metric/global
++go.opentelemetry.io/otel/metric/internal/global
++# go.opentelemetry.io/otel/trace v1.15.0
++## explicit; go 1.19
++go.opentelemetry.io/otel/trace
++# go.uber.org/atomic v1.10.0
++## explicit; go 1.18
++go.uber.org/atomic
++# go.uber.org/multierr v1.11.0
++## explicit; go 1.19
++go.uber.org/multierr
++# go.uber.org/zap v1.19.0
++## explicit; go 1.13
++go.uber.org/zap
++go.uber.org/zap/buffer
++go.uber.org/zap/internal/bufferpool
++go.uber.org/zap/internal/color
++go.uber.org/zap/internal/exit
++go.uber.org/zap/zapcore
++# golang.org/x/net v0.17.0
+ ## explicit; go 1.17
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -69,12 +108,11 @@ golang.org/x/net/http2/hpack
+ golang.org/x/net/idna
+ golang.org/x/net/internal/timeseries
+ golang.org/x/net/trace
+-# golang.org/x/sys v0.10.0
++# golang.org/x/sys v0.13.0
+ ## explicit; go 1.17
+-golang.org/x/sys/internal/unsafeheader
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-# golang.org/x/text v0.11.0
++# golang.org/x/text v0.13.0
+ ## explicit; go 1.17
+ golang.org/x/text/secure/bidirule
+ golang.org/x/text/transform
+-- 
+2.39.1
+

--- a/projects/kubernetes-csi/livenessprobe/1-26/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-26/CHECKSUMS
@@ -1,3 +1,3 @@
-76c4a0a6d54a987744cc1ee11a6a59c75c863db7088ac7a88b6a635ba871024a  _output/1-26/bin/livenessprobe/linux-amd64/livenessprobe
-61349ff8a583832aab8254c3c3ba90c03373324cc6eff7ef1c890811903cc726  _output/1-26/bin/livenessprobe/linux-arm64/livenessprobe
-059722d18e2b0d29632f4a6f760d331f0ba053d6a0dfd758582d2131164b1f0d  _output/1-26/bin/livenessprobe/windows-amd64/livenessprobe.exe
+069068a60fdf7739331586e4ad9f3258690ffe44d066514612dfcc0d8a6c2063  _output/1-26/bin/livenessprobe/linux-amd64/livenessprobe
+d3508a41fee454aea498b9b8841f2b299895a153594b89877a1dac7ed5a56812  _output/1-26/bin/livenessprobe/linux-arm64/livenessprobe
+7c2eda8690b52b3fdf51f1855a6c070afc8bceee41ef2fe8fbdb36b9f07acfc0  _output/1-26/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-26/patches/0001-Fix-CVE-2023-44487-and-CVE-2023-39325-bump-golang.or.patch
+++ b/projects/kubernetes-csi/livenessprobe/1-26/patches/0001-Fix-CVE-2023-44487-and-CVE-2023-39325-bump-golang.or.patch
@@ -1,0 +1,6786 @@
+From 0da68f237a1f971d899df26ee722ddf72905aa15 Mon Sep 17 00:00:00 2001
+From: Jonathan Dobson <jdobson@redhat.com>
+Date: Wed, 18 Oct 2023 14:27:39 -0600
+Subject: [PATCH] Fix CVE-2023-44487 and CVE-2023-39325: bump golang.org/x/net
+
+Signed-off-by: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
+---
+ go.mod                                        |  13 +-
+ go.sum                                        |  31 +-
+ vendor/golang.org/x/net/http2/Dockerfile      |  51 ----
+ vendor/golang.org/x/net/http2/Makefile        |   3 -
+ vendor/golang.org/x/net/http2/server.go       |  86 ++++--
+ vendor/golang.org/x/net/http2/transport.go    |   3 +-
+ .../sys/internal/unsafeheader/unsafeheader.go |  30 --
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |   1 +
+ vendor/golang.org/x/sys/unix/ptrace_darwin.go |   6 -
+ vendor/golang.org/x/sys/unix/ptrace_ios.go    |   6 -
+ vendor/golang.org/x/sys/unix/syscall_aix.go   |   2 -
+ .../golang.org/x/sys/unix/syscall_darwin.go   | 186 ------------
+ .../x/sys/unix/syscall_darwin_amd64.go        |   1 -
+ .../x/sys/unix/syscall_darwin_arm64.go        |   1 -
+ .../x/sys/unix/syscall_dragonfly.go           | 198 -------------
+ .../golang.org/x/sys/unix/syscall_freebsd.go  | 192 -------------
+ vendor/golang.org/x/sys/unix/syscall_linux.go |  77 ++++-
+ .../golang.org/x/sys/unix/syscall_netbsd.go   | 272 +-----------------
+ .../golang.org/x/sys/unix/syscall_openbsd.go  |  74 -----
+ .../golang.org/x/sys/unix/syscall_solaris.go  |  32 ---
+ vendor/golang.org/x/sys/unix/syscall_unix.go  |   3 +
+ .../x/sys/unix/syscall_zos_s390x.go           |   1 -
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  26 ++
+ .../x/sys/unix/zerrors_linux_386.go           |   2 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   2 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   4 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   2 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   2 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   2 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   2 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   2 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   2 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   2 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   2 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   2 +
+ .../golang.org/x/sys/unix/zsyscall_aix_ppc.go |  22 --
+ .../x/sys/unix/zsyscall_aix_ppc64.go          |  22 --
+ .../x/sys/unix/zsyscall_darwin_amd64.go       |  40 +--
+ .../x/sys/unix/zsyscall_darwin_amd64.s        | 149 ----------
+ .../x/sys/unix/zsyscall_darwin_arm64.go       |  40 +--
+ .../x/sys/unix/zsyscall_darwin_arm64.s        | 149 ----------
+ .../x/sys/unix/zsyscall_dragonfly_amd64.go    |  22 --
+ .../x/sys/unix/zsyscall_freebsd_386.go        |  22 --
+ .../x/sys/unix/zsyscall_freebsd_amd64.go      |  22 --
+ .../x/sys/unix/zsyscall_freebsd_arm.go        |  22 --
+ .../x/sys/unix/zsyscall_freebsd_arm64.go      |  22 --
+ .../x/sys/unix/zsyscall_freebsd_riscv64.go    |  22 --
+ .../x/sys/unix/zsyscall_illumos_amd64.go      |  10 +-
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  42 ++-
+ .../x/sys/unix/zsyscall_netbsd_386.go         |  22 --
+ .../x/sys/unix/zsyscall_netbsd_amd64.go       |  22 --
+ .../x/sys/unix/zsyscall_netbsd_arm.go         |  22 --
+ .../x/sys/unix/zsyscall_netbsd_arm64.go       |  22 --
+ .../x/sys/unix/zsyscall_openbsd_386.go        |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |  22 --
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |  32 +--
+ .../x/sys/unix/zsyscall_solaris_amd64.go      | 256 ++++++++---------
+ .../x/sys/unix/zsyscall_zos_s390x.go          |  11 -
+ .../x/sys/unix/zsysnum_linux_386.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   1 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   1 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   1 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   1 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  |  23 +-
+ .../x/sys/unix/ztypes_linux_riscv64.go        |  27 ++
+ .../golang.org/x/sys/windows/exec_windows.go  |  89 +++++-
+ .../x/sys/windows/security_windows.go         |  21 +-
+ .../x/sys/windows/syscall_windows.go          |  53 ++--
+ .../golang.org/x/sys/windows/types_windows.go |   7 +
+ .../x/sys/windows/zsyscall_windows.go         |  54 +++-
+ vendor/golang.org/x/text/unicode/norm/trie.go |   2 +-
+ vendor/modules.txt                            |  46 ++-
+ 89 files changed, 698 insertions(+), 2141 deletions(-)
+ delete mode 100644 vendor/golang.org/x/net/http2/Dockerfile
+ delete mode 100644 vendor/golang.org/x/net/http2/Makefile
+ delete mode 100644 vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
+
+diff --git a/go.mod b/go.mod
+index 3c87bf0..1d87210 100644
+--- a/go.mod
++++ b/go.mod
+@@ -23,9 +23,16 @@ require (
+ 	github.com/prometheus/common v0.44.0 // indirect
+ 	github.com/prometheus/procfs v0.10.1 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+-	golang.org/x/net v0.13.0 // indirect
+-	golang.org/x/sys v0.10.0 // indirect
+-	golang.org/x/text v0.11.0 // indirect
++	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.0 // indirect
++	go.opentelemetry.io/otel v1.15.0 // indirect
++	go.opentelemetry.io/otel/metric v0.38.0 // indirect
++	go.opentelemetry.io/otel/trace v1.15.0 // indirect
++	go.uber.org/atomic v1.10.0 // indirect
++	go.uber.org/multierr v1.11.0 // indirect
++	go.uber.org/zap v1.19.0 // indirect
++	golang.org/x/net v0.17.0 // indirect
++	golang.org/x/sys v0.13.0 // indirect
++	golang.org/x/text v0.13.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
+ 	google.golang.org/protobuf v1.31.0 // indirect
+ 	k8s.io/apimachinery v0.28.0 // indirect
+diff --git a/go.sum b/go.sum
+index 038cdf3..d4a9711 100644
+--- a/go.sum
++++ b/go.sum
+@@ -137,17 +137,9 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
+-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+-golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+-golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+-golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+-golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=
+-golang.org/x/net v0.13.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
+-golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+-golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
++golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
++golang.org/x/oauth2 v0.10.0 h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -168,23 +160,14 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220731174439-a90be440212d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
++golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+-golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
+-golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
++golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
++golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+diff --git a/vendor/golang.org/x/net/http2/Dockerfile b/vendor/golang.org/x/net/http2/Dockerfile
+deleted file mode 100644
+index 8512245..0000000
+--- a/vendor/golang.org/x/net/http2/Dockerfile
++++ /dev/null
+@@ -1,51 +0,0 @@
+-#
+-# This Dockerfile builds a recent curl with HTTP/2 client support, using
+-# a recent nghttp2 build.
+-#
+-# See the Makefile for how to tag it. If Docker and that image is found, the
+-# Go tests use this curl binary for integration tests.
+-#
+-
+-FROM ubuntu:trusty
+-
+-RUN apt-get update && \
+-    apt-get upgrade -y && \
+-    apt-get install -y git-core build-essential wget
+-
+-RUN apt-get install -y --no-install-recommends \
+-       autotools-dev libtool pkg-config zlib1g-dev \
+-       libcunit1-dev libssl-dev libxml2-dev libevent-dev \
+-       automake autoconf
+-
+-# The list of packages nghttp2 recommends for h2load:
+-RUN apt-get install -y --no-install-recommends make binutils \
+-        autoconf automake autotools-dev \
+-        libtool pkg-config zlib1g-dev libcunit1-dev libssl-dev libxml2-dev \
+-        libev-dev libevent-dev libjansson-dev libjemalloc-dev \
+-        cython python3.4-dev python-setuptools
+-
+-# Note: setting NGHTTP2_VER before the git clone, so an old git clone isn't cached:
+-ENV NGHTTP2_VER 895da9a
+-RUN cd /root && git clone https://github.com/tatsuhiro-t/nghttp2.git
+-
+-WORKDIR /root/nghttp2
+-RUN git reset --hard $NGHTTP2_VER
+-RUN autoreconf -i
+-RUN automake
+-RUN autoconf
+-RUN ./configure
+-RUN make
+-RUN make install
+-
+-WORKDIR /root
+-RUN wget https://curl.se/download/curl-7.45.0.tar.gz
+-RUN tar -zxvf curl-7.45.0.tar.gz
+-WORKDIR /root/curl-7.45.0
+-RUN ./configure --with-ssl --with-nghttp2=/usr/local
+-RUN make
+-RUN make install
+-RUN ldconfig
+-
+-CMD ["-h"]
+-ENTRYPOINT ["/usr/local/bin/curl"]
+-
+diff --git a/vendor/golang.org/x/net/http2/Makefile b/vendor/golang.org/x/net/http2/Makefile
+deleted file mode 100644
+index 55fd826..0000000
+--- a/vendor/golang.org/x/net/http2/Makefile
++++ /dev/null
+@@ -1,3 +0,0 @@
+-curlimage:
+-	docker build -t gohttp2/curl .
+-
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index 033b6e6..02c88b6 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -581,9 +581,11 @@ type serverConn struct {
+ 	advMaxStreams               uint32 // our SETTINGS_MAX_CONCURRENT_STREAMS advertised the client
+ 	curClientStreams            uint32 // number of open streams initiated by the client
+ 	curPushedStreams            uint32 // number of open streams initiated by server push
++	curHandlers                 uint32 // number of running handler goroutines
+ 	maxClientStreamID           uint32 // max ever seen from client (odd), or 0 if there have been no client requests
+ 	maxPushPromiseID            uint32 // ID of the last push promise (even), or 0 if there have been no pushes
+ 	streams                     map[uint32]*stream
++	unstartedHandlers           []unstartedHandler
+ 	initialStreamSendWindowSize int32
+ 	maxFrameSize                int32
+ 	peerMaxHeaderListSize       uint32            // zero means unknown (default)
+@@ -981,6 +983,8 @@ func (sc *serverConn) serve() {
+ 					return
+ 				case gracefulShutdownMsg:
+ 					sc.startGracefulShutdownInternal()
++				case handlerDoneMsg:
++					sc.handlerDone()
+ 				default:
+ 					panic("unknown timer")
+ 				}
+@@ -1012,14 +1016,6 @@ func (sc *serverConn) serve() {
+ 	}
+ }
+ 
+-func (sc *serverConn) awaitGracefulShutdown(sharedCh <-chan struct{}, privateCh chan struct{}) {
+-	select {
+-	case <-sc.doneServing:
+-	case <-sharedCh:
+-		close(privateCh)
+-	}
+-}
+-
+ type serverMessage int
+ 
+ // Message values sent to serveMsgCh.
+@@ -1028,6 +1024,7 @@ var (
+ 	idleTimerMsg        = new(serverMessage)
+ 	shutdownTimerMsg    = new(serverMessage)
+ 	gracefulShutdownMsg = new(serverMessage)
++	handlerDoneMsg      = new(serverMessage)
+ )
+ 
+ func (sc *serverConn) onSettingsTimer() { sc.sendServeMsg(settingsTimerMsg) }
+@@ -1900,9 +1897,11 @@ func (st *stream) copyTrailersToHandlerRequest() {
+ // onReadTimeout is run on its own goroutine (from time.AfterFunc)
+ // when the stream's ReadTimeout has fired.
+ func (st *stream) onReadTimeout() {
+-	// Wrap the ErrDeadlineExceeded to avoid callers depending on us
+-	// returning the bare error.
+-	st.body.CloseWithError(fmt.Errorf("%w", os.ErrDeadlineExceeded))
++	if st.body != nil {
++		// Wrap the ErrDeadlineExceeded to avoid callers depending on us
++		// returning the bare error.
++		st.body.CloseWithError(fmt.Errorf("%w", os.ErrDeadlineExceeded))
++	}
+ }
+ 
+ // onWriteTimeout is run on its own goroutine (from time.AfterFunc)
+@@ -2020,13 +2019,10 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+ 	if sc.hs.ReadTimeout != 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+-		if st.body != nil {
+-			st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+-		}
++		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+ 
+-	go sc.runHandler(rw, req, handler)
+-	return nil
++	return sc.scheduleHandler(id, rw, req, handler)
+ }
+ 
+ func (sc *serverConn) upgradeRequest(req *http.Request) {
+@@ -2046,6 +2042,10 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
++	// This is the first request on the connection,
++	// so start the handler directly rather than going
++	// through scheduleHandler.
++	sc.curHandlers++
+ 	go sc.runHandler(rw, req, sc.handler.ServeHTTP)
+ }
+ 
+@@ -2286,8 +2286,62 @@ func (sc *serverConn) newResponseWriter(st *stream, req *http.Request) *response
+ 	return &responseWriter{rws: rws}
+ }
+ 
++type unstartedHandler struct {
++	streamID uint32
++	rw       *responseWriter
++	req      *http.Request
++	handler  func(http.ResponseWriter, *http.Request)
++}
++
++// scheduleHandler starts a handler goroutine,
++// or schedules one to start as soon as an existing handler finishes.
++func (sc *serverConn) scheduleHandler(streamID uint32, rw *responseWriter, req *http.Request, handler func(http.ResponseWriter, *http.Request)) error {
++	sc.serveG.check()
++	maxHandlers := sc.advMaxStreams
++	if sc.curHandlers < maxHandlers {
++		sc.curHandlers++
++		go sc.runHandler(rw, req, handler)
++		return nil
++	}
++	if len(sc.unstartedHandlers) > int(4*sc.advMaxStreams) {
++		return sc.countError("too_many_early_resets", ConnectionError(ErrCodeEnhanceYourCalm))
++	}
++	sc.unstartedHandlers = append(sc.unstartedHandlers, unstartedHandler{
++		streamID: streamID,
++		rw:       rw,
++		req:      req,
++		handler:  handler,
++	})
++	return nil
++}
++
++func (sc *serverConn) handlerDone() {
++	sc.serveG.check()
++	sc.curHandlers--
++	i := 0
++	maxHandlers := sc.advMaxStreams
++	for ; i < len(sc.unstartedHandlers); i++ {
++		u := sc.unstartedHandlers[i]
++		if sc.streams[u.streamID] == nil {
++			// This stream was reset before its goroutine had a chance to start.
++			continue
++		}
++		if sc.curHandlers >= maxHandlers {
++			break
++		}
++		sc.curHandlers++
++		go sc.runHandler(u.rw, u.req, u.handler)
++		sc.unstartedHandlers[i] = unstartedHandler{} // don't retain references
++	}
++	sc.unstartedHandlers = sc.unstartedHandlers[i:]
++	if len(sc.unstartedHandlers) == 0 {
++		sc.unstartedHandlers = nil
++	}
++}
++
+ // Run on its own goroutine.
+ func (sc *serverConn) runHandler(rw *responseWriter, req *http.Request, handler func(http.ResponseWriter, *http.Request)) {
++	defer sc.sendServeMsg(handlerDoneMsg)
+ 	didPanic := true
+ 	defer func() {
+ 		rw.rws.stream.cancelCtx()
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index b20c749..7497f56 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -290,8 +290,7 @@ func (t *Transport) initConnPool() {
+ // HTTP/2 server.
+ type ClientConn struct {
+ 	t             *Transport
+-	tconn         net.Conn // usually *tls.Conn, except specialized impls
+-	tconnClosed   bool
++	tconn         net.Conn             // usually *tls.Conn, except specialized impls
+ 	tlsState      *tls.ConnectionState // nil only for specialized impls
+ 	reused        uint32               // whether conn is being reused; atomic
+ 	singleUse     bool                 // whether being used for a single http.Request
+diff --git a/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go b/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
+deleted file mode 100644
+index e07899b..0000000
+--- a/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
++++ /dev/null
+@@ -1,30 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-// Package unsafeheader contains header declarations for the Go runtime's
+-// slice and string implementations.
+-//
+-// This package allows x/sys to use types equivalent to
+-// reflect.SliceHeader and reflect.StringHeader without introducing
+-// a dependency on the (relatively heavy) "reflect" package.
+-package unsafeheader
+-
+-import (
+-	"unsafe"
+-)
+-
+-// Slice is the runtime representation of a slice.
+-// It cannot be used safely or portably and its representation may change in a later release.
+-type Slice struct {
+-	Data unsafe.Pointer
+-	Len  int
+-	Cap  int
+-}
+-
+-// String is the runtime representation of a string.
+-// It cannot be used safely or portably and its representation may change in a later release.
+-type String struct {
+-	Data unsafe.Pointer
+-	Len  int
+-}
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index 0c4d149..831f9e3 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -583,6 +583,7 @@ ccflags="$@"
+ 		$2 ~ /^PERF_/ ||
+ 		$2 ~ /^SECCOMP_MODE_/ ||
+ 		$2 ~ /^SEEK_/ ||
++		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+ 		$2 ~ /^SYNC_FILE_RANGE_/ ||
+ 		$2 !~ /IOC_MAGIC/ &&
+diff --git a/vendor/golang.org/x/sys/unix/ptrace_darwin.go b/vendor/golang.org/x/sys/unix/ptrace_darwin.go
+index 39dba6c..463c3ef 100644
+--- a/vendor/golang.org/x/sys/unix/ptrace_darwin.go
++++ b/vendor/golang.org/x/sys/unix/ptrace_darwin.go
+@@ -7,12 +7,6 @@
+ 
+ package unix
+ 
+-import "unsafe"
+-
+ func ptrace(request int, pid int, addr uintptr, data uintptr) error {
+ 	return ptrace1(request, pid, addr, data)
+ }
+-
+-func ptracePtr(request int, pid int, addr uintptr, data unsafe.Pointer) error {
+-	return ptrace1Ptr(request, pid, addr, data)
+-}
+diff --git a/vendor/golang.org/x/sys/unix/ptrace_ios.go b/vendor/golang.org/x/sys/unix/ptrace_ios.go
+index 9ea6633..ed0509a 100644
+--- a/vendor/golang.org/x/sys/unix/ptrace_ios.go
++++ b/vendor/golang.org/x/sys/unix/ptrace_ios.go
+@@ -7,12 +7,6 @@
+ 
+ package unix
+ 
+-import "unsafe"
+-
+ func ptrace(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return ENOTSUP
+ }
+-
+-func ptracePtr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	return ENOTSUP
+-}
+diff --git a/vendor/golang.org/x/sys/unix/syscall_aix.go b/vendor/golang.org/x/sys/unix/syscall_aix.go
+index c406ae0..6f77ff5 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_aix.go
++++ b/vendor/golang.org/x/sys/unix/syscall_aix.go
+@@ -487,8 +487,6 @@ func Fsync(fd int) error {
+ //sys	Unlinkat(dirfd int, path string, flags int) (err error)
+ //sys	Ustat(dev int, ubuf *Ustat_t) (err error)
+ //sys	write(fd int, p []byte) (n int, err error)
+-//sys	readlen(fd int, p *byte, np int) (n int, err error) = read
+-//sys	writelen(fd int, p *byte, np int) (n int, err error) = write
+ 
+ //sys	Dup2(oldfd int, newfd int) (err error)
+ //sys	Fadvise(fd int, offset int64, length int64, advice int) (err error) = posix_fadvise64
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin.go b/vendor/golang.org/x/sys/unix/syscall_darwin.go
+index 2069215..3b0bd2d 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin.go
+@@ -638,189 +638,3 @@ func SysctlKinfoProcSlice(name string, args ...int) ([]KinfoProc, error) {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+-
+-/*
+- * Unimplemented
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Ioctl
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// sendfile
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Poll_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go b/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
+index 9fa8798..b37310c 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
+@@ -47,6 +47,5 @@ func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr,
+ //sys	getfsstat(buf unsafe.Pointer, size uintptr, flags int) (n int, err error) = SYS_GETFSSTAT64
+ //sys	Lstat(path string, stat *Stat_t) (err error) = SYS_LSTAT64
+ //sys	ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) = SYS_ptrace
+-//sys	ptrace1Ptr(request int, pid int, addr unsafe.Pointer, data uintptr) (err error) = SYS_ptrace
+ //sys	Stat(path string, stat *Stat_t) (err error) = SYS_STAT64
+ //sys	Statfs(path string, stat *Statfs_t) (err error) = SYS_STATFS64
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go b/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
+index f17b8c5..d51ec99 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
+@@ -47,6 +47,5 @@ func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr,
+ //sys	getfsstat(buf unsafe.Pointer, size uintptr, flags int) (n int, err error) = SYS_GETFSSTAT
+ //sys	Lstat(path string, stat *Stat_t) (err error)
+ //sys	ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) = SYS_ptrace
+-//sys	ptrace1Ptr(request int, pid int, addr unsafe.Pointer, data uintptr) (err error) = SYS_ptrace
+ //sys	Stat(path string, stat *Stat_t) (err error)
+ //sys	Statfs(path string, stat *Statfs_t) (err error)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+index d4ce988..97cb916 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
++++ b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+@@ -343,203 +343,5 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error)
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- * TODO(jsing): Update this list for DragonFly.
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Mount
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Setattrlist
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Getxattr
+-// Fgetxattr
+-// Setxattr
+-// Fsetxattr
+-// Removexattr
+-// Fremovexattr
+-// Listxattr
+-// Flistxattr
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shmat
+-// Shmctl
+-// Shmdt
+-// Shmget
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index afb1010..64d1bb4 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -449,197 +449,5 @@ func Dup3(oldfd, newfd, flags int) error {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error)
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Ioctl
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Mount
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Setattrlist
+-// Getdents
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shmat
+-// Shmctl
+-// Shmdt
+-// Shmget
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Poll_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index 39de5f1..c905ec8 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -693,10 +693,10 @@ type SockaddrALG struct {
+ 
+ func (sa *SockaddrALG) sockaddr() (unsafe.Pointer, _Socklen, error) {
+ 	// Leave room for NUL byte terminator.
+-	if len(sa.Type) > 13 {
++	if len(sa.Type) > len(sa.raw.Type)-1 {
+ 		return nil, 0, EINVAL
+ 	}
+-	if len(sa.Name) > 63 {
++	if len(sa.Name) > len(sa.raw.Name)-1 {
+ 		return nil, 0, EINVAL
+ 	}
+ 
+@@ -704,17 +704,8 @@ func (sa *SockaddrALG) sockaddr() (unsafe.Pointer, _Socklen, error) {
+ 	sa.raw.Feat = sa.Feature
+ 	sa.raw.Mask = sa.Mask
+ 
+-	typ, err := ByteSliceFromString(sa.Type)
+-	if err != nil {
+-		return nil, 0, err
+-	}
+-	name, err := ByteSliceFromString(sa.Name)
+-	if err != nil {
+-		return nil, 0, err
+-	}
+-
+-	copy(sa.raw.Type[:], typ)
+-	copy(sa.raw.Name[:], name)
++	copy(sa.raw.Type[:], sa.Type)
++	copy(sa.raw.Name[:], sa.Name)
+ 
+ 	return unsafe.Pointer(&sa.raw), SizeofSockaddrALG, nil
+ }
+@@ -1988,8 +1979,6 @@ func Signalfd(fd int, sigmask *Sigset_t, flags int) (newfd int, err error) {
+ //sys	Unshare(flags int) (err error)
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	exitThread(code int) (err error) = SYS_EXIT
+-//sys	readlen(fd int, p *byte, np int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, p *byte, np int) (n int, err error) = SYS_WRITE
+ //sys	readv(fd int, iovs []Iovec) (n int, err error) = SYS_READV
+ //sys	writev(fd int, iovs []Iovec) (n int, err error) = SYS_WRITEV
+ //sys	preadv(fd int, iovs []Iovec, offs_l uintptr, offs_h uintptr) (n int, err error) = SYS_PREADV
+@@ -2454,6 +2443,7 @@ func Getresgid() (rgid, egid, sgid int) {
+ 	return int(r), int(e), int(s)
+ }
+ 
++<<<<<<< HEAD
+ /*
+  * Unimplemented
+  */
+@@ -2549,3 +2539,60 @@ func Getresgid() (rgid, egid, sgid int) {
+ // Vhangup
+ // Vserver
+ // _Sysctl
++=======
++// Pselect is a wrapper around the Linux pselect6 system call.
++// This version does not modify the timeout argument.
++func Pselect(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
++	// Per https://man7.org/linux/man-pages/man2/select.2.html#NOTES,
++	// The Linux pselect6() system call modifies its timeout argument.
++	// [Not modifying the argument] is the behavior required by POSIX.1-2001.
++	var mutableTimeout *Timespec
++	if timeout != nil {
++		mutableTimeout = new(Timespec)
++		*mutableTimeout = *timeout
++	}
++
++	// The final argument of the pselect6() system call is not a
++	// sigset_t * pointer, but is instead a structure
++	var kernelMask *sigset_argpack
++	if sigmask != nil {
++		wordBits := 32 << (^uintptr(0) >> 63) // see math.intSize
++
++		// A sigset stores one bit per signal,
++		// offset by 1 (because signal 0 does not exist).
++		// So the number of words needed is ⌈__C_NSIG - 1 / wordBits⌉.
++		sigsetWords := (_C__NSIG - 1 + wordBits - 1) / (wordBits)
++
++		sigsetBytes := uintptr(sigsetWords * (wordBits / 8))
++		kernelMask = &sigset_argpack{
++			ss:    sigmask,
++			ssLen: sigsetBytes,
++		}
++	}
++
++	return pselect6(nfd, r, w, e, mutableTimeout, kernelMask)
++}
++
++//sys	schedSetattr(pid int, attr *SchedAttr, flags uint) (err error)
++//sys	schedGetattr(pid int, attr *SchedAttr, size uint, flags uint) (err error)
++
++// SchedSetAttr is a wrapper for sched_setattr(2) syscall.
++// https://man7.org/linux/man-pages/man2/sched_setattr.2.html
++func SchedSetAttr(pid int, attr *SchedAttr, flags uint) error {
++	if attr == nil {
++		return EINVAL
++	}
++	attr.Size = SizeofSchedAttr
++	return schedSetattr(pid, attr, flags)
++}
++
++// SchedGetAttr is a wrapper for sched_getattr(2) syscall.
++// https://man7.org/linux/man-pages/man2/sched_getattr.2.html
++func SchedGetAttr(pid int, flags uint) (*SchedAttr, error) {
++	attr := &SchedAttr{}
++	if err := schedGetattr(pid, attr, SizeofSchedAttr, flags); err != nil {
++		return nil, err
++	}
++	return attr, nil
++}
++>>>>>>> 48ed37b (CVE-2023-44487: bump golang.org/x/net to v0.17.0)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_netbsd.go b/vendor/golang.org/x/sys/unix/syscall_netbsd.go
+index 018d7d4..8816209 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_netbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_netbsd.go
+@@ -356,266 +356,16 @@ func Statvfs(path string, buf *Statvfs_t) (err error) {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+ 
+-/*
+- * Unimplemented
+- */
+-// ____semctl13
+-// __clone
+-// __fhopen40
+-// __fhstat40
+-// __fhstatvfs140
+-// __fstat30
+-// __getcwd
+-// __getfh30
+-// __getlogin
+-// __lstat30
+-// __mount50
+-// __msgctl13
+-// __msync13
+-// __ntp_gettime30
+-// __posix_chown
+-// __posix_fchown
+-// __posix_lchown
+-// __posix_rename
+-// __setlogin
+-// __shmctl13
+-// __sigaction_sigtramp
+-// __sigaltstack14
+-// __sigpending14
+-// __sigprocmask14
+-// __sigsuspend14
+-// __sigtimedwait
+-// __stat30
+-// __syscall
+-// __vfork14
+-// _ksem_close
+-// _ksem_destroy
+-// _ksem_getvalue
+-// _ksem_init
+-// _ksem_open
+-// _ksem_post
+-// _ksem_trywait
+-// _ksem_unlink
+-// _ksem_wait
+-// _lwp_continue
+-// _lwp_create
+-// _lwp_ctl
+-// _lwp_detach
+-// _lwp_exit
+-// _lwp_getname
+-// _lwp_getprivate
+-// _lwp_kill
+-// _lwp_park
+-// _lwp_self
+-// _lwp_setname
+-// _lwp_setprivate
+-// _lwp_suspend
+-// _lwp_unpark
+-// _lwp_unpark_all
+-// _lwp_wait
+-// _lwp_wakeup
+-// _pset_bind
+-// _sched_getaffinity
+-// _sched_getparam
+-// _sched_setaffinity
+-// _sched_setparam
+-// acct
+-// aio_cancel
+-// aio_error
+-// aio_fsync
+-// aio_read
+-// aio_return
+-// aio_suspend
+-// aio_write
+-// break
+-// clock_getres
+-// clock_gettime
+-// clock_settime
+-// compat_09_ogetdomainname
+-// compat_09_osetdomainname
+-// compat_09_ouname
+-// compat_10_omsgsys
+-// compat_10_osemsys
+-// compat_10_oshmsys
+-// compat_12_fstat12
+-// compat_12_getdirentries
+-// compat_12_lstat12
+-// compat_12_msync
+-// compat_12_oreboot
+-// compat_12_oswapon
+-// compat_12_stat12
+-// compat_13_sigaction13
+-// compat_13_sigaltstack13
+-// compat_13_sigpending13
+-// compat_13_sigprocmask13
+-// compat_13_sigreturn13
+-// compat_13_sigsuspend13
+-// compat_14___semctl
+-// compat_14_msgctl
+-// compat_14_shmctl
+-// compat_16___sigaction14
+-// compat_16___sigreturn14
+-// compat_20_fhstatfs
+-// compat_20_fstatfs
+-// compat_20_getfsstat
+-// compat_20_statfs
+-// compat_30___fhstat30
+-// compat_30___fstat13
+-// compat_30___lstat13
+-// compat_30___stat13
+-// compat_30_fhopen
+-// compat_30_fhstat
+-// compat_30_fhstatvfs1
+-// compat_30_getdents
+-// compat_30_getfh
+-// compat_30_ntp_gettime
+-// compat_30_socket
+-// compat_40_mount
+-// compat_43_fstat43
+-// compat_43_lstat43
+-// compat_43_oaccept
+-// compat_43_ocreat
+-// compat_43_oftruncate
+-// compat_43_ogetdirentries
+-// compat_43_ogetdtablesize
+-// compat_43_ogethostid
+-// compat_43_ogethostname
+-// compat_43_ogetkerninfo
+-// compat_43_ogetpagesize
+-// compat_43_ogetpeername
+-// compat_43_ogetrlimit
+-// compat_43_ogetsockname
+-// compat_43_okillpg
+-// compat_43_olseek
+-// compat_43_ommap
+-// compat_43_oquota
+-// compat_43_orecv
+-// compat_43_orecvfrom
+-// compat_43_orecvmsg
+-// compat_43_osend
+-// compat_43_osendmsg
+-// compat_43_osethostid
+-// compat_43_osethostname
+-// compat_43_osigblock
+-// compat_43_osigsetmask
+-// compat_43_osigstack
+-// compat_43_osigvec
+-// compat_43_otruncate
+-// compat_43_owait
+-// compat_43_stat43
+-// execve
+-// extattr_delete_fd
+-// extattr_delete_file
+-// extattr_delete_link
+-// extattr_get_fd
+-// extattr_get_file
+-// extattr_get_link
+-// extattr_list_fd
+-// extattr_list_file
+-// extattr_list_link
+-// extattr_set_fd
+-// extattr_set_file
+-// extattr_set_link
+-// extattrctl
+-// fchroot
+-// fdatasync
+-// fgetxattr
+-// fktrace
+-// flistxattr
+-// fork
+-// fremovexattr
+-// fsetxattr
+-// fstatvfs1
+-// fsync_range
+-// getcontext
+-// getitimer
+-// getvfsstat
+-// getxattr
+-// ktrace
+-// lchflags
+-// lchmod
+-// lfs_bmapv
+-// lfs_markv
+-// lfs_segclean
+-// lfs_segwait
+-// lgetxattr
+-// lio_listio
+-// listxattr
+-// llistxattr
+-// lremovexattr
+-// lseek
+-// lsetxattr
+-// lutimes
+-// madvise
+-// mincore
+-// minherit
+-// modctl
+-// mq_close
+-// mq_getattr
+-// mq_notify
+-// mq_open
+-// mq_receive
+-// mq_send
+-// mq_setattr
+-// mq_timedreceive
+-// mq_timedsend
+-// mq_unlink
+-// mremap
+-// msgget
+-// msgrcv
+-// msgsnd
+-// nfssvc
+-// ntp_adjtime
+-// pmc_control
+-// pmc_get_info
+-// pollts
+-// preadv
+-// profil
+-// pselect
+-// pset_assign
+-// pset_create
+-// pset_destroy
+-// ptrace
+-// pwritev
+-// quotactl
+-// rasctl
+-// readv
+-// reboot
+-// removexattr
+-// sa_enable
+-// sa_preempt
+-// sa_register
+-// sa_setconcurrency
+-// sa_stacks
+-// sa_yield
+-// sbrk
+-// sched_yield
+-// semconfig
+-// semget
+-// semop
+-// setcontext
+-// setitimer
+-// setxattr
+-// shmat
+-// shmdt
+-// shmget
+-// sstk
+-// statvfs1
+-// swapctl
+-// sysarch
+-// syscall
+-// timer_create
+-// timer_delete
+-// timer_getoverrun
+-// timer_gettime
+-// timer_settime
+-// undelete
+-// utrace
+-// uuidgen
+-// vadvise
+-// vfork
+-// writev
++const (
++	mremapFixed     = MAP_FIXED
++	mremapDontunmap = 0
++	mremapMaymove   = 0
++)
++
++//sys	mremapNetBSD(oldp uintptr, oldsize uintptr, newp uintptr, newsize uintptr, flags int) (xaddr uintptr, err error) = SYS_MREMAP
++
++func mremap(oldaddr uintptr, oldlength uintptr, newlength uintptr, flags int, newaddr uintptr) (uintptr, error) {
++	return mremapNetBSD(oldaddr, oldlength, newaddr, newlength, flags)
++}
+diff --git a/vendor/golang.org/x/sys/unix/syscall_openbsd.go b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+index c5f166a..6f34479 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_openbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+@@ -326,78 +326,4 @@ func Uname(uname *Utsname) error {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- */
+-// __getcwd
+-// __semctl
+-// __syscall
+-// __sysctl
+-// adjfreq
+-// break
+-// clock_getres
+-// clock_gettime
+-// clock_settime
+-// closefrom
+-// execve
+-// fhopen
+-// fhstat
+-// fhstatfs
+-// fork
+-// futimens
+-// getfh
+-// getgid
+-// getitimer
+-// getlogin
+-// getthrid
+-// ktrace
+-// lfs_bmapv
+-// lfs_markv
+-// lfs_segclean
+-// lfs_segwait
+-// mincore
+-// minherit
+-// mount
+-// mquery
+-// msgctl
+-// msgget
+-// msgrcv
+-// msgsnd
+-// nfssvc
+-// nnpfspioctl
+-// preadv
+-// profil
+-// pwritev
+-// quotactl
+-// readv
+-// reboot
+-// renameat
+-// rfork
+-// sched_yield
+-// semget
+-// semop
+-// setgroups
+-// setitimer
+-// setsockopt
+-// shmat
+-// shmctl
+-// shmdt
+-// shmget
+-// sigaction
+-// sigaltstack
+-// sigpending
+-// sigprocmask
+-// sigreturn
+-// sigsuspend
+-// sysarch
+-// syscall
+-// threxit
+-// thrsigdivert
+-// thrsleep
+-// thrwakeup
+-// vfork
+-// writev
+diff --git a/vendor/golang.org/x/sys/unix/syscall_solaris.go b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+index b600a28..b99cfa1 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
++++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+@@ -698,38 +698,6 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ //sys	setsockopt(s int, level int, name int, val unsafe.Pointer, vallen uintptr) (err error) = libsocket.setsockopt
+ //sys	recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Socklen) (n int, err error) = libsocket.recvfrom
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procread)), 3, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf), 0, 0, 0)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = e1
+-	}
+-	return
+-}
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwrite)), 3, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf), 0, 0, 0)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = e1
+-	}
+-	return
+-}
+-
+-var mapper = &mmapper{
+-	active: make(map[*byte][]byte),
+-	mmap:   mmap,
+-	munmap: munmap,
+-}
+-
+-func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
+-	return mapper.Mmap(fd, offset, length, prot, flags)
+-}
+-
+-func Munmap(b []byte) (err error) {
+-	return mapper.Munmap(b)
+-}
+-
+ // Event Ports
+ 
+ type fileObjCookie struct {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_unix.go b/vendor/golang.org/x/sys/unix/syscall_unix.go
+index 8e48c29..a4b2c98 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_unix.go
++++ b/vendor/golang.org/x/sys/unix/syscall_unix.go
+@@ -541,6 +541,9 @@ func SetNonblock(fd int, nonblocking bool) (err error) {
+ 	if err != nil {
+ 		return err
+ 	}
++	if (flag&O_NONBLOCK != 0) == nonblocking {
++		return nil
++	}
+ 	if nonblocking {
+ 		flag |= O_NONBLOCK
+ 	} else {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+index d3d49ec..799302f 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+@@ -192,7 +192,6 @@ func (cmsg *Cmsghdr) SetLen(length int) {
+ 
+ //sys   fcntl(fd int, cmd int, arg int) (val int, err error)
+ //sys	read(fd int, p []byte) (n int, err error)
+-//sys   readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+ //sys	write(fd int, p []byte) (n int, err error)
+ 
+ //sys	accept(s int, rsa *RawSockaddrAny, addrlen *_Socklen) (fd int, err error) = SYS___ACCEPT_A
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index 3784f40..f9c7f47 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -2421,6 +2421,15 @@ const (
+ 	PR_PAC_GET_ENABLED_KEYS                     = 0x3d
+ 	PR_PAC_RESET_KEYS                           = 0x36
+ 	PR_PAC_SET_ENABLED_KEYS                     = 0x3c
++	PR_RISCV_V_GET_CONTROL                      = 0x46
++	PR_RISCV_V_SET_CONTROL                      = 0x45
++	PR_RISCV_V_VSTATE_CTRL_CUR_MASK             = 0x3
++	PR_RISCV_V_VSTATE_CTRL_DEFAULT              = 0x0
++	PR_RISCV_V_VSTATE_CTRL_INHERIT              = 0x10
++	PR_RISCV_V_VSTATE_CTRL_MASK                 = 0x1f
++	PR_RISCV_V_VSTATE_CTRL_NEXT_MASK            = 0xc
++	PR_RISCV_V_VSTATE_CTRL_OFF                  = 0x1
++	PR_RISCV_V_VSTATE_CTRL_ON                   = 0x2
+ 	PR_SCHED_CORE                               = 0x3e
+ 	PR_SCHED_CORE_CREATE                        = 0x1
+ 	PR_SCHED_CORE_GET                           = 0x0
+@@ -2821,6 +2830,23 @@ const (
+ 	RWF_SUPPORTED                               = 0x1f
+ 	RWF_SYNC                                    = 0x4
+ 	RWF_WRITE_LIFE_NOT_SET                      = 0x0
++	SCHED_BATCH                                 = 0x3
++	SCHED_DEADLINE                              = 0x6
++	SCHED_FIFO                                  = 0x1
++	SCHED_FLAG_ALL                              = 0x7f
++	SCHED_FLAG_DL_OVERRUN                       = 0x4
++	SCHED_FLAG_KEEP_ALL                         = 0x18
++	SCHED_FLAG_KEEP_PARAMS                      = 0x10
++	SCHED_FLAG_KEEP_POLICY                      = 0x8
++	SCHED_FLAG_RECLAIM                          = 0x2
++	SCHED_FLAG_RESET_ON_FORK                    = 0x1
++	SCHED_FLAG_UTIL_CLAMP                       = 0x60
++	SCHED_FLAG_UTIL_CLAMP_MAX                   = 0x40
++	SCHED_FLAG_UTIL_CLAMP_MIN                   = 0x20
++	SCHED_IDLE                                  = 0x5
++	SCHED_NORMAL                                = 0x0
++	SCHED_RESET_ON_FORK                         = 0x40000000
++	SCHED_RR                                    = 0x2
+ 	SCM_CREDENTIALS                             = 0x2
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index a46df0f..c5aeab3 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index 6cd4a3e..6b9fda9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -318,10 +318,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c7ebee2..f015600 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -324,10 +324,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 12a9a13..f760f2a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -314,10 +314,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index f26a164..12f266c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -109,6 +109,8 @@ const (
+ 	IUCLC                            = 0x200
+ 	IXOFF                            = 0x1000
+ 	IXON                             = 0x400
++	LASX_CTX_MAGIC                   = 0x41535801
++	LSX_CTX_MAGIC                    = 0x53580001
+ 	MAP_ANON                         = 0x20
+ 	MAP_ANONYMOUS                    = 0x20
+ 	MAP_DENYWRITE                    = 0x800
+@@ -308,10 +310,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 890bc3c..7fd3806 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 549f26a..c38d426 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index e0365e3..17a5f97 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index fdccce1..b73088d 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index b2205c8..80b8d52 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -372,10 +372,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 81aa5ad..8292e16 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -376,10 +376,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index 76807a1..bb1ebb8 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -376,10 +376,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index d4a5ab9..28006d4 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -305,10 +305,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 66e65db..75e263b 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -380,10 +380,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 4898420..5d2d76a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -419,10 +419,12 @@ const (
+ 	SO_NOFCS                         = 0x27
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x2
++	SO_PASSPIDFD                     = 0x55
+ 	SO_PASSSEC                       = 0x1f
+ 	SO_PEEK_OFF                      = 0x26
+ 	SO_PEERCRED                      = 0x40
+ 	SO_PEERGROUPS                    = 0x3d
++	SO_PEERPIDFD                     = 0x56
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x48
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
+index 9a25721..d1d1d23 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
+@@ -817,28 +817,6 @@ func write(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, er := C.read(C.int(fd), C.uintptr_t(uintptr(unsafe.Pointer(p))), C.size_t(np))
+-	n = int(r0)
+-	if r0 == -1 && er != nil {
+-		err = er
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, er := C.write(C.int(fd), C.uintptr_t(uintptr(unsafe.Pointer(p))), C.size_t(np))
+-	n = int(r0)
+-	if r0 == -1 && er != nil {
+-		err = er
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	r0, er := C.dup2(C.int(oldfd), C.int(newfd))
+ 	if r0 == -1 && er != nil {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
+index 6de80c2..f99a18a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
+@@ -762,28 +762,6 @@ func write(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, e1 := callread(fd, uintptr(unsafe.Pointer(p)), np)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, e1 := callwrite(fd, uintptr(unsafe.Pointer(p)), np)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	_, e1 := calldup2(oldfd, newfd)
+ 	if e1 != 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
+index 4037ccf..1cad561 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
+@@ -725,6 +725,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -733,10 +739,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2410,28 +2412,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_fstat64_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0)
+ 	if e1 != 0 {
+@@ -2521,14 +2501,6 @@ func ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return
+ }
+ 
+-func ptrace1Ptr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	_, _, e1 := syscall_syscall6(libc_ptrace_trampoline_addr, uintptr(request), uintptr(pid), addr, uintptr(data), 0, 0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+ var libc_ptrace_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_ptrace ptrace "/usr/lib/libSystem.B.dylib"
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
+index 4baaed0..8b8bb28 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
+@@ -5,703 +5,586 @@
+ 
+ TEXT libc_fdopendir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fdopendir(SB)
+-
+ GLOBL	·libc_fdopendir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fdopendir_trampoline_addr(SB)/8, $libc_fdopendir_trampoline<>(SB)
+ 
+ TEXT libc_getgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgroups(SB)
+-
+ GLOBL	·libc_getgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgroups_trampoline_addr(SB)/8, $libc_getgroups_trampoline<>(SB)
+ 
+ TEXT libc_setgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgroups(SB)
+-
+ GLOBL	·libc_setgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgroups_trampoline_addr(SB)/8, $libc_setgroups_trampoline<>(SB)
+ 
+ TEXT libc_wait4_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_wait4(SB)
+-
+ GLOBL	·libc_wait4_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_wait4_trampoline_addr(SB)/8, $libc_wait4_trampoline<>(SB)
+ 
+ TEXT libc_accept_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_accept(SB)
+-
+ GLOBL	·libc_accept_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_accept_trampoline_addr(SB)/8, $libc_accept_trampoline<>(SB)
+ 
+ TEXT libc_bind_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_bind(SB)
+-
+ GLOBL	·libc_bind_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_bind_trampoline_addr(SB)/8, $libc_bind_trampoline<>(SB)
+ 
+ TEXT libc_connect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_connect(SB)
+-
+ GLOBL	·libc_connect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_connect_trampoline_addr(SB)/8, $libc_connect_trampoline<>(SB)
+ 
+ TEXT libc_socket_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socket(SB)
+-
+ GLOBL	·libc_socket_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socket_trampoline_addr(SB)/8, $libc_socket_trampoline<>(SB)
+ 
+ TEXT libc_getsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockopt(SB)
+-
+ GLOBL	·libc_getsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockopt_trampoline_addr(SB)/8, $libc_getsockopt_trampoline<>(SB)
+ 
+ TEXT libc_setsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsockopt(SB)
+-
+ GLOBL	·libc_setsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsockopt_trampoline_addr(SB)/8, $libc_setsockopt_trampoline<>(SB)
+ 
+ TEXT libc_getpeername_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpeername(SB)
+-
+ GLOBL	·libc_getpeername_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpeername_trampoline_addr(SB)/8, $libc_getpeername_trampoline<>(SB)
+ 
+ TEXT libc_getsockname_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockname(SB)
+-
+ GLOBL	·libc_getsockname_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockname_trampoline_addr(SB)/8, $libc_getsockname_trampoline<>(SB)
+ 
+ TEXT libc_shutdown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shutdown(SB)
+-
+ GLOBL	·libc_shutdown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shutdown_trampoline_addr(SB)/8, $libc_shutdown_trampoline<>(SB)
+ 
+ TEXT libc_socketpair_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socketpair(SB)
+-
+ GLOBL	·libc_socketpair_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socketpair_trampoline_addr(SB)/8, $libc_socketpair_trampoline<>(SB)
+ 
+ TEXT libc_recvfrom_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvfrom(SB)
+-
+ GLOBL	·libc_recvfrom_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvfrom_trampoline_addr(SB)/8, $libc_recvfrom_trampoline<>(SB)
+ 
+ TEXT libc_sendto_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendto(SB)
+-
+ GLOBL	·libc_sendto_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendto_trampoline_addr(SB)/8, $libc_sendto_trampoline<>(SB)
+ 
+ TEXT libc_recvmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvmsg(SB)
+-
+ GLOBL	·libc_recvmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvmsg_trampoline_addr(SB)/8, $libc_recvmsg_trampoline<>(SB)
+ 
+ TEXT libc_sendmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendmsg(SB)
+-
+ GLOBL	·libc_sendmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendmsg_trampoline_addr(SB)/8, $libc_sendmsg_trampoline<>(SB)
+ 
+ TEXT libc_kevent_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kevent(SB)
+-
+ GLOBL	·libc_kevent_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kevent_trampoline_addr(SB)/8, $libc_kevent_trampoline<>(SB)
+ 
+ TEXT libc_utimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimes(SB)
+-
+ GLOBL	·libc_utimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimes_trampoline_addr(SB)/8, $libc_utimes_trampoline<>(SB)
+ 
+ TEXT libc_futimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_futimes(SB)
+-
+ GLOBL	·libc_futimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_futimes_trampoline_addr(SB)/8, $libc_futimes_trampoline<>(SB)
+ 
+ TEXT libc_poll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_poll(SB)
+-
+ GLOBL	·libc_poll_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_poll_trampoline_addr(SB)/8, $libc_poll_trampoline<>(SB)
+ 
+ TEXT libc_madvise_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_madvise(SB)
+-
+ GLOBL	·libc_madvise_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_madvise_trampoline_addr(SB)/8, $libc_madvise_trampoline<>(SB)
+ 
+ TEXT libc_mlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlock(SB)
+-
+ GLOBL	·libc_mlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlock_trampoline_addr(SB)/8, $libc_mlock_trampoline<>(SB)
+ 
+ TEXT libc_mlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlockall(SB)
+-
+ GLOBL	·libc_mlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlockall_trampoline_addr(SB)/8, $libc_mlockall_trampoline<>(SB)
+ 
+ TEXT libc_mprotect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mprotect(SB)
+-
+ GLOBL	·libc_mprotect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mprotect_trampoline_addr(SB)/8, $libc_mprotect_trampoline<>(SB)
+ 
+ TEXT libc_msync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_msync(SB)
+-
+ GLOBL	·libc_msync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_msync_trampoline_addr(SB)/8, $libc_msync_trampoline<>(SB)
+ 
+ TEXT libc_munlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlock(SB)
+-
+ GLOBL	·libc_munlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlock_trampoline_addr(SB)/8, $libc_munlock_trampoline<>(SB)
+ 
+ TEXT libc_munlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlockall(SB)
+-
+ GLOBL	·libc_munlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlockall_trampoline_addr(SB)/8, $libc_munlockall_trampoline<>(SB)
+ 
+ TEXT libc_closedir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_closedir(SB)
+-
+ GLOBL	·libc_closedir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_closedir_trampoline_addr(SB)/8, $libc_closedir_trampoline<>(SB)
+ 
+ TEXT libc_readdir_r_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readdir_r(SB)
+-
+ GLOBL	·libc_readdir_r_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readdir_r_trampoline_addr(SB)/8, $libc_readdir_r_trampoline<>(SB)
+ 
+ TEXT libc_pipe_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pipe(SB)
+-
+ GLOBL	·libc_pipe_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pipe_trampoline_addr(SB)/8, $libc_pipe_trampoline<>(SB)
+ 
+ TEXT libc_getxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getxattr(SB)
+-
+ GLOBL	·libc_getxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getxattr_trampoline_addr(SB)/8, $libc_getxattr_trampoline<>(SB)
+ 
+ TEXT libc_fgetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fgetxattr(SB)
+-
+ GLOBL	·libc_fgetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fgetxattr_trampoline_addr(SB)/8, $libc_fgetxattr_trampoline<>(SB)
+ 
+ TEXT libc_setxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setxattr(SB)
+-
+ GLOBL	·libc_setxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setxattr_trampoline_addr(SB)/8, $libc_setxattr_trampoline<>(SB)
+ 
+ TEXT libc_fsetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsetxattr(SB)
+-
+ GLOBL	·libc_fsetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsetxattr_trampoline_addr(SB)/8, $libc_fsetxattr_trampoline<>(SB)
+ 
+ TEXT libc_removexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_removexattr(SB)
+-
+ GLOBL	·libc_removexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_removexattr_trampoline_addr(SB)/8, $libc_removexattr_trampoline<>(SB)
+ 
+ TEXT libc_fremovexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fremovexattr(SB)
+-
+ GLOBL	·libc_fremovexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fremovexattr_trampoline_addr(SB)/8, $libc_fremovexattr_trampoline<>(SB)
+ 
+ TEXT libc_listxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listxattr(SB)
+-
+ GLOBL	·libc_listxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listxattr_trampoline_addr(SB)/8, $libc_listxattr_trampoline<>(SB)
+ 
+ TEXT libc_flistxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flistxattr(SB)
+-
+ GLOBL	·libc_flistxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flistxattr_trampoline_addr(SB)/8, $libc_flistxattr_trampoline<>(SB)
+ 
+ TEXT libc_utimensat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimensat(SB)
+-
+ GLOBL	·libc_utimensat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimensat_trampoline_addr(SB)/8, $libc_utimensat_trampoline<>(SB)
+ 
+ TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fcntl(SB)
+-
+ GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
+ 
+ TEXT libc_kill_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kill(SB)
+-
+ GLOBL	·libc_kill_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kill_trampoline_addr(SB)/8, $libc_kill_trampoline<>(SB)
+ 
+ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ioctl(SB)
+-
+ GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
+ 
+ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sysctl(SB)
+-
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
+ TEXT libc_sendfile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendfile(SB)
+-
+ GLOBL	·libc_sendfile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendfile_trampoline_addr(SB)/8, $libc_sendfile_trampoline<>(SB)
+ 
+ TEXT libc_shmat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmat(SB)
+-
+ GLOBL	·libc_shmat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmat_trampoline_addr(SB)/8, $libc_shmat_trampoline<>(SB)
+ 
+ TEXT libc_shmctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmctl(SB)
+-
+ GLOBL	·libc_shmctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmctl_trampoline_addr(SB)/8, $libc_shmctl_trampoline<>(SB)
+ 
+ TEXT libc_shmdt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmdt(SB)
+-
+ GLOBL	·libc_shmdt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmdt_trampoline_addr(SB)/8, $libc_shmdt_trampoline<>(SB)
+ 
+ TEXT libc_shmget_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmget(SB)
+-
+ GLOBL	·libc_shmget_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmget_trampoline_addr(SB)/8, $libc_shmget_trampoline<>(SB)
+ 
+ TEXT libc_access_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_access(SB)
+-
+ GLOBL	·libc_access_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_access_trampoline_addr(SB)/8, $libc_access_trampoline<>(SB)
+ 
+ TEXT libc_adjtime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_adjtime(SB)
+-
+ GLOBL	·libc_adjtime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_adjtime_trampoline_addr(SB)/8, $libc_adjtime_trampoline<>(SB)
+ 
+ TEXT libc_chdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chdir(SB)
+-
+ GLOBL	·libc_chdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chdir_trampoline_addr(SB)/8, $libc_chdir_trampoline<>(SB)
+ 
+ TEXT libc_chflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chflags(SB)
+-
+ GLOBL	·libc_chflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chflags_trampoline_addr(SB)/8, $libc_chflags_trampoline<>(SB)
+ 
+ TEXT libc_chmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chmod(SB)
+-
+ GLOBL	·libc_chmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chmod_trampoline_addr(SB)/8, $libc_chmod_trampoline<>(SB)
+ 
+ TEXT libc_chown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chown(SB)
+-
+ GLOBL	·libc_chown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chown_trampoline_addr(SB)/8, $libc_chown_trampoline<>(SB)
+ 
+ TEXT libc_chroot_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chroot(SB)
+-
+ GLOBL	·libc_chroot_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chroot_trampoline_addr(SB)/8, $libc_chroot_trampoline<>(SB)
+ 
+ TEXT libc_clock_gettime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clock_gettime(SB)
+-
+ GLOBL	·libc_clock_gettime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clock_gettime_trampoline_addr(SB)/8, $libc_clock_gettime_trampoline<>(SB)
+ 
+ TEXT libc_close_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_close(SB)
+-
+ GLOBL	·libc_close_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_close_trampoline_addr(SB)/8, $libc_close_trampoline<>(SB)
+ 
+ TEXT libc_clonefile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefile(SB)
+-
+ GLOBL	·libc_clonefile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefile_trampoline_addr(SB)/8, $libc_clonefile_trampoline<>(SB)
+ 
+ TEXT libc_clonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefileat(SB)
+-
+ GLOBL	·libc_clonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefileat_trampoline_addr(SB)/8, $libc_clonefileat_trampoline<>(SB)
+ 
+ TEXT libc_dup_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup(SB)
+-
+ GLOBL	·libc_dup_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup_trampoline_addr(SB)/8, $libc_dup_trampoline<>(SB)
+ 
+ TEXT libc_dup2_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup2(SB)
+-
+ GLOBL	·libc_dup2_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup2_trampoline_addr(SB)/8, $libc_dup2_trampoline<>(SB)
+ 
+ TEXT libc_exchangedata_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exchangedata(SB)
+-
+ GLOBL	·libc_exchangedata_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exchangedata_trampoline_addr(SB)/8, $libc_exchangedata_trampoline<>(SB)
+ 
+ TEXT libc_exit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exit(SB)
+-
+ GLOBL	·libc_exit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exit_trampoline_addr(SB)/8, $libc_exit_trampoline<>(SB)
+ 
+ TEXT libc_faccessat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_faccessat(SB)
+-
+ GLOBL	·libc_faccessat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_faccessat_trampoline_addr(SB)/8, $libc_faccessat_trampoline<>(SB)
+ 
+ TEXT libc_fchdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchdir(SB)
+-
+ GLOBL	·libc_fchdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchdir_trampoline_addr(SB)/8, $libc_fchdir_trampoline<>(SB)
+ 
+ TEXT libc_fchflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchflags(SB)
+-
+ GLOBL	·libc_fchflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchflags_trampoline_addr(SB)/8, $libc_fchflags_trampoline<>(SB)
+ 
+ TEXT libc_fchmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmod(SB)
+-
+ GLOBL	·libc_fchmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmod_trampoline_addr(SB)/8, $libc_fchmod_trampoline<>(SB)
+ 
+ TEXT libc_fchmodat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmodat(SB)
+-
+ GLOBL	·libc_fchmodat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmodat_trampoline_addr(SB)/8, $libc_fchmodat_trampoline<>(SB)
+ 
+ TEXT libc_fchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchown(SB)
+-
+ GLOBL	·libc_fchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchown_trampoline_addr(SB)/8, $libc_fchown_trampoline<>(SB)
+ 
+ TEXT libc_fchownat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchownat(SB)
+-
+ GLOBL	·libc_fchownat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchownat_trampoline_addr(SB)/8, $libc_fchownat_trampoline<>(SB)
+ 
+ TEXT libc_fclonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fclonefileat(SB)
+-
+ GLOBL	·libc_fclonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fclonefileat_trampoline_addr(SB)/8, $libc_fclonefileat_trampoline<>(SB)
+ 
+ TEXT libc_flock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flock(SB)
+-
+ GLOBL	·libc_flock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flock_trampoline_addr(SB)/8, $libc_flock_trampoline<>(SB)
+ 
+ TEXT libc_fpathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fpathconf(SB)
+-
+ GLOBL	·libc_fpathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fpathconf_trampoline_addr(SB)/8, $libc_fpathconf_trampoline<>(SB)
+ 
+ TEXT libc_fsync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsync(SB)
+-
+ GLOBL	·libc_fsync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsync_trampoline_addr(SB)/8, $libc_fsync_trampoline<>(SB)
+ 
+ TEXT libc_ftruncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ftruncate(SB)
+-
+ GLOBL	·libc_ftruncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ftruncate_trampoline_addr(SB)/8, $libc_ftruncate_trampoline<>(SB)
+ 
+ TEXT libc_getcwd_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getcwd(SB)
+-
+ GLOBL	·libc_getcwd_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getcwd_trampoline_addr(SB)/8, $libc_getcwd_trampoline<>(SB)
+ 
+ TEXT libc_getdtablesize_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getdtablesize(SB)
+-
+ GLOBL	·libc_getdtablesize_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getdtablesize_trampoline_addr(SB)/8, $libc_getdtablesize_trampoline<>(SB)
+ 
+ TEXT libc_getegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getegid(SB)
+-
+ GLOBL	·libc_getegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getegid_trampoline_addr(SB)/8, $libc_getegid_trampoline<>(SB)
+ 
+ TEXT libc_geteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_geteuid(SB)
+-
+ GLOBL	·libc_geteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_geteuid_trampoline_addr(SB)/8, $libc_geteuid_trampoline<>(SB)
+ 
+ TEXT libc_getgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgid(SB)
+-
+ GLOBL	·libc_getgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgid_trampoline_addr(SB)/8, $libc_getgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgid(SB)
+-
+ GLOBL	·libc_getpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgid_trampoline_addr(SB)/8, $libc_getpgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgrp_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgrp(SB)
+-
+ GLOBL	·libc_getpgrp_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgrp_trampoline_addr(SB)/8, $libc_getpgrp_trampoline<>(SB)
+ 
+ TEXT libc_getpid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpid(SB)
+-
+ GLOBL	·libc_getpid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpid_trampoline_addr(SB)/8, $libc_getpid_trampoline<>(SB)
+ 
+ TEXT libc_getppid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getppid(SB)
+-
+ GLOBL	·libc_getppid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getppid_trampoline_addr(SB)/8, $libc_getppid_trampoline<>(SB)
+ 
+ TEXT libc_getpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpriority(SB)
+-
+ GLOBL	·libc_getpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpriority_trampoline_addr(SB)/8, $libc_getpriority_trampoline<>(SB)
+ 
+ TEXT libc_getrlimit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrlimit(SB)
+-
+ GLOBL	·libc_getrlimit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrlimit_trampoline_addr(SB)/8, $libc_getrlimit_trampoline<>(SB)
+ 
+ TEXT libc_getrusage_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrusage(SB)
+-
+ GLOBL	·libc_getrusage_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrusage_trampoline_addr(SB)/8, $libc_getrusage_trampoline<>(SB)
+ 
+ TEXT libc_getsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsid(SB)
+-
+ GLOBL	·libc_getsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsid_trampoline_addr(SB)/8, $libc_getsid_trampoline<>(SB)
+ 
+ TEXT libc_gettimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_gettimeofday(SB)
+-
+ GLOBL	·libc_gettimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_gettimeofday_trampoline_addr(SB)/8, $libc_gettimeofday_trampoline<>(SB)
+ 
+ TEXT libc_getuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getuid(SB)
+-
+ GLOBL	·libc_getuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getuid_trampoline_addr(SB)/8, $libc_getuid_trampoline<>(SB)
+ 
+ TEXT libc_issetugid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_issetugid(SB)
+-
+ GLOBL	·libc_issetugid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_issetugid_trampoline_addr(SB)/8, $libc_issetugid_trampoline<>(SB)
+ 
+ TEXT libc_kqueue_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kqueue(SB)
+-
+ GLOBL	·libc_kqueue_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kqueue_trampoline_addr(SB)/8, $libc_kqueue_trampoline<>(SB)
+ 
+ TEXT libc_lchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lchown(SB)
+-
+ GLOBL	·libc_lchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lchown_trampoline_addr(SB)/8, $libc_lchown_trampoline<>(SB)
+ 
+ TEXT libc_link_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_link(SB)
+-
+ GLOBL	·libc_link_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_link_trampoline_addr(SB)/8, $libc_link_trampoline<>(SB)
+ 
+ TEXT libc_linkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_linkat(SB)
+-
+ GLOBL	·libc_linkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_linkat_trampoline_addr(SB)/8, $libc_linkat_trampoline<>(SB)
+ 
+ TEXT libc_listen_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listen(SB)
+-
+ GLOBL	·libc_listen_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listen_trampoline_addr(SB)/8, $libc_listen_trampoline<>(SB)
+ 
+ TEXT libc_mkdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdir(SB)
+-
+ GLOBL	·libc_mkdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdir_trampoline_addr(SB)/8, $libc_mkdir_trampoline<>(SB)
+ 
+ TEXT libc_mkdirat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdirat(SB)
+-
+ GLOBL	·libc_mkdirat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdirat_trampoline_addr(SB)/8, $libc_mkdirat_trampoline<>(SB)
+ 
+ TEXT libc_mkfifo_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkfifo(SB)
+-
+ GLOBL	·libc_mkfifo_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkfifo_trampoline_addr(SB)/8, $libc_mkfifo_trampoline<>(SB)
+ 
+ TEXT libc_mknod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mknod(SB)
+-
+ GLOBL	·libc_mknod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mknod_trampoline_addr(SB)/8, $libc_mknod_trampoline<>(SB)
+ 
+ TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mount(SB)
+-
+ GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mount_trampoline_addr(SB)/8, $libc_mount_trampoline<>(SB)
+ 
+ TEXT libc_open_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_open(SB)
+-
+ GLOBL	·libc_open_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_open_trampoline_addr(SB)/8, $libc_open_trampoline<>(SB)
+ 
+ TEXT libc_openat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_openat(SB)
+-
+ GLOBL	·libc_openat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_openat_trampoline_addr(SB)/8, $libc_openat_trampoline<>(SB)
+ 
+ TEXT libc_pathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pathconf(SB)
+-
+ GLOBL	·libc_pathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pathconf_trampoline_addr(SB)/8, $libc_pathconf_trampoline<>(SB)
+ 
+ TEXT libc_pread_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pread(SB)
+-
+ GLOBL	·libc_pread_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pread_trampoline_addr(SB)/8, $libc_pread_trampoline<>(SB)
+ 
+ TEXT libc_pwrite_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pwrite(SB)
+-
+ GLOBL	·libc_pwrite_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pwrite_trampoline_addr(SB)/8, $libc_pwrite_trampoline<>(SB)
+ 
+ TEXT libc_read_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_read(SB)
+-
+ GLOBL	·libc_read_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_read_trampoline_addr(SB)/8, $libc_read_trampoline<>(SB)
+ 
+ TEXT libc_readlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlink(SB)
+-
+ GLOBL	·libc_readlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlink_trampoline_addr(SB)/8, $libc_readlink_trampoline<>(SB)
+ 
+ TEXT libc_readlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlinkat(SB)
+-
+ GLOBL	·libc_readlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlinkat_trampoline_addr(SB)/8, $libc_readlinkat_trampoline<>(SB)
+ 
+ TEXT libc_rename_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rename(SB)
+-
+ GLOBL	·libc_rename_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rename_trampoline_addr(SB)/8, $libc_rename_trampoline<>(SB)
+ 
+ TEXT libc_renameat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_renameat(SB)
+-
+ GLOBL	·libc_renameat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_renameat_trampoline_addr(SB)/8, $libc_renameat_trampoline<>(SB)
+ 
+ TEXT libc_revoke_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_revoke(SB)
+-
+ GLOBL	·libc_revoke_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_revoke_trampoline_addr(SB)/8, $libc_revoke_trampoline<>(SB)
+ 
+ TEXT libc_rmdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rmdir(SB)
+-
+ GLOBL	·libc_rmdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rmdir_trampoline_addr(SB)/8, $libc_rmdir_trampoline<>(SB)
+ 
+ TEXT libc_lseek_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lseek(SB)
+-
+ GLOBL	·libc_lseek_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lseek_trampoline_addr(SB)/8, $libc_lseek_trampoline<>(SB)
+ 
+ TEXT libc_select_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_select(SB)
+-
+ GLOBL	·libc_select_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_select_trampoline_addr(SB)/8, $libc_select_trampoline<>(SB)
+ 
+@@ -712,192 +595,160 @@ DATA	·libc_setattrlist_trampoline_addr(SB)/8, $libc_setattrlist_trampoline<>(SB
+ 
+ TEXT libc_setegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setegid(SB)
+-
+ GLOBL	·libc_setegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setegid_trampoline_addr(SB)/8, $libc_setegid_trampoline<>(SB)
+ 
+ TEXT libc_seteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_seteuid(SB)
+-
+ GLOBL	·libc_seteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_seteuid_trampoline_addr(SB)/8, $libc_seteuid_trampoline<>(SB)
+ 
+ TEXT libc_setgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgid(SB)
+-
+ GLOBL	·libc_setgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgid_trampoline_addr(SB)/8, $libc_setgid_trampoline<>(SB)
+ 
+ TEXT libc_setlogin_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setlogin(SB)
+-
+ GLOBL	·libc_setlogin_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setlogin_trampoline_addr(SB)/8, $libc_setlogin_trampoline<>(SB)
+ 
+ TEXT libc_setpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpgid(SB)
+-
+ GLOBL	·libc_setpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpgid_trampoline_addr(SB)/8, $libc_setpgid_trampoline<>(SB)
+ 
+ TEXT libc_setpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpriority(SB)
+-
+ GLOBL	·libc_setpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpriority_trampoline_addr(SB)/8, $libc_setpriority_trampoline<>(SB)
+ 
+ TEXT libc_setprivexec_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setprivexec(SB)
+-
+ GLOBL	·libc_setprivexec_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setprivexec_trampoline_addr(SB)/8, $libc_setprivexec_trampoline<>(SB)
+ 
+ TEXT libc_setregid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setregid(SB)
+-
+ GLOBL	·libc_setregid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setregid_trampoline_addr(SB)/8, $libc_setregid_trampoline<>(SB)
+ 
+ TEXT libc_setreuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setreuid(SB)
+-
+ GLOBL	·libc_setreuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setreuid_trampoline_addr(SB)/8, $libc_setreuid_trampoline<>(SB)
+ 
+ TEXT libc_setsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsid(SB)
+-
+ GLOBL	·libc_setsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsid_trampoline_addr(SB)/8, $libc_setsid_trampoline<>(SB)
+ 
+ TEXT libc_settimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_settimeofday(SB)
+-
+ GLOBL	·libc_settimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_settimeofday_trampoline_addr(SB)/8, $libc_settimeofday_trampoline<>(SB)
+ 
+ TEXT libc_setuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setuid(SB)
+-
+ GLOBL	·libc_setuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setuid_trampoline_addr(SB)/8, $libc_setuid_trampoline<>(SB)
+ 
+ TEXT libc_symlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlink(SB)
+-
+ GLOBL	·libc_symlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlink_trampoline_addr(SB)/8, $libc_symlink_trampoline<>(SB)
+ 
+ TEXT libc_symlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlinkat(SB)
+-
+ GLOBL	·libc_symlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlinkat_trampoline_addr(SB)/8, $libc_symlinkat_trampoline<>(SB)
+ 
+ TEXT libc_sync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sync(SB)
+-
+ GLOBL	·libc_sync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sync_trampoline_addr(SB)/8, $libc_sync_trampoline<>(SB)
+ 
+ TEXT libc_truncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_truncate(SB)
+-
+ GLOBL	·libc_truncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_truncate_trampoline_addr(SB)/8, $libc_truncate_trampoline<>(SB)
+ 
+ TEXT libc_umask_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_umask(SB)
+-
+ GLOBL	·libc_umask_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_umask_trampoline_addr(SB)/8, $libc_umask_trampoline<>(SB)
+ 
+ TEXT libc_undelete_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_undelete(SB)
+-
+ GLOBL	·libc_undelete_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_undelete_trampoline_addr(SB)/8, $libc_undelete_trampoline<>(SB)
+ 
+ TEXT libc_unlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlink(SB)
+-
+ GLOBL	·libc_unlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlink_trampoline_addr(SB)/8, $libc_unlink_trampoline<>(SB)
+ 
+ TEXT libc_unlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlinkat(SB)
+-
+ GLOBL	·libc_unlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlinkat_trampoline_addr(SB)/8, $libc_unlinkat_trampoline<>(SB)
+ 
+ TEXT libc_unmount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unmount(SB)
+-
+ GLOBL	·libc_unmount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unmount_trampoline_addr(SB)/8, $libc_unmount_trampoline<>(SB)
+ 
+ TEXT libc_write_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_write(SB)
+-
+ GLOBL	·libc_write_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_write_trampoline_addr(SB)/8, $libc_write_trampoline<>(SB)
+ 
+ TEXT libc_mmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mmap(SB)
+-
+ GLOBL	·libc_mmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mmap_trampoline_addr(SB)/8, $libc_mmap_trampoline<>(SB)
+ 
+ TEXT libc_munmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munmap(SB)
+-
+ GLOBL	·libc_munmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munmap_trampoline_addr(SB)/8, $libc_munmap_trampoline<>(SB)
+ 
+ TEXT libc_fstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstat64(SB)
+-
+ GLOBL	·libc_fstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstat64_trampoline_addr(SB)/8, $libc_fstat64_trampoline<>(SB)
+ 
+ TEXT libc_fstatat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatat64(SB)
+-
+ GLOBL	·libc_fstatat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatat64_trampoline_addr(SB)/8, $libc_fstatat64_trampoline<>(SB)
+ 
+ TEXT libc_fstatfs64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatfs64(SB)
+-
+ GLOBL	·libc_fstatfs64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatfs64_trampoline_addr(SB)/8, $libc_fstatfs64_trampoline<>(SB)
+ 
+ TEXT libc_getfsstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getfsstat64(SB)
+-
+ GLOBL	·libc_getfsstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getfsstat64_trampoline_addr(SB)/8, $libc_getfsstat64_trampoline<>(SB)
+ 
+ TEXT libc_lstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lstat64(SB)
+-
+ GLOBL	·libc_lstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lstat64_trampoline_addr(SB)/8, $libc_lstat64_trampoline<>(SB)
+ 
+ TEXT libc_ptrace_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ptrace(SB)
+-
+ GLOBL	·libc_ptrace_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ptrace_trampoline_addr(SB)/8, $libc_ptrace_trampoline<>(SB)
+ 
+ TEXT libc_stat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_stat64(SB)
+-
+ GLOBL	·libc_stat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_stat64_trampoline_addr(SB)/8, $libc_stat64_trampoline<>(SB)
+ 
+ TEXT libc_statfs64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_statfs64(SB)
+-
+ GLOBL	·libc_statfs64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_statfs64_trampoline_addr(SB)/8, $libc_statfs64_trampoline<>(SB)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
+index 51d6f3f..b18edbd 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
+@@ -725,6 +725,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -733,10 +739,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2410,28 +2412,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_fstat_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0)
+ 	if e1 != 0 {
+@@ -2521,14 +2501,6 @@ func ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return
+ }
+ 
+-func ptrace1Ptr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	_, _, e1 := syscall_syscall6(libc_ptrace_trampoline_addr, uintptr(request), uintptr(pid), addr, uintptr(data), 0, 0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+ var libc_ptrace_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_ptrace ptrace "/usr/lib/libSystem.B.dylib"
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
+index c3b82c0..08362c1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
+@@ -5,703 +5,586 @@
+ 
+ TEXT libc_fdopendir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fdopendir(SB)
+-
+ GLOBL	·libc_fdopendir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fdopendir_trampoline_addr(SB)/8, $libc_fdopendir_trampoline<>(SB)
+ 
+ TEXT libc_getgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgroups(SB)
+-
+ GLOBL	·libc_getgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgroups_trampoline_addr(SB)/8, $libc_getgroups_trampoline<>(SB)
+ 
+ TEXT libc_setgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgroups(SB)
+-
+ GLOBL	·libc_setgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgroups_trampoline_addr(SB)/8, $libc_setgroups_trampoline<>(SB)
+ 
+ TEXT libc_wait4_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_wait4(SB)
+-
+ GLOBL	·libc_wait4_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_wait4_trampoline_addr(SB)/8, $libc_wait4_trampoline<>(SB)
+ 
+ TEXT libc_accept_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_accept(SB)
+-
+ GLOBL	·libc_accept_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_accept_trampoline_addr(SB)/8, $libc_accept_trampoline<>(SB)
+ 
+ TEXT libc_bind_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_bind(SB)
+-
+ GLOBL	·libc_bind_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_bind_trampoline_addr(SB)/8, $libc_bind_trampoline<>(SB)
+ 
+ TEXT libc_connect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_connect(SB)
+-
+ GLOBL	·libc_connect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_connect_trampoline_addr(SB)/8, $libc_connect_trampoline<>(SB)
+ 
+ TEXT libc_socket_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socket(SB)
+-
+ GLOBL	·libc_socket_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socket_trampoline_addr(SB)/8, $libc_socket_trampoline<>(SB)
+ 
+ TEXT libc_getsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockopt(SB)
+-
+ GLOBL	·libc_getsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockopt_trampoline_addr(SB)/8, $libc_getsockopt_trampoline<>(SB)
+ 
+ TEXT libc_setsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsockopt(SB)
+-
+ GLOBL	·libc_setsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsockopt_trampoline_addr(SB)/8, $libc_setsockopt_trampoline<>(SB)
+ 
+ TEXT libc_getpeername_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpeername(SB)
+-
+ GLOBL	·libc_getpeername_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpeername_trampoline_addr(SB)/8, $libc_getpeername_trampoline<>(SB)
+ 
+ TEXT libc_getsockname_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockname(SB)
+-
+ GLOBL	·libc_getsockname_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockname_trampoline_addr(SB)/8, $libc_getsockname_trampoline<>(SB)
+ 
+ TEXT libc_shutdown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shutdown(SB)
+-
+ GLOBL	·libc_shutdown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shutdown_trampoline_addr(SB)/8, $libc_shutdown_trampoline<>(SB)
+ 
+ TEXT libc_socketpair_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socketpair(SB)
+-
+ GLOBL	·libc_socketpair_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socketpair_trampoline_addr(SB)/8, $libc_socketpair_trampoline<>(SB)
+ 
+ TEXT libc_recvfrom_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvfrom(SB)
+-
+ GLOBL	·libc_recvfrom_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvfrom_trampoline_addr(SB)/8, $libc_recvfrom_trampoline<>(SB)
+ 
+ TEXT libc_sendto_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendto(SB)
+-
+ GLOBL	·libc_sendto_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendto_trampoline_addr(SB)/8, $libc_sendto_trampoline<>(SB)
+ 
+ TEXT libc_recvmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvmsg(SB)
+-
+ GLOBL	·libc_recvmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvmsg_trampoline_addr(SB)/8, $libc_recvmsg_trampoline<>(SB)
+ 
+ TEXT libc_sendmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendmsg(SB)
+-
+ GLOBL	·libc_sendmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendmsg_trampoline_addr(SB)/8, $libc_sendmsg_trampoline<>(SB)
+ 
+ TEXT libc_kevent_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kevent(SB)
+-
+ GLOBL	·libc_kevent_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kevent_trampoline_addr(SB)/8, $libc_kevent_trampoline<>(SB)
+ 
+ TEXT libc_utimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimes(SB)
+-
+ GLOBL	·libc_utimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimes_trampoline_addr(SB)/8, $libc_utimes_trampoline<>(SB)
+ 
+ TEXT libc_futimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_futimes(SB)
+-
+ GLOBL	·libc_futimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_futimes_trampoline_addr(SB)/8, $libc_futimes_trampoline<>(SB)
+ 
+ TEXT libc_poll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_poll(SB)
+-
+ GLOBL	·libc_poll_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_poll_trampoline_addr(SB)/8, $libc_poll_trampoline<>(SB)
+ 
+ TEXT libc_madvise_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_madvise(SB)
+-
+ GLOBL	·libc_madvise_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_madvise_trampoline_addr(SB)/8, $libc_madvise_trampoline<>(SB)
+ 
+ TEXT libc_mlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlock(SB)
+-
+ GLOBL	·libc_mlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlock_trampoline_addr(SB)/8, $libc_mlock_trampoline<>(SB)
+ 
+ TEXT libc_mlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlockall(SB)
+-
+ GLOBL	·libc_mlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlockall_trampoline_addr(SB)/8, $libc_mlockall_trampoline<>(SB)
+ 
+ TEXT libc_mprotect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mprotect(SB)
+-
+ GLOBL	·libc_mprotect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mprotect_trampoline_addr(SB)/8, $libc_mprotect_trampoline<>(SB)
+ 
+ TEXT libc_msync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_msync(SB)
+-
+ GLOBL	·libc_msync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_msync_trampoline_addr(SB)/8, $libc_msync_trampoline<>(SB)
+ 
+ TEXT libc_munlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlock(SB)
+-
+ GLOBL	·libc_munlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlock_trampoline_addr(SB)/8, $libc_munlock_trampoline<>(SB)
+ 
+ TEXT libc_munlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlockall(SB)
+-
+ GLOBL	·libc_munlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlockall_trampoline_addr(SB)/8, $libc_munlockall_trampoline<>(SB)
+ 
+ TEXT libc_closedir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_closedir(SB)
+-
+ GLOBL	·libc_closedir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_closedir_trampoline_addr(SB)/8, $libc_closedir_trampoline<>(SB)
+ 
+ TEXT libc_readdir_r_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readdir_r(SB)
+-
+ GLOBL	·libc_readdir_r_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readdir_r_trampoline_addr(SB)/8, $libc_readdir_r_trampoline<>(SB)
+ 
+ TEXT libc_pipe_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pipe(SB)
+-
+ GLOBL	·libc_pipe_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pipe_trampoline_addr(SB)/8, $libc_pipe_trampoline<>(SB)
+ 
+ TEXT libc_getxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getxattr(SB)
+-
+ GLOBL	·libc_getxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getxattr_trampoline_addr(SB)/8, $libc_getxattr_trampoline<>(SB)
+ 
+ TEXT libc_fgetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fgetxattr(SB)
+-
+ GLOBL	·libc_fgetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fgetxattr_trampoline_addr(SB)/8, $libc_fgetxattr_trampoline<>(SB)
+ 
+ TEXT libc_setxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setxattr(SB)
+-
+ GLOBL	·libc_setxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setxattr_trampoline_addr(SB)/8, $libc_setxattr_trampoline<>(SB)
+ 
+ TEXT libc_fsetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsetxattr(SB)
+-
+ GLOBL	·libc_fsetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsetxattr_trampoline_addr(SB)/8, $libc_fsetxattr_trampoline<>(SB)
+ 
+ TEXT libc_removexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_removexattr(SB)
+-
+ GLOBL	·libc_removexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_removexattr_trampoline_addr(SB)/8, $libc_removexattr_trampoline<>(SB)
+ 
+ TEXT libc_fremovexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fremovexattr(SB)
+-
+ GLOBL	·libc_fremovexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fremovexattr_trampoline_addr(SB)/8, $libc_fremovexattr_trampoline<>(SB)
+ 
+ TEXT libc_listxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listxattr(SB)
+-
+ GLOBL	·libc_listxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listxattr_trampoline_addr(SB)/8, $libc_listxattr_trampoline<>(SB)
+ 
+ TEXT libc_flistxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flistxattr(SB)
+-
+ GLOBL	·libc_flistxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flistxattr_trampoline_addr(SB)/8, $libc_flistxattr_trampoline<>(SB)
+ 
+ TEXT libc_utimensat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimensat(SB)
+-
+ GLOBL	·libc_utimensat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimensat_trampoline_addr(SB)/8, $libc_utimensat_trampoline<>(SB)
+ 
+ TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fcntl(SB)
+-
+ GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
+ 
+ TEXT libc_kill_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kill(SB)
+-
+ GLOBL	·libc_kill_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kill_trampoline_addr(SB)/8, $libc_kill_trampoline<>(SB)
+ 
+ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ioctl(SB)
+-
+ GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
+ 
+ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sysctl(SB)
+-
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
+ TEXT libc_sendfile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendfile(SB)
+-
+ GLOBL	·libc_sendfile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendfile_trampoline_addr(SB)/8, $libc_sendfile_trampoline<>(SB)
+ 
+ TEXT libc_shmat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmat(SB)
+-
+ GLOBL	·libc_shmat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmat_trampoline_addr(SB)/8, $libc_shmat_trampoline<>(SB)
+ 
+ TEXT libc_shmctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmctl(SB)
+-
+ GLOBL	·libc_shmctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmctl_trampoline_addr(SB)/8, $libc_shmctl_trampoline<>(SB)
+ 
+ TEXT libc_shmdt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmdt(SB)
+-
+ GLOBL	·libc_shmdt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmdt_trampoline_addr(SB)/8, $libc_shmdt_trampoline<>(SB)
+ 
+ TEXT libc_shmget_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmget(SB)
+-
+ GLOBL	·libc_shmget_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmget_trampoline_addr(SB)/8, $libc_shmget_trampoline<>(SB)
+ 
+ TEXT libc_access_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_access(SB)
+-
+ GLOBL	·libc_access_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_access_trampoline_addr(SB)/8, $libc_access_trampoline<>(SB)
+ 
+ TEXT libc_adjtime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_adjtime(SB)
+-
+ GLOBL	·libc_adjtime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_adjtime_trampoline_addr(SB)/8, $libc_adjtime_trampoline<>(SB)
+ 
+ TEXT libc_chdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chdir(SB)
+-
+ GLOBL	·libc_chdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chdir_trampoline_addr(SB)/8, $libc_chdir_trampoline<>(SB)
+ 
+ TEXT libc_chflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chflags(SB)
+-
+ GLOBL	·libc_chflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chflags_trampoline_addr(SB)/8, $libc_chflags_trampoline<>(SB)
+ 
+ TEXT libc_chmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chmod(SB)
+-
+ GLOBL	·libc_chmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chmod_trampoline_addr(SB)/8, $libc_chmod_trampoline<>(SB)
+ 
+ TEXT libc_chown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chown(SB)
+-
+ GLOBL	·libc_chown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chown_trampoline_addr(SB)/8, $libc_chown_trampoline<>(SB)
+ 
+ TEXT libc_chroot_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chroot(SB)
+-
+ GLOBL	·libc_chroot_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chroot_trampoline_addr(SB)/8, $libc_chroot_trampoline<>(SB)
+ 
+ TEXT libc_clock_gettime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clock_gettime(SB)
+-
+ GLOBL	·libc_clock_gettime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clock_gettime_trampoline_addr(SB)/8, $libc_clock_gettime_trampoline<>(SB)
+ 
+ TEXT libc_close_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_close(SB)
+-
+ GLOBL	·libc_close_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_close_trampoline_addr(SB)/8, $libc_close_trampoline<>(SB)
+ 
+ TEXT libc_clonefile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefile(SB)
+-
+ GLOBL	·libc_clonefile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefile_trampoline_addr(SB)/8, $libc_clonefile_trampoline<>(SB)
+ 
+ TEXT libc_clonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefileat(SB)
+-
+ GLOBL	·libc_clonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefileat_trampoline_addr(SB)/8, $libc_clonefileat_trampoline<>(SB)
+ 
+ TEXT libc_dup_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup(SB)
+-
+ GLOBL	·libc_dup_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup_trampoline_addr(SB)/8, $libc_dup_trampoline<>(SB)
+ 
+ TEXT libc_dup2_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup2(SB)
+-
+ GLOBL	·libc_dup2_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup2_trampoline_addr(SB)/8, $libc_dup2_trampoline<>(SB)
+ 
+ TEXT libc_exchangedata_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exchangedata(SB)
+-
+ GLOBL	·libc_exchangedata_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exchangedata_trampoline_addr(SB)/8, $libc_exchangedata_trampoline<>(SB)
+ 
+ TEXT libc_exit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exit(SB)
+-
+ GLOBL	·libc_exit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exit_trampoline_addr(SB)/8, $libc_exit_trampoline<>(SB)
+ 
+ TEXT libc_faccessat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_faccessat(SB)
+-
+ GLOBL	·libc_faccessat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_faccessat_trampoline_addr(SB)/8, $libc_faccessat_trampoline<>(SB)
+ 
+ TEXT libc_fchdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchdir(SB)
+-
+ GLOBL	·libc_fchdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchdir_trampoline_addr(SB)/8, $libc_fchdir_trampoline<>(SB)
+ 
+ TEXT libc_fchflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchflags(SB)
+-
+ GLOBL	·libc_fchflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchflags_trampoline_addr(SB)/8, $libc_fchflags_trampoline<>(SB)
+ 
+ TEXT libc_fchmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmod(SB)
+-
+ GLOBL	·libc_fchmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmod_trampoline_addr(SB)/8, $libc_fchmod_trampoline<>(SB)
+ 
+ TEXT libc_fchmodat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmodat(SB)
+-
+ GLOBL	·libc_fchmodat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmodat_trampoline_addr(SB)/8, $libc_fchmodat_trampoline<>(SB)
+ 
+ TEXT libc_fchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchown(SB)
+-
+ GLOBL	·libc_fchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchown_trampoline_addr(SB)/8, $libc_fchown_trampoline<>(SB)
+ 
+ TEXT libc_fchownat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchownat(SB)
+-
+ GLOBL	·libc_fchownat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchownat_trampoline_addr(SB)/8, $libc_fchownat_trampoline<>(SB)
+ 
+ TEXT libc_fclonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fclonefileat(SB)
+-
+ GLOBL	·libc_fclonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fclonefileat_trampoline_addr(SB)/8, $libc_fclonefileat_trampoline<>(SB)
+ 
+ TEXT libc_flock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flock(SB)
+-
+ GLOBL	·libc_flock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flock_trampoline_addr(SB)/8, $libc_flock_trampoline<>(SB)
+ 
+ TEXT libc_fpathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fpathconf(SB)
+-
+ GLOBL	·libc_fpathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fpathconf_trampoline_addr(SB)/8, $libc_fpathconf_trampoline<>(SB)
+ 
+ TEXT libc_fsync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsync(SB)
+-
+ GLOBL	·libc_fsync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsync_trampoline_addr(SB)/8, $libc_fsync_trampoline<>(SB)
+ 
+ TEXT libc_ftruncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ftruncate(SB)
+-
+ GLOBL	·libc_ftruncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ftruncate_trampoline_addr(SB)/8, $libc_ftruncate_trampoline<>(SB)
+ 
+ TEXT libc_getcwd_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getcwd(SB)
+-
+ GLOBL	·libc_getcwd_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getcwd_trampoline_addr(SB)/8, $libc_getcwd_trampoline<>(SB)
+ 
+ TEXT libc_getdtablesize_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getdtablesize(SB)
+-
+ GLOBL	·libc_getdtablesize_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getdtablesize_trampoline_addr(SB)/8, $libc_getdtablesize_trampoline<>(SB)
+ 
+ TEXT libc_getegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getegid(SB)
+-
+ GLOBL	·libc_getegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getegid_trampoline_addr(SB)/8, $libc_getegid_trampoline<>(SB)
+ 
+ TEXT libc_geteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_geteuid(SB)
+-
+ GLOBL	·libc_geteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_geteuid_trampoline_addr(SB)/8, $libc_geteuid_trampoline<>(SB)
+ 
+ TEXT libc_getgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgid(SB)
+-
+ GLOBL	·libc_getgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgid_trampoline_addr(SB)/8, $libc_getgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgid(SB)
+-
+ GLOBL	·libc_getpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgid_trampoline_addr(SB)/8, $libc_getpgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgrp_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgrp(SB)
+-
+ GLOBL	·libc_getpgrp_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgrp_trampoline_addr(SB)/8, $libc_getpgrp_trampoline<>(SB)
+ 
+ TEXT libc_getpid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpid(SB)
+-
+ GLOBL	·libc_getpid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpid_trampoline_addr(SB)/8, $libc_getpid_trampoline<>(SB)
+ 
+ TEXT libc_getppid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getppid(SB)
+-
+ GLOBL	·libc_getppid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getppid_trampoline_addr(SB)/8, $libc_getppid_trampoline<>(SB)
+ 
+ TEXT libc_getpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpriority(SB)
+-
+ GLOBL	·libc_getpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpriority_trampoline_addr(SB)/8, $libc_getpriority_trampoline<>(SB)
+ 
+ TEXT libc_getrlimit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrlimit(SB)
+-
+ GLOBL	·libc_getrlimit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrlimit_trampoline_addr(SB)/8, $libc_getrlimit_trampoline<>(SB)
+ 
+ TEXT libc_getrusage_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrusage(SB)
+-
+ GLOBL	·libc_getrusage_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrusage_trampoline_addr(SB)/8, $libc_getrusage_trampoline<>(SB)
+ 
+ TEXT libc_getsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsid(SB)
+-
+ GLOBL	·libc_getsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsid_trampoline_addr(SB)/8, $libc_getsid_trampoline<>(SB)
+ 
+ TEXT libc_gettimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_gettimeofday(SB)
+-
+ GLOBL	·libc_gettimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_gettimeofday_trampoline_addr(SB)/8, $libc_gettimeofday_trampoline<>(SB)
+ 
+ TEXT libc_getuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getuid(SB)
+-
+ GLOBL	·libc_getuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getuid_trampoline_addr(SB)/8, $libc_getuid_trampoline<>(SB)
+ 
+ TEXT libc_issetugid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_issetugid(SB)
+-
+ GLOBL	·libc_issetugid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_issetugid_trampoline_addr(SB)/8, $libc_issetugid_trampoline<>(SB)
+ 
+ TEXT libc_kqueue_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kqueue(SB)
+-
+ GLOBL	·libc_kqueue_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kqueue_trampoline_addr(SB)/8, $libc_kqueue_trampoline<>(SB)
+ 
+ TEXT libc_lchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lchown(SB)
+-
+ GLOBL	·libc_lchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lchown_trampoline_addr(SB)/8, $libc_lchown_trampoline<>(SB)
+ 
+ TEXT libc_link_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_link(SB)
+-
+ GLOBL	·libc_link_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_link_trampoline_addr(SB)/8, $libc_link_trampoline<>(SB)
+ 
+ TEXT libc_linkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_linkat(SB)
+-
+ GLOBL	·libc_linkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_linkat_trampoline_addr(SB)/8, $libc_linkat_trampoline<>(SB)
+ 
+ TEXT libc_listen_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listen(SB)
+-
+ GLOBL	·libc_listen_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listen_trampoline_addr(SB)/8, $libc_listen_trampoline<>(SB)
+ 
+ TEXT libc_mkdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdir(SB)
+-
+ GLOBL	·libc_mkdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdir_trampoline_addr(SB)/8, $libc_mkdir_trampoline<>(SB)
+ 
+ TEXT libc_mkdirat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdirat(SB)
+-
+ GLOBL	·libc_mkdirat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdirat_trampoline_addr(SB)/8, $libc_mkdirat_trampoline<>(SB)
+ 
+ TEXT libc_mkfifo_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkfifo(SB)
+-
+ GLOBL	·libc_mkfifo_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkfifo_trampoline_addr(SB)/8, $libc_mkfifo_trampoline<>(SB)
+ 
+ TEXT libc_mknod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mknod(SB)
+-
+ GLOBL	·libc_mknod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mknod_trampoline_addr(SB)/8, $libc_mknod_trampoline<>(SB)
+ 
+ TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mount(SB)
+-
+ GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mount_trampoline_addr(SB)/8, $libc_mount_trampoline<>(SB)
+ 
+ TEXT libc_open_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_open(SB)
+-
+ GLOBL	·libc_open_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_open_trampoline_addr(SB)/8, $libc_open_trampoline<>(SB)
+ 
+ TEXT libc_openat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_openat(SB)
+-
+ GLOBL	·libc_openat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_openat_trampoline_addr(SB)/8, $libc_openat_trampoline<>(SB)
+ 
+ TEXT libc_pathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pathconf(SB)
+-
+ GLOBL	·libc_pathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pathconf_trampoline_addr(SB)/8, $libc_pathconf_trampoline<>(SB)
+ 
+ TEXT libc_pread_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pread(SB)
+-
+ GLOBL	·libc_pread_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pread_trampoline_addr(SB)/8, $libc_pread_trampoline<>(SB)
+ 
+ TEXT libc_pwrite_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pwrite(SB)
+-
+ GLOBL	·libc_pwrite_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pwrite_trampoline_addr(SB)/8, $libc_pwrite_trampoline<>(SB)
+ 
+ TEXT libc_read_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_read(SB)
+-
+ GLOBL	·libc_read_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_read_trampoline_addr(SB)/8, $libc_read_trampoline<>(SB)
+ 
+ TEXT libc_readlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlink(SB)
+-
+ GLOBL	·libc_readlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlink_trampoline_addr(SB)/8, $libc_readlink_trampoline<>(SB)
+ 
+ TEXT libc_readlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlinkat(SB)
+-
+ GLOBL	·libc_readlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlinkat_trampoline_addr(SB)/8, $libc_readlinkat_trampoline<>(SB)
+ 
+ TEXT libc_rename_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rename(SB)
+-
+ GLOBL	·libc_rename_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rename_trampoline_addr(SB)/8, $libc_rename_trampoline<>(SB)
+ 
+ TEXT libc_renameat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_renameat(SB)
+-
+ GLOBL	·libc_renameat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_renameat_trampoline_addr(SB)/8, $libc_renameat_trampoline<>(SB)
+ 
+ TEXT libc_revoke_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_revoke(SB)
+-
+ GLOBL	·libc_revoke_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_revoke_trampoline_addr(SB)/8, $libc_revoke_trampoline<>(SB)
+ 
+ TEXT libc_rmdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rmdir(SB)
+-
+ GLOBL	·libc_rmdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rmdir_trampoline_addr(SB)/8, $libc_rmdir_trampoline<>(SB)
+ 
+ TEXT libc_lseek_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lseek(SB)
+-
+ GLOBL	·libc_lseek_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lseek_trampoline_addr(SB)/8, $libc_lseek_trampoline<>(SB)
+ 
+ TEXT libc_select_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_select(SB)
+-
+ GLOBL	·libc_select_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_select_trampoline_addr(SB)/8, $libc_select_trampoline<>(SB)
+ 
+@@ -712,192 +595,160 @@ DATA	·libc_setattrlist_trampoline_addr(SB)/8, $libc_setattrlist_trampoline<>(SB
+ 
+ TEXT libc_setegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setegid(SB)
+-
+ GLOBL	·libc_setegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setegid_trampoline_addr(SB)/8, $libc_setegid_trampoline<>(SB)
+ 
+ TEXT libc_seteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_seteuid(SB)
+-
+ GLOBL	·libc_seteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_seteuid_trampoline_addr(SB)/8, $libc_seteuid_trampoline<>(SB)
+ 
+ TEXT libc_setgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgid(SB)
+-
+ GLOBL	·libc_setgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgid_trampoline_addr(SB)/8, $libc_setgid_trampoline<>(SB)
+ 
+ TEXT libc_setlogin_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setlogin(SB)
+-
+ GLOBL	·libc_setlogin_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setlogin_trampoline_addr(SB)/8, $libc_setlogin_trampoline<>(SB)
+ 
+ TEXT libc_setpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpgid(SB)
+-
+ GLOBL	·libc_setpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpgid_trampoline_addr(SB)/8, $libc_setpgid_trampoline<>(SB)
+ 
+ TEXT libc_setpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpriority(SB)
+-
+ GLOBL	·libc_setpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpriority_trampoline_addr(SB)/8, $libc_setpriority_trampoline<>(SB)
+ 
+ TEXT libc_setprivexec_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setprivexec(SB)
+-
+ GLOBL	·libc_setprivexec_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setprivexec_trampoline_addr(SB)/8, $libc_setprivexec_trampoline<>(SB)
+ 
+ TEXT libc_setregid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setregid(SB)
+-
+ GLOBL	·libc_setregid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setregid_trampoline_addr(SB)/8, $libc_setregid_trampoline<>(SB)
+ 
+ TEXT libc_setreuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setreuid(SB)
+-
+ GLOBL	·libc_setreuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setreuid_trampoline_addr(SB)/8, $libc_setreuid_trampoline<>(SB)
+ 
+ TEXT libc_setsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsid(SB)
+-
+ GLOBL	·libc_setsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsid_trampoline_addr(SB)/8, $libc_setsid_trampoline<>(SB)
+ 
+ TEXT libc_settimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_settimeofday(SB)
+-
+ GLOBL	·libc_settimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_settimeofday_trampoline_addr(SB)/8, $libc_settimeofday_trampoline<>(SB)
+ 
+ TEXT libc_setuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setuid(SB)
+-
+ GLOBL	·libc_setuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setuid_trampoline_addr(SB)/8, $libc_setuid_trampoline<>(SB)
+ 
+ TEXT libc_symlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlink(SB)
+-
+ GLOBL	·libc_symlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlink_trampoline_addr(SB)/8, $libc_symlink_trampoline<>(SB)
+ 
+ TEXT libc_symlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlinkat(SB)
+-
+ GLOBL	·libc_symlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlinkat_trampoline_addr(SB)/8, $libc_symlinkat_trampoline<>(SB)
+ 
+ TEXT libc_sync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sync(SB)
+-
+ GLOBL	·libc_sync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sync_trampoline_addr(SB)/8, $libc_sync_trampoline<>(SB)
+ 
+ TEXT libc_truncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_truncate(SB)
+-
+ GLOBL	·libc_truncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_truncate_trampoline_addr(SB)/8, $libc_truncate_trampoline<>(SB)
+ 
+ TEXT libc_umask_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_umask(SB)
+-
+ GLOBL	·libc_umask_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_umask_trampoline_addr(SB)/8, $libc_umask_trampoline<>(SB)
+ 
+ TEXT libc_undelete_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_undelete(SB)
+-
+ GLOBL	·libc_undelete_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_undelete_trampoline_addr(SB)/8, $libc_undelete_trampoline<>(SB)
+ 
+ TEXT libc_unlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlink(SB)
+-
+ GLOBL	·libc_unlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlink_trampoline_addr(SB)/8, $libc_unlink_trampoline<>(SB)
+ 
+ TEXT libc_unlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlinkat(SB)
+-
+ GLOBL	·libc_unlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlinkat_trampoline_addr(SB)/8, $libc_unlinkat_trampoline<>(SB)
+ 
+ TEXT libc_unmount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unmount(SB)
+-
+ GLOBL	·libc_unmount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unmount_trampoline_addr(SB)/8, $libc_unmount_trampoline<>(SB)
+ 
+ TEXT libc_write_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_write(SB)
+-
+ GLOBL	·libc_write_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_write_trampoline_addr(SB)/8, $libc_write_trampoline<>(SB)
+ 
+ TEXT libc_mmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mmap(SB)
+-
+ GLOBL	·libc_mmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mmap_trampoline_addr(SB)/8, $libc_mmap_trampoline<>(SB)
+ 
+ TEXT libc_munmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munmap(SB)
+-
+ GLOBL	·libc_munmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munmap_trampoline_addr(SB)/8, $libc_munmap_trampoline<>(SB)
+ 
+ TEXT libc_fstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstat(SB)
+-
+ GLOBL	·libc_fstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstat_trampoline_addr(SB)/8, $libc_fstat_trampoline<>(SB)
+ 
+ TEXT libc_fstatat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatat(SB)
+-
+ GLOBL	·libc_fstatat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatat_trampoline_addr(SB)/8, $libc_fstatat_trampoline<>(SB)
+ 
+ TEXT libc_fstatfs_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatfs(SB)
+-
+ GLOBL	·libc_fstatfs_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatfs_trampoline_addr(SB)/8, $libc_fstatfs_trampoline<>(SB)
+ 
+ TEXT libc_getfsstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getfsstat(SB)
+-
+ GLOBL	·libc_getfsstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getfsstat_trampoline_addr(SB)/8, $libc_getfsstat_trampoline<>(SB)
+ 
+ TEXT libc_lstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lstat(SB)
+-
+ GLOBL	·libc_lstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lstat_trampoline_addr(SB)/8, $libc_lstat_trampoline<>(SB)
+ 
+ TEXT libc_ptrace_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ptrace(SB)
+-
+ GLOBL	·libc_ptrace_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ptrace_trampoline_addr(SB)/8, $libc_ptrace_trampoline<>(SB)
+ 
+ TEXT libc_stat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_stat(SB)
+-
+ GLOBL	·libc_stat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_stat_trampoline_addr(SB)/8, $libc_stat_trampoline<>(SB)
+ 
+ TEXT libc_statfs_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_statfs(SB)
+-
+ GLOBL	·libc_statfs_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_statfs_trampoline_addr(SB)/8, $libc_statfs_trampoline<>(SB)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
+index 0eabac7..0c67df6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
+@@ -1642,28 +1642,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
+index ee313eb..e6e05d1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
+index 4c986e4..7508acc 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
+index 5552169..7b56aea 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
+index 67a226f..cc623dc 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
+index f0b9dda..5818491 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
+index b57c705..6be25cd 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
+@@ -40,7 +40,7 @@ func readv(fd int, iovs []Iovec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procreadv)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -55,7 +55,7 @@ func preadv(fd int, iovs []Iovec, off int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpreadv)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), uintptr(off), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -70,7 +70,7 @@ func writev(fd int, iovs []Iovec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwritev)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -85,7 +85,7 @@ func pwritev(fd int, iovs []Iovec, off int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpwritev)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), uintptr(off), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -96,7 +96,7 @@ func accept4(s int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (fd int,
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procaccept4)), 4, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index 7ceec23..8e5cee2 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -1734,28 +1734,6 @@ func exitThread(code int) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(p)), uintptr(np))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(p)), uintptr(np))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func readv(fd int, iovs []Iovec) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(iovs) > 0 {
+@@ -2197,3 +2175,23 @@ func getresgid(rgid *_C_int, egid *_C_int, sgid *_C_int) {
+ 	RawSyscallNoError(SYS_GETRESGID, uintptr(unsafe.Pointer(rgid)), uintptr(unsafe.Pointer(egid)), uintptr(unsafe.Pointer(sgid)))
+ 	return
+ }
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func schedSetattr(pid int, attr *SchedAttr, flags uint) (err error) {
++	_, _, e1 := Syscall(SYS_SCHED_SETATTR, uintptr(pid), uintptr(unsafe.Pointer(attr)), uintptr(flags))
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func schedGetattr(pid int, attr *SchedAttr, size uint, flags uint) (err error) {
++	_, _, e1 := Syscall6(SYS_SCHED_GETATTR, uintptr(pid), uintptr(unsafe.Pointer(attr)), uintptr(size), uintptr(flags), 0, 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
+index cdb2af5..af06b23 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
+index 9d25f76..093fcf3 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
+index d3f8035..4a78567 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
+index 887188a..741d8be 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index 9ab9abf..66b3b64 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index 915761e..c5c4cc1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -2213,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index 8e87fdf..93bfbb3 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 12a7a21..a107b8f 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index b19e8aa..c427de5 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index fb99594..60c1a99 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index 32cbbbc..52eba36 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
+index 609d1c5..b401894 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
+@@ -436,7 +436,7 @@ func pipe(p *[2]_C_int) (n int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procpipe)), 1, uintptr(unsafe.Pointer(p)), 0, 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -446,7 +446,7 @@ func pipe(p *[2]_C_int) (n int, err error) {
+ func pipe2(p *[2]_C_int, flags int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procpipe2)), 2, uintptr(unsafe.Pointer(p)), uintptr(flags), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -456,7 +456,7 @@ func pipe2(p *[2]_C_int, flags int) (err error) {
+ func getsockname(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgetsockname)), 3, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -471,7 +471,7 @@ func Getcwd(buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetcwd)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -482,7 +482,7 @@ func getgroups(ngid int, gid *_Gid_t) (n int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procgetgroups)), 2, uintptr(ngid), uintptr(unsafe.Pointer(gid)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -492,7 +492,7 @@ func getgroups(ngid int, gid *_Gid_t) (n int, err error) {
+ func setgroups(ngid int, gid *_Gid_t) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procsetgroups)), 2, uintptr(ngid), uintptr(unsafe.Pointer(gid)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -503,7 +503,7 @@ func wait4(pid int32, statusp *_C_int, options int, rusage *Rusage) (wpid int32,
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwait4)), 4, uintptr(pid), uintptr(unsafe.Pointer(statusp)), uintptr(options), uintptr(unsafe.Pointer(rusage)), 0, 0)
+ 	wpid = int32(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -518,7 +518,7 @@ func gethostname(buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgethostname)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -533,7 +533,7 @@ func utimes(path string, times *[2]Timeval) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procutimes)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(times)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -548,7 +548,7 @@ func utimensat(fd int, path string, times *[2]Timespec, flag int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procutimensat)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(times)), uintptr(flag), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -559,7 +559,7 @@ func fcntl(fd int, cmd int, arg int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procfcntl)), 3, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -569,7 +569,7 @@ func fcntl(fd int, cmd int, arg int) (val int, err error) {
+ func futimesat(fildes int, path *byte, times *[2]Timeval) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procfutimesat)), 3, uintptr(fildes), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(times)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -580,7 +580,7 @@ func accept(s int, rsa *RawSockaddrAny, addrlen *_Socklen) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procaccept)), 3, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -591,7 +591,7 @@ func recvmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_recvmsg)), 3, uintptr(s), uintptr(unsafe.Pointer(msg)), uintptr(flags), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -602,7 +602,7 @@ func sendmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_sendmsg)), 3, uintptr(s), uintptr(unsafe.Pointer(msg)), uintptr(flags), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -612,7 +612,7 @@ func sendmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ func acct(path *byte) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procacct)), 1, uintptr(unsafe.Pointer(path)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -647,7 +647,7 @@ func ioctlRet(fd int, req int, arg uintptr) (ret int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, uintptr(fd), uintptr(req), uintptr(arg), 0, 0, 0)
+ 	ret = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -658,7 +658,7 @@ func ioctlPtrRet(fd int, req int, arg unsafe.Pointer) (ret int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, uintptr(fd), uintptr(req), uintptr(arg), 0, 0, 0)
+ 	ret = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -669,7 +669,7 @@ func poll(fds *PollFd, nfds int, timeout int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpoll)), 3, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(timeout), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -684,7 +684,7 @@ func Access(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procAccess)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -694,7 +694,7 @@ func Access(path string, mode uint32) (err error) {
+ func Adjtime(delta *Timeval, olddelta *Timeval) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procAdjtime)), 2, uintptr(unsafe.Pointer(delta)), uintptr(unsafe.Pointer(olddelta)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -709,7 +709,7 @@ func Chdir(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChdir)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -724,7 +724,7 @@ func Chmod(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChmod)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -739,7 +739,7 @@ func Chown(path string, uid int, gid int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChown)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -754,7 +754,7 @@ func Chroot(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChroot)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -764,7 +764,7 @@ func Chroot(path string) (err error) {
+ func ClockGettime(clockid int32, time *Timespec) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procClockGettime)), 2, uintptr(clockid), uintptr(unsafe.Pointer(time)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -774,7 +774,7 @@ func ClockGettime(clockid int32, time *Timespec) (err error) {
+ func Close(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procClose)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -790,7 +790,7 @@ func Creat(path string, mode uint32) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procCreat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -801,7 +801,7 @@ func Dup(fd int) (nfd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procDup)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	nfd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -811,7 +811,7 @@ func Dup(fd int) (nfd int, err error) {
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procDup2)), 2, uintptr(oldfd), uintptr(newfd), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -833,7 +833,7 @@ func Faccessat(dirfd int, path string, mode uint32, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFaccessat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -843,7 +843,7 @@ func Faccessat(dirfd int, path string, mode uint32, flags int) (err error) {
+ func Fchdir(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchdir)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -853,7 +853,7 @@ func Fchdir(fd int) (err error) {
+ func Fchmod(fd int, mode uint32) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchmod)), 2, uintptr(fd), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -868,7 +868,7 @@ func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchmodat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -878,7 +878,7 @@ func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+ func Fchown(fd int, uid int, gid int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchown)), 3, uintptr(fd), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -893,7 +893,7 @@ func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchownat)), 5, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), uintptr(flags), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -903,7 +903,7 @@ func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
+ func Fdatasync(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFdatasync)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -913,7 +913,7 @@ func Fdatasync(fd int) (err error) {
+ func Flock(fd int, how int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFlock)), 2, uintptr(fd), uintptr(how), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -924,7 +924,7 @@ func Fpathconf(fd int, name int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFpathconf)), 2, uintptr(fd), uintptr(name), 0, 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -934,7 +934,7 @@ func Fpathconf(fd int, name int) (val int, err error) {
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstat)), 2, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -949,7 +949,7 @@ func Fstatat(fd int, path string, stat *Stat_t, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstatat)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -959,7 +959,7 @@ func Fstatat(fd int, path string, stat *Stat_t, flags int) (err error) {
+ func Fstatvfs(fd int, vfsstat *Statvfs_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstatvfs)), 2, uintptr(fd), uintptr(unsafe.Pointer(vfsstat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -974,7 +974,7 @@ func Getdents(fd int, buf []byte, basep *uintptr) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetdents)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(basep)), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1001,7 +1001,7 @@ func Getpgid(pid int) (pgid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetpgid)), 1, uintptr(pid), 0, 0, 0, 0, 0)
+ 	pgid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1012,7 +1012,7 @@ func Getpgrp() (pgid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetpgrp)), 0, 0, 0, 0, 0, 0, 0)
+ 	pgid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1047,7 +1047,7 @@ func Getpriority(which int, who int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetpriority)), 2, uintptr(which), uintptr(who), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1057,7 +1057,7 @@ func Getpriority(which int, who int) (n int, err error) {
+ func Getrlimit(which int, lim *Rlimit) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetrlimit)), 2, uintptr(which), uintptr(unsafe.Pointer(lim)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1067,7 +1067,7 @@ func Getrlimit(which int, lim *Rlimit) (err error) {
+ func Getrusage(who int, rusage *Rusage) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetrusage)), 2, uintptr(who), uintptr(unsafe.Pointer(rusage)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1078,7 +1078,7 @@ func Getsid(pid int) (sid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetsid)), 1, uintptr(pid), 0, 0, 0, 0, 0)
+ 	sid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1088,7 +1088,7 @@ func Getsid(pid int) (sid int, err error) {
+ func Gettimeofday(tv *Timeval) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGettimeofday)), 1, uintptr(unsafe.Pointer(tv)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1106,7 +1106,7 @@ func Getuid() (uid int) {
+ func Kill(pid int, signum syscall.Signal) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procKill)), 2, uintptr(pid), uintptr(signum), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1121,7 +1121,7 @@ func Lchown(path string, uid int, gid int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLchown)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1141,7 +1141,7 @@ func Link(path string, link string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLink)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1151,7 +1151,7 @@ func Link(path string, link string) (err error) {
+ func Listen(s int, backlog int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_llisten)), 2, uintptr(s), uintptr(backlog), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1166,7 +1166,7 @@ func Lstat(path string, stat *Stat_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLstat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1180,7 +1180,7 @@ func Madvise(b []byte, advice int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMadvise)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(advice), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1195,7 +1195,7 @@ func Mkdir(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkdir)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1210,7 +1210,7 @@ func Mkdirat(dirfd int, path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkdirat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1225,7 +1225,7 @@ func Mkfifo(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkfifo)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1240,7 +1240,7 @@ func Mkfifoat(dirfd int, path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkfifoat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1255,7 +1255,7 @@ func Mknod(path string, mode uint32, dev int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMknod)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(dev), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1270,7 +1270,7 @@ func Mknodat(dirfd int, path string, mode uint32, dev int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMknodat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(dev), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1284,7 +1284,7 @@ func Mlock(b []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMlock)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1294,7 +1294,7 @@ func Mlock(b []byte) (err error) {
+ func Mlockall(flags int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMlockall)), 1, uintptr(flags), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1308,7 +1308,7 @@ func Mprotect(b []byte, prot int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMprotect)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(prot), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1322,7 +1322,7 @@ func Msync(b []byte, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMsync)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(flags), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1336,7 +1336,7 @@ func Munlock(b []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMunlock)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1346,7 +1346,7 @@ func Munlock(b []byte) (err error) {
+ func Munlockall() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMunlockall)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1356,7 +1356,7 @@ func Munlockall() (err error) {
+ func Nanosleep(time *Timespec, leftover *Timespec) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procNanosleep)), 2, uintptr(unsafe.Pointer(time)), uintptr(unsafe.Pointer(leftover)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1372,7 +1372,7 @@ func Open(path string, mode int, perm uint32) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procOpen)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(perm), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1388,7 +1388,7 @@ func Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error)
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procOpenat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(flags), uintptr(mode), 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1404,7 +1404,7 @@ func Pathconf(path string, name int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procPathconf)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(name), 0, 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1414,7 +1414,7 @@ func Pathconf(path string, name int) (val int, err error) {
+ func Pause() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procPause)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1429,7 +1429,7 @@ func pread(fd int, p []byte, offset int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpread)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(offset), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1444,7 +1444,7 @@ func pwrite(fd int, p []byte, offset int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpwrite)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(offset), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1459,7 +1459,7 @@ func read(fd int, p []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procread)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1479,7 +1479,7 @@ func Readlink(path string, buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procReadlink)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), uintptr(len(buf)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1499,7 +1499,7 @@ func Rename(from string, to string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRename)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1519,7 +1519,7 @@ func Renameat(olddirfd int, oldpath string, newdirfd int, newpath string) (err e
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRenameat)), 4, uintptr(olddirfd), uintptr(unsafe.Pointer(_p0)), uintptr(newdirfd), uintptr(unsafe.Pointer(_p1)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1534,7 +1534,7 @@ func Rmdir(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRmdir)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1545,7 +1545,7 @@ func Seek(fd int, offset int64, whence int) (newoffset int64, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proclseek)), 3, uintptr(fd), uintptr(offset), uintptr(whence), 0, 0, 0)
+ 	newoffset = int64(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1556,7 +1556,7 @@ func Select(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timeval) (n int, err
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSelect)), 5, uintptr(nfd), uintptr(unsafe.Pointer(r)), uintptr(unsafe.Pointer(w)), uintptr(unsafe.Pointer(e)), uintptr(unsafe.Pointer(timeout)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1566,7 +1566,7 @@ func Select(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timeval) (n int, err
+ func Setegid(egid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetegid)), 1, uintptr(egid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1576,7 +1576,7 @@ func Setegid(egid int) (err error) {
+ func Seteuid(euid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSeteuid)), 1, uintptr(euid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1586,7 +1586,7 @@ func Seteuid(euid int) (err error) {
+ func Setgid(gid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetgid)), 1, uintptr(gid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1600,7 +1600,7 @@ func Sethostname(p []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSethostname)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1610,7 +1610,7 @@ func Sethostname(p []byte) (err error) {
+ func Setpgid(pid int, pgid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetpgid)), 2, uintptr(pid), uintptr(pgid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1620,7 +1620,7 @@ func Setpgid(pid int, pgid int) (err error) {
+ func Setpriority(which int, who int, prio int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSetpriority)), 3, uintptr(which), uintptr(who), uintptr(prio), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1630,7 +1630,7 @@ func Setpriority(which int, who int, prio int) (err error) {
+ func Setregid(rgid int, egid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetregid)), 2, uintptr(rgid), uintptr(egid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1640,7 +1640,7 @@ func Setregid(rgid int, egid int) (err error) {
+ func Setreuid(ruid int, euid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetreuid)), 2, uintptr(ruid), uintptr(euid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1651,7 +1651,7 @@ func Setsid() (pid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetsid)), 0, 0, 0, 0, 0, 0, 0)
+ 	pid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1661,7 +1661,7 @@ func Setsid() (pid int, err error) {
+ func Setuid(uid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetuid)), 1, uintptr(uid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1671,7 +1671,7 @@ func Setuid(uid int) (err error) {
+ func Shutdown(s int, how int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procshutdown)), 2, uintptr(s), uintptr(how), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1686,7 +1686,7 @@ func Stat(path string, stat *Stat_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procStat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1701,7 +1701,7 @@ func Statvfs(path string, vfsstat *Statvfs_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procStatvfs)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(vfsstat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1721,7 +1721,7 @@ func Symlink(path string, link string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSymlink)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1731,7 +1731,7 @@ func Symlink(path string, link string) (err error) {
+ func Sync() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSync)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1742,7 +1742,7 @@ func Sysconf(which int) (n int64, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSysconf)), 1, uintptr(which), 0, 0, 0, 0, 0)
+ 	n = int64(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1753,7 +1753,7 @@ func Times(tms *Tms) (ticks uintptr, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procTimes)), 1, uintptr(unsafe.Pointer(tms)), 0, 0, 0, 0, 0)
+ 	ticks = uintptr(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1768,7 +1768,7 @@ func Truncate(path string, length int64) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procTruncate)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1778,7 +1778,7 @@ func Truncate(path string, length int64) (err error) {
+ func Fsync(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFsync)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1788,7 +1788,7 @@ func Fsync(fd int) (err error) {
+ func Ftruncate(fd int, length int64) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFtruncate)), 2, uintptr(fd), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1806,7 +1806,7 @@ func Umask(mask int) (oldmask int) {
+ func Uname(buf *Utsname) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procUname)), 1, uintptr(unsafe.Pointer(buf)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1821,7 +1821,7 @@ func Unmount(target string, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procumount)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(flags), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1836,7 +1836,7 @@ func Unlink(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUnlink)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1851,7 +1851,7 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUnlinkat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(flags), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1861,7 +1861,7 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
+ func Ustat(dev int, ubuf *Ustat_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUstat)), 2, uintptr(dev), uintptr(unsafe.Pointer(ubuf)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1876,7 +1876,7 @@ func Utime(path string, buf *Utimbuf) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUtime)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(buf)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1886,7 +1886,7 @@ func Utime(path string, buf *Utimbuf) (err error) {
+ func bind(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_bind)), 3, uintptr(s), uintptr(addr), uintptr(addrlen), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1896,7 +1896,7 @@ func bind(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ func connect(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_connect)), 3, uintptr(s), uintptr(addr), uintptr(addrlen), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1907,7 +1907,7 @@ func mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procmmap)), 6, uintptr(addr), uintptr(length), uintptr(prot), uintptr(flag), uintptr(fd), uintptr(pos))
+ 	ret = uintptr(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1917,7 +1917,7 @@ func mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (
+ func munmap(addr uintptr, length uintptr) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procmunmap)), 2, uintptr(addr), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1928,7 +1928,7 @@ func sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procsendfile)), 4, uintptr(outfd), uintptr(infd), uintptr(unsafe.Pointer(offset)), uintptr(count), 0, 0)
+ 	written = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1942,7 +1942,7 @@ func sendto(s int, buf []byte, flags int, to unsafe.Pointer, addrlen _Socklen) (
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_sendto)), 6, uintptr(s), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(flags), uintptr(to), uintptr(addrlen))
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1953,7 +1953,7 @@ func socket(domain int, typ int, proto int) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_socket)), 3, uintptr(domain), uintptr(typ), uintptr(proto), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1963,7 +1963,7 @@ func socket(domain int, typ int, proto int) (fd int, err error) {
+ func socketpair(domain int, typ int, proto int, fd *[2]int32) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&proc__xnet_socketpair)), 4, uintptr(domain), uintptr(typ), uintptr(proto), uintptr(unsafe.Pointer(fd)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1978,7 +1978,7 @@ func write(fd int, p []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwrite)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1988,7 +1988,7 @@ func write(fd int, p []byte) (n int, err error) {
+ func getsockopt(s int, level int, name int, val unsafe.Pointer, vallen *_Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_getsockopt)), 5, uintptr(s), uintptr(level), uintptr(name), uintptr(val), uintptr(unsafe.Pointer(vallen)), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1998,7 +1998,7 @@ func getsockopt(s int, level int, name int, val unsafe.Pointer, vallen *_Socklen
+ func getpeername(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procgetpeername)), 3, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2008,7 +2008,7 @@ func getpeername(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ func setsockopt(s int, level int, name int, val unsafe.Pointer, vallen uintptr) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procsetsockopt)), 5, uintptr(s), uintptr(level), uintptr(name), uintptr(val), uintptr(vallen), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2023,7 +2023,7 @@ func recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Sockl
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procrecvfrom)), 6, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(flags), uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(fromlen)))
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2034,7 +2034,7 @@ func port_create() (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_create)), 0, 0, 0, 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2045,7 +2045,7 @@ func port_associate(port int, source int, object uintptr, events int, user *byte
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_associate)), 5, uintptr(port), uintptr(source), uintptr(object), uintptr(events), uintptr(unsafe.Pointer(user)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2056,7 +2056,7 @@ func port_dissociate(port int, source int, object uintptr) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_dissociate)), 3, uintptr(port), uintptr(source), uintptr(object), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2067,7 +2067,7 @@ func port_get(port int, pe *portEvent, timeout *Timespec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_get)), 3, uintptr(port), uintptr(unsafe.Pointer(pe)), uintptr(unsafe.Pointer(timeout)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2078,7 +2078,7 @@ func port_getn(port int, pe *portEvent, max uint32, nget *uint32, timeout *Times
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_getn)), 5, uintptr(port), uintptr(unsafe.Pointer(pe)), uintptr(max), uintptr(unsafe.Pointer(nget)), uintptr(unsafe.Pointer(timeout)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2088,7 +2088,7 @@ func port_getn(port int, pe *portEvent, max uint32, nget *uint32, timeout *Times
+ func putmsg(fd int, clptr *strbuf, dataptr *strbuf, flags int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procputmsg)), 4, uintptr(fd), uintptr(unsafe.Pointer(clptr)), uintptr(unsafe.Pointer(dataptr)), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2098,7 +2098,7 @@ func putmsg(fd int, clptr *strbuf, dataptr *strbuf, flags int) (err error) {
+ func getmsg(fd int, clptr *strbuf, dataptr *strbuf, flags *int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgetmsg)), 4, uintptr(fd), uintptr(unsafe.Pointer(clptr)), uintptr(unsafe.Pointer(dataptr)), uintptr(unsafe.Pointer(flags)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
+index c316817..1d8fe1d 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
+@@ -40,17 +40,6 @@ func read(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func write(fd int, p []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(p) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index c9c4ad0..9862853 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -447,4 +447,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index 12ff341..8901f0f 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -369,4 +369,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index c3fb5e7..6902c37 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -411,4 +411,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 358c847..a6d3dff 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -314,4 +314,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index 81c4849..b18f3f7 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -308,4 +308,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 202a57e..0302e5e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -431,4 +431,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 4448
+ 	SYS_FUTEX_WAITV                  = 4449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
++	SYS_CACHESTAT                    = 4451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index 1fbceb5..6693ba4 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -361,4 +361,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 5448
+ 	SYS_FUTEX_WAITV             = 5449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
++	SYS_CACHESTAT               = 5451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index b4ffb7a..fd93f49 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -361,4 +361,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 5448
+ 	SYS_FUTEX_WAITV             = 5449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
++	SYS_CACHESTAT               = 5451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index 867985f..760ddca 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -431,4 +431,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 4448
+ 	SYS_FUTEX_WAITV                  = 4449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
++	SYS_CACHESTAT                    = 4451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index a8cce69..cff2b25 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -438,4 +438,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index d44c5b3..a4b2405 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -410,4 +410,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index 4214dd9..aca54b4 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -410,4 +410,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 3e594a8..676245e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -313,4 +313,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index e6ed7d6..022878d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -376,4 +376,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index 92f628e..4100a76 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -389,4 +389,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index 02e2462..2d93b09 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -1972,7 +1972,7 @@ const (
+ 	NFT_MSG_GETFLOWTABLE              = 0x17
+ 	NFT_MSG_DELFLOWTABLE              = 0x18
+ 	NFT_MSG_GETRULE_RESET             = 0x19
+-	NFT_MSG_MAX                       = 0x21
++	NFT_MSG_MAX                       = 0x22
+ 	NFTA_LIST_UNSPEC                  = 0x0
+ 	NFTA_LIST_ELEM                    = 0x1
+ 	NFTA_HOOK_UNSPEC                  = 0x0
+@@ -4494,7 +4494,7 @@ const (
+ 	NL80211_ATTR_MAC_HINT                                   = 0xc8
+ 	NL80211_ATTR_MAC_MASK                                   = 0xd7
+ 	NL80211_ATTR_MAX_AP_ASSOC_STA                           = 0xca
+-	NL80211_ATTR_MAX                                        = 0x145
++	NL80211_ATTR_MAX                                        = 0x146
+ 	NL80211_ATTR_MAX_CRIT_PROT_DURATION                     = 0xb4
+ 	NL80211_ATTR_MAX_CSA_COUNTERS                           = 0xce
+ 	NL80211_ATTR_MAX_MATCH_SETS                             = 0x85
+@@ -4864,7 +4864,7 @@ const (
+ 	NL80211_CMD_LEAVE_IBSS                                  = 0x2c
+ 	NL80211_CMD_LEAVE_MESH                                  = 0x45
+ 	NL80211_CMD_LEAVE_OCB                                   = 0x6d
+-	NL80211_CMD_MAX                                         = 0x99
++	NL80211_CMD_MAX                                         = 0x9a
+ 	NL80211_CMD_MICHAEL_MIC_FAILURE                         = 0x29
+ 	NL80211_CMD_MODIFY_LINK_STA                             = 0x97
+ 	NL80211_CMD_NAN_MATCH                                   = 0x78
+@@ -5498,7 +5498,7 @@ const (
+ 	NL80211_RATE_INFO_HE_RU_ALLOC_52                        = 0x1
+ 	NL80211_RATE_INFO_HE_RU_ALLOC_996                       = 0x5
+ 	NL80211_RATE_INFO_HE_RU_ALLOC                           = 0x11
+-	NL80211_RATE_INFO_MAX                                   = 0x16
++	NL80211_RATE_INFO_MAX                                   = 0x1d
+ 	NL80211_RATE_INFO_MCS                                   = 0x2
+ 	NL80211_RATE_INFO_SHORT_GI                              = 0x4
+ 	NL80211_RATE_INFO_VHT_MCS                               = 0x6
+@@ -5863,3 +5863,18 @@ const (
+ 	VIRTIO_NET_HDR_GSO_UDP_L4 = 0x5
+ 	VIRTIO_NET_HDR_GSO_ECN    = 0x80
+ )
++
++type SchedAttr struct {
++	Size     uint32
++	Policy   uint32
++	Flags    uint64
++	Nice     int32
++	Priority uint32
++	Runtime  uint64
++	Deadline uint64
++	Period   uint64
++	Util_min uint32
++	Util_max uint32
++}
++
++const SizeofSchedAttr = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+index 9ea54b7..1b4c97c 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+@@ -718,3 +718,30 @@ type SysvShmDesc struct {
+ 	_      uint64
+ 	_      uint64
+ }
++
++type RISCVHWProbePairs struct {
++	Key   int64
++	Value uint64
++}
++
++const (
++	RISCV_HWPROBE_KEY_MVENDORID          = 0x0
++	RISCV_HWPROBE_KEY_MARCHID            = 0x1
++	RISCV_HWPROBE_KEY_MIMPID             = 0x2
++	RISCV_HWPROBE_KEY_BASE_BEHAVIOR      = 0x3
++	RISCV_HWPROBE_BASE_BEHAVIOR_IMA      = 0x1
++	RISCV_HWPROBE_KEY_IMA_EXT_0          = 0x4
++	RISCV_HWPROBE_IMA_FD                 = 0x1
++	RISCV_HWPROBE_IMA_C                  = 0x2
++	RISCV_HWPROBE_IMA_V                  = 0x4
++	RISCV_HWPROBE_EXT_ZBA                = 0x8
++	RISCV_HWPROBE_EXT_ZBB                = 0x10
++	RISCV_HWPROBE_EXT_ZBS                = 0x20
++	RISCV_HWPROBE_KEY_CPUPERF_0          = 0x5
++	RISCV_HWPROBE_MISALIGNED_UNKNOWN     = 0x0
++	RISCV_HWPROBE_MISALIGNED_EMULATED    = 0x1
++	RISCV_HWPROBE_MISALIGNED_SLOW        = 0x2
++	RISCV_HWPROBE_MISALIGNED_FAST        = 0x3
++	RISCV_HWPROBE_MISALIGNED_UNSUPPORTED = 0x4
++	RISCV_HWPROBE_MISALIGNED_MASK        = 0x7
++)
+diff --git a/vendor/golang.org/x/sys/windows/exec_windows.go b/vendor/golang.org/x/sys/windows/exec_windows.go
+index a52e033..9cabbb6 100644
+--- a/vendor/golang.org/x/sys/windows/exec_windows.go
++++ b/vendor/golang.org/x/sys/windows/exec_windows.go
+@@ -22,7 +22,7 @@ import (
+ //     but only if there is space or tab inside s.
+ func EscapeArg(s string) string {
+ 	if len(s) == 0 {
+-		return "\"\""
++		return `""`
+ 	}
+ 	n := len(s)
+ 	hasSpace := false
+@@ -35,7 +35,7 @@ func EscapeArg(s string) string {
+ 		}
+ 	}
+ 	if hasSpace {
+-		n += 2
++		n += 2 // Reserve space for quotes.
+ 	}
+ 	if n == len(s) {
+ 		return s
+@@ -82,20 +82,68 @@ func EscapeArg(s string) string {
+ // in CreateProcess's CommandLine argument, CreateService/ChangeServiceConfig's BinaryPathName argument,
+ // or any program that uses CommandLineToArgv.
+ func ComposeCommandLine(args []string) string {
+-	var commandLine string
+-	for i := range args {
+-		if i > 0 {
+-			commandLine += " "
++	if len(args) == 0 {
++		return ""
++	}
++
++	// Per https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw:
++	// “This function accepts command lines that contain a program name; the
++	// program name can be enclosed in quotation marks or not.”
++	//
++	// Unfortunately, it provides no means of escaping interior quotation marks
++	// within that program name, and we have no way to report them here.
++	prog := args[0]
++	mustQuote := len(prog) == 0
++	for i := 0; i < len(prog); i++ {
++		c := prog[i]
++		if c <= ' ' || (c == '"' && i == 0) {
++			// Force quotes for not only the ASCII space and tab as described in the
++			// MSDN article, but also ASCII control characters.
++			// The documentation for CommandLineToArgvW doesn't say what happens when
++			// the first argument is not a valid program name, but it empirically
++			// seems to drop unquoted control characters.
++			mustQuote = true
++			break
++		}
++	}
++	var commandLine []byte
++	if mustQuote {
++		commandLine = make([]byte, 0, len(prog)+2)
++		commandLine = append(commandLine, '"')
++		for i := 0; i < len(prog); i++ {
++			c := prog[i]
++			if c == '"' {
++				// This quote would interfere with our surrounding quotes.
++				// We have no way to report an error, so just strip out
++				// the offending character instead.
++				continue
++			}
++			commandLine = append(commandLine, c)
+ 		}
+-		commandLine += EscapeArg(args[i])
++		commandLine = append(commandLine, '"')
++	} else {
++		if len(args) == 1 {
++			// args[0] is a valid command line representing itself.
++			// No need to allocate a new slice or string for it.
++			return prog
++		}
++		commandLine = []byte(prog)
+ 	}
+-	return commandLine
++
++	for _, arg := range args[1:] {
++		commandLine = append(commandLine, ' ')
++		// TODO(bcmills): since we're already appending to a slice, it would be nice
++		// to avoid the intermediate allocations of EscapeArg.
++		// Perhaps we can factor out an appendEscapedArg function.
++		commandLine = append(commandLine, EscapeArg(arg)...)
++	}
++	return string(commandLine)
+ }
+ 
+ // DecomposeCommandLine breaks apart its argument command line into unescaped parts using CommandLineToArgv,
+ // as gathered from GetCommandLine, QUERY_SERVICE_CONFIG's BinaryPathName argument, or elsewhere that
+ // command lines are passed around.
+-// DecomposeCommandLine returns error if commandLine contains NUL.
++// DecomposeCommandLine returns an error if commandLine contains NUL.
+ func DecomposeCommandLine(commandLine string) ([]string, error) {
+ 	if len(commandLine) == 0 {
+ 		return []string{}, nil
+@@ -105,18 +153,35 @@ func DecomposeCommandLine(commandLine string) ([]string, error) {
+ 		return nil, errorspkg.New("string with NUL passed to DecomposeCommandLine")
+ 	}
+ 	var argc int32
+-	argv, err := CommandLineToArgv(&utf16CommandLine[0], &argc)
++	argv, err := commandLineToArgv(&utf16CommandLine[0], &argc)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 	defer LocalFree(Handle(unsafe.Pointer(argv)))
++
+ 	var args []string
+-	for _, v := range (*argv)[:argc] {
+-		args = append(args, UTF16ToString((*v)[:]))
++	for _, p := range unsafe.Slice(argv, argc) {
++		args = append(args, UTF16PtrToString(p))
+ 	}
+ 	return args, nil
+ }
+ 
++// CommandLineToArgv parses a Unicode command line string and sets
++// argc to the number of parsed arguments.
++//
++// The returned memory should be freed using a single call to LocalFree.
++//
++// Note that although the return type of CommandLineToArgv indicates 8192
++// entries of up to 8192 characters each, the actual count of parsed arguments
++// may exceed 8192, and the documentation for CommandLineToArgvW does not mention
++// any bound on the lengths of the individual argument strings.
++// (See https://go.dev/issue/63236.)
++func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) {
++	argp, err := commandLineToArgv(cmd, argc)
++	argv = (*[8192]*[8192]uint16)(unsafe.Pointer(argp))
++	return argv, err
++}
++
+ func CloseOnExec(fd Handle) {
+ 	SetHandleInformation(Handle(fd), HANDLE_FLAG_INHERIT, 0)
+ }
+diff --git a/vendor/golang.org/x/sys/windows/security_windows.go b/vendor/golang.org/x/sys/windows/security_windows.go
+index d414ef1..26be94a 100644
+--- a/vendor/golang.org/x/sys/windows/security_windows.go
++++ b/vendor/golang.org/x/sys/windows/security_windows.go
+@@ -7,8 +7,6 @@ package windows
+ import (
+ 	"syscall"
+ 	"unsafe"
+-
+-	"golang.org/x/sys/internal/unsafeheader"
+ )
+ 
+ const (
+@@ -1341,21 +1339,14 @@ func (selfRelativeSD *SECURITY_DESCRIPTOR) copySelfRelativeSecurityDescriptor()
+ 		sdLen = min
+ 	}
+ 
+-	var src []byte
+-	h := (*unsafeheader.Slice)(unsafe.Pointer(&src))
+-	h.Data = unsafe.Pointer(selfRelativeSD)
+-	h.Len = sdLen
+-	h.Cap = sdLen
+-
++	src := unsafe.Slice((*byte)(unsafe.Pointer(selfRelativeSD)), sdLen)
++	// SECURITY_DESCRIPTOR has pointers in it, which means checkptr expects for it to
++	// be aligned properly. When we're copying a Windows-allocated struct to a
++	// Go-allocated one, make sure that the Go allocation is aligned to the
++	// pointer size.
+ 	const psize = int(unsafe.Sizeof(uintptr(0)))
+-
+-	var dst []byte
+-	h = (*unsafeheader.Slice)(unsafe.Pointer(&dst))
+ 	alloc := make([]uintptr, (sdLen+psize-1)/psize)
+-	h.Data = (*unsafeheader.Slice)(unsafe.Pointer(&alloc)).Data
+-	h.Len = sdLen
+-	h.Cap = sdLen
+-
++	dst := unsafe.Slice((*byte)(unsafe.Pointer(&alloc[0])), sdLen)
+ 	copy(dst, src)
+ 	return (*SECURITY_DESCRIPTOR)(unsafe.Pointer(&dst[0]))
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index 9645900..a3cf746 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -15,8 +15,6 @@ import (
+ 	"time"
+ 	"unicode/utf16"
+ 	"unsafe"
+-
+-	"golang.org/x/sys/internal/unsafeheader"
+ )
+ 
+ type Handle uintptr
+@@ -216,7 +214,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	shGetKnownFolderPath(id *KNOWNFOLDERID, flags uint32, token Token, path **uint16) (ret error) = shell32.SHGetKnownFolderPath
+ //sys	TerminateProcess(handle Handle, exitcode uint32) (err error)
+ //sys	GetExitCodeProcess(handle Handle, exitcode *uint32) (err error)
+-//sys	GetStartupInfo(startupInfo *StartupInfo) (err error) = GetStartupInfoW
++//sys	getStartupInfo(startupInfo *StartupInfo) = GetStartupInfoW
+ //sys	GetProcessTimes(handle Handle, creationTime *Filetime, exitTime *Filetime, kernelTime *Filetime, userTime *Filetime) (err error)
+ //sys	DuplicateHandle(hSourceProcessHandle Handle, hSourceHandle Handle, hTargetProcessHandle Handle, lpTargetHandle *Handle, dwDesiredAccess uint32, bInheritHandle bool, dwOptions uint32) (err error)
+ //sys	WaitForSingleObject(handle Handle, waitMilliseconds uint32) (event uint32, err error) [failretval==0xffffffff]
+@@ -240,7 +238,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	SetFileAttributes(name *uint16, attrs uint32) (err error) = kernel32.SetFileAttributesW
+ //sys	GetFileAttributesEx(name *uint16, level uint32, info *byte) (err error) = kernel32.GetFileAttributesExW
+ //sys	GetCommandLine() (cmd *uint16) = kernel32.GetCommandLineW
+-//sys	CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) [failretval==nil] = shell32.CommandLineToArgvW
++//sys	commandLineToArgv(cmd *uint16, argc *int32) (argv **uint16, err error) [failretval==nil] = shell32.CommandLineToArgvW
+ //sys	LocalFree(hmem Handle) (handle Handle, err error) [failretval!=0]
+ //sys	LocalAlloc(flags uint32, length uint32) (ptr uintptr, err error)
+ //sys	SetHandleInformation(handle Handle, mask uint32, flags uint32) (err error)
+@@ -299,12 +297,15 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	RegNotifyChangeKeyValue(key Handle, watchSubtree bool, notifyFilter uint32, event Handle, asynchronous bool) (regerrno error) = advapi32.RegNotifyChangeKeyValue
+ //sys	GetCurrentProcessId() (pid uint32) = kernel32.GetCurrentProcessId
+ //sys	ProcessIdToSessionId(pid uint32, sessionid *uint32) (err error) = kernel32.ProcessIdToSessionId
++//sys	ClosePseudoConsole(console Handle) = kernel32.ClosePseudoConsole
++//sys	createPseudoConsole(size uint32, in Handle, out Handle, flags uint32, pconsole *Handle) (hr error) = kernel32.CreatePseudoConsole
+ //sys	GetConsoleMode(console Handle, mode *uint32) (err error) = kernel32.GetConsoleMode
+ //sys	SetConsoleMode(console Handle, mode uint32) (err error) = kernel32.SetConsoleMode
+ //sys	GetConsoleScreenBufferInfo(console Handle, info *ConsoleScreenBufferInfo) (err error) = kernel32.GetConsoleScreenBufferInfo
+ //sys	setConsoleCursorPosition(console Handle, position uint32) (err error) = kernel32.SetConsoleCursorPosition
+ //sys	WriteConsole(console Handle, buf *uint16, towrite uint32, written *uint32, reserved *byte) (err error) = kernel32.WriteConsoleW
+ //sys	ReadConsole(console Handle, buf *uint16, toread uint32, read *uint32, inputControl *byte) (err error) = kernel32.ReadConsoleW
++//sys	resizePseudoConsole(pconsole Handle, size uint32) (hr error) = kernel32.ResizePseudoConsole
+ //sys	CreateToolhelp32Snapshot(flags uint32, processId uint32) (handle Handle, err error) [failretval==InvalidHandle] = kernel32.CreateToolhelp32Snapshot
+ //sys	Module32First(snapshot Handle, moduleEntry *ModuleEntry32) (err error) = kernel32.Module32FirstW
+ //sys	Module32Next(snapshot Handle, moduleEntry *ModuleEntry32) (err error) = kernel32.Module32NextW
+@@ -437,6 +438,10 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	DwmGetWindowAttribute(hwnd HWND, attribute uint32, value unsafe.Pointer, size uint32) (ret error) = dwmapi.DwmGetWindowAttribute
+ //sys	DwmSetWindowAttribute(hwnd HWND, attribute uint32, value unsafe.Pointer, size uint32) (ret error) = dwmapi.DwmSetWindowAttribute
+ 
++// Windows Multimedia API
++//sys TimeBeginPeriod (period uint32) (err error) [failretval != 0] = winmm.timeBeginPeriod
++//sys TimeEndPeriod (period uint32) (err error) [failretval != 0] = winmm.timeEndPeriod
++
+ // syscall interface implementation for other packages
+ 
+ // GetCurrentProcess returns the handle for the current process.
+@@ -1624,6 +1629,11 @@ func SetConsoleCursorPosition(console Handle, position Coord) error {
+ 	return setConsoleCursorPosition(console, *((*uint32)(unsafe.Pointer(&position))))
+ }
+ 
++func GetStartupInfo(startupInfo *StartupInfo) error {
++	getStartupInfo(startupInfo)
++	return nil
++}
++
+ func (s NTStatus) Errno() syscall.Errno {
+ 	return rtlNtStatusToDosErrorNoTeb(s)
+ }
+@@ -1658,12 +1668,8 @@ func NewNTUnicodeString(s string) (*NTUnicodeString, error) {
+ 
+ // Slice returns a uint16 slice that aliases the data in the NTUnicodeString.
+ func (s *NTUnicodeString) Slice() []uint16 {
+-	var slice []uint16
+-	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&slice))
+-	hdr.Data = unsafe.Pointer(s.Buffer)
+-	hdr.Len = int(s.Length)
+-	hdr.Cap = int(s.MaximumLength)
+-	return slice
++	slice := unsafe.Slice(s.Buffer, s.MaximumLength)
++	return slice[:s.Length]
+ }
+ 
+ func (s *NTUnicodeString) String() string {
+@@ -1686,12 +1692,8 @@ func NewNTString(s string) (*NTString, error) {
+ 
+ // Slice returns a byte slice that aliases the data in the NTString.
+ func (s *NTString) Slice() []byte {
+-	var slice []byte
+-	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&slice))
+-	hdr.Data = unsafe.Pointer(s.Buffer)
+-	hdr.Len = int(s.Length)
+-	hdr.Cap = int(s.MaximumLength)
+-	return slice
++	slice := unsafe.Slice(s.Buffer, s.MaximumLength)
++	return slice[:s.Length]
+ }
+ 
+ func (s *NTString) String() string {
+@@ -1743,10 +1745,7 @@ func LoadResourceData(module, resInfo Handle) (data []byte, err error) {
+ 	if err != nil {
+ 		return
+ 	}
+-	h := (*unsafeheader.Slice)(unsafe.Pointer(&data))
+-	h.Data = unsafe.Pointer(ptr)
+-	h.Len = int(size)
+-	h.Cap = int(size)
++	data = unsafe.Slice((*byte)(unsafe.Pointer(ptr)), size)
+ 	return
+ }
+ 
+@@ -1817,3 +1816,17 @@ type PSAPI_WORKING_SET_EX_INFORMATION struct {
+ 	// A PSAPI_WORKING_SET_EX_BLOCK union that indicates the attributes of the page at VirtualAddress.
+ 	VirtualAttributes PSAPI_WORKING_SET_EX_BLOCK
+ }
++
++// CreatePseudoConsole creates a windows pseudo console.
++func CreatePseudoConsole(size Coord, in Handle, out Handle, flags uint32, pconsole *Handle) error {
++	// We need this wrapper to manually cast Coord to uint32. The autogenerated wrappers only
++	// accept arguments that can be casted to uintptr, and Coord can't.
++	return createPseudoConsole(*((*uint32)(unsafe.Pointer(&size))), in, out, flags, pconsole)
++}
++
++// ResizePseudoConsole resizes the internal buffers of the pseudo console to the width and height specified in `size`.
++func ResizePseudoConsole(pconsole Handle, size Coord) error {
++	// We need this wrapper to manually cast Coord to uint32. The autogenerated wrappers only
++	// accept arguments that can be casted to uintptr, and Coord can't.
++	return resizePseudoConsole(pconsole, *((*uint32)(unsafe.Pointer(&size))))
++}
+diff --git a/vendor/golang.org/x/sys/windows/types_windows.go b/vendor/golang.org/x/sys/windows/types_windows.go
+index 88e62a6..b88dc7c 100644
+--- a/vendor/golang.org/x/sys/windows/types_windows.go
++++ b/vendor/golang.org/x/sys/windows/types_windows.go
+@@ -247,6 +247,7 @@ const (
+ 	PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY = 0x00020007
+ 	PROC_THREAD_ATTRIBUTE_UMS_THREAD        = 0x00030006
+ 	PROC_THREAD_ATTRIBUTE_PROTECTION_LEVEL  = 0x0002000b
++	PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE     = 0x00020016
+ )
+ 
+ const (
+@@ -2139,6 +2140,12 @@ const (
+ 	ENABLE_LVB_GRID_WORLDWIDE          = 0x10
+ )
+ 
++// Pseudo console related constants used for the flags parameter to
++// CreatePseudoConsole. See: https://learn.microsoft.com/en-us/windows/console/createpseudoconsole
++const (
++	PSEUDOCONSOLE_INHERIT_CURSOR = 0x1
++)
++
+ type Coord struct {
+ 	X int16
+ 	Y int16
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index 566dd3e..8b1688d 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -55,6 +55,7 @@ var (
+ 	moduser32   = NewLazySystemDLL("user32.dll")
+ 	moduserenv  = NewLazySystemDLL("userenv.dll")
+ 	modversion  = NewLazySystemDLL("version.dll")
++	modwinmm    = NewLazySystemDLL("winmm.dll")
+ 	modwintrust = NewLazySystemDLL("wintrust.dll")
+ 	modws2_32   = NewLazySystemDLL("ws2_32.dll")
+ 	modwtsapi32 = NewLazySystemDLL("wtsapi32.dll")
+@@ -187,6 +188,7 @@ var (
+ 	procCancelIo                                             = modkernel32.NewProc("CancelIo")
+ 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
+ 	procCloseHandle                                          = modkernel32.NewProc("CloseHandle")
++	procClosePseudoConsole                                   = modkernel32.NewProc("ClosePseudoConsole")
+ 	procConnectNamedPipe                                     = modkernel32.NewProc("ConnectNamedPipe")
+ 	procCreateDirectoryW                                     = modkernel32.NewProc("CreateDirectoryW")
+ 	procCreateEventExW                                       = modkernel32.NewProc("CreateEventExW")
+@@ -201,6 +203,7 @@ var (
+ 	procCreateNamedPipeW                                     = modkernel32.NewProc("CreateNamedPipeW")
+ 	procCreatePipe                                           = modkernel32.NewProc("CreatePipe")
+ 	procCreateProcessW                                       = modkernel32.NewProc("CreateProcessW")
++	procCreatePseudoConsole                                  = modkernel32.NewProc("CreatePseudoConsole")
+ 	procCreateSymbolicLinkW                                  = modkernel32.NewProc("CreateSymbolicLinkW")
+ 	procCreateToolhelp32Snapshot                             = modkernel32.NewProc("CreateToolhelp32Snapshot")
+ 	procDefineDosDeviceW                                     = modkernel32.NewProc("DefineDosDeviceW")
+@@ -327,6 +330,7 @@ var (
+ 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
+ 	procRemoveDirectoryW                                     = modkernel32.NewProc("RemoveDirectoryW")
+ 	procResetEvent                                           = modkernel32.NewProc("ResetEvent")
++	procResizePseudoConsole                                  = modkernel32.NewProc("ResizePseudoConsole")
+ 	procResumeThread                                         = modkernel32.NewProc("ResumeThread")
+ 	procSetCommTimeouts                                      = modkernel32.NewProc("SetCommTimeouts")
+ 	procSetConsoleCursorPosition                             = modkernel32.NewProc("SetConsoleCursorPosition")
+@@ -468,6 +472,8 @@ var (
+ 	procGetFileVersionInfoSizeW                              = modversion.NewProc("GetFileVersionInfoSizeW")
+ 	procGetFileVersionInfoW                                  = modversion.NewProc("GetFileVersionInfoW")
+ 	procVerQueryValueW                                       = modversion.NewProc("VerQueryValueW")
++	proctimeBeginPeriod                                      = modwinmm.NewProc("timeBeginPeriod")
++	proctimeEndPeriod                                        = modwinmm.NewProc("timeEndPeriod")
+ 	procWinVerifyTrustEx                                     = modwintrust.NewProc("WinVerifyTrustEx")
+ 	procFreeAddrInfoW                                        = modws2_32.NewProc("FreeAddrInfoW")
+ 	procGetAddrInfoW                                         = modws2_32.NewProc("GetAddrInfoW")
+@@ -1630,6 +1636,11 @@ func CloseHandle(handle Handle) (err error) {
+ 	return
+ }
+ 
++func ClosePseudoConsole(console Handle) {
++	syscall.Syscall(procClosePseudoConsole.Addr(), 1, uintptr(console), 0, 0)
++	return
++}
++
+ func ConnectNamedPipe(pipe Handle, overlapped *Overlapped) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procConnectNamedPipe.Addr(), 2, uintptr(pipe), uintptr(unsafe.Pointer(overlapped)), 0)
+ 	if r1 == 0 {
+@@ -1759,6 +1770,14 @@ func CreateProcess(appName *uint16, commandLine *uint16, procSecurity *SecurityA
+ 	return
+ }
+ 
++func createPseudoConsole(size uint32, in Handle, out Handle, flags uint32, pconsole *Handle) (hr error) {
++	r0, _, _ := syscall.Syscall6(procCreatePseudoConsole.Addr(), 5, uintptr(size), uintptr(in), uintptr(out), uintptr(flags), uintptr(unsafe.Pointer(pconsole)), 0)
++	if r0 != 0 {
++		hr = syscall.Errno(r0)
++	}
++	return
++}
++
+ func CreateSymbolicLink(symlinkfilename *uint16, targetfilename *uint16, flags uint32) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procCreateSymbolicLinkW.Addr(), 3, uintptr(unsafe.Pointer(symlinkfilename)), uintptr(unsafe.Pointer(targetfilename)), uintptr(flags))
+ 	if r1&0xff == 0 {
+@@ -2367,11 +2386,8 @@ func GetShortPathName(longpath *uint16, shortpath *uint16, buflen uint32) (n uin
+ 	return
+ }
+ 
+-func GetStartupInfo(startupInfo *StartupInfo) (err error) {
+-	r1, _, e1 := syscall.Syscall(procGetStartupInfoW.Addr(), 1, uintptr(unsafe.Pointer(startupInfo)), 0, 0)
+-	if r1 == 0 {
+-		err = errnoErr(e1)
+-	}
++func getStartupInfo(startupInfo *StartupInfo) {
++	syscall.Syscall(procGetStartupInfoW.Addr(), 1, uintptr(unsafe.Pointer(startupInfo)), 0, 0)
+ 	return
+ }
+ 
+@@ -2862,6 +2878,14 @@ func ResetEvent(event Handle) (err error) {
+ 	return
+ }
+ 
++func resizePseudoConsole(pconsole Handle, size uint32) (hr error) {
++	r0, _, _ := syscall.Syscall(procResizePseudoConsole.Addr(), 2, uintptr(pconsole), uintptr(size), 0)
++	if r0 != 0 {
++		hr = syscall.Errno(r0)
++	}
++	return
++}
++
+ func ResumeThread(thread Handle) (ret uint32, err error) {
+ 	r0, _, e1 := syscall.Syscall(procResumeThread.Addr(), 1, uintptr(thread), 0, 0)
+ 	ret = uint32(r0)
+@@ -3820,9 +3844,9 @@ func setupUninstallOEMInf(infFileName *uint16, flags SUOI, reserved uintptr) (er
+ 	return
+ }
+ 
+-func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) {
++func commandLineToArgv(cmd *uint16, argc *int32) (argv **uint16, err error) {
+ 	r0, _, e1 := syscall.Syscall(procCommandLineToArgvW.Addr(), 2, uintptr(unsafe.Pointer(cmd)), uintptr(unsafe.Pointer(argc)), 0)
+-	argv = (*[8192]*[8192]uint16)(unsafe.Pointer(r0))
++	argv = (**uint16)(unsafe.Pointer(r0))
+ 	if argv == nil {
+ 		err = errnoErr(e1)
+ 	}
+@@ -4017,6 +4041,22 @@ func _VerQueryValue(block unsafe.Pointer, subBlock *uint16, pointerToBufferPoint
+ 	return
+ }
+ 
++func TimeBeginPeriod(period uint32) (err error) {
++	r1, _, e1 := syscall.Syscall(proctimeBeginPeriod.Addr(), 1, uintptr(period), 0, 0)
++	if r1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++func TimeEndPeriod(period uint32) (err error) {
++	r1, _, e1 := syscall.Syscall(proctimeEndPeriod.Addr(), 1, uintptr(period), 0, 0)
++	if r1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func WinVerifyTrustEx(hwnd HWND, actionId *GUID, data *WinTrustData) (ret error) {
+ 	r0, _, _ := syscall.Syscall(procWinVerifyTrustEx.Addr(), 3, uintptr(hwnd), uintptr(unsafe.Pointer(actionId)), uintptr(unsafe.Pointer(data)))
+ 	if r0 != 0 {
+diff --git a/vendor/golang.org/x/text/unicode/norm/trie.go b/vendor/golang.org/x/text/unicode/norm/trie.go
+index 423386b..e4250ae 100644
+--- a/vendor/golang.org/x/text/unicode/norm/trie.go
++++ b/vendor/golang.org/x/text/unicode/norm/trie.go
+@@ -29,7 +29,7 @@ var (
+ 	nfkcData = newNfkcTrie(0)
+ )
+ 
+-// lookupValue determines the type of block n and looks up the value for b.
++// lookup determines the type of block n and looks up the value for b.
+ // For n < t.cutoff, the block is a simple lookup table. Otherwise, the block
+ // is a list of ranges with an accompanying value. Given a matching range r,
+ // the value for b is by r.value + (b - r.lo) * stride.
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 352cad7..a028c0a 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -61,7 +61,46 @@ github.com/prometheus/procfs/internal/util
+ # github.com/spf13/pflag v1.0.5
+ ## explicit; go 1.12
+ github.com/spf13/pflag
+-# golang.org/x/net v0.13.0
++# go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.0
++## explicit; go 1.19
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/internal
++# go.opentelemetry.io/otel v1.15.0
++## explicit; go 1.19
++go.opentelemetry.io/otel
++go.opentelemetry.io/otel/attribute
++go.opentelemetry.io/otel/baggage
++go.opentelemetry.io/otel/codes
++go.opentelemetry.io/otel/internal
++go.opentelemetry.io/otel/internal/attribute
++go.opentelemetry.io/otel/internal/baggage
++go.opentelemetry.io/otel/internal/global
++go.opentelemetry.io/otel/propagation
++go.opentelemetry.io/otel/semconv/v1.17.0
++# go.opentelemetry.io/otel/metric v0.38.0
++## explicit; go 1.19
++go.opentelemetry.io/otel/metric
++go.opentelemetry.io/otel/metric/embedded
++go.opentelemetry.io/otel/metric/global
++go.opentelemetry.io/otel/metric/internal/global
++# go.opentelemetry.io/otel/trace v1.15.0
++## explicit; go 1.19
++go.opentelemetry.io/otel/trace
++# go.uber.org/atomic v1.10.0
++## explicit; go 1.18
++go.uber.org/atomic
++# go.uber.org/multierr v1.11.0
++## explicit; go 1.19
++go.uber.org/multierr
++# go.uber.org/zap v1.19.0
++## explicit; go 1.13
++go.uber.org/zap
++go.uber.org/zap/buffer
++go.uber.org/zap/internal/bufferpool
++go.uber.org/zap/internal/color
++go.uber.org/zap/internal/exit
++go.uber.org/zap/zapcore
++# golang.org/x/net v0.17.0
+ ## explicit; go 1.17
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -69,12 +108,11 @@ golang.org/x/net/http2/hpack
+ golang.org/x/net/idna
+ golang.org/x/net/internal/timeseries
+ golang.org/x/net/trace
+-# golang.org/x/sys v0.10.0
++# golang.org/x/sys v0.13.0
+ ## explicit; go 1.17
+-golang.org/x/sys/internal/unsafeheader
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-# golang.org/x/text v0.11.0
++# golang.org/x/text v0.13.0
+ ## explicit; go 1.17
+ golang.org/x/text/secure/bidirule
+ golang.org/x/text/transform
+-- 
+2.39.1
+

--- a/projects/kubernetes-csi/livenessprobe/1-27/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-27/CHECKSUMS
@@ -1,3 +1,3 @@
-76c4a0a6d54a987744cc1ee11a6a59c75c863db7088ac7a88b6a635ba871024a  _output/1-27/bin/livenessprobe/linux-amd64/livenessprobe
-61349ff8a583832aab8254c3c3ba90c03373324cc6eff7ef1c890811903cc726  _output/1-27/bin/livenessprobe/linux-arm64/livenessprobe
-059722d18e2b0d29632f4a6f760d331f0ba053d6a0dfd758582d2131164b1f0d  _output/1-27/bin/livenessprobe/windows-amd64/livenessprobe.exe
+069068a60fdf7739331586e4ad9f3258690ffe44d066514612dfcc0d8a6c2063  _output/1-27/bin/livenessprobe/linux-amd64/livenessprobe
+d3508a41fee454aea498b9b8841f2b299895a153594b89877a1dac7ed5a56812  _output/1-27/bin/livenessprobe/linux-arm64/livenessprobe
+7c2eda8690b52b3fdf51f1855a6c070afc8bceee41ef2fe8fbdb36b9f07acfc0  _output/1-27/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-27/patches/0001-Fix-CVE-2023-44487-and-CVE-2023-39325-bump-golang.or.patch
+++ b/projects/kubernetes-csi/livenessprobe/1-27/patches/0001-Fix-CVE-2023-44487-and-CVE-2023-39325-bump-golang.or.patch
@@ -1,0 +1,6786 @@
+From 0da68f237a1f971d899df26ee722ddf72905aa15 Mon Sep 17 00:00:00 2001
+From: Jonathan Dobson <jdobson@redhat.com>
+Date: Wed, 18 Oct 2023 14:27:39 -0600
+Subject: [PATCH] Fix CVE-2023-44487 and CVE-2023-39325: bump golang.org/x/net
+
+Signed-off-by: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
+---
+ go.mod                                        |  13 +-
+ go.sum                                        |  31 +-
+ vendor/golang.org/x/net/http2/Dockerfile      |  51 ----
+ vendor/golang.org/x/net/http2/Makefile        |   3 -
+ vendor/golang.org/x/net/http2/server.go       |  86 ++++--
+ vendor/golang.org/x/net/http2/transport.go    |   3 +-
+ .../sys/internal/unsafeheader/unsafeheader.go |  30 --
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |   1 +
+ vendor/golang.org/x/sys/unix/ptrace_darwin.go |   6 -
+ vendor/golang.org/x/sys/unix/ptrace_ios.go    |   6 -
+ vendor/golang.org/x/sys/unix/syscall_aix.go   |   2 -
+ .../golang.org/x/sys/unix/syscall_darwin.go   | 186 ------------
+ .../x/sys/unix/syscall_darwin_amd64.go        |   1 -
+ .../x/sys/unix/syscall_darwin_arm64.go        |   1 -
+ .../x/sys/unix/syscall_dragonfly.go           | 198 -------------
+ .../golang.org/x/sys/unix/syscall_freebsd.go  | 192 -------------
+ vendor/golang.org/x/sys/unix/syscall_linux.go |  77 ++++-
+ .../golang.org/x/sys/unix/syscall_netbsd.go   | 272 +-----------------
+ .../golang.org/x/sys/unix/syscall_openbsd.go  |  74 -----
+ .../golang.org/x/sys/unix/syscall_solaris.go  |  32 ---
+ vendor/golang.org/x/sys/unix/syscall_unix.go  |   3 +
+ .../x/sys/unix/syscall_zos_s390x.go           |   1 -
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  26 ++
+ .../x/sys/unix/zerrors_linux_386.go           |   2 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   2 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   4 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   2 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   2 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   2 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   2 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   2 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   2 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   2 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   2 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   2 +
+ .../golang.org/x/sys/unix/zsyscall_aix_ppc.go |  22 --
+ .../x/sys/unix/zsyscall_aix_ppc64.go          |  22 --
+ .../x/sys/unix/zsyscall_darwin_amd64.go       |  40 +--
+ .../x/sys/unix/zsyscall_darwin_amd64.s        | 149 ----------
+ .../x/sys/unix/zsyscall_darwin_arm64.go       |  40 +--
+ .../x/sys/unix/zsyscall_darwin_arm64.s        | 149 ----------
+ .../x/sys/unix/zsyscall_dragonfly_amd64.go    |  22 --
+ .../x/sys/unix/zsyscall_freebsd_386.go        |  22 --
+ .../x/sys/unix/zsyscall_freebsd_amd64.go      |  22 --
+ .../x/sys/unix/zsyscall_freebsd_arm.go        |  22 --
+ .../x/sys/unix/zsyscall_freebsd_arm64.go      |  22 --
+ .../x/sys/unix/zsyscall_freebsd_riscv64.go    |  22 --
+ .../x/sys/unix/zsyscall_illumos_amd64.go      |  10 +-
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  42 ++-
+ .../x/sys/unix/zsyscall_netbsd_386.go         |  22 --
+ .../x/sys/unix/zsyscall_netbsd_amd64.go       |  22 --
+ .../x/sys/unix/zsyscall_netbsd_arm.go         |  22 --
+ .../x/sys/unix/zsyscall_netbsd_arm64.go       |  22 --
+ .../x/sys/unix/zsyscall_openbsd_386.go        |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |  22 --
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |  32 +--
+ .../x/sys/unix/zsyscall_solaris_amd64.go      | 256 ++++++++---------
+ .../x/sys/unix/zsyscall_zos_s390x.go          |  11 -
+ .../x/sys/unix/zsysnum_linux_386.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   1 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   1 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   1 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   1 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  |  23 +-
+ .../x/sys/unix/ztypes_linux_riscv64.go        |  27 ++
+ .../golang.org/x/sys/windows/exec_windows.go  |  89 +++++-
+ .../x/sys/windows/security_windows.go         |  21 +-
+ .../x/sys/windows/syscall_windows.go          |  53 ++--
+ .../golang.org/x/sys/windows/types_windows.go |   7 +
+ .../x/sys/windows/zsyscall_windows.go         |  54 +++-
+ vendor/golang.org/x/text/unicode/norm/trie.go |   2 +-
+ vendor/modules.txt                            |  46 ++-
+ 89 files changed, 698 insertions(+), 2141 deletions(-)
+ delete mode 100644 vendor/golang.org/x/net/http2/Dockerfile
+ delete mode 100644 vendor/golang.org/x/net/http2/Makefile
+ delete mode 100644 vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
+
+diff --git a/go.mod b/go.mod
+index 3c87bf0..1d87210 100644
+--- a/go.mod
++++ b/go.mod
+@@ -23,9 +23,16 @@ require (
+ 	github.com/prometheus/common v0.44.0 // indirect
+ 	github.com/prometheus/procfs v0.10.1 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+-	golang.org/x/net v0.13.0 // indirect
+-	golang.org/x/sys v0.10.0 // indirect
+-	golang.org/x/text v0.11.0 // indirect
++	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.0 // indirect
++	go.opentelemetry.io/otel v1.15.0 // indirect
++	go.opentelemetry.io/otel/metric v0.38.0 // indirect
++	go.opentelemetry.io/otel/trace v1.15.0 // indirect
++	go.uber.org/atomic v1.10.0 // indirect
++	go.uber.org/multierr v1.11.0 // indirect
++	go.uber.org/zap v1.19.0 // indirect
++	golang.org/x/net v0.17.0 // indirect
++	golang.org/x/sys v0.13.0 // indirect
++	golang.org/x/text v0.13.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
+ 	google.golang.org/protobuf v1.31.0 // indirect
+ 	k8s.io/apimachinery v0.28.0 // indirect
+diff --git a/go.sum b/go.sum
+index 038cdf3..d4a9711 100644
+--- a/go.sum
++++ b/go.sum
+@@ -137,17 +137,9 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
+-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+-golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+-golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+-golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+-golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=
+-golang.org/x/net v0.13.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
+-golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+-golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
++golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
++golang.org/x/oauth2 v0.10.0 h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -168,23 +160,14 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220731174439-a90be440212d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
++golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+-golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
+-golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
++golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
++golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+diff --git a/vendor/golang.org/x/net/http2/Dockerfile b/vendor/golang.org/x/net/http2/Dockerfile
+deleted file mode 100644
+index 8512245..0000000
+--- a/vendor/golang.org/x/net/http2/Dockerfile
++++ /dev/null
+@@ -1,51 +0,0 @@
+-#
+-# This Dockerfile builds a recent curl with HTTP/2 client support, using
+-# a recent nghttp2 build.
+-#
+-# See the Makefile for how to tag it. If Docker and that image is found, the
+-# Go tests use this curl binary for integration tests.
+-#
+-
+-FROM ubuntu:trusty
+-
+-RUN apt-get update && \
+-    apt-get upgrade -y && \
+-    apt-get install -y git-core build-essential wget
+-
+-RUN apt-get install -y --no-install-recommends \
+-       autotools-dev libtool pkg-config zlib1g-dev \
+-       libcunit1-dev libssl-dev libxml2-dev libevent-dev \
+-       automake autoconf
+-
+-# The list of packages nghttp2 recommends for h2load:
+-RUN apt-get install -y --no-install-recommends make binutils \
+-        autoconf automake autotools-dev \
+-        libtool pkg-config zlib1g-dev libcunit1-dev libssl-dev libxml2-dev \
+-        libev-dev libevent-dev libjansson-dev libjemalloc-dev \
+-        cython python3.4-dev python-setuptools
+-
+-# Note: setting NGHTTP2_VER before the git clone, so an old git clone isn't cached:
+-ENV NGHTTP2_VER 895da9a
+-RUN cd /root && git clone https://github.com/tatsuhiro-t/nghttp2.git
+-
+-WORKDIR /root/nghttp2
+-RUN git reset --hard $NGHTTP2_VER
+-RUN autoreconf -i
+-RUN automake
+-RUN autoconf
+-RUN ./configure
+-RUN make
+-RUN make install
+-
+-WORKDIR /root
+-RUN wget https://curl.se/download/curl-7.45.0.tar.gz
+-RUN tar -zxvf curl-7.45.0.tar.gz
+-WORKDIR /root/curl-7.45.0
+-RUN ./configure --with-ssl --with-nghttp2=/usr/local
+-RUN make
+-RUN make install
+-RUN ldconfig
+-
+-CMD ["-h"]
+-ENTRYPOINT ["/usr/local/bin/curl"]
+-
+diff --git a/vendor/golang.org/x/net/http2/Makefile b/vendor/golang.org/x/net/http2/Makefile
+deleted file mode 100644
+index 55fd826..0000000
+--- a/vendor/golang.org/x/net/http2/Makefile
++++ /dev/null
+@@ -1,3 +0,0 @@
+-curlimage:
+-	docker build -t gohttp2/curl .
+-
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index 033b6e6..02c88b6 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -581,9 +581,11 @@ type serverConn struct {
+ 	advMaxStreams               uint32 // our SETTINGS_MAX_CONCURRENT_STREAMS advertised the client
+ 	curClientStreams            uint32 // number of open streams initiated by the client
+ 	curPushedStreams            uint32 // number of open streams initiated by server push
++	curHandlers                 uint32 // number of running handler goroutines
+ 	maxClientStreamID           uint32 // max ever seen from client (odd), or 0 if there have been no client requests
+ 	maxPushPromiseID            uint32 // ID of the last push promise (even), or 0 if there have been no pushes
+ 	streams                     map[uint32]*stream
++	unstartedHandlers           []unstartedHandler
+ 	initialStreamSendWindowSize int32
+ 	maxFrameSize                int32
+ 	peerMaxHeaderListSize       uint32            // zero means unknown (default)
+@@ -981,6 +983,8 @@ func (sc *serverConn) serve() {
+ 					return
+ 				case gracefulShutdownMsg:
+ 					sc.startGracefulShutdownInternal()
++				case handlerDoneMsg:
++					sc.handlerDone()
+ 				default:
+ 					panic("unknown timer")
+ 				}
+@@ -1012,14 +1016,6 @@ func (sc *serverConn) serve() {
+ 	}
+ }
+ 
+-func (sc *serverConn) awaitGracefulShutdown(sharedCh <-chan struct{}, privateCh chan struct{}) {
+-	select {
+-	case <-sc.doneServing:
+-	case <-sharedCh:
+-		close(privateCh)
+-	}
+-}
+-
+ type serverMessage int
+ 
+ // Message values sent to serveMsgCh.
+@@ -1028,6 +1024,7 @@ var (
+ 	idleTimerMsg        = new(serverMessage)
+ 	shutdownTimerMsg    = new(serverMessage)
+ 	gracefulShutdownMsg = new(serverMessage)
++	handlerDoneMsg      = new(serverMessage)
+ )
+ 
+ func (sc *serverConn) onSettingsTimer() { sc.sendServeMsg(settingsTimerMsg) }
+@@ -1900,9 +1897,11 @@ func (st *stream) copyTrailersToHandlerRequest() {
+ // onReadTimeout is run on its own goroutine (from time.AfterFunc)
+ // when the stream's ReadTimeout has fired.
+ func (st *stream) onReadTimeout() {
+-	// Wrap the ErrDeadlineExceeded to avoid callers depending on us
+-	// returning the bare error.
+-	st.body.CloseWithError(fmt.Errorf("%w", os.ErrDeadlineExceeded))
++	if st.body != nil {
++		// Wrap the ErrDeadlineExceeded to avoid callers depending on us
++		// returning the bare error.
++		st.body.CloseWithError(fmt.Errorf("%w", os.ErrDeadlineExceeded))
++	}
+ }
+ 
+ // onWriteTimeout is run on its own goroutine (from time.AfterFunc)
+@@ -2020,13 +2019,10 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+ 	if sc.hs.ReadTimeout != 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+-		if st.body != nil {
+-			st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+-		}
++		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+ 
+-	go sc.runHandler(rw, req, handler)
+-	return nil
++	return sc.scheduleHandler(id, rw, req, handler)
+ }
+ 
+ func (sc *serverConn) upgradeRequest(req *http.Request) {
+@@ -2046,6 +2042,10 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
++	// This is the first request on the connection,
++	// so start the handler directly rather than going
++	// through scheduleHandler.
++	sc.curHandlers++
+ 	go sc.runHandler(rw, req, sc.handler.ServeHTTP)
+ }
+ 
+@@ -2286,8 +2286,62 @@ func (sc *serverConn) newResponseWriter(st *stream, req *http.Request) *response
+ 	return &responseWriter{rws: rws}
+ }
+ 
++type unstartedHandler struct {
++	streamID uint32
++	rw       *responseWriter
++	req      *http.Request
++	handler  func(http.ResponseWriter, *http.Request)
++}
++
++// scheduleHandler starts a handler goroutine,
++// or schedules one to start as soon as an existing handler finishes.
++func (sc *serverConn) scheduleHandler(streamID uint32, rw *responseWriter, req *http.Request, handler func(http.ResponseWriter, *http.Request)) error {
++	sc.serveG.check()
++	maxHandlers := sc.advMaxStreams
++	if sc.curHandlers < maxHandlers {
++		sc.curHandlers++
++		go sc.runHandler(rw, req, handler)
++		return nil
++	}
++	if len(sc.unstartedHandlers) > int(4*sc.advMaxStreams) {
++		return sc.countError("too_many_early_resets", ConnectionError(ErrCodeEnhanceYourCalm))
++	}
++	sc.unstartedHandlers = append(sc.unstartedHandlers, unstartedHandler{
++		streamID: streamID,
++		rw:       rw,
++		req:      req,
++		handler:  handler,
++	})
++	return nil
++}
++
++func (sc *serverConn) handlerDone() {
++	sc.serveG.check()
++	sc.curHandlers--
++	i := 0
++	maxHandlers := sc.advMaxStreams
++	for ; i < len(sc.unstartedHandlers); i++ {
++		u := sc.unstartedHandlers[i]
++		if sc.streams[u.streamID] == nil {
++			// This stream was reset before its goroutine had a chance to start.
++			continue
++		}
++		if sc.curHandlers >= maxHandlers {
++			break
++		}
++		sc.curHandlers++
++		go sc.runHandler(u.rw, u.req, u.handler)
++		sc.unstartedHandlers[i] = unstartedHandler{} // don't retain references
++	}
++	sc.unstartedHandlers = sc.unstartedHandlers[i:]
++	if len(sc.unstartedHandlers) == 0 {
++		sc.unstartedHandlers = nil
++	}
++}
++
+ // Run on its own goroutine.
+ func (sc *serverConn) runHandler(rw *responseWriter, req *http.Request, handler func(http.ResponseWriter, *http.Request)) {
++	defer sc.sendServeMsg(handlerDoneMsg)
+ 	didPanic := true
+ 	defer func() {
+ 		rw.rws.stream.cancelCtx()
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index b20c749..7497f56 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -290,8 +290,7 @@ func (t *Transport) initConnPool() {
+ // HTTP/2 server.
+ type ClientConn struct {
+ 	t             *Transport
+-	tconn         net.Conn // usually *tls.Conn, except specialized impls
+-	tconnClosed   bool
++	tconn         net.Conn             // usually *tls.Conn, except specialized impls
+ 	tlsState      *tls.ConnectionState // nil only for specialized impls
+ 	reused        uint32               // whether conn is being reused; atomic
+ 	singleUse     bool                 // whether being used for a single http.Request
+diff --git a/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go b/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
+deleted file mode 100644
+index e07899b..0000000
+--- a/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
++++ /dev/null
+@@ -1,30 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-// Package unsafeheader contains header declarations for the Go runtime's
+-// slice and string implementations.
+-//
+-// This package allows x/sys to use types equivalent to
+-// reflect.SliceHeader and reflect.StringHeader without introducing
+-// a dependency on the (relatively heavy) "reflect" package.
+-package unsafeheader
+-
+-import (
+-	"unsafe"
+-)
+-
+-// Slice is the runtime representation of a slice.
+-// It cannot be used safely or portably and its representation may change in a later release.
+-type Slice struct {
+-	Data unsafe.Pointer
+-	Len  int
+-	Cap  int
+-}
+-
+-// String is the runtime representation of a string.
+-// It cannot be used safely or portably and its representation may change in a later release.
+-type String struct {
+-	Data unsafe.Pointer
+-	Len  int
+-}
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index 0c4d149..831f9e3 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -583,6 +583,7 @@ ccflags="$@"
+ 		$2 ~ /^PERF_/ ||
+ 		$2 ~ /^SECCOMP_MODE_/ ||
+ 		$2 ~ /^SEEK_/ ||
++		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+ 		$2 ~ /^SYNC_FILE_RANGE_/ ||
+ 		$2 !~ /IOC_MAGIC/ &&
+diff --git a/vendor/golang.org/x/sys/unix/ptrace_darwin.go b/vendor/golang.org/x/sys/unix/ptrace_darwin.go
+index 39dba6c..463c3ef 100644
+--- a/vendor/golang.org/x/sys/unix/ptrace_darwin.go
++++ b/vendor/golang.org/x/sys/unix/ptrace_darwin.go
+@@ -7,12 +7,6 @@
+ 
+ package unix
+ 
+-import "unsafe"
+-
+ func ptrace(request int, pid int, addr uintptr, data uintptr) error {
+ 	return ptrace1(request, pid, addr, data)
+ }
+-
+-func ptracePtr(request int, pid int, addr uintptr, data unsafe.Pointer) error {
+-	return ptrace1Ptr(request, pid, addr, data)
+-}
+diff --git a/vendor/golang.org/x/sys/unix/ptrace_ios.go b/vendor/golang.org/x/sys/unix/ptrace_ios.go
+index 9ea6633..ed0509a 100644
+--- a/vendor/golang.org/x/sys/unix/ptrace_ios.go
++++ b/vendor/golang.org/x/sys/unix/ptrace_ios.go
+@@ -7,12 +7,6 @@
+ 
+ package unix
+ 
+-import "unsafe"
+-
+ func ptrace(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return ENOTSUP
+ }
+-
+-func ptracePtr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	return ENOTSUP
+-}
+diff --git a/vendor/golang.org/x/sys/unix/syscall_aix.go b/vendor/golang.org/x/sys/unix/syscall_aix.go
+index c406ae0..6f77ff5 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_aix.go
++++ b/vendor/golang.org/x/sys/unix/syscall_aix.go
+@@ -487,8 +487,6 @@ func Fsync(fd int) error {
+ //sys	Unlinkat(dirfd int, path string, flags int) (err error)
+ //sys	Ustat(dev int, ubuf *Ustat_t) (err error)
+ //sys	write(fd int, p []byte) (n int, err error)
+-//sys	readlen(fd int, p *byte, np int) (n int, err error) = read
+-//sys	writelen(fd int, p *byte, np int) (n int, err error) = write
+ 
+ //sys	Dup2(oldfd int, newfd int) (err error)
+ //sys	Fadvise(fd int, offset int64, length int64, advice int) (err error) = posix_fadvise64
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin.go b/vendor/golang.org/x/sys/unix/syscall_darwin.go
+index 2069215..3b0bd2d 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin.go
+@@ -638,189 +638,3 @@ func SysctlKinfoProcSlice(name string, args ...int) ([]KinfoProc, error) {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+-
+-/*
+- * Unimplemented
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Ioctl
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// sendfile
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Poll_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go b/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
+index 9fa8798..b37310c 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
+@@ -47,6 +47,5 @@ func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr,
+ //sys	getfsstat(buf unsafe.Pointer, size uintptr, flags int) (n int, err error) = SYS_GETFSSTAT64
+ //sys	Lstat(path string, stat *Stat_t) (err error) = SYS_LSTAT64
+ //sys	ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) = SYS_ptrace
+-//sys	ptrace1Ptr(request int, pid int, addr unsafe.Pointer, data uintptr) (err error) = SYS_ptrace
+ //sys	Stat(path string, stat *Stat_t) (err error) = SYS_STAT64
+ //sys	Statfs(path string, stat *Statfs_t) (err error) = SYS_STATFS64
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go b/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
+index f17b8c5..d51ec99 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
+@@ -47,6 +47,5 @@ func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr,
+ //sys	getfsstat(buf unsafe.Pointer, size uintptr, flags int) (n int, err error) = SYS_GETFSSTAT
+ //sys	Lstat(path string, stat *Stat_t) (err error)
+ //sys	ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) = SYS_ptrace
+-//sys	ptrace1Ptr(request int, pid int, addr unsafe.Pointer, data uintptr) (err error) = SYS_ptrace
+ //sys	Stat(path string, stat *Stat_t) (err error)
+ //sys	Statfs(path string, stat *Statfs_t) (err error)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+index d4ce988..97cb916 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
++++ b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+@@ -343,203 +343,5 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error)
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- * TODO(jsing): Update this list for DragonFly.
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Mount
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Setattrlist
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Getxattr
+-// Fgetxattr
+-// Setxattr
+-// Fsetxattr
+-// Removexattr
+-// Fremovexattr
+-// Listxattr
+-// Flistxattr
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shmat
+-// Shmctl
+-// Shmdt
+-// Shmget
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index afb1010..64d1bb4 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -449,197 +449,5 @@ func Dup3(oldfd, newfd, flags int) error {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error)
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Ioctl
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Mount
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Setattrlist
+-// Getdents
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shmat
+-// Shmctl
+-// Shmdt
+-// Shmget
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Poll_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index 39de5f1..c905ec8 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -693,10 +693,10 @@ type SockaddrALG struct {
+ 
+ func (sa *SockaddrALG) sockaddr() (unsafe.Pointer, _Socklen, error) {
+ 	// Leave room for NUL byte terminator.
+-	if len(sa.Type) > 13 {
++	if len(sa.Type) > len(sa.raw.Type)-1 {
+ 		return nil, 0, EINVAL
+ 	}
+-	if len(sa.Name) > 63 {
++	if len(sa.Name) > len(sa.raw.Name)-1 {
+ 		return nil, 0, EINVAL
+ 	}
+ 
+@@ -704,17 +704,8 @@ func (sa *SockaddrALG) sockaddr() (unsafe.Pointer, _Socklen, error) {
+ 	sa.raw.Feat = sa.Feature
+ 	sa.raw.Mask = sa.Mask
+ 
+-	typ, err := ByteSliceFromString(sa.Type)
+-	if err != nil {
+-		return nil, 0, err
+-	}
+-	name, err := ByteSliceFromString(sa.Name)
+-	if err != nil {
+-		return nil, 0, err
+-	}
+-
+-	copy(sa.raw.Type[:], typ)
+-	copy(sa.raw.Name[:], name)
++	copy(sa.raw.Type[:], sa.Type)
++	copy(sa.raw.Name[:], sa.Name)
+ 
+ 	return unsafe.Pointer(&sa.raw), SizeofSockaddrALG, nil
+ }
+@@ -1988,8 +1979,6 @@ func Signalfd(fd int, sigmask *Sigset_t, flags int) (newfd int, err error) {
+ //sys	Unshare(flags int) (err error)
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	exitThread(code int) (err error) = SYS_EXIT
+-//sys	readlen(fd int, p *byte, np int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, p *byte, np int) (n int, err error) = SYS_WRITE
+ //sys	readv(fd int, iovs []Iovec) (n int, err error) = SYS_READV
+ //sys	writev(fd int, iovs []Iovec) (n int, err error) = SYS_WRITEV
+ //sys	preadv(fd int, iovs []Iovec, offs_l uintptr, offs_h uintptr) (n int, err error) = SYS_PREADV
+@@ -2454,6 +2443,7 @@ func Getresgid() (rgid, egid, sgid int) {
+ 	return int(r), int(e), int(s)
+ }
+ 
++<<<<<<< HEAD
+ /*
+  * Unimplemented
+  */
+@@ -2549,3 +2539,60 @@ func Getresgid() (rgid, egid, sgid int) {
+ // Vhangup
+ // Vserver
+ // _Sysctl
++=======
++// Pselect is a wrapper around the Linux pselect6 system call.
++// This version does not modify the timeout argument.
++func Pselect(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
++	// Per https://man7.org/linux/man-pages/man2/select.2.html#NOTES,
++	// The Linux pselect6() system call modifies its timeout argument.
++	// [Not modifying the argument] is the behavior required by POSIX.1-2001.
++	var mutableTimeout *Timespec
++	if timeout != nil {
++		mutableTimeout = new(Timespec)
++		*mutableTimeout = *timeout
++	}
++
++	// The final argument of the pselect6() system call is not a
++	// sigset_t * pointer, but is instead a structure
++	var kernelMask *sigset_argpack
++	if sigmask != nil {
++		wordBits := 32 << (^uintptr(0) >> 63) // see math.intSize
++
++		// A sigset stores one bit per signal,
++		// offset by 1 (because signal 0 does not exist).
++		// So the number of words needed is ⌈__C_NSIG - 1 / wordBits⌉.
++		sigsetWords := (_C__NSIG - 1 + wordBits - 1) / (wordBits)
++
++		sigsetBytes := uintptr(sigsetWords * (wordBits / 8))
++		kernelMask = &sigset_argpack{
++			ss:    sigmask,
++			ssLen: sigsetBytes,
++		}
++	}
++
++	return pselect6(nfd, r, w, e, mutableTimeout, kernelMask)
++}
++
++//sys	schedSetattr(pid int, attr *SchedAttr, flags uint) (err error)
++//sys	schedGetattr(pid int, attr *SchedAttr, size uint, flags uint) (err error)
++
++// SchedSetAttr is a wrapper for sched_setattr(2) syscall.
++// https://man7.org/linux/man-pages/man2/sched_setattr.2.html
++func SchedSetAttr(pid int, attr *SchedAttr, flags uint) error {
++	if attr == nil {
++		return EINVAL
++	}
++	attr.Size = SizeofSchedAttr
++	return schedSetattr(pid, attr, flags)
++}
++
++// SchedGetAttr is a wrapper for sched_getattr(2) syscall.
++// https://man7.org/linux/man-pages/man2/sched_getattr.2.html
++func SchedGetAttr(pid int, flags uint) (*SchedAttr, error) {
++	attr := &SchedAttr{}
++	if err := schedGetattr(pid, attr, SizeofSchedAttr, flags); err != nil {
++		return nil, err
++	}
++	return attr, nil
++}
++>>>>>>> 48ed37b (CVE-2023-44487: bump golang.org/x/net to v0.17.0)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_netbsd.go b/vendor/golang.org/x/sys/unix/syscall_netbsd.go
+index 018d7d4..8816209 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_netbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_netbsd.go
+@@ -356,266 +356,16 @@ func Statvfs(path string, buf *Statvfs_t) (err error) {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+ 
+-/*
+- * Unimplemented
+- */
+-// ____semctl13
+-// __clone
+-// __fhopen40
+-// __fhstat40
+-// __fhstatvfs140
+-// __fstat30
+-// __getcwd
+-// __getfh30
+-// __getlogin
+-// __lstat30
+-// __mount50
+-// __msgctl13
+-// __msync13
+-// __ntp_gettime30
+-// __posix_chown
+-// __posix_fchown
+-// __posix_lchown
+-// __posix_rename
+-// __setlogin
+-// __shmctl13
+-// __sigaction_sigtramp
+-// __sigaltstack14
+-// __sigpending14
+-// __sigprocmask14
+-// __sigsuspend14
+-// __sigtimedwait
+-// __stat30
+-// __syscall
+-// __vfork14
+-// _ksem_close
+-// _ksem_destroy
+-// _ksem_getvalue
+-// _ksem_init
+-// _ksem_open
+-// _ksem_post
+-// _ksem_trywait
+-// _ksem_unlink
+-// _ksem_wait
+-// _lwp_continue
+-// _lwp_create
+-// _lwp_ctl
+-// _lwp_detach
+-// _lwp_exit
+-// _lwp_getname
+-// _lwp_getprivate
+-// _lwp_kill
+-// _lwp_park
+-// _lwp_self
+-// _lwp_setname
+-// _lwp_setprivate
+-// _lwp_suspend
+-// _lwp_unpark
+-// _lwp_unpark_all
+-// _lwp_wait
+-// _lwp_wakeup
+-// _pset_bind
+-// _sched_getaffinity
+-// _sched_getparam
+-// _sched_setaffinity
+-// _sched_setparam
+-// acct
+-// aio_cancel
+-// aio_error
+-// aio_fsync
+-// aio_read
+-// aio_return
+-// aio_suspend
+-// aio_write
+-// break
+-// clock_getres
+-// clock_gettime
+-// clock_settime
+-// compat_09_ogetdomainname
+-// compat_09_osetdomainname
+-// compat_09_ouname
+-// compat_10_omsgsys
+-// compat_10_osemsys
+-// compat_10_oshmsys
+-// compat_12_fstat12
+-// compat_12_getdirentries
+-// compat_12_lstat12
+-// compat_12_msync
+-// compat_12_oreboot
+-// compat_12_oswapon
+-// compat_12_stat12
+-// compat_13_sigaction13
+-// compat_13_sigaltstack13
+-// compat_13_sigpending13
+-// compat_13_sigprocmask13
+-// compat_13_sigreturn13
+-// compat_13_sigsuspend13
+-// compat_14___semctl
+-// compat_14_msgctl
+-// compat_14_shmctl
+-// compat_16___sigaction14
+-// compat_16___sigreturn14
+-// compat_20_fhstatfs
+-// compat_20_fstatfs
+-// compat_20_getfsstat
+-// compat_20_statfs
+-// compat_30___fhstat30
+-// compat_30___fstat13
+-// compat_30___lstat13
+-// compat_30___stat13
+-// compat_30_fhopen
+-// compat_30_fhstat
+-// compat_30_fhstatvfs1
+-// compat_30_getdents
+-// compat_30_getfh
+-// compat_30_ntp_gettime
+-// compat_30_socket
+-// compat_40_mount
+-// compat_43_fstat43
+-// compat_43_lstat43
+-// compat_43_oaccept
+-// compat_43_ocreat
+-// compat_43_oftruncate
+-// compat_43_ogetdirentries
+-// compat_43_ogetdtablesize
+-// compat_43_ogethostid
+-// compat_43_ogethostname
+-// compat_43_ogetkerninfo
+-// compat_43_ogetpagesize
+-// compat_43_ogetpeername
+-// compat_43_ogetrlimit
+-// compat_43_ogetsockname
+-// compat_43_okillpg
+-// compat_43_olseek
+-// compat_43_ommap
+-// compat_43_oquota
+-// compat_43_orecv
+-// compat_43_orecvfrom
+-// compat_43_orecvmsg
+-// compat_43_osend
+-// compat_43_osendmsg
+-// compat_43_osethostid
+-// compat_43_osethostname
+-// compat_43_osigblock
+-// compat_43_osigsetmask
+-// compat_43_osigstack
+-// compat_43_osigvec
+-// compat_43_otruncate
+-// compat_43_owait
+-// compat_43_stat43
+-// execve
+-// extattr_delete_fd
+-// extattr_delete_file
+-// extattr_delete_link
+-// extattr_get_fd
+-// extattr_get_file
+-// extattr_get_link
+-// extattr_list_fd
+-// extattr_list_file
+-// extattr_list_link
+-// extattr_set_fd
+-// extattr_set_file
+-// extattr_set_link
+-// extattrctl
+-// fchroot
+-// fdatasync
+-// fgetxattr
+-// fktrace
+-// flistxattr
+-// fork
+-// fremovexattr
+-// fsetxattr
+-// fstatvfs1
+-// fsync_range
+-// getcontext
+-// getitimer
+-// getvfsstat
+-// getxattr
+-// ktrace
+-// lchflags
+-// lchmod
+-// lfs_bmapv
+-// lfs_markv
+-// lfs_segclean
+-// lfs_segwait
+-// lgetxattr
+-// lio_listio
+-// listxattr
+-// llistxattr
+-// lremovexattr
+-// lseek
+-// lsetxattr
+-// lutimes
+-// madvise
+-// mincore
+-// minherit
+-// modctl
+-// mq_close
+-// mq_getattr
+-// mq_notify
+-// mq_open
+-// mq_receive
+-// mq_send
+-// mq_setattr
+-// mq_timedreceive
+-// mq_timedsend
+-// mq_unlink
+-// mremap
+-// msgget
+-// msgrcv
+-// msgsnd
+-// nfssvc
+-// ntp_adjtime
+-// pmc_control
+-// pmc_get_info
+-// pollts
+-// preadv
+-// profil
+-// pselect
+-// pset_assign
+-// pset_create
+-// pset_destroy
+-// ptrace
+-// pwritev
+-// quotactl
+-// rasctl
+-// readv
+-// reboot
+-// removexattr
+-// sa_enable
+-// sa_preempt
+-// sa_register
+-// sa_setconcurrency
+-// sa_stacks
+-// sa_yield
+-// sbrk
+-// sched_yield
+-// semconfig
+-// semget
+-// semop
+-// setcontext
+-// setitimer
+-// setxattr
+-// shmat
+-// shmdt
+-// shmget
+-// sstk
+-// statvfs1
+-// swapctl
+-// sysarch
+-// syscall
+-// timer_create
+-// timer_delete
+-// timer_getoverrun
+-// timer_gettime
+-// timer_settime
+-// undelete
+-// utrace
+-// uuidgen
+-// vadvise
+-// vfork
+-// writev
++const (
++	mremapFixed     = MAP_FIXED
++	mremapDontunmap = 0
++	mremapMaymove   = 0
++)
++
++//sys	mremapNetBSD(oldp uintptr, oldsize uintptr, newp uintptr, newsize uintptr, flags int) (xaddr uintptr, err error) = SYS_MREMAP
++
++func mremap(oldaddr uintptr, oldlength uintptr, newlength uintptr, flags int, newaddr uintptr) (uintptr, error) {
++	return mremapNetBSD(oldaddr, oldlength, newaddr, newlength, flags)
++}
+diff --git a/vendor/golang.org/x/sys/unix/syscall_openbsd.go b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+index c5f166a..6f34479 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_openbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+@@ -326,78 +326,4 @@ func Uname(uname *Utsname) error {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- */
+-// __getcwd
+-// __semctl
+-// __syscall
+-// __sysctl
+-// adjfreq
+-// break
+-// clock_getres
+-// clock_gettime
+-// clock_settime
+-// closefrom
+-// execve
+-// fhopen
+-// fhstat
+-// fhstatfs
+-// fork
+-// futimens
+-// getfh
+-// getgid
+-// getitimer
+-// getlogin
+-// getthrid
+-// ktrace
+-// lfs_bmapv
+-// lfs_markv
+-// lfs_segclean
+-// lfs_segwait
+-// mincore
+-// minherit
+-// mount
+-// mquery
+-// msgctl
+-// msgget
+-// msgrcv
+-// msgsnd
+-// nfssvc
+-// nnpfspioctl
+-// preadv
+-// profil
+-// pwritev
+-// quotactl
+-// readv
+-// reboot
+-// renameat
+-// rfork
+-// sched_yield
+-// semget
+-// semop
+-// setgroups
+-// setitimer
+-// setsockopt
+-// shmat
+-// shmctl
+-// shmdt
+-// shmget
+-// sigaction
+-// sigaltstack
+-// sigpending
+-// sigprocmask
+-// sigreturn
+-// sigsuspend
+-// sysarch
+-// syscall
+-// threxit
+-// thrsigdivert
+-// thrsleep
+-// thrwakeup
+-// vfork
+-// writev
+diff --git a/vendor/golang.org/x/sys/unix/syscall_solaris.go b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+index b600a28..b99cfa1 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
++++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+@@ -698,38 +698,6 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ //sys	setsockopt(s int, level int, name int, val unsafe.Pointer, vallen uintptr) (err error) = libsocket.setsockopt
+ //sys	recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Socklen) (n int, err error) = libsocket.recvfrom
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procread)), 3, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf), 0, 0, 0)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = e1
+-	}
+-	return
+-}
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwrite)), 3, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf), 0, 0, 0)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = e1
+-	}
+-	return
+-}
+-
+-var mapper = &mmapper{
+-	active: make(map[*byte][]byte),
+-	mmap:   mmap,
+-	munmap: munmap,
+-}
+-
+-func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
+-	return mapper.Mmap(fd, offset, length, prot, flags)
+-}
+-
+-func Munmap(b []byte) (err error) {
+-	return mapper.Munmap(b)
+-}
+-
+ // Event Ports
+ 
+ type fileObjCookie struct {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_unix.go b/vendor/golang.org/x/sys/unix/syscall_unix.go
+index 8e48c29..a4b2c98 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_unix.go
++++ b/vendor/golang.org/x/sys/unix/syscall_unix.go
+@@ -541,6 +541,9 @@ func SetNonblock(fd int, nonblocking bool) (err error) {
+ 	if err != nil {
+ 		return err
+ 	}
++	if (flag&O_NONBLOCK != 0) == nonblocking {
++		return nil
++	}
+ 	if nonblocking {
+ 		flag |= O_NONBLOCK
+ 	} else {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+index d3d49ec..799302f 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+@@ -192,7 +192,6 @@ func (cmsg *Cmsghdr) SetLen(length int) {
+ 
+ //sys   fcntl(fd int, cmd int, arg int) (val int, err error)
+ //sys	read(fd int, p []byte) (n int, err error)
+-//sys   readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+ //sys	write(fd int, p []byte) (n int, err error)
+ 
+ //sys	accept(s int, rsa *RawSockaddrAny, addrlen *_Socklen) (fd int, err error) = SYS___ACCEPT_A
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index 3784f40..f9c7f47 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -2421,6 +2421,15 @@ const (
+ 	PR_PAC_GET_ENABLED_KEYS                     = 0x3d
+ 	PR_PAC_RESET_KEYS                           = 0x36
+ 	PR_PAC_SET_ENABLED_KEYS                     = 0x3c
++	PR_RISCV_V_GET_CONTROL                      = 0x46
++	PR_RISCV_V_SET_CONTROL                      = 0x45
++	PR_RISCV_V_VSTATE_CTRL_CUR_MASK             = 0x3
++	PR_RISCV_V_VSTATE_CTRL_DEFAULT              = 0x0
++	PR_RISCV_V_VSTATE_CTRL_INHERIT              = 0x10
++	PR_RISCV_V_VSTATE_CTRL_MASK                 = 0x1f
++	PR_RISCV_V_VSTATE_CTRL_NEXT_MASK            = 0xc
++	PR_RISCV_V_VSTATE_CTRL_OFF                  = 0x1
++	PR_RISCV_V_VSTATE_CTRL_ON                   = 0x2
+ 	PR_SCHED_CORE                               = 0x3e
+ 	PR_SCHED_CORE_CREATE                        = 0x1
+ 	PR_SCHED_CORE_GET                           = 0x0
+@@ -2821,6 +2830,23 @@ const (
+ 	RWF_SUPPORTED                               = 0x1f
+ 	RWF_SYNC                                    = 0x4
+ 	RWF_WRITE_LIFE_NOT_SET                      = 0x0
++	SCHED_BATCH                                 = 0x3
++	SCHED_DEADLINE                              = 0x6
++	SCHED_FIFO                                  = 0x1
++	SCHED_FLAG_ALL                              = 0x7f
++	SCHED_FLAG_DL_OVERRUN                       = 0x4
++	SCHED_FLAG_KEEP_ALL                         = 0x18
++	SCHED_FLAG_KEEP_PARAMS                      = 0x10
++	SCHED_FLAG_KEEP_POLICY                      = 0x8
++	SCHED_FLAG_RECLAIM                          = 0x2
++	SCHED_FLAG_RESET_ON_FORK                    = 0x1
++	SCHED_FLAG_UTIL_CLAMP                       = 0x60
++	SCHED_FLAG_UTIL_CLAMP_MAX                   = 0x40
++	SCHED_FLAG_UTIL_CLAMP_MIN                   = 0x20
++	SCHED_IDLE                                  = 0x5
++	SCHED_NORMAL                                = 0x0
++	SCHED_RESET_ON_FORK                         = 0x40000000
++	SCHED_RR                                    = 0x2
+ 	SCM_CREDENTIALS                             = 0x2
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index a46df0f..c5aeab3 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index 6cd4a3e..6b9fda9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -318,10 +318,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c7ebee2..f015600 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -324,10 +324,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 12a9a13..f760f2a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -314,10 +314,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index f26a164..12f266c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -109,6 +109,8 @@ const (
+ 	IUCLC                            = 0x200
+ 	IXOFF                            = 0x1000
+ 	IXON                             = 0x400
++	LASX_CTX_MAGIC                   = 0x41535801
++	LSX_CTX_MAGIC                    = 0x53580001
+ 	MAP_ANON                         = 0x20
+ 	MAP_ANONYMOUS                    = 0x20
+ 	MAP_DENYWRITE                    = 0x800
+@@ -308,10 +310,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 890bc3c..7fd3806 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 549f26a..c38d426 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index e0365e3..17a5f97 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index fdccce1..b73088d 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index b2205c8..80b8d52 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -372,10 +372,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 81aa5ad..8292e16 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -376,10 +376,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index 76807a1..bb1ebb8 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -376,10 +376,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index d4a5ab9..28006d4 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -305,10 +305,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 66e65db..75e263b 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -380,10 +380,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 4898420..5d2d76a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -419,10 +419,12 @@ const (
+ 	SO_NOFCS                         = 0x27
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x2
++	SO_PASSPIDFD                     = 0x55
+ 	SO_PASSSEC                       = 0x1f
+ 	SO_PEEK_OFF                      = 0x26
+ 	SO_PEERCRED                      = 0x40
+ 	SO_PEERGROUPS                    = 0x3d
++	SO_PEERPIDFD                     = 0x56
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x48
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
+index 9a25721..d1d1d23 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
+@@ -817,28 +817,6 @@ func write(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, er := C.read(C.int(fd), C.uintptr_t(uintptr(unsafe.Pointer(p))), C.size_t(np))
+-	n = int(r0)
+-	if r0 == -1 && er != nil {
+-		err = er
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, er := C.write(C.int(fd), C.uintptr_t(uintptr(unsafe.Pointer(p))), C.size_t(np))
+-	n = int(r0)
+-	if r0 == -1 && er != nil {
+-		err = er
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	r0, er := C.dup2(C.int(oldfd), C.int(newfd))
+ 	if r0 == -1 && er != nil {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
+index 6de80c2..f99a18a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
+@@ -762,28 +762,6 @@ func write(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, e1 := callread(fd, uintptr(unsafe.Pointer(p)), np)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, e1 := callwrite(fd, uintptr(unsafe.Pointer(p)), np)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	_, e1 := calldup2(oldfd, newfd)
+ 	if e1 != 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
+index 4037ccf..1cad561 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
+@@ -725,6 +725,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -733,10 +739,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2410,28 +2412,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_fstat64_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0)
+ 	if e1 != 0 {
+@@ -2521,14 +2501,6 @@ func ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return
+ }
+ 
+-func ptrace1Ptr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	_, _, e1 := syscall_syscall6(libc_ptrace_trampoline_addr, uintptr(request), uintptr(pid), addr, uintptr(data), 0, 0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+ var libc_ptrace_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_ptrace ptrace "/usr/lib/libSystem.B.dylib"
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
+index 4baaed0..8b8bb28 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
+@@ -5,703 +5,586 @@
+ 
+ TEXT libc_fdopendir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fdopendir(SB)
+-
+ GLOBL	·libc_fdopendir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fdopendir_trampoline_addr(SB)/8, $libc_fdopendir_trampoline<>(SB)
+ 
+ TEXT libc_getgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgroups(SB)
+-
+ GLOBL	·libc_getgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgroups_trampoline_addr(SB)/8, $libc_getgroups_trampoline<>(SB)
+ 
+ TEXT libc_setgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgroups(SB)
+-
+ GLOBL	·libc_setgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgroups_trampoline_addr(SB)/8, $libc_setgroups_trampoline<>(SB)
+ 
+ TEXT libc_wait4_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_wait4(SB)
+-
+ GLOBL	·libc_wait4_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_wait4_trampoline_addr(SB)/8, $libc_wait4_trampoline<>(SB)
+ 
+ TEXT libc_accept_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_accept(SB)
+-
+ GLOBL	·libc_accept_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_accept_trampoline_addr(SB)/8, $libc_accept_trampoline<>(SB)
+ 
+ TEXT libc_bind_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_bind(SB)
+-
+ GLOBL	·libc_bind_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_bind_trampoline_addr(SB)/8, $libc_bind_trampoline<>(SB)
+ 
+ TEXT libc_connect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_connect(SB)
+-
+ GLOBL	·libc_connect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_connect_trampoline_addr(SB)/8, $libc_connect_trampoline<>(SB)
+ 
+ TEXT libc_socket_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socket(SB)
+-
+ GLOBL	·libc_socket_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socket_trampoline_addr(SB)/8, $libc_socket_trampoline<>(SB)
+ 
+ TEXT libc_getsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockopt(SB)
+-
+ GLOBL	·libc_getsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockopt_trampoline_addr(SB)/8, $libc_getsockopt_trampoline<>(SB)
+ 
+ TEXT libc_setsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsockopt(SB)
+-
+ GLOBL	·libc_setsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsockopt_trampoline_addr(SB)/8, $libc_setsockopt_trampoline<>(SB)
+ 
+ TEXT libc_getpeername_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpeername(SB)
+-
+ GLOBL	·libc_getpeername_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpeername_trampoline_addr(SB)/8, $libc_getpeername_trampoline<>(SB)
+ 
+ TEXT libc_getsockname_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockname(SB)
+-
+ GLOBL	·libc_getsockname_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockname_trampoline_addr(SB)/8, $libc_getsockname_trampoline<>(SB)
+ 
+ TEXT libc_shutdown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shutdown(SB)
+-
+ GLOBL	·libc_shutdown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shutdown_trampoline_addr(SB)/8, $libc_shutdown_trampoline<>(SB)
+ 
+ TEXT libc_socketpair_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socketpair(SB)
+-
+ GLOBL	·libc_socketpair_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socketpair_trampoline_addr(SB)/8, $libc_socketpair_trampoline<>(SB)
+ 
+ TEXT libc_recvfrom_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvfrom(SB)
+-
+ GLOBL	·libc_recvfrom_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvfrom_trampoline_addr(SB)/8, $libc_recvfrom_trampoline<>(SB)
+ 
+ TEXT libc_sendto_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendto(SB)
+-
+ GLOBL	·libc_sendto_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendto_trampoline_addr(SB)/8, $libc_sendto_trampoline<>(SB)
+ 
+ TEXT libc_recvmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvmsg(SB)
+-
+ GLOBL	·libc_recvmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvmsg_trampoline_addr(SB)/8, $libc_recvmsg_trampoline<>(SB)
+ 
+ TEXT libc_sendmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendmsg(SB)
+-
+ GLOBL	·libc_sendmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendmsg_trampoline_addr(SB)/8, $libc_sendmsg_trampoline<>(SB)
+ 
+ TEXT libc_kevent_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kevent(SB)
+-
+ GLOBL	·libc_kevent_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kevent_trampoline_addr(SB)/8, $libc_kevent_trampoline<>(SB)
+ 
+ TEXT libc_utimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimes(SB)
+-
+ GLOBL	·libc_utimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimes_trampoline_addr(SB)/8, $libc_utimes_trampoline<>(SB)
+ 
+ TEXT libc_futimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_futimes(SB)
+-
+ GLOBL	·libc_futimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_futimes_trampoline_addr(SB)/8, $libc_futimes_trampoline<>(SB)
+ 
+ TEXT libc_poll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_poll(SB)
+-
+ GLOBL	·libc_poll_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_poll_trampoline_addr(SB)/8, $libc_poll_trampoline<>(SB)
+ 
+ TEXT libc_madvise_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_madvise(SB)
+-
+ GLOBL	·libc_madvise_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_madvise_trampoline_addr(SB)/8, $libc_madvise_trampoline<>(SB)
+ 
+ TEXT libc_mlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlock(SB)
+-
+ GLOBL	·libc_mlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlock_trampoline_addr(SB)/8, $libc_mlock_trampoline<>(SB)
+ 
+ TEXT libc_mlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlockall(SB)
+-
+ GLOBL	·libc_mlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlockall_trampoline_addr(SB)/8, $libc_mlockall_trampoline<>(SB)
+ 
+ TEXT libc_mprotect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mprotect(SB)
+-
+ GLOBL	·libc_mprotect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mprotect_trampoline_addr(SB)/8, $libc_mprotect_trampoline<>(SB)
+ 
+ TEXT libc_msync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_msync(SB)
+-
+ GLOBL	·libc_msync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_msync_trampoline_addr(SB)/8, $libc_msync_trampoline<>(SB)
+ 
+ TEXT libc_munlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlock(SB)
+-
+ GLOBL	·libc_munlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlock_trampoline_addr(SB)/8, $libc_munlock_trampoline<>(SB)
+ 
+ TEXT libc_munlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlockall(SB)
+-
+ GLOBL	·libc_munlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlockall_trampoline_addr(SB)/8, $libc_munlockall_trampoline<>(SB)
+ 
+ TEXT libc_closedir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_closedir(SB)
+-
+ GLOBL	·libc_closedir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_closedir_trampoline_addr(SB)/8, $libc_closedir_trampoline<>(SB)
+ 
+ TEXT libc_readdir_r_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readdir_r(SB)
+-
+ GLOBL	·libc_readdir_r_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readdir_r_trampoline_addr(SB)/8, $libc_readdir_r_trampoline<>(SB)
+ 
+ TEXT libc_pipe_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pipe(SB)
+-
+ GLOBL	·libc_pipe_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pipe_trampoline_addr(SB)/8, $libc_pipe_trampoline<>(SB)
+ 
+ TEXT libc_getxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getxattr(SB)
+-
+ GLOBL	·libc_getxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getxattr_trampoline_addr(SB)/8, $libc_getxattr_trampoline<>(SB)
+ 
+ TEXT libc_fgetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fgetxattr(SB)
+-
+ GLOBL	·libc_fgetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fgetxattr_trampoline_addr(SB)/8, $libc_fgetxattr_trampoline<>(SB)
+ 
+ TEXT libc_setxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setxattr(SB)
+-
+ GLOBL	·libc_setxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setxattr_trampoline_addr(SB)/8, $libc_setxattr_trampoline<>(SB)
+ 
+ TEXT libc_fsetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsetxattr(SB)
+-
+ GLOBL	·libc_fsetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsetxattr_trampoline_addr(SB)/8, $libc_fsetxattr_trampoline<>(SB)
+ 
+ TEXT libc_removexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_removexattr(SB)
+-
+ GLOBL	·libc_removexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_removexattr_trampoline_addr(SB)/8, $libc_removexattr_trampoline<>(SB)
+ 
+ TEXT libc_fremovexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fremovexattr(SB)
+-
+ GLOBL	·libc_fremovexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fremovexattr_trampoline_addr(SB)/8, $libc_fremovexattr_trampoline<>(SB)
+ 
+ TEXT libc_listxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listxattr(SB)
+-
+ GLOBL	·libc_listxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listxattr_trampoline_addr(SB)/8, $libc_listxattr_trampoline<>(SB)
+ 
+ TEXT libc_flistxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flistxattr(SB)
+-
+ GLOBL	·libc_flistxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flistxattr_trampoline_addr(SB)/8, $libc_flistxattr_trampoline<>(SB)
+ 
+ TEXT libc_utimensat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimensat(SB)
+-
+ GLOBL	·libc_utimensat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimensat_trampoline_addr(SB)/8, $libc_utimensat_trampoline<>(SB)
+ 
+ TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fcntl(SB)
+-
+ GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
+ 
+ TEXT libc_kill_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kill(SB)
+-
+ GLOBL	·libc_kill_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kill_trampoline_addr(SB)/8, $libc_kill_trampoline<>(SB)
+ 
+ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ioctl(SB)
+-
+ GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
+ 
+ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sysctl(SB)
+-
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
+ TEXT libc_sendfile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendfile(SB)
+-
+ GLOBL	·libc_sendfile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendfile_trampoline_addr(SB)/8, $libc_sendfile_trampoline<>(SB)
+ 
+ TEXT libc_shmat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmat(SB)
+-
+ GLOBL	·libc_shmat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmat_trampoline_addr(SB)/8, $libc_shmat_trampoline<>(SB)
+ 
+ TEXT libc_shmctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmctl(SB)
+-
+ GLOBL	·libc_shmctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmctl_trampoline_addr(SB)/8, $libc_shmctl_trampoline<>(SB)
+ 
+ TEXT libc_shmdt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmdt(SB)
+-
+ GLOBL	·libc_shmdt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmdt_trampoline_addr(SB)/8, $libc_shmdt_trampoline<>(SB)
+ 
+ TEXT libc_shmget_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmget(SB)
+-
+ GLOBL	·libc_shmget_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmget_trampoline_addr(SB)/8, $libc_shmget_trampoline<>(SB)
+ 
+ TEXT libc_access_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_access(SB)
+-
+ GLOBL	·libc_access_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_access_trampoline_addr(SB)/8, $libc_access_trampoline<>(SB)
+ 
+ TEXT libc_adjtime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_adjtime(SB)
+-
+ GLOBL	·libc_adjtime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_adjtime_trampoline_addr(SB)/8, $libc_adjtime_trampoline<>(SB)
+ 
+ TEXT libc_chdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chdir(SB)
+-
+ GLOBL	·libc_chdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chdir_trampoline_addr(SB)/8, $libc_chdir_trampoline<>(SB)
+ 
+ TEXT libc_chflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chflags(SB)
+-
+ GLOBL	·libc_chflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chflags_trampoline_addr(SB)/8, $libc_chflags_trampoline<>(SB)
+ 
+ TEXT libc_chmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chmod(SB)
+-
+ GLOBL	·libc_chmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chmod_trampoline_addr(SB)/8, $libc_chmod_trampoline<>(SB)
+ 
+ TEXT libc_chown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chown(SB)
+-
+ GLOBL	·libc_chown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chown_trampoline_addr(SB)/8, $libc_chown_trampoline<>(SB)
+ 
+ TEXT libc_chroot_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chroot(SB)
+-
+ GLOBL	·libc_chroot_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chroot_trampoline_addr(SB)/8, $libc_chroot_trampoline<>(SB)
+ 
+ TEXT libc_clock_gettime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clock_gettime(SB)
+-
+ GLOBL	·libc_clock_gettime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clock_gettime_trampoline_addr(SB)/8, $libc_clock_gettime_trampoline<>(SB)
+ 
+ TEXT libc_close_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_close(SB)
+-
+ GLOBL	·libc_close_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_close_trampoline_addr(SB)/8, $libc_close_trampoline<>(SB)
+ 
+ TEXT libc_clonefile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefile(SB)
+-
+ GLOBL	·libc_clonefile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefile_trampoline_addr(SB)/8, $libc_clonefile_trampoline<>(SB)
+ 
+ TEXT libc_clonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefileat(SB)
+-
+ GLOBL	·libc_clonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefileat_trampoline_addr(SB)/8, $libc_clonefileat_trampoline<>(SB)
+ 
+ TEXT libc_dup_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup(SB)
+-
+ GLOBL	·libc_dup_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup_trampoline_addr(SB)/8, $libc_dup_trampoline<>(SB)
+ 
+ TEXT libc_dup2_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup2(SB)
+-
+ GLOBL	·libc_dup2_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup2_trampoline_addr(SB)/8, $libc_dup2_trampoline<>(SB)
+ 
+ TEXT libc_exchangedata_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exchangedata(SB)
+-
+ GLOBL	·libc_exchangedata_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exchangedata_trampoline_addr(SB)/8, $libc_exchangedata_trampoline<>(SB)
+ 
+ TEXT libc_exit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exit(SB)
+-
+ GLOBL	·libc_exit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exit_trampoline_addr(SB)/8, $libc_exit_trampoline<>(SB)
+ 
+ TEXT libc_faccessat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_faccessat(SB)
+-
+ GLOBL	·libc_faccessat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_faccessat_trampoline_addr(SB)/8, $libc_faccessat_trampoline<>(SB)
+ 
+ TEXT libc_fchdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchdir(SB)
+-
+ GLOBL	·libc_fchdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchdir_trampoline_addr(SB)/8, $libc_fchdir_trampoline<>(SB)
+ 
+ TEXT libc_fchflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchflags(SB)
+-
+ GLOBL	·libc_fchflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchflags_trampoline_addr(SB)/8, $libc_fchflags_trampoline<>(SB)
+ 
+ TEXT libc_fchmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmod(SB)
+-
+ GLOBL	·libc_fchmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmod_trampoline_addr(SB)/8, $libc_fchmod_trampoline<>(SB)
+ 
+ TEXT libc_fchmodat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmodat(SB)
+-
+ GLOBL	·libc_fchmodat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmodat_trampoline_addr(SB)/8, $libc_fchmodat_trampoline<>(SB)
+ 
+ TEXT libc_fchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchown(SB)
+-
+ GLOBL	·libc_fchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchown_trampoline_addr(SB)/8, $libc_fchown_trampoline<>(SB)
+ 
+ TEXT libc_fchownat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchownat(SB)
+-
+ GLOBL	·libc_fchownat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchownat_trampoline_addr(SB)/8, $libc_fchownat_trampoline<>(SB)
+ 
+ TEXT libc_fclonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fclonefileat(SB)
+-
+ GLOBL	·libc_fclonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fclonefileat_trampoline_addr(SB)/8, $libc_fclonefileat_trampoline<>(SB)
+ 
+ TEXT libc_flock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flock(SB)
+-
+ GLOBL	·libc_flock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flock_trampoline_addr(SB)/8, $libc_flock_trampoline<>(SB)
+ 
+ TEXT libc_fpathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fpathconf(SB)
+-
+ GLOBL	·libc_fpathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fpathconf_trampoline_addr(SB)/8, $libc_fpathconf_trampoline<>(SB)
+ 
+ TEXT libc_fsync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsync(SB)
+-
+ GLOBL	·libc_fsync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsync_trampoline_addr(SB)/8, $libc_fsync_trampoline<>(SB)
+ 
+ TEXT libc_ftruncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ftruncate(SB)
+-
+ GLOBL	·libc_ftruncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ftruncate_trampoline_addr(SB)/8, $libc_ftruncate_trampoline<>(SB)
+ 
+ TEXT libc_getcwd_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getcwd(SB)
+-
+ GLOBL	·libc_getcwd_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getcwd_trampoline_addr(SB)/8, $libc_getcwd_trampoline<>(SB)
+ 
+ TEXT libc_getdtablesize_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getdtablesize(SB)
+-
+ GLOBL	·libc_getdtablesize_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getdtablesize_trampoline_addr(SB)/8, $libc_getdtablesize_trampoline<>(SB)
+ 
+ TEXT libc_getegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getegid(SB)
+-
+ GLOBL	·libc_getegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getegid_trampoline_addr(SB)/8, $libc_getegid_trampoline<>(SB)
+ 
+ TEXT libc_geteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_geteuid(SB)
+-
+ GLOBL	·libc_geteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_geteuid_trampoline_addr(SB)/8, $libc_geteuid_trampoline<>(SB)
+ 
+ TEXT libc_getgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgid(SB)
+-
+ GLOBL	·libc_getgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgid_trampoline_addr(SB)/8, $libc_getgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgid(SB)
+-
+ GLOBL	·libc_getpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgid_trampoline_addr(SB)/8, $libc_getpgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgrp_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgrp(SB)
+-
+ GLOBL	·libc_getpgrp_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgrp_trampoline_addr(SB)/8, $libc_getpgrp_trampoline<>(SB)
+ 
+ TEXT libc_getpid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpid(SB)
+-
+ GLOBL	·libc_getpid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpid_trampoline_addr(SB)/8, $libc_getpid_trampoline<>(SB)
+ 
+ TEXT libc_getppid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getppid(SB)
+-
+ GLOBL	·libc_getppid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getppid_trampoline_addr(SB)/8, $libc_getppid_trampoline<>(SB)
+ 
+ TEXT libc_getpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpriority(SB)
+-
+ GLOBL	·libc_getpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpriority_trampoline_addr(SB)/8, $libc_getpriority_trampoline<>(SB)
+ 
+ TEXT libc_getrlimit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrlimit(SB)
+-
+ GLOBL	·libc_getrlimit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrlimit_trampoline_addr(SB)/8, $libc_getrlimit_trampoline<>(SB)
+ 
+ TEXT libc_getrusage_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrusage(SB)
+-
+ GLOBL	·libc_getrusage_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrusage_trampoline_addr(SB)/8, $libc_getrusage_trampoline<>(SB)
+ 
+ TEXT libc_getsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsid(SB)
+-
+ GLOBL	·libc_getsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsid_trampoline_addr(SB)/8, $libc_getsid_trampoline<>(SB)
+ 
+ TEXT libc_gettimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_gettimeofday(SB)
+-
+ GLOBL	·libc_gettimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_gettimeofday_trampoline_addr(SB)/8, $libc_gettimeofday_trampoline<>(SB)
+ 
+ TEXT libc_getuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getuid(SB)
+-
+ GLOBL	·libc_getuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getuid_trampoline_addr(SB)/8, $libc_getuid_trampoline<>(SB)
+ 
+ TEXT libc_issetugid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_issetugid(SB)
+-
+ GLOBL	·libc_issetugid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_issetugid_trampoline_addr(SB)/8, $libc_issetugid_trampoline<>(SB)
+ 
+ TEXT libc_kqueue_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kqueue(SB)
+-
+ GLOBL	·libc_kqueue_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kqueue_trampoline_addr(SB)/8, $libc_kqueue_trampoline<>(SB)
+ 
+ TEXT libc_lchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lchown(SB)
+-
+ GLOBL	·libc_lchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lchown_trampoline_addr(SB)/8, $libc_lchown_trampoline<>(SB)
+ 
+ TEXT libc_link_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_link(SB)
+-
+ GLOBL	·libc_link_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_link_trampoline_addr(SB)/8, $libc_link_trampoline<>(SB)
+ 
+ TEXT libc_linkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_linkat(SB)
+-
+ GLOBL	·libc_linkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_linkat_trampoline_addr(SB)/8, $libc_linkat_trampoline<>(SB)
+ 
+ TEXT libc_listen_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listen(SB)
+-
+ GLOBL	·libc_listen_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listen_trampoline_addr(SB)/8, $libc_listen_trampoline<>(SB)
+ 
+ TEXT libc_mkdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdir(SB)
+-
+ GLOBL	·libc_mkdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdir_trampoline_addr(SB)/8, $libc_mkdir_trampoline<>(SB)
+ 
+ TEXT libc_mkdirat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdirat(SB)
+-
+ GLOBL	·libc_mkdirat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdirat_trampoline_addr(SB)/8, $libc_mkdirat_trampoline<>(SB)
+ 
+ TEXT libc_mkfifo_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkfifo(SB)
+-
+ GLOBL	·libc_mkfifo_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkfifo_trampoline_addr(SB)/8, $libc_mkfifo_trampoline<>(SB)
+ 
+ TEXT libc_mknod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mknod(SB)
+-
+ GLOBL	·libc_mknod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mknod_trampoline_addr(SB)/8, $libc_mknod_trampoline<>(SB)
+ 
+ TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mount(SB)
+-
+ GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mount_trampoline_addr(SB)/8, $libc_mount_trampoline<>(SB)
+ 
+ TEXT libc_open_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_open(SB)
+-
+ GLOBL	·libc_open_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_open_trampoline_addr(SB)/8, $libc_open_trampoline<>(SB)
+ 
+ TEXT libc_openat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_openat(SB)
+-
+ GLOBL	·libc_openat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_openat_trampoline_addr(SB)/8, $libc_openat_trampoline<>(SB)
+ 
+ TEXT libc_pathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pathconf(SB)
+-
+ GLOBL	·libc_pathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pathconf_trampoline_addr(SB)/8, $libc_pathconf_trampoline<>(SB)
+ 
+ TEXT libc_pread_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pread(SB)
+-
+ GLOBL	·libc_pread_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pread_trampoline_addr(SB)/8, $libc_pread_trampoline<>(SB)
+ 
+ TEXT libc_pwrite_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pwrite(SB)
+-
+ GLOBL	·libc_pwrite_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pwrite_trampoline_addr(SB)/8, $libc_pwrite_trampoline<>(SB)
+ 
+ TEXT libc_read_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_read(SB)
+-
+ GLOBL	·libc_read_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_read_trampoline_addr(SB)/8, $libc_read_trampoline<>(SB)
+ 
+ TEXT libc_readlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlink(SB)
+-
+ GLOBL	·libc_readlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlink_trampoline_addr(SB)/8, $libc_readlink_trampoline<>(SB)
+ 
+ TEXT libc_readlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlinkat(SB)
+-
+ GLOBL	·libc_readlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlinkat_trampoline_addr(SB)/8, $libc_readlinkat_trampoline<>(SB)
+ 
+ TEXT libc_rename_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rename(SB)
+-
+ GLOBL	·libc_rename_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rename_trampoline_addr(SB)/8, $libc_rename_trampoline<>(SB)
+ 
+ TEXT libc_renameat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_renameat(SB)
+-
+ GLOBL	·libc_renameat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_renameat_trampoline_addr(SB)/8, $libc_renameat_trampoline<>(SB)
+ 
+ TEXT libc_revoke_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_revoke(SB)
+-
+ GLOBL	·libc_revoke_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_revoke_trampoline_addr(SB)/8, $libc_revoke_trampoline<>(SB)
+ 
+ TEXT libc_rmdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rmdir(SB)
+-
+ GLOBL	·libc_rmdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rmdir_trampoline_addr(SB)/8, $libc_rmdir_trampoline<>(SB)
+ 
+ TEXT libc_lseek_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lseek(SB)
+-
+ GLOBL	·libc_lseek_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lseek_trampoline_addr(SB)/8, $libc_lseek_trampoline<>(SB)
+ 
+ TEXT libc_select_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_select(SB)
+-
+ GLOBL	·libc_select_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_select_trampoline_addr(SB)/8, $libc_select_trampoline<>(SB)
+ 
+@@ -712,192 +595,160 @@ DATA	·libc_setattrlist_trampoline_addr(SB)/8, $libc_setattrlist_trampoline<>(SB
+ 
+ TEXT libc_setegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setegid(SB)
+-
+ GLOBL	·libc_setegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setegid_trampoline_addr(SB)/8, $libc_setegid_trampoline<>(SB)
+ 
+ TEXT libc_seteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_seteuid(SB)
+-
+ GLOBL	·libc_seteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_seteuid_trampoline_addr(SB)/8, $libc_seteuid_trampoline<>(SB)
+ 
+ TEXT libc_setgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgid(SB)
+-
+ GLOBL	·libc_setgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgid_trampoline_addr(SB)/8, $libc_setgid_trampoline<>(SB)
+ 
+ TEXT libc_setlogin_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setlogin(SB)
+-
+ GLOBL	·libc_setlogin_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setlogin_trampoline_addr(SB)/8, $libc_setlogin_trampoline<>(SB)
+ 
+ TEXT libc_setpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpgid(SB)
+-
+ GLOBL	·libc_setpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpgid_trampoline_addr(SB)/8, $libc_setpgid_trampoline<>(SB)
+ 
+ TEXT libc_setpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpriority(SB)
+-
+ GLOBL	·libc_setpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpriority_trampoline_addr(SB)/8, $libc_setpriority_trampoline<>(SB)
+ 
+ TEXT libc_setprivexec_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setprivexec(SB)
+-
+ GLOBL	·libc_setprivexec_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setprivexec_trampoline_addr(SB)/8, $libc_setprivexec_trampoline<>(SB)
+ 
+ TEXT libc_setregid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setregid(SB)
+-
+ GLOBL	·libc_setregid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setregid_trampoline_addr(SB)/8, $libc_setregid_trampoline<>(SB)
+ 
+ TEXT libc_setreuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setreuid(SB)
+-
+ GLOBL	·libc_setreuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setreuid_trampoline_addr(SB)/8, $libc_setreuid_trampoline<>(SB)
+ 
+ TEXT libc_setsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsid(SB)
+-
+ GLOBL	·libc_setsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsid_trampoline_addr(SB)/8, $libc_setsid_trampoline<>(SB)
+ 
+ TEXT libc_settimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_settimeofday(SB)
+-
+ GLOBL	·libc_settimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_settimeofday_trampoline_addr(SB)/8, $libc_settimeofday_trampoline<>(SB)
+ 
+ TEXT libc_setuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setuid(SB)
+-
+ GLOBL	·libc_setuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setuid_trampoline_addr(SB)/8, $libc_setuid_trampoline<>(SB)
+ 
+ TEXT libc_symlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlink(SB)
+-
+ GLOBL	·libc_symlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlink_trampoline_addr(SB)/8, $libc_symlink_trampoline<>(SB)
+ 
+ TEXT libc_symlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlinkat(SB)
+-
+ GLOBL	·libc_symlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlinkat_trampoline_addr(SB)/8, $libc_symlinkat_trampoline<>(SB)
+ 
+ TEXT libc_sync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sync(SB)
+-
+ GLOBL	·libc_sync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sync_trampoline_addr(SB)/8, $libc_sync_trampoline<>(SB)
+ 
+ TEXT libc_truncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_truncate(SB)
+-
+ GLOBL	·libc_truncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_truncate_trampoline_addr(SB)/8, $libc_truncate_trampoline<>(SB)
+ 
+ TEXT libc_umask_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_umask(SB)
+-
+ GLOBL	·libc_umask_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_umask_trampoline_addr(SB)/8, $libc_umask_trampoline<>(SB)
+ 
+ TEXT libc_undelete_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_undelete(SB)
+-
+ GLOBL	·libc_undelete_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_undelete_trampoline_addr(SB)/8, $libc_undelete_trampoline<>(SB)
+ 
+ TEXT libc_unlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlink(SB)
+-
+ GLOBL	·libc_unlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlink_trampoline_addr(SB)/8, $libc_unlink_trampoline<>(SB)
+ 
+ TEXT libc_unlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlinkat(SB)
+-
+ GLOBL	·libc_unlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlinkat_trampoline_addr(SB)/8, $libc_unlinkat_trampoline<>(SB)
+ 
+ TEXT libc_unmount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unmount(SB)
+-
+ GLOBL	·libc_unmount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unmount_trampoline_addr(SB)/8, $libc_unmount_trampoline<>(SB)
+ 
+ TEXT libc_write_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_write(SB)
+-
+ GLOBL	·libc_write_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_write_trampoline_addr(SB)/8, $libc_write_trampoline<>(SB)
+ 
+ TEXT libc_mmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mmap(SB)
+-
+ GLOBL	·libc_mmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mmap_trampoline_addr(SB)/8, $libc_mmap_trampoline<>(SB)
+ 
+ TEXT libc_munmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munmap(SB)
+-
+ GLOBL	·libc_munmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munmap_trampoline_addr(SB)/8, $libc_munmap_trampoline<>(SB)
+ 
+ TEXT libc_fstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstat64(SB)
+-
+ GLOBL	·libc_fstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstat64_trampoline_addr(SB)/8, $libc_fstat64_trampoline<>(SB)
+ 
+ TEXT libc_fstatat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatat64(SB)
+-
+ GLOBL	·libc_fstatat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatat64_trampoline_addr(SB)/8, $libc_fstatat64_trampoline<>(SB)
+ 
+ TEXT libc_fstatfs64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatfs64(SB)
+-
+ GLOBL	·libc_fstatfs64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatfs64_trampoline_addr(SB)/8, $libc_fstatfs64_trampoline<>(SB)
+ 
+ TEXT libc_getfsstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getfsstat64(SB)
+-
+ GLOBL	·libc_getfsstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getfsstat64_trampoline_addr(SB)/8, $libc_getfsstat64_trampoline<>(SB)
+ 
+ TEXT libc_lstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lstat64(SB)
+-
+ GLOBL	·libc_lstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lstat64_trampoline_addr(SB)/8, $libc_lstat64_trampoline<>(SB)
+ 
+ TEXT libc_ptrace_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ptrace(SB)
+-
+ GLOBL	·libc_ptrace_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ptrace_trampoline_addr(SB)/8, $libc_ptrace_trampoline<>(SB)
+ 
+ TEXT libc_stat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_stat64(SB)
+-
+ GLOBL	·libc_stat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_stat64_trampoline_addr(SB)/8, $libc_stat64_trampoline<>(SB)
+ 
+ TEXT libc_statfs64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_statfs64(SB)
+-
+ GLOBL	·libc_statfs64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_statfs64_trampoline_addr(SB)/8, $libc_statfs64_trampoline<>(SB)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
+index 51d6f3f..b18edbd 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
+@@ -725,6 +725,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -733,10 +739,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2410,28 +2412,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_fstat_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0)
+ 	if e1 != 0 {
+@@ -2521,14 +2501,6 @@ func ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return
+ }
+ 
+-func ptrace1Ptr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	_, _, e1 := syscall_syscall6(libc_ptrace_trampoline_addr, uintptr(request), uintptr(pid), addr, uintptr(data), 0, 0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+ var libc_ptrace_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_ptrace ptrace "/usr/lib/libSystem.B.dylib"
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
+index c3b82c0..08362c1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
+@@ -5,703 +5,586 @@
+ 
+ TEXT libc_fdopendir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fdopendir(SB)
+-
+ GLOBL	·libc_fdopendir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fdopendir_trampoline_addr(SB)/8, $libc_fdopendir_trampoline<>(SB)
+ 
+ TEXT libc_getgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgroups(SB)
+-
+ GLOBL	·libc_getgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgroups_trampoline_addr(SB)/8, $libc_getgroups_trampoline<>(SB)
+ 
+ TEXT libc_setgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgroups(SB)
+-
+ GLOBL	·libc_setgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgroups_trampoline_addr(SB)/8, $libc_setgroups_trampoline<>(SB)
+ 
+ TEXT libc_wait4_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_wait4(SB)
+-
+ GLOBL	·libc_wait4_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_wait4_trampoline_addr(SB)/8, $libc_wait4_trampoline<>(SB)
+ 
+ TEXT libc_accept_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_accept(SB)
+-
+ GLOBL	·libc_accept_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_accept_trampoline_addr(SB)/8, $libc_accept_trampoline<>(SB)
+ 
+ TEXT libc_bind_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_bind(SB)
+-
+ GLOBL	·libc_bind_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_bind_trampoline_addr(SB)/8, $libc_bind_trampoline<>(SB)
+ 
+ TEXT libc_connect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_connect(SB)
+-
+ GLOBL	·libc_connect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_connect_trampoline_addr(SB)/8, $libc_connect_trampoline<>(SB)
+ 
+ TEXT libc_socket_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socket(SB)
+-
+ GLOBL	·libc_socket_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socket_trampoline_addr(SB)/8, $libc_socket_trampoline<>(SB)
+ 
+ TEXT libc_getsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockopt(SB)
+-
+ GLOBL	·libc_getsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockopt_trampoline_addr(SB)/8, $libc_getsockopt_trampoline<>(SB)
+ 
+ TEXT libc_setsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsockopt(SB)
+-
+ GLOBL	·libc_setsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsockopt_trampoline_addr(SB)/8, $libc_setsockopt_trampoline<>(SB)
+ 
+ TEXT libc_getpeername_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpeername(SB)
+-
+ GLOBL	·libc_getpeername_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpeername_trampoline_addr(SB)/8, $libc_getpeername_trampoline<>(SB)
+ 
+ TEXT libc_getsockname_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockname(SB)
+-
+ GLOBL	·libc_getsockname_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockname_trampoline_addr(SB)/8, $libc_getsockname_trampoline<>(SB)
+ 
+ TEXT libc_shutdown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shutdown(SB)
+-
+ GLOBL	·libc_shutdown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shutdown_trampoline_addr(SB)/8, $libc_shutdown_trampoline<>(SB)
+ 
+ TEXT libc_socketpair_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socketpair(SB)
+-
+ GLOBL	·libc_socketpair_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socketpair_trampoline_addr(SB)/8, $libc_socketpair_trampoline<>(SB)
+ 
+ TEXT libc_recvfrom_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvfrom(SB)
+-
+ GLOBL	·libc_recvfrom_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvfrom_trampoline_addr(SB)/8, $libc_recvfrom_trampoline<>(SB)
+ 
+ TEXT libc_sendto_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendto(SB)
+-
+ GLOBL	·libc_sendto_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendto_trampoline_addr(SB)/8, $libc_sendto_trampoline<>(SB)
+ 
+ TEXT libc_recvmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvmsg(SB)
+-
+ GLOBL	·libc_recvmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvmsg_trampoline_addr(SB)/8, $libc_recvmsg_trampoline<>(SB)
+ 
+ TEXT libc_sendmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendmsg(SB)
+-
+ GLOBL	·libc_sendmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendmsg_trampoline_addr(SB)/8, $libc_sendmsg_trampoline<>(SB)
+ 
+ TEXT libc_kevent_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kevent(SB)
+-
+ GLOBL	·libc_kevent_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kevent_trampoline_addr(SB)/8, $libc_kevent_trampoline<>(SB)
+ 
+ TEXT libc_utimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimes(SB)
+-
+ GLOBL	·libc_utimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimes_trampoline_addr(SB)/8, $libc_utimes_trampoline<>(SB)
+ 
+ TEXT libc_futimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_futimes(SB)
+-
+ GLOBL	·libc_futimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_futimes_trampoline_addr(SB)/8, $libc_futimes_trampoline<>(SB)
+ 
+ TEXT libc_poll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_poll(SB)
+-
+ GLOBL	·libc_poll_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_poll_trampoline_addr(SB)/8, $libc_poll_trampoline<>(SB)
+ 
+ TEXT libc_madvise_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_madvise(SB)
+-
+ GLOBL	·libc_madvise_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_madvise_trampoline_addr(SB)/8, $libc_madvise_trampoline<>(SB)
+ 
+ TEXT libc_mlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlock(SB)
+-
+ GLOBL	·libc_mlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlock_trampoline_addr(SB)/8, $libc_mlock_trampoline<>(SB)
+ 
+ TEXT libc_mlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlockall(SB)
+-
+ GLOBL	·libc_mlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlockall_trampoline_addr(SB)/8, $libc_mlockall_trampoline<>(SB)
+ 
+ TEXT libc_mprotect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mprotect(SB)
+-
+ GLOBL	·libc_mprotect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mprotect_trampoline_addr(SB)/8, $libc_mprotect_trampoline<>(SB)
+ 
+ TEXT libc_msync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_msync(SB)
+-
+ GLOBL	·libc_msync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_msync_trampoline_addr(SB)/8, $libc_msync_trampoline<>(SB)
+ 
+ TEXT libc_munlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlock(SB)
+-
+ GLOBL	·libc_munlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlock_trampoline_addr(SB)/8, $libc_munlock_trampoline<>(SB)
+ 
+ TEXT libc_munlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlockall(SB)
+-
+ GLOBL	·libc_munlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlockall_trampoline_addr(SB)/8, $libc_munlockall_trampoline<>(SB)
+ 
+ TEXT libc_closedir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_closedir(SB)
+-
+ GLOBL	·libc_closedir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_closedir_trampoline_addr(SB)/8, $libc_closedir_trampoline<>(SB)
+ 
+ TEXT libc_readdir_r_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readdir_r(SB)
+-
+ GLOBL	·libc_readdir_r_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readdir_r_trampoline_addr(SB)/8, $libc_readdir_r_trampoline<>(SB)
+ 
+ TEXT libc_pipe_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pipe(SB)
+-
+ GLOBL	·libc_pipe_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pipe_trampoline_addr(SB)/8, $libc_pipe_trampoline<>(SB)
+ 
+ TEXT libc_getxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getxattr(SB)
+-
+ GLOBL	·libc_getxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getxattr_trampoline_addr(SB)/8, $libc_getxattr_trampoline<>(SB)
+ 
+ TEXT libc_fgetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fgetxattr(SB)
+-
+ GLOBL	·libc_fgetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fgetxattr_trampoline_addr(SB)/8, $libc_fgetxattr_trampoline<>(SB)
+ 
+ TEXT libc_setxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setxattr(SB)
+-
+ GLOBL	·libc_setxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setxattr_trampoline_addr(SB)/8, $libc_setxattr_trampoline<>(SB)
+ 
+ TEXT libc_fsetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsetxattr(SB)
+-
+ GLOBL	·libc_fsetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsetxattr_trampoline_addr(SB)/8, $libc_fsetxattr_trampoline<>(SB)
+ 
+ TEXT libc_removexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_removexattr(SB)
+-
+ GLOBL	·libc_removexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_removexattr_trampoline_addr(SB)/8, $libc_removexattr_trampoline<>(SB)
+ 
+ TEXT libc_fremovexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fremovexattr(SB)
+-
+ GLOBL	·libc_fremovexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fremovexattr_trampoline_addr(SB)/8, $libc_fremovexattr_trampoline<>(SB)
+ 
+ TEXT libc_listxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listxattr(SB)
+-
+ GLOBL	·libc_listxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listxattr_trampoline_addr(SB)/8, $libc_listxattr_trampoline<>(SB)
+ 
+ TEXT libc_flistxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flistxattr(SB)
+-
+ GLOBL	·libc_flistxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flistxattr_trampoline_addr(SB)/8, $libc_flistxattr_trampoline<>(SB)
+ 
+ TEXT libc_utimensat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimensat(SB)
+-
+ GLOBL	·libc_utimensat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimensat_trampoline_addr(SB)/8, $libc_utimensat_trampoline<>(SB)
+ 
+ TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fcntl(SB)
+-
+ GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
+ 
+ TEXT libc_kill_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kill(SB)
+-
+ GLOBL	·libc_kill_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kill_trampoline_addr(SB)/8, $libc_kill_trampoline<>(SB)
+ 
+ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ioctl(SB)
+-
+ GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
+ 
+ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sysctl(SB)
+-
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
+ TEXT libc_sendfile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendfile(SB)
+-
+ GLOBL	·libc_sendfile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendfile_trampoline_addr(SB)/8, $libc_sendfile_trampoline<>(SB)
+ 
+ TEXT libc_shmat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmat(SB)
+-
+ GLOBL	·libc_shmat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmat_trampoline_addr(SB)/8, $libc_shmat_trampoline<>(SB)
+ 
+ TEXT libc_shmctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmctl(SB)
+-
+ GLOBL	·libc_shmctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmctl_trampoline_addr(SB)/8, $libc_shmctl_trampoline<>(SB)
+ 
+ TEXT libc_shmdt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmdt(SB)
+-
+ GLOBL	·libc_shmdt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmdt_trampoline_addr(SB)/8, $libc_shmdt_trampoline<>(SB)
+ 
+ TEXT libc_shmget_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmget(SB)
+-
+ GLOBL	·libc_shmget_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmget_trampoline_addr(SB)/8, $libc_shmget_trampoline<>(SB)
+ 
+ TEXT libc_access_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_access(SB)
+-
+ GLOBL	·libc_access_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_access_trampoline_addr(SB)/8, $libc_access_trampoline<>(SB)
+ 
+ TEXT libc_adjtime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_adjtime(SB)
+-
+ GLOBL	·libc_adjtime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_adjtime_trampoline_addr(SB)/8, $libc_adjtime_trampoline<>(SB)
+ 
+ TEXT libc_chdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chdir(SB)
+-
+ GLOBL	·libc_chdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chdir_trampoline_addr(SB)/8, $libc_chdir_trampoline<>(SB)
+ 
+ TEXT libc_chflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chflags(SB)
+-
+ GLOBL	·libc_chflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chflags_trampoline_addr(SB)/8, $libc_chflags_trampoline<>(SB)
+ 
+ TEXT libc_chmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chmod(SB)
+-
+ GLOBL	·libc_chmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chmod_trampoline_addr(SB)/8, $libc_chmod_trampoline<>(SB)
+ 
+ TEXT libc_chown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chown(SB)
+-
+ GLOBL	·libc_chown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chown_trampoline_addr(SB)/8, $libc_chown_trampoline<>(SB)
+ 
+ TEXT libc_chroot_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chroot(SB)
+-
+ GLOBL	·libc_chroot_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chroot_trampoline_addr(SB)/8, $libc_chroot_trampoline<>(SB)
+ 
+ TEXT libc_clock_gettime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clock_gettime(SB)
+-
+ GLOBL	·libc_clock_gettime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clock_gettime_trampoline_addr(SB)/8, $libc_clock_gettime_trampoline<>(SB)
+ 
+ TEXT libc_close_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_close(SB)
+-
+ GLOBL	·libc_close_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_close_trampoline_addr(SB)/8, $libc_close_trampoline<>(SB)
+ 
+ TEXT libc_clonefile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefile(SB)
+-
+ GLOBL	·libc_clonefile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefile_trampoline_addr(SB)/8, $libc_clonefile_trampoline<>(SB)
+ 
+ TEXT libc_clonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefileat(SB)
+-
+ GLOBL	·libc_clonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefileat_trampoline_addr(SB)/8, $libc_clonefileat_trampoline<>(SB)
+ 
+ TEXT libc_dup_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup(SB)
+-
+ GLOBL	·libc_dup_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup_trampoline_addr(SB)/8, $libc_dup_trampoline<>(SB)
+ 
+ TEXT libc_dup2_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup2(SB)
+-
+ GLOBL	·libc_dup2_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup2_trampoline_addr(SB)/8, $libc_dup2_trampoline<>(SB)
+ 
+ TEXT libc_exchangedata_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exchangedata(SB)
+-
+ GLOBL	·libc_exchangedata_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exchangedata_trampoline_addr(SB)/8, $libc_exchangedata_trampoline<>(SB)
+ 
+ TEXT libc_exit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exit(SB)
+-
+ GLOBL	·libc_exit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exit_trampoline_addr(SB)/8, $libc_exit_trampoline<>(SB)
+ 
+ TEXT libc_faccessat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_faccessat(SB)
+-
+ GLOBL	·libc_faccessat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_faccessat_trampoline_addr(SB)/8, $libc_faccessat_trampoline<>(SB)
+ 
+ TEXT libc_fchdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchdir(SB)
+-
+ GLOBL	·libc_fchdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchdir_trampoline_addr(SB)/8, $libc_fchdir_trampoline<>(SB)
+ 
+ TEXT libc_fchflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchflags(SB)
+-
+ GLOBL	·libc_fchflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchflags_trampoline_addr(SB)/8, $libc_fchflags_trampoline<>(SB)
+ 
+ TEXT libc_fchmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmod(SB)
+-
+ GLOBL	·libc_fchmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmod_trampoline_addr(SB)/8, $libc_fchmod_trampoline<>(SB)
+ 
+ TEXT libc_fchmodat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmodat(SB)
+-
+ GLOBL	·libc_fchmodat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmodat_trampoline_addr(SB)/8, $libc_fchmodat_trampoline<>(SB)
+ 
+ TEXT libc_fchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchown(SB)
+-
+ GLOBL	·libc_fchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchown_trampoline_addr(SB)/8, $libc_fchown_trampoline<>(SB)
+ 
+ TEXT libc_fchownat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchownat(SB)
+-
+ GLOBL	·libc_fchownat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchownat_trampoline_addr(SB)/8, $libc_fchownat_trampoline<>(SB)
+ 
+ TEXT libc_fclonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fclonefileat(SB)
+-
+ GLOBL	·libc_fclonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fclonefileat_trampoline_addr(SB)/8, $libc_fclonefileat_trampoline<>(SB)
+ 
+ TEXT libc_flock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flock(SB)
+-
+ GLOBL	·libc_flock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flock_trampoline_addr(SB)/8, $libc_flock_trampoline<>(SB)
+ 
+ TEXT libc_fpathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fpathconf(SB)
+-
+ GLOBL	·libc_fpathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fpathconf_trampoline_addr(SB)/8, $libc_fpathconf_trampoline<>(SB)
+ 
+ TEXT libc_fsync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsync(SB)
+-
+ GLOBL	·libc_fsync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsync_trampoline_addr(SB)/8, $libc_fsync_trampoline<>(SB)
+ 
+ TEXT libc_ftruncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ftruncate(SB)
+-
+ GLOBL	·libc_ftruncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ftruncate_trampoline_addr(SB)/8, $libc_ftruncate_trampoline<>(SB)
+ 
+ TEXT libc_getcwd_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getcwd(SB)
+-
+ GLOBL	·libc_getcwd_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getcwd_trampoline_addr(SB)/8, $libc_getcwd_trampoline<>(SB)
+ 
+ TEXT libc_getdtablesize_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getdtablesize(SB)
+-
+ GLOBL	·libc_getdtablesize_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getdtablesize_trampoline_addr(SB)/8, $libc_getdtablesize_trampoline<>(SB)
+ 
+ TEXT libc_getegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getegid(SB)
+-
+ GLOBL	·libc_getegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getegid_trampoline_addr(SB)/8, $libc_getegid_trampoline<>(SB)
+ 
+ TEXT libc_geteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_geteuid(SB)
+-
+ GLOBL	·libc_geteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_geteuid_trampoline_addr(SB)/8, $libc_geteuid_trampoline<>(SB)
+ 
+ TEXT libc_getgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgid(SB)
+-
+ GLOBL	·libc_getgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgid_trampoline_addr(SB)/8, $libc_getgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgid(SB)
+-
+ GLOBL	·libc_getpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgid_trampoline_addr(SB)/8, $libc_getpgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgrp_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgrp(SB)
+-
+ GLOBL	·libc_getpgrp_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgrp_trampoline_addr(SB)/8, $libc_getpgrp_trampoline<>(SB)
+ 
+ TEXT libc_getpid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpid(SB)
+-
+ GLOBL	·libc_getpid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpid_trampoline_addr(SB)/8, $libc_getpid_trampoline<>(SB)
+ 
+ TEXT libc_getppid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getppid(SB)
+-
+ GLOBL	·libc_getppid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getppid_trampoline_addr(SB)/8, $libc_getppid_trampoline<>(SB)
+ 
+ TEXT libc_getpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpriority(SB)
+-
+ GLOBL	·libc_getpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpriority_trampoline_addr(SB)/8, $libc_getpriority_trampoline<>(SB)
+ 
+ TEXT libc_getrlimit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrlimit(SB)
+-
+ GLOBL	·libc_getrlimit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrlimit_trampoline_addr(SB)/8, $libc_getrlimit_trampoline<>(SB)
+ 
+ TEXT libc_getrusage_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrusage(SB)
+-
+ GLOBL	·libc_getrusage_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrusage_trampoline_addr(SB)/8, $libc_getrusage_trampoline<>(SB)
+ 
+ TEXT libc_getsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsid(SB)
+-
+ GLOBL	·libc_getsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsid_trampoline_addr(SB)/8, $libc_getsid_trampoline<>(SB)
+ 
+ TEXT libc_gettimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_gettimeofday(SB)
+-
+ GLOBL	·libc_gettimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_gettimeofday_trampoline_addr(SB)/8, $libc_gettimeofday_trampoline<>(SB)
+ 
+ TEXT libc_getuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getuid(SB)
+-
+ GLOBL	·libc_getuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getuid_trampoline_addr(SB)/8, $libc_getuid_trampoline<>(SB)
+ 
+ TEXT libc_issetugid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_issetugid(SB)
+-
+ GLOBL	·libc_issetugid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_issetugid_trampoline_addr(SB)/8, $libc_issetugid_trampoline<>(SB)
+ 
+ TEXT libc_kqueue_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kqueue(SB)
+-
+ GLOBL	·libc_kqueue_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kqueue_trampoline_addr(SB)/8, $libc_kqueue_trampoline<>(SB)
+ 
+ TEXT libc_lchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lchown(SB)
+-
+ GLOBL	·libc_lchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lchown_trampoline_addr(SB)/8, $libc_lchown_trampoline<>(SB)
+ 
+ TEXT libc_link_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_link(SB)
+-
+ GLOBL	·libc_link_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_link_trampoline_addr(SB)/8, $libc_link_trampoline<>(SB)
+ 
+ TEXT libc_linkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_linkat(SB)
+-
+ GLOBL	·libc_linkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_linkat_trampoline_addr(SB)/8, $libc_linkat_trampoline<>(SB)
+ 
+ TEXT libc_listen_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listen(SB)
+-
+ GLOBL	·libc_listen_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listen_trampoline_addr(SB)/8, $libc_listen_trampoline<>(SB)
+ 
+ TEXT libc_mkdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdir(SB)
+-
+ GLOBL	·libc_mkdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdir_trampoline_addr(SB)/8, $libc_mkdir_trampoline<>(SB)
+ 
+ TEXT libc_mkdirat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdirat(SB)
+-
+ GLOBL	·libc_mkdirat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdirat_trampoline_addr(SB)/8, $libc_mkdirat_trampoline<>(SB)
+ 
+ TEXT libc_mkfifo_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkfifo(SB)
+-
+ GLOBL	·libc_mkfifo_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkfifo_trampoline_addr(SB)/8, $libc_mkfifo_trampoline<>(SB)
+ 
+ TEXT libc_mknod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mknod(SB)
+-
+ GLOBL	·libc_mknod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mknod_trampoline_addr(SB)/8, $libc_mknod_trampoline<>(SB)
+ 
+ TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mount(SB)
+-
+ GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mount_trampoline_addr(SB)/8, $libc_mount_trampoline<>(SB)
+ 
+ TEXT libc_open_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_open(SB)
+-
+ GLOBL	·libc_open_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_open_trampoline_addr(SB)/8, $libc_open_trampoline<>(SB)
+ 
+ TEXT libc_openat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_openat(SB)
+-
+ GLOBL	·libc_openat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_openat_trampoline_addr(SB)/8, $libc_openat_trampoline<>(SB)
+ 
+ TEXT libc_pathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pathconf(SB)
+-
+ GLOBL	·libc_pathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pathconf_trampoline_addr(SB)/8, $libc_pathconf_trampoline<>(SB)
+ 
+ TEXT libc_pread_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pread(SB)
+-
+ GLOBL	·libc_pread_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pread_trampoline_addr(SB)/8, $libc_pread_trampoline<>(SB)
+ 
+ TEXT libc_pwrite_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pwrite(SB)
+-
+ GLOBL	·libc_pwrite_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pwrite_trampoline_addr(SB)/8, $libc_pwrite_trampoline<>(SB)
+ 
+ TEXT libc_read_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_read(SB)
+-
+ GLOBL	·libc_read_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_read_trampoline_addr(SB)/8, $libc_read_trampoline<>(SB)
+ 
+ TEXT libc_readlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlink(SB)
+-
+ GLOBL	·libc_readlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlink_trampoline_addr(SB)/8, $libc_readlink_trampoline<>(SB)
+ 
+ TEXT libc_readlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlinkat(SB)
+-
+ GLOBL	·libc_readlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlinkat_trampoline_addr(SB)/8, $libc_readlinkat_trampoline<>(SB)
+ 
+ TEXT libc_rename_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rename(SB)
+-
+ GLOBL	·libc_rename_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rename_trampoline_addr(SB)/8, $libc_rename_trampoline<>(SB)
+ 
+ TEXT libc_renameat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_renameat(SB)
+-
+ GLOBL	·libc_renameat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_renameat_trampoline_addr(SB)/8, $libc_renameat_trampoline<>(SB)
+ 
+ TEXT libc_revoke_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_revoke(SB)
+-
+ GLOBL	·libc_revoke_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_revoke_trampoline_addr(SB)/8, $libc_revoke_trampoline<>(SB)
+ 
+ TEXT libc_rmdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rmdir(SB)
+-
+ GLOBL	·libc_rmdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rmdir_trampoline_addr(SB)/8, $libc_rmdir_trampoline<>(SB)
+ 
+ TEXT libc_lseek_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lseek(SB)
+-
+ GLOBL	·libc_lseek_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lseek_trampoline_addr(SB)/8, $libc_lseek_trampoline<>(SB)
+ 
+ TEXT libc_select_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_select(SB)
+-
+ GLOBL	·libc_select_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_select_trampoline_addr(SB)/8, $libc_select_trampoline<>(SB)
+ 
+@@ -712,192 +595,160 @@ DATA	·libc_setattrlist_trampoline_addr(SB)/8, $libc_setattrlist_trampoline<>(SB
+ 
+ TEXT libc_setegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setegid(SB)
+-
+ GLOBL	·libc_setegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setegid_trampoline_addr(SB)/8, $libc_setegid_trampoline<>(SB)
+ 
+ TEXT libc_seteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_seteuid(SB)
+-
+ GLOBL	·libc_seteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_seteuid_trampoline_addr(SB)/8, $libc_seteuid_trampoline<>(SB)
+ 
+ TEXT libc_setgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgid(SB)
+-
+ GLOBL	·libc_setgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgid_trampoline_addr(SB)/8, $libc_setgid_trampoline<>(SB)
+ 
+ TEXT libc_setlogin_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setlogin(SB)
+-
+ GLOBL	·libc_setlogin_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setlogin_trampoline_addr(SB)/8, $libc_setlogin_trampoline<>(SB)
+ 
+ TEXT libc_setpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpgid(SB)
+-
+ GLOBL	·libc_setpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpgid_trampoline_addr(SB)/8, $libc_setpgid_trampoline<>(SB)
+ 
+ TEXT libc_setpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpriority(SB)
+-
+ GLOBL	·libc_setpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpriority_trampoline_addr(SB)/8, $libc_setpriority_trampoline<>(SB)
+ 
+ TEXT libc_setprivexec_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setprivexec(SB)
+-
+ GLOBL	·libc_setprivexec_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setprivexec_trampoline_addr(SB)/8, $libc_setprivexec_trampoline<>(SB)
+ 
+ TEXT libc_setregid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setregid(SB)
+-
+ GLOBL	·libc_setregid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setregid_trampoline_addr(SB)/8, $libc_setregid_trampoline<>(SB)
+ 
+ TEXT libc_setreuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setreuid(SB)
+-
+ GLOBL	·libc_setreuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setreuid_trampoline_addr(SB)/8, $libc_setreuid_trampoline<>(SB)
+ 
+ TEXT libc_setsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsid(SB)
+-
+ GLOBL	·libc_setsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsid_trampoline_addr(SB)/8, $libc_setsid_trampoline<>(SB)
+ 
+ TEXT libc_settimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_settimeofday(SB)
+-
+ GLOBL	·libc_settimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_settimeofday_trampoline_addr(SB)/8, $libc_settimeofday_trampoline<>(SB)
+ 
+ TEXT libc_setuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setuid(SB)
+-
+ GLOBL	·libc_setuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setuid_trampoline_addr(SB)/8, $libc_setuid_trampoline<>(SB)
+ 
+ TEXT libc_symlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlink(SB)
+-
+ GLOBL	·libc_symlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlink_trampoline_addr(SB)/8, $libc_symlink_trampoline<>(SB)
+ 
+ TEXT libc_symlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlinkat(SB)
+-
+ GLOBL	·libc_symlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlinkat_trampoline_addr(SB)/8, $libc_symlinkat_trampoline<>(SB)
+ 
+ TEXT libc_sync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sync(SB)
+-
+ GLOBL	·libc_sync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sync_trampoline_addr(SB)/8, $libc_sync_trampoline<>(SB)
+ 
+ TEXT libc_truncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_truncate(SB)
+-
+ GLOBL	·libc_truncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_truncate_trampoline_addr(SB)/8, $libc_truncate_trampoline<>(SB)
+ 
+ TEXT libc_umask_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_umask(SB)
+-
+ GLOBL	·libc_umask_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_umask_trampoline_addr(SB)/8, $libc_umask_trampoline<>(SB)
+ 
+ TEXT libc_undelete_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_undelete(SB)
+-
+ GLOBL	·libc_undelete_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_undelete_trampoline_addr(SB)/8, $libc_undelete_trampoline<>(SB)
+ 
+ TEXT libc_unlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlink(SB)
+-
+ GLOBL	·libc_unlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlink_trampoline_addr(SB)/8, $libc_unlink_trampoline<>(SB)
+ 
+ TEXT libc_unlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlinkat(SB)
+-
+ GLOBL	·libc_unlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlinkat_trampoline_addr(SB)/8, $libc_unlinkat_trampoline<>(SB)
+ 
+ TEXT libc_unmount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unmount(SB)
+-
+ GLOBL	·libc_unmount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unmount_trampoline_addr(SB)/8, $libc_unmount_trampoline<>(SB)
+ 
+ TEXT libc_write_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_write(SB)
+-
+ GLOBL	·libc_write_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_write_trampoline_addr(SB)/8, $libc_write_trampoline<>(SB)
+ 
+ TEXT libc_mmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mmap(SB)
+-
+ GLOBL	·libc_mmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mmap_trampoline_addr(SB)/8, $libc_mmap_trampoline<>(SB)
+ 
+ TEXT libc_munmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munmap(SB)
+-
+ GLOBL	·libc_munmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munmap_trampoline_addr(SB)/8, $libc_munmap_trampoline<>(SB)
+ 
+ TEXT libc_fstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstat(SB)
+-
+ GLOBL	·libc_fstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstat_trampoline_addr(SB)/8, $libc_fstat_trampoline<>(SB)
+ 
+ TEXT libc_fstatat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatat(SB)
+-
+ GLOBL	·libc_fstatat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatat_trampoline_addr(SB)/8, $libc_fstatat_trampoline<>(SB)
+ 
+ TEXT libc_fstatfs_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatfs(SB)
+-
+ GLOBL	·libc_fstatfs_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatfs_trampoline_addr(SB)/8, $libc_fstatfs_trampoline<>(SB)
+ 
+ TEXT libc_getfsstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getfsstat(SB)
+-
+ GLOBL	·libc_getfsstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getfsstat_trampoline_addr(SB)/8, $libc_getfsstat_trampoline<>(SB)
+ 
+ TEXT libc_lstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lstat(SB)
+-
+ GLOBL	·libc_lstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lstat_trampoline_addr(SB)/8, $libc_lstat_trampoline<>(SB)
+ 
+ TEXT libc_ptrace_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ptrace(SB)
+-
+ GLOBL	·libc_ptrace_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ptrace_trampoline_addr(SB)/8, $libc_ptrace_trampoline<>(SB)
+ 
+ TEXT libc_stat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_stat(SB)
+-
+ GLOBL	·libc_stat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_stat_trampoline_addr(SB)/8, $libc_stat_trampoline<>(SB)
+ 
+ TEXT libc_statfs_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_statfs(SB)
+-
+ GLOBL	·libc_statfs_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_statfs_trampoline_addr(SB)/8, $libc_statfs_trampoline<>(SB)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
+index 0eabac7..0c67df6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
+@@ -1642,28 +1642,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
+index ee313eb..e6e05d1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
+index 4c986e4..7508acc 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
+index 5552169..7b56aea 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
+index 67a226f..cc623dc 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
+index f0b9dda..5818491 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
+index b57c705..6be25cd 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
+@@ -40,7 +40,7 @@ func readv(fd int, iovs []Iovec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procreadv)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -55,7 +55,7 @@ func preadv(fd int, iovs []Iovec, off int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpreadv)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), uintptr(off), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -70,7 +70,7 @@ func writev(fd int, iovs []Iovec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwritev)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -85,7 +85,7 @@ func pwritev(fd int, iovs []Iovec, off int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpwritev)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), uintptr(off), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -96,7 +96,7 @@ func accept4(s int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (fd int,
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procaccept4)), 4, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index 7ceec23..8e5cee2 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -1734,28 +1734,6 @@ func exitThread(code int) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(p)), uintptr(np))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(p)), uintptr(np))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func readv(fd int, iovs []Iovec) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(iovs) > 0 {
+@@ -2197,3 +2175,23 @@ func getresgid(rgid *_C_int, egid *_C_int, sgid *_C_int) {
+ 	RawSyscallNoError(SYS_GETRESGID, uintptr(unsafe.Pointer(rgid)), uintptr(unsafe.Pointer(egid)), uintptr(unsafe.Pointer(sgid)))
+ 	return
+ }
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func schedSetattr(pid int, attr *SchedAttr, flags uint) (err error) {
++	_, _, e1 := Syscall(SYS_SCHED_SETATTR, uintptr(pid), uintptr(unsafe.Pointer(attr)), uintptr(flags))
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func schedGetattr(pid int, attr *SchedAttr, size uint, flags uint) (err error) {
++	_, _, e1 := Syscall6(SYS_SCHED_GETATTR, uintptr(pid), uintptr(unsafe.Pointer(attr)), uintptr(size), uintptr(flags), 0, 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
+index cdb2af5..af06b23 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
+index 9d25f76..093fcf3 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
+index d3f8035..4a78567 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
+index 887188a..741d8be 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index 9ab9abf..66b3b64 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index 915761e..c5c4cc1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -2213,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index 8e87fdf..93bfbb3 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 12a7a21..a107b8f 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index b19e8aa..c427de5 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index fb99594..60c1a99 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index 32cbbbc..52eba36 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
+index 609d1c5..b401894 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
+@@ -436,7 +436,7 @@ func pipe(p *[2]_C_int) (n int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procpipe)), 1, uintptr(unsafe.Pointer(p)), 0, 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -446,7 +446,7 @@ func pipe(p *[2]_C_int) (n int, err error) {
+ func pipe2(p *[2]_C_int, flags int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procpipe2)), 2, uintptr(unsafe.Pointer(p)), uintptr(flags), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -456,7 +456,7 @@ func pipe2(p *[2]_C_int, flags int) (err error) {
+ func getsockname(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgetsockname)), 3, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -471,7 +471,7 @@ func Getcwd(buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetcwd)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -482,7 +482,7 @@ func getgroups(ngid int, gid *_Gid_t) (n int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procgetgroups)), 2, uintptr(ngid), uintptr(unsafe.Pointer(gid)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -492,7 +492,7 @@ func getgroups(ngid int, gid *_Gid_t) (n int, err error) {
+ func setgroups(ngid int, gid *_Gid_t) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procsetgroups)), 2, uintptr(ngid), uintptr(unsafe.Pointer(gid)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -503,7 +503,7 @@ func wait4(pid int32, statusp *_C_int, options int, rusage *Rusage) (wpid int32,
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwait4)), 4, uintptr(pid), uintptr(unsafe.Pointer(statusp)), uintptr(options), uintptr(unsafe.Pointer(rusage)), 0, 0)
+ 	wpid = int32(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -518,7 +518,7 @@ func gethostname(buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgethostname)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -533,7 +533,7 @@ func utimes(path string, times *[2]Timeval) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procutimes)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(times)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -548,7 +548,7 @@ func utimensat(fd int, path string, times *[2]Timespec, flag int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procutimensat)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(times)), uintptr(flag), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -559,7 +559,7 @@ func fcntl(fd int, cmd int, arg int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procfcntl)), 3, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -569,7 +569,7 @@ func fcntl(fd int, cmd int, arg int) (val int, err error) {
+ func futimesat(fildes int, path *byte, times *[2]Timeval) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procfutimesat)), 3, uintptr(fildes), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(times)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -580,7 +580,7 @@ func accept(s int, rsa *RawSockaddrAny, addrlen *_Socklen) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procaccept)), 3, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -591,7 +591,7 @@ func recvmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_recvmsg)), 3, uintptr(s), uintptr(unsafe.Pointer(msg)), uintptr(flags), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -602,7 +602,7 @@ func sendmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_sendmsg)), 3, uintptr(s), uintptr(unsafe.Pointer(msg)), uintptr(flags), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -612,7 +612,7 @@ func sendmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ func acct(path *byte) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procacct)), 1, uintptr(unsafe.Pointer(path)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -647,7 +647,7 @@ func ioctlRet(fd int, req int, arg uintptr) (ret int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, uintptr(fd), uintptr(req), uintptr(arg), 0, 0, 0)
+ 	ret = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -658,7 +658,7 @@ func ioctlPtrRet(fd int, req int, arg unsafe.Pointer) (ret int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, uintptr(fd), uintptr(req), uintptr(arg), 0, 0, 0)
+ 	ret = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -669,7 +669,7 @@ func poll(fds *PollFd, nfds int, timeout int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpoll)), 3, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(timeout), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -684,7 +684,7 @@ func Access(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procAccess)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -694,7 +694,7 @@ func Access(path string, mode uint32) (err error) {
+ func Adjtime(delta *Timeval, olddelta *Timeval) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procAdjtime)), 2, uintptr(unsafe.Pointer(delta)), uintptr(unsafe.Pointer(olddelta)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -709,7 +709,7 @@ func Chdir(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChdir)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -724,7 +724,7 @@ func Chmod(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChmod)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -739,7 +739,7 @@ func Chown(path string, uid int, gid int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChown)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -754,7 +754,7 @@ func Chroot(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChroot)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -764,7 +764,7 @@ func Chroot(path string) (err error) {
+ func ClockGettime(clockid int32, time *Timespec) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procClockGettime)), 2, uintptr(clockid), uintptr(unsafe.Pointer(time)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -774,7 +774,7 @@ func ClockGettime(clockid int32, time *Timespec) (err error) {
+ func Close(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procClose)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -790,7 +790,7 @@ func Creat(path string, mode uint32) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procCreat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -801,7 +801,7 @@ func Dup(fd int) (nfd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procDup)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	nfd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -811,7 +811,7 @@ func Dup(fd int) (nfd int, err error) {
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procDup2)), 2, uintptr(oldfd), uintptr(newfd), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -833,7 +833,7 @@ func Faccessat(dirfd int, path string, mode uint32, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFaccessat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -843,7 +843,7 @@ func Faccessat(dirfd int, path string, mode uint32, flags int) (err error) {
+ func Fchdir(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchdir)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -853,7 +853,7 @@ func Fchdir(fd int) (err error) {
+ func Fchmod(fd int, mode uint32) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchmod)), 2, uintptr(fd), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -868,7 +868,7 @@ func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchmodat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -878,7 +878,7 @@ func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+ func Fchown(fd int, uid int, gid int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchown)), 3, uintptr(fd), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -893,7 +893,7 @@ func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchownat)), 5, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), uintptr(flags), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -903,7 +903,7 @@ func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
+ func Fdatasync(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFdatasync)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -913,7 +913,7 @@ func Fdatasync(fd int) (err error) {
+ func Flock(fd int, how int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFlock)), 2, uintptr(fd), uintptr(how), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -924,7 +924,7 @@ func Fpathconf(fd int, name int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFpathconf)), 2, uintptr(fd), uintptr(name), 0, 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -934,7 +934,7 @@ func Fpathconf(fd int, name int) (val int, err error) {
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstat)), 2, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -949,7 +949,7 @@ func Fstatat(fd int, path string, stat *Stat_t, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstatat)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -959,7 +959,7 @@ func Fstatat(fd int, path string, stat *Stat_t, flags int) (err error) {
+ func Fstatvfs(fd int, vfsstat *Statvfs_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstatvfs)), 2, uintptr(fd), uintptr(unsafe.Pointer(vfsstat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -974,7 +974,7 @@ func Getdents(fd int, buf []byte, basep *uintptr) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetdents)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(basep)), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1001,7 +1001,7 @@ func Getpgid(pid int) (pgid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetpgid)), 1, uintptr(pid), 0, 0, 0, 0, 0)
+ 	pgid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1012,7 +1012,7 @@ func Getpgrp() (pgid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetpgrp)), 0, 0, 0, 0, 0, 0, 0)
+ 	pgid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1047,7 +1047,7 @@ func Getpriority(which int, who int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetpriority)), 2, uintptr(which), uintptr(who), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1057,7 +1057,7 @@ func Getpriority(which int, who int) (n int, err error) {
+ func Getrlimit(which int, lim *Rlimit) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetrlimit)), 2, uintptr(which), uintptr(unsafe.Pointer(lim)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1067,7 +1067,7 @@ func Getrlimit(which int, lim *Rlimit) (err error) {
+ func Getrusage(who int, rusage *Rusage) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetrusage)), 2, uintptr(who), uintptr(unsafe.Pointer(rusage)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1078,7 +1078,7 @@ func Getsid(pid int) (sid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetsid)), 1, uintptr(pid), 0, 0, 0, 0, 0)
+ 	sid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1088,7 +1088,7 @@ func Getsid(pid int) (sid int, err error) {
+ func Gettimeofday(tv *Timeval) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGettimeofday)), 1, uintptr(unsafe.Pointer(tv)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1106,7 +1106,7 @@ func Getuid() (uid int) {
+ func Kill(pid int, signum syscall.Signal) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procKill)), 2, uintptr(pid), uintptr(signum), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1121,7 +1121,7 @@ func Lchown(path string, uid int, gid int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLchown)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1141,7 +1141,7 @@ func Link(path string, link string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLink)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1151,7 +1151,7 @@ func Link(path string, link string) (err error) {
+ func Listen(s int, backlog int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_llisten)), 2, uintptr(s), uintptr(backlog), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1166,7 +1166,7 @@ func Lstat(path string, stat *Stat_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLstat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1180,7 +1180,7 @@ func Madvise(b []byte, advice int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMadvise)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(advice), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1195,7 +1195,7 @@ func Mkdir(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkdir)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1210,7 +1210,7 @@ func Mkdirat(dirfd int, path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkdirat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1225,7 +1225,7 @@ func Mkfifo(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkfifo)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1240,7 +1240,7 @@ func Mkfifoat(dirfd int, path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkfifoat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1255,7 +1255,7 @@ func Mknod(path string, mode uint32, dev int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMknod)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(dev), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1270,7 +1270,7 @@ func Mknodat(dirfd int, path string, mode uint32, dev int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMknodat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(dev), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1284,7 +1284,7 @@ func Mlock(b []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMlock)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1294,7 +1294,7 @@ func Mlock(b []byte) (err error) {
+ func Mlockall(flags int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMlockall)), 1, uintptr(flags), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1308,7 +1308,7 @@ func Mprotect(b []byte, prot int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMprotect)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(prot), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1322,7 +1322,7 @@ func Msync(b []byte, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMsync)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(flags), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1336,7 +1336,7 @@ func Munlock(b []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMunlock)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1346,7 +1346,7 @@ func Munlock(b []byte) (err error) {
+ func Munlockall() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMunlockall)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1356,7 +1356,7 @@ func Munlockall() (err error) {
+ func Nanosleep(time *Timespec, leftover *Timespec) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procNanosleep)), 2, uintptr(unsafe.Pointer(time)), uintptr(unsafe.Pointer(leftover)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1372,7 +1372,7 @@ func Open(path string, mode int, perm uint32) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procOpen)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(perm), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1388,7 +1388,7 @@ func Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error)
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procOpenat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(flags), uintptr(mode), 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1404,7 +1404,7 @@ func Pathconf(path string, name int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procPathconf)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(name), 0, 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1414,7 +1414,7 @@ func Pathconf(path string, name int) (val int, err error) {
+ func Pause() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procPause)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1429,7 +1429,7 @@ func pread(fd int, p []byte, offset int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpread)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(offset), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1444,7 +1444,7 @@ func pwrite(fd int, p []byte, offset int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpwrite)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(offset), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1459,7 +1459,7 @@ func read(fd int, p []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procread)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1479,7 +1479,7 @@ func Readlink(path string, buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procReadlink)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), uintptr(len(buf)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1499,7 +1499,7 @@ func Rename(from string, to string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRename)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1519,7 +1519,7 @@ func Renameat(olddirfd int, oldpath string, newdirfd int, newpath string) (err e
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRenameat)), 4, uintptr(olddirfd), uintptr(unsafe.Pointer(_p0)), uintptr(newdirfd), uintptr(unsafe.Pointer(_p1)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1534,7 +1534,7 @@ func Rmdir(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRmdir)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1545,7 +1545,7 @@ func Seek(fd int, offset int64, whence int) (newoffset int64, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proclseek)), 3, uintptr(fd), uintptr(offset), uintptr(whence), 0, 0, 0)
+ 	newoffset = int64(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1556,7 +1556,7 @@ func Select(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timeval) (n int, err
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSelect)), 5, uintptr(nfd), uintptr(unsafe.Pointer(r)), uintptr(unsafe.Pointer(w)), uintptr(unsafe.Pointer(e)), uintptr(unsafe.Pointer(timeout)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1566,7 +1566,7 @@ func Select(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timeval) (n int, err
+ func Setegid(egid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetegid)), 1, uintptr(egid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1576,7 +1576,7 @@ func Setegid(egid int) (err error) {
+ func Seteuid(euid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSeteuid)), 1, uintptr(euid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1586,7 +1586,7 @@ func Seteuid(euid int) (err error) {
+ func Setgid(gid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetgid)), 1, uintptr(gid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1600,7 +1600,7 @@ func Sethostname(p []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSethostname)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1610,7 +1610,7 @@ func Sethostname(p []byte) (err error) {
+ func Setpgid(pid int, pgid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetpgid)), 2, uintptr(pid), uintptr(pgid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1620,7 +1620,7 @@ func Setpgid(pid int, pgid int) (err error) {
+ func Setpriority(which int, who int, prio int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSetpriority)), 3, uintptr(which), uintptr(who), uintptr(prio), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1630,7 +1630,7 @@ func Setpriority(which int, who int, prio int) (err error) {
+ func Setregid(rgid int, egid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetregid)), 2, uintptr(rgid), uintptr(egid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1640,7 +1640,7 @@ func Setregid(rgid int, egid int) (err error) {
+ func Setreuid(ruid int, euid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetreuid)), 2, uintptr(ruid), uintptr(euid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1651,7 +1651,7 @@ func Setsid() (pid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetsid)), 0, 0, 0, 0, 0, 0, 0)
+ 	pid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1661,7 +1661,7 @@ func Setsid() (pid int, err error) {
+ func Setuid(uid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetuid)), 1, uintptr(uid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1671,7 +1671,7 @@ func Setuid(uid int) (err error) {
+ func Shutdown(s int, how int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procshutdown)), 2, uintptr(s), uintptr(how), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1686,7 +1686,7 @@ func Stat(path string, stat *Stat_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procStat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1701,7 +1701,7 @@ func Statvfs(path string, vfsstat *Statvfs_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procStatvfs)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(vfsstat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1721,7 +1721,7 @@ func Symlink(path string, link string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSymlink)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1731,7 +1731,7 @@ func Symlink(path string, link string) (err error) {
+ func Sync() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSync)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1742,7 +1742,7 @@ func Sysconf(which int) (n int64, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSysconf)), 1, uintptr(which), 0, 0, 0, 0, 0)
+ 	n = int64(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1753,7 +1753,7 @@ func Times(tms *Tms) (ticks uintptr, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procTimes)), 1, uintptr(unsafe.Pointer(tms)), 0, 0, 0, 0, 0)
+ 	ticks = uintptr(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1768,7 +1768,7 @@ func Truncate(path string, length int64) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procTruncate)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1778,7 +1778,7 @@ func Truncate(path string, length int64) (err error) {
+ func Fsync(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFsync)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1788,7 +1788,7 @@ func Fsync(fd int) (err error) {
+ func Ftruncate(fd int, length int64) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFtruncate)), 2, uintptr(fd), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1806,7 +1806,7 @@ func Umask(mask int) (oldmask int) {
+ func Uname(buf *Utsname) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procUname)), 1, uintptr(unsafe.Pointer(buf)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1821,7 +1821,7 @@ func Unmount(target string, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procumount)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(flags), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1836,7 +1836,7 @@ func Unlink(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUnlink)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1851,7 +1851,7 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUnlinkat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(flags), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1861,7 +1861,7 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
+ func Ustat(dev int, ubuf *Ustat_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUstat)), 2, uintptr(dev), uintptr(unsafe.Pointer(ubuf)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1876,7 +1876,7 @@ func Utime(path string, buf *Utimbuf) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUtime)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(buf)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1886,7 +1886,7 @@ func Utime(path string, buf *Utimbuf) (err error) {
+ func bind(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_bind)), 3, uintptr(s), uintptr(addr), uintptr(addrlen), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1896,7 +1896,7 @@ func bind(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ func connect(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_connect)), 3, uintptr(s), uintptr(addr), uintptr(addrlen), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1907,7 +1907,7 @@ func mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procmmap)), 6, uintptr(addr), uintptr(length), uintptr(prot), uintptr(flag), uintptr(fd), uintptr(pos))
+ 	ret = uintptr(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1917,7 +1917,7 @@ func mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (
+ func munmap(addr uintptr, length uintptr) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procmunmap)), 2, uintptr(addr), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1928,7 +1928,7 @@ func sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procsendfile)), 4, uintptr(outfd), uintptr(infd), uintptr(unsafe.Pointer(offset)), uintptr(count), 0, 0)
+ 	written = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1942,7 +1942,7 @@ func sendto(s int, buf []byte, flags int, to unsafe.Pointer, addrlen _Socklen) (
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_sendto)), 6, uintptr(s), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(flags), uintptr(to), uintptr(addrlen))
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1953,7 +1953,7 @@ func socket(domain int, typ int, proto int) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_socket)), 3, uintptr(domain), uintptr(typ), uintptr(proto), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1963,7 +1963,7 @@ func socket(domain int, typ int, proto int) (fd int, err error) {
+ func socketpair(domain int, typ int, proto int, fd *[2]int32) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&proc__xnet_socketpair)), 4, uintptr(domain), uintptr(typ), uintptr(proto), uintptr(unsafe.Pointer(fd)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1978,7 +1978,7 @@ func write(fd int, p []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwrite)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1988,7 +1988,7 @@ func write(fd int, p []byte) (n int, err error) {
+ func getsockopt(s int, level int, name int, val unsafe.Pointer, vallen *_Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_getsockopt)), 5, uintptr(s), uintptr(level), uintptr(name), uintptr(val), uintptr(unsafe.Pointer(vallen)), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1998,7 +1998,7 @@ func getsockopt(s int, level int, name int, val unsafe.Pointer, vallen *_Socklen
+ func getpeername(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procgetpeername)), 3, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2008,7 +2008,7 @@ func getpeername(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ func setsockopt(s int, level int, name int, val unsafe.Pointer, vallen uintptr) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procsetsockopt)), 5, uintptr(s), uintptr(level), uintptr(name), uintptr(val), uintptr(vallen), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2023,7 +2023,7 @@ func recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Sockl
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procrecvfrom)), 6, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(flags), uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(fromlen)))
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2034,7 +2034,7 @@ func port_create() (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_create)), 0, 0, 0, 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2045,7 +2045,7 @@ func port_associate(port int, source int, object uintptr, events int, user *byte
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_associate)), 5, uintptr(port), uintptr(source), uintptr(object), uintptr(events), uintptr(unsafe.Pointer(user)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2056,7 +2056,7 @@ func port_dissociate(port int, source int, object uintptr) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_dissociate)), 3, uintptr(port), uintptr(source), uintptr(object), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2067,7 +2067,7 @@ func port_get(port int, pe *portEvent, timeout *Timespec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_get)), 3, uintptr(port), uintptr(unsafe.Pointer(pe)), uintptr(unsafe.Pointer(timeout)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2078,7 +2078,7 @@ func port_getn(port int, pe *portEvent, max uint32, nget *uint32, timeout *Times
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_getn)), 5, uintptr(port), uintptr(unsafe.Pointer(pe)), uintptr(max), uintptr(unsafe.Pointer(nget)), uintptr(unsafe.Pointer(timeout)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2088,7 +2088,7 @@ func port_getn(port int, pe *portEvent, max uint32, nget *uint32, timeout *Times
+ func putmsg(fd int, clptr *strbuf, dataptr *strbuf, flags int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procputmsg)), 4, uintptr(fd), uintptr(unsafe.Pointer(clptr)), uintptr(unsafe.Pointer(dataptr)), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2098,7 +2098,7 @@ func putmsg(fd int, clptr *strbuf, dataptr *strbuf, flags int) (err error) {
+ func getmsg(fd int, clptr *strbuf, dataptr *strbuf, flags *int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgetmsg)), 4, uintptr(fd), uintptr(unsafe.Pointer(clptr)), uintptr(unsafe.Pointer(dataptr)), uintptr(unsafe.Pointer(flags)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
+index c316817..1d8fe1d 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
+@@ -40,17 +40,6 @@ func read(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func write(fd int, p []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(p) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index c9c4ad0..9862853 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -447,4 +447,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index 12ff341..8901f0f 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -369,4 +369,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index c3fb5e7..6902c37 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -411,4 +411,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 358c847..a6d3dff 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -314,4 +314,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index 81c4849..b18f3f7 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -308,4 +308,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 202a57e..0302e5e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -431,4 +431,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 4448
+ 	SYS_FUTEX_WAITV                  = 4449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
++	SYS_CACHESTAT                    = 4451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index 1fbceb5..6693ba4 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -361,4 +361,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 5448
+ 	SYS_FUTEX_WAITV             = 5449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
++	SYS_CACHESTAT               = 5451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index b4ffb7a..fd93f49 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -361,4 +361,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 5448
+ 	SYS_FUTEX_WAITV             = 5449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
++	SYS_CACHESTAT               = 5451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index 867985f..760ddca 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -431,4 +431,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 4448
+ 	SYS_FUTEX_WAITV                  = 4449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
++	SYS_CACHESTAT                    = 4451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index a8cce69..cff2b25 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -438,4 +438,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index d44c5b3..a4b2405 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -410,4 +410,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index 4214dd9..aca54b4 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -410,4 +410,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 3e594a8..676245e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -313,4 +313,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index e6ed7d6..022878d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -376,4 +376,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index 92f628e..4100a76 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -389,4 +389,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index 02e2462..2d93b09 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -1972,7 +1972,7 @@ const (
+ 	NFT_MSG_GETFLOWTABLE              = 0x17
+ 	NFT_MSG_DELFLOWTABLE              = 0x18
+ 	NFT_MSG_GETRULE_RESET             = 0x19
+-	NFT_MSG_MAX                       = 0x21
++	NFT_MSG_MAX                       = 0x22
+ 	NFTA_LIST_UNSPEC                  = 0x0
+ 	NFTA_LIST_ELEM                    = 0x1
+ 	NFTA_HOOK_UNSPEC                  = 0x0
+@@ -4494,7 +4494,7 @@ const (
+ 	NL80211_ATTR_MAC_HINT                                   = 0xc8
+ 	NL80211_ATTR_MAC_MASK                                   = 0xd7
+ 	NL80211_ATTR_MAX_AP_ASSOC_STA                           = 0xca
+-	NL80211_ATTR_MAX                                        = 0x145
++	NL80211_ATTR_MAX                                        = 0x146
+ 	NL80211_ATTR_MAX_CRIT_PROT_DURATION                     = 0xb4
+ 	NL80211_ATTR_MAX_CSA_COUNTERS                           = 0xce
+ 	NL80211_ATTR_MAX_MATCH_SETS                             = 0x85
+@@ -4864,7 +4864,7 @@ const (
+ 	NL80211_CMD_LEAVE_IBSS                                  = 0x2c
+ 	NL80211_CMD_LEAVE_MESH                                  = 0x45
+ 	NL80211_CMD_LEAVE_OCB                                   = 0x6d
+-	NL80211_CMD_MAX                                         = 0x99
++	NL80211_CMD_MAX                                         = 0x9a
+ 	NL80211_CMD_MICHAEL_MIC_FAILURE                         = 0x29
+ 	NL80211_CMD_MODIFY_LINK_STA                             = 0x97
+ 	NL80211_CMD_NAN_MATCH                                   = 0x78
+@@ -5498,7 +5498,7 @@ const (
+ 	NL80211_RATE_INFO_HE_RU_ALLOC_52                        = 0x1
+ 	NL80211_RATE_INFO_HE_RU_ALLOC_996                       = 0x5
+ 	NL80211_RATE_INFO_HE_RU_ALLOC                           = 0x11
+-	NL80211_RATE_INFO_MAX                                   = 0x16
++	NL80211_RATE_INFO_MAX                                   = 0x1d
+ 	NL80211_RATE_INFO_MCS                                   = 0x2
+ 	NL80211_RATE_INFO_SHORT_GI                              = 0x4
+ 	NL80211_RATE_INFO_VHT_MCS                               = 0x6
+@@ -5863,3 +5863,18 @@ const (
+ 	VIRTIO_NET_HDR_GSO_UDP_L4 = 0x5
+ 	VIRTIO_NET_HDR_GSO_ECN    = 0x80
+ )
++
++type SchedAttr struct {
++	Size     uint32
++	Policy   uint32
++	Flags    uint64
++	Nice     int32
++	Priority uint32
++	Runtime  uint64
++	Deadline uint64
++	Period   uint64
++	Util_min uint32
++	Util_max uint32
++}
++
++const SizeofSchedAttr = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+index 9ea54b7..1b4c97c 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+@@ -718,3 +718,30 @@ type SysvShmDesc struct {
+ 	_      uint64
+ 	_      uint64
+ }
++
++type RISCVHWProbePairs struct {
++	Key   int64
++	Value uint64
++}
++
++const (
++	RISCV_HWPROBE_KEY_MVENDORID          = 0x0
++	RISCV_HWPROBE_KEY_MARCHID            = 0x1
++	RISCV_HWPROBE_KEY_MIMPID             = 0x2
++	RISCV_HWPROBE_KEY_BASE_BEHAVIOR      = 0x3
++	RISCV_HWPROBE_BASE_BEHAVIOR_IMA      = 0x1
++	RISCV_HWPROBE_KEY_IMA_EXT_0          = 0x4
++	RISCV_HWPROBE_IMA_FD                 = 0x1
++	RISCV_HWPROBE_IMA_C                  = 0x2
++	RISCV_HWPROBE_IMA_V                  = 0x4
++	RISCV_HWPROBE_EXT_ZBA                = 0x8
++	RISCV_HWPROBE_EXT_ZBB                = 0x10
++	RISCV_HWPROBE_EXT_ZBS                = 0x20
++	RISCV_HWPROBE_KEY_CPUPERF_0          = 0x5
++	RISCV_HWPROBE_MISALIGNED_UNKNOWN     = 0x0
++	RISCV_HWPROBE_MISALIGNED_EMULATED    = 0x1
++	RISCV_HWPROBE_MISALIGNED_SLOW        = 0x2
++	RISCV_HWPROBE_MISALIGNED_FAST        = 0x3
++	RISCV_HWPROBE_MISALIGNED_UNSUPPORTED = 0x4
++	RISCV_HWPROBE_MISALIGNED_MASK        = 0x7
++)
+diff --git a/vendor/golang.org/x/sys/windows/exec_windows.go b/vendor/golang.org/x/sys/windows/exec_windows.go
+index a52e033..9cabbb6 100644
+--- a/vendor/golang.org/x/sys/windows/exec_windows.go
++++ b/vendor/golang.org/x/sys/windows/exec_windows.go
+@@ -22,7 +22,7 @@ import (
+ //     but only if there is space or tab inside s.
+ func EscapeArg(s string) string {
+ 	if len(s) == 0 {
+-		return "\"\""
++		return `""`
+ 	}
+ 	n := len(s)
+ 	hasSpace := false
+@@ -35,7 +35,7 @@ func EscapeArg(s string) string {
+ 		}
+ 	}
+ 	if hasSpace {
+-		n += 2
++		n += 2 // Reserve space for quotes.
+ 	}
+ 	if n == len(s) {
+ 		return s
+@@ -82,20 +82,68 @@ func EscapeArg(s string) string {
+ // in CreateProcess's CommandLine argument, CreateService/ChangeServiceConfig's BinaryPathName argument,
+ // or any program that uses CommandLineToArgv.
+ func ComposeCommandLine(args []string) string {
+-	var commandLine string
+-	for i := range args {
+-		if i > 0 {
+-			commandLine += " "
++	if len(args) == 0 {
++		return ""
++	}
++
++	// Per https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw:
++	// “This function accepts command lines that contain a program name; the
++	// program name can be enclosed in quotation marks or not.”
++	//
++	// Unfortunately, it provides no means of escaping interior quotation marks
++	// within that program name, and we have no way to report them here.
++	prog := args[0]
++	mustQuote := len(prog) == 0
++	for i := 0; i < len(prog); i++ {
++		c := prog[i]
++		if c <= ' ' || (c == '"' && i == 0) {
++			// Force quotes for not only the ASCII space and tab as described in the
++			// MSDN article, but also ASCII control characters.
++			// The documentation for CommandLineToArgvW doesn't say what happens when
++			// the first argument is not a valid program name, but it empirically
++			// seems to drop unquoted control characters.
++			mustQuote = true
++			break
++		}
++	}
++	var commandLine []byte
++	if mustQuote {
++		commandLine = make([]byte, 0, len(prog)+2)
++		commandLine = append(commandLine, '"')
++		for i := 0; i < len(prog); i++ {
++			c := prog[i]
++			if c == '"' {
++				// This quote would interfere with our surrounding quotes.
++				// We have no way to report an error, so just strip out
++				// the offending character instead.
++				continue
++			}
++			commandLine = append(commandLine, c)
+ 		}
+-		commandLine += EscapeArg(args[i])
++		commandLine = append(commandLine, '"')
++	} else {
++		if len(args) == 1 {
++			// args[0] is a valid command line representing itself.
++			// No need to allocate a new slice or string for it.
++			return prog
++		}
++		commandLine = []byte(prog)
+ 	}
+-	return commandLine
++
++	for _, arg := range args[1:] {
++		commandLine = append(commandLine, ' ')
++		// TODO(bcmills): since we're already appending to a slice, it would be nice
++		// to avoid the intermediate allocations of EscapeArg.
++		// Perhaps we can factor out an appendEscapedArg function.
++		commandLine = append(commandLine, EscapeArg(arg)...)
++	}
++	return string(commandLine)
+ }
+ 
+ // DecomposeCommandLine breaks apart its argument command line into unescaped parts using CommandLineToArgv,
+ // as gathered from GetCommandLine, QUERY_SERVICE_CONFIG's BinaryPathName argument, or elsewhere that
+ // command lines are passed around.
+-// DecomposeCommandLine returns error if commandLine contains NUL.
++// DecomposeCommandLine returns an error if commandLine contains NUL.
+ func DecomposeCommandLine(commandLine string) ([]string, error) {
+ 	if len(commandLine) == 0 {
+ 		return []string{}, nil
+@@ -105,18 +153,35 @@ func DecomposeCommandLine(commandLine string) ([]string, error) {
+ 		return nil, errorspkg.New("string with NUL passed to DecomposeCommandLine")
+ 	}
+ 	var argc int32
+-	argv, err := CommandLineToArgv(&utf16CommandLine[0], &argc)
++	argv, err := commandLineToArgv(&utf16CommandLine[0], &argc)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 	defer LocalFree(Handle(unsafe.Pointer(argv)))
++
+ 	var args []string
+-	for _, v := range (*argv)[:argc] {
+-		args = append(args, UTF16ToString((*v)[:]))
++	for _, p := range unsafe.Slice(argv, argc) {
++		args = append(args, UTF16PtrToString(p))
+ 	}
+ 	return args, nil
+ }
+ 
++// CommandLineToArgv parses a Unicode command line string and sets
++// argc to the number of parsed arguments.
++//
++// The returned memory should be freed using a single call to LocalFree.
++//
++// Note that although the return type of CommandLineToArgv indicates 8192
++// entries of up to 8192 characters each, the actual count of parsed arguments
++// may exceed 8192, and the documentation for CommandLineToArgvW does not mention
++// any bound on the lengths of the individual argument strings.
++// (See https://go.dev/issue/63236.)
++func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) {
++	argp, err := commandLineToArgv(cmd, argc)
++	argv = (*[8192]*[8192]uint16)(unsafe.Pointer(argp))
++	return argv, err
++}
++
+ func CloseOnExec(fd Handle) {
+ 	SetHandleInformation(Handle(fd), HANDLE_FLAG_INHERIT, 0)
+ }
+diff --git a/vendor/golang.org/x/sys/windows/security_windows.go b/vendor/golang.org/x/sys/windows/security_windows.go
+index d414ef1..26be94a 100644
+--- a/vendor/golang.org/x/sys/windows/security_windows.go
++++ b/vendor/golang.org/x/sys/windows/security_windows.go
+@@ -7,8 +7,6 @@ package windows
+ import (
+ 	"syscall"
+ 	"unsafe"
+-
+-	"golang.org/x/sys/internal/unsafeheader"
+ )
+ 
+ const (
+@@ -1341,21 +1339,14 @@ func (selfRelativeSD *SECURITY_DESCRIPTOR) copySelfRelativeSecurityDescriptor()
+ 		sdLen = min
+ 	}
+ 
+-	var src []byte
+-	h := (*unsafeheader.Slice)(unsafe.Pointer(&src))
+-	h.Data = unsafe.Pointer(selfRelativeSD)
+-	h.Len = sdLen
+-	h.Cap = sdLen
+-
++	src := unsafe.Slice((*byte)(unsafe.Pointer(selfRelativeSD)), sdLen)
++	// SECURITY_DESCRIPTOR has pointers in it, which means checkptr expects for it to
++	// be aligned properly. When we're copying a Windows-allocated struct to a
++	// Go-allocated one, make sure that the Go allocation is aligned to the
++	// pointer size.
+ 	const psize = int(unsafe.Sizeof(uintptr(0)))
+-
+-	var dst []byte
+-	h = (*unsafeheader.Slice)(unsafe.Pointer(&dst))
+ 	alloc := make([]uintptr, (sdLen+psize-1)/psize)
+-	h.Data = (*unsafeheader.Slice)(unsafe.Pointer(&alloc)).Data
+-	h.Len = sdLen
+-	h.Cap = sdLen
+-
++	dst := unsafe.Slice((*byte)(unsafe.Pointer(&alloc[0])), sdLen)
+ 	copy(dst, src)
+ 	return (*SECURITY_DESCRIPTOR)(unsafe.Pointer(&dst[0]))
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index 9645900..a3cf746 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -15,8 +15,6 @@ import (
+ 	"time"
+ 	"unicode/utf16"
+ 	"unsafe"
+-
+-	"golang.org/x/sys/internal/unsafeheader"
+ )
+ 
+ type Handle uintptr
+@@ -216,7 +214,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	shGetKnownFolderPath(id *KNOWNFOLDERID, flags uint32, token Token, path **uint16) (ret error) = shell32.SHGetKnownFolderPath
+ //sys	TerminateProcess(handle Handle, exitcode uint32) (err error)
+ //sys	GetExitCodeProcess(handle Handle, exitcode *uint32) (err error)
+-//sys	GetStartupInfo(startupInfo *StartupInfo) (err error) = GetStartupInfoW
++//sys	getStartupInfo(startupInfo *StartupInfo) = GetStartupInfoW
+ //sys	GetProcessTimes(handle Handle, creationTime *Filetime, exitTime *Filetime, kernelTime *Filetime, userTime *Filetime) (err error)
+ //sys	DuplicateHandle(hSourceProcessHandle Handle, hSourceHandle Handle, hTargetProcessHandle Handle, lpTargetHandle *Handle, dwDesiredAccess uint32, bInheritHandle bool, dwOptions uint32) (err error)
+ //sys	WaitForSingleObject(handle Handle, waitMilliseconds uint32) (event uint32, err error) [failretval==0xffffffff]
+@@ -240,7 +238,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	SetFileAttributes(name *uint16, attrs uint32) (err error) = kernel32.SetFileAttributesW
+ //sys	GetFileAttributesEx(name *uint16, level uint32, info *byte) (err error) = kernel32.GetFileAttributesExW
+ //sys	GetCommandLine() (cmd *uint16) = kernel32.GetCommandLineW
+-//sys	CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) [failretval==nil] = shell32.CommandLineToArgvW
++//sys	commandLineToArgv(cmd *uint16, argc *int32) (argv **uint16, err error) [failretval==nil] = shell32.CommandLineToArgvW
+ //sys	LocalFree(hmem Handle) (handle Handle, err error) [failretval!=0]
+ //sys	LocalAlloc(flags uint32, length uint32) (ptr uintptr, err error)
+ //sys	SetHandleInformation(handle Handle, mask uint32, flags uint32) (err error)
+@@ -299,12 +297,15 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	RegNotifyChangeKeyValue(key Handle, watchSubtree bool, notifyFilter uint32, event Handle, asynchronous bool) (regerrno error) = advapi32.RegNotifyChangeKeyValue
+ //sys	GetCurrentProcessId() (pid uint32) = kernel32.GetCurrentProcessId
+ //sys	ProcessIdToSessionId(pid uint32, sessionid *uint32) (err error) = kernel32.ProcessIdToSessionId
++//sys	ClosePseudoConsole(console Handle) = kernel32.ClosePseudoConsole
++//sys	createPseudoConsole(size uint32, in Handle, out Handle, flags uint32, pconsole *Handle) (hr error) = kernel32.CreatePseudoConsole
+ //sys	GetConsoleMode(console Handle, mode *uint32) (err error) = kernel32.GetConsoleMode
+ //sys	SetConsoleMode(console Handle, mode uint32) (err error) = kernel32.SetConsoleMode
+ //sys	GetConsoleScreenBufferInfo(console Handle, info *ConsoleScreenBufferInfo) (err error) = kernel32.GetConsoleScreenBufferInfo
+ //sys	setConsoleCursorPosition(console Handle, position uint32) (err error) = kernel32.SetConsoleCursorPosition
+ //sys	WriteConsole(console Handle, buf *uint16, towrite uint32, written *uint32, reserved *byte) (err error) = kernel32.WriteConsoleW
+ //sys	ReadConsole(console Handle, buf *uint16, toread uint32, read *uint32, inputControl *byte) (err error) = kernel32.ReadConsoleW
++//sys	resizePseudoConsole(pconsole Handle, size uint32) (hr error) = kernel32.ResizePseudoConsole
+ //sys	CreateToolhelp32Snapshot(flags uint32, processId uint32) (handle Handle, err error) [failretval==InvalidHandle] = kernel32.CreateToolhelp32Snapshot
+ //sys	Module32First(snapshot Handle, moduleEntry *ModuleEntry32) (err error) = kernel32.Module32FirstW
+ //sys	Module32Next(snapshot Handle, moduleEntry *ModuleEntry32) (err error) = kernel32.Module32NextW
+@@ -437,6 +438,10 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	DwmGetWindowAttribute(hwnd HWND, attribute uint32, value unsafe.Pointer, size uint32) (ret error) = dwmapi.DwmGetWindowAttribute
+ //sys	DwmSetWindowAttribute(hwnd HWND, attribute uint32, value unsafe.Pointer, size uint32) (ret error) = dwmapi.DwmSetWindowAttribute
+ 
++// Windows Multimedia API
++//sys TimeBeginPeriod (period uint32) (err error) [failretval != 0] = winmm.timeBeginPeriod
++//sys TimeEndPeriod (period uint32) (err error) [failretval != 0] = winmm.timeEndPeriod
++
+ // syscall interface implementation for other packages
+ 
+ // GetCurrentProcess returns the handle for the current process.
+@@ -1624,6 +1629,11 @@ func SetConsoleCursorPosition(console Handle, position Coord) error {
+ 	return setConsoleCursorPosition(console, *((*uint32)(unsafe.Pointer(&position))))
+ }
+ 
++func GetStartupInfo(startupInfo *StartupInfo) error {
++	getStartupInfo(startupInfo)
++	return nil
++}
++
+ func (s NTStatus) Errno() syscall.Errno {
+ 	return rtlNtStatusToDosErrorNoTeb(s)
+ }
+@@ -1658,12 +1668,8 @@ func NewNTUnicodeString(s string) (*NTUnicodeString, error) {
+ 
+ // Slice returns a uint16 slice that aliases the data in the NTUnicodeString.
+ func (s *NTUnicodeString) Slice() []uint16 {
+-	var slice []uint16
+-	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&slice))
+-	hdr.Data = unsafe.Pointer(s.Buffer)
+-	hdr.Len = int(s.Length)
+-	hdr.Cap = int(s.MaximumLength)
+-	return slice
++	slice := unsafe.Slice(s.Buffer, s.MaximumLength)
++	return slice[:s.Length]
+ }
+ 
+ func (s *NTUnicodeString) String() string {
+@@ -1686,12 +1692,8 @@ func NewNTString(s string) (*NTString, error) {
+ 
+ // Slice returns a byte slice that aliases the data in the NTString.
+ func (s *NTString) Slice() []byte {
+-	var slice []byte
+-	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&slice))
+-	hdr.Data = unsafe.Pointer(s.Buffer)
+-	hdr.Len = int(s.Length)
+-	hdr.Cap = int(s.MaximumLength)
+-	return slice
++	slice := unsafe.Slice(s.Buffer, s.MaximumLength)
++	return slice[:s.Length]
+ }
+ 
+ func (s *NTString) String() string {
+@@ -1743,10 +1745,7 @@ func LoadResourceData(module, resInfo Handle) (data []byte, err error) {
+ 	if err != nil {
+ 		return
+ 	}
+-	h := (*unsafeheader.Slice)(unsafe.Pointer(&data))
+-	h.Data = unsafe.Pointer(ptr)
+-	h.Len = int(size)
+-	h.Cap = int(size)
++	data = unsafe.Slice((*byte)(unsafe.Pointer(ptr)), size)
+ 	return
+ }
+ 
+@@ -1817,3 +1816,17 @@ type PSAPI_WORKING_SET_EX_INFORMATION struct {
+ 	// A PSAPI_WORKING_SET_EX_BLOCK union that indicates the attributes of the page at VirtualAddress.
+ 	VirtualAttributes PSAPI_WORKING_SET_EX_BLOCK
+ }
++
++// CreatePseudoConsole creates a windows pseudo console.
++func CreatePseudoConsole(size Coord, in Handle, out Handle, flags uint32, pconsole *Handle) error {
++	// We need this wrapper to manually cast Coord to uint32. The autogenerated wrappers only
++	// accept arguments that can be casted to uintptr, and Coord can't.
++	return createPseudoConsole(*((*uint32)(unsafe.Pointer(&size))), in, out, flags, pconsole)
++}
++
++// ResizePseudoConsole resizes the internal buffers of the pseudo console to the width and height specified in `size`.
++func ResizePseudoConsole(pconsole Handle, size Coord) error {
++	// We need this wrapper to manually cast Coord to uint32. The autogenerated wrappers only
++	// accept arguments that can be casted to uintptr, and Coord can't.
++	return resizePseudoConsole(pconsole, *((*uint32)(unsafe.Pointer(&size))))
++}
+diff --git a/vendor/golang.org/x/sys/windows/types_windows.go b/vendor/golang.org/x/sys/windows/types_windows.go
+index 88e62a6..b88dc7c 100644
+--- a/vendor/golang.org/x/sys/windows/types_windows.go
++++ b/vendor/golang.org/x/sys/windows/types_windows.go
+@@ -247,6 +247,7 @@ const (
+ 	PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY = 0x00020007
+ 	PROC_THREAD_ATTRIBUTE_UMS_THREAD        = 0x00030006
+ 	PROC_THREAD_ATTRIBUTE_PROTECTION_LEVEL  = 0x0002000b
++	PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE     = 0x00020016
+ )
+ 
+ const (
+@@ -2139,6 +2140,12 @@ const (
+ 	ENABLE_LVB_GRID_WORLDWIDE          = 0x10
+ )
+ 
++// Pseudo console related constants used for the flags parameter to
++// CreatePseudoConsole. See: https://learn.microsoft.com/en-us/windows/console/createpseudoconsole
++const (
++	PSEUDOCONSOLE_INHERIT_CURSOR = 0x1
++)
++
+ type Coord struct {
+ 	X int16
+ 	Y int16
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index 566dd3e..8b1688d 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -55,6 +55,7 @@ var (
+ 	moduser32   = NewLazySystemDLL("user32.dll")
+ 	moduserenv  = NewLazySystemDLL("userenv.dll")
+ 	modversion  = NewLazySystemDLL("version.dll")
++	modwinmm    = NewLazySystemDLL("winmm.dll")
+ 	modwintrust = NewLazySystemDLL("wintrust.dll")
+ 	modws2_32   = NewLazySystemDLL("ws2_32.dll")
+ 	modwtsapi32 = NewLazySystemDLL("wtsapi32.dll")
+@@ -187,6 +188,7 @@ var (
+ 	procCancelIo                                             = modkernel32.NewProc("CancelIo")
+ 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
+ 	procCloseHandle                                          = modkernel32.NewProc("CloseHandle")
++	procClosePseudoConsole                                   = modkernel32.NewProc("ClosePseudoConsole")
+ 	procConnectNamedPipe                                     = modkernel32.NewProc("ConnectNamedPipe")
+ 	procCreateDirectoryW                                     = modkernel32.NewProc("CreateDirectoryW")
+ 	procCreateEventExW                                       = modkernel32.NewProc("CreateEventExW")
+@@ -201,6 +203,7 @@ var (
+ 	procCreateNamedPipeW                                     = modkernel32.NewProc("CreateNamedPipeW")
+ 	procCreatePipe                                           = modkernel32.NewProc("CreatePipe")
+ 	procCreateProcessW                                       = modkernel32.NewProc("CreateProcessW")
++	procCreatePseudoConsole                                  = modkernel32.NewProc("CreatePseudoConsole")
+ 	procCreateSymbolicLinkW                                  = modkernel32.NewProc("CreateSymbolicLinkW")
+ 	procCreateToolhelp32Snapshot                             = modkernel32.NewProc("CreateToolhelp32Snapshot")
+ 	procDefineDosDeviceW                                     = modkernel32.NewProc("DefineDosDeviceW")
+@@ -327,6 +330,7 @@ var (
+ 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
+ 	procRemoveDirectoryW                                     = modkernel32.NewProc("RemoveDirectoryW")
+ 	procResetEvent                                           = modkernel32.NewProc("ResetEvent")
++	procResizePseudoConsole                                  = modkernel32.NewProc("ResizePseudoConsole")
+ 	procResumeThread                                         = modkernel32.NewProc("ResumeThread")
+ 	procSetCommTimeouts                                      = modkernel32.NewProc("SetCommTimeouts")
+ 	procSetConsoleCursorPosition                             = modkernel32.NewProc("SetConsoleCursorPosition")
+@@ -468,6 +472,8 @@ var (
+ 	procGetFileVersionInfoSizeW                              = modversion.NewProc("GetFileVersionInfoSizeW")
+ 	procGetFileVersionInfoW                                  = modversion.NewProc("GetFileVersionInfoW")
+ 	procVerQueryValueW                                       = modversion.NewProc("VerQueryValueW")
++	proctimeBeginPeriod                                      = modwinmm.NewProc("timeBeginPeriod")
++	proctimeEndPeriod                                        = modwinmm.NewProc("timeEndPeriod")
+ 	procWinVerifyTrustEx                                     = modwintrust.NewProc("WinVerifyTrustEx")
+ 	procFreeAddrInfoW                                        = modws2_32.NewProc("FreeAddrInfoW")
+ 	procGetAddrInfoW                                         = modws2_32.NewProc("GetAddrInfoW")
+@@ -1630,6 +1636,11 @@ func CloseHandle(handle Handle) (err error) {
+ 	return
+ }
+ 
++func ClosePseudoConsole(console Handle) {
++	syscall.Syscall(procClosePseudoConsole.Addr(), 1, uintptr(console), 0, 0)
++	return
++}
++
+ func ConnectNamedPipe(pipe Handle, overlapped *Overlapped) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procConnectNamedPipe.Addr(), 2, uintptr(pipe), uintptr(unsafe.Pointer(overlapped)), 0)
+ 	if r1 == 0 {
+@@ -1759,6 +1770,14 @@ func CreateProcess(appName *uint16, commandLine *uint16, procSecurity *SecurityA
+ 	return
+ }
+ 
++func createPseudoConsole(size uint32, in Handle, out Handle, flags uint32, pconsole *Handle) (hr error) {
++	r0, _, _ := syscall.Syscall6(procCreatePseudoConsole.Addr(), 5, uintptr(size), uintptr(in), uintptr(out), uintptr(flags), uintptr(unsafe.Pointer(pconsole)), 0)
++	if r0 != 0 {
++		hr = syscall.Errno(r0)
++	}
++	return
++}
++
+ func CreateSymbolicLink(symlinkfilename *uint16, targetfilename *uint16, flags uint32) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procCreateSymbolicLinkW.Addr(), 3, uintptr(unsafe.Pointer(symlinkfilename)), uintptr(unsafe.Pointer(targetfilename)), uintptr(flags))
+ 	if r1&0xff == 0 {
+@@ -2367,11 +2386,8 @@ func GetShortPathName(longpath *uint16, shortpath *uint16, buflen uint32) (n uin
+ 	return
+ }
+ 
+-func GetStartupInfo(startupInfo *StartupInfo) (err error) {
+-	r1, _, e1 := syscall.Syscall(procGetStartupInfoW.Addr(), 1, uintptr(unsafe.Pointer(startupInfo)), 0, 0)
+-	if r1 == 0 {
+-		err = errnoErr(e1)
+-	}
++func getStartupInfo(startupInfo *StartupInfo) {
++	syscall.Syscall(procGetStartupInfoW.Addr(), 1, uintptr(unsafe.Pointer(startupInfo)), 0, 0)
+ 	return
+ }
+ 
+@@ -2862,6 +2878,14 @@ func ResetEvent(event Handle) (err error) {
+ 	return
+ }
+ 
++func resizePseudoConsole(pconsole Handle, size uint32) (hr error) {
++	r0, _, _ := syscall.Syscall(procResizePseudoConsole.Addr(), 2, uintptr(pconsole), uintptr(size), 0)
++	if r0 != 0 {
++		hr = syscall.Errno(r0)
++	}
++	return
++}
++
+ func ResumeThread(thread Handle) (ret uint32, err error) {
+ 	r0, _, e1 := syscall.Syscall(procResumeThread.Addr(), 1, uintptr(thread), 0, 0)
+ 	ret = uint32(r0)
+@@ -3820,9 +3844,9 @@ func setupUninstallOEMInf(infFileName *uint16, flags SUOI, reserved uintptr) (er
+ 	return
+ }
+ 
+-func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) {
++func commandLineToArgv(cmd *uint16, argc *int32) (argv **uint16, err error) {
+ 	r0, _, e1 := syscall.Syscall(procCommandLineToArgvW.Addr(), 2, uintptr(unsafe.Pointer(cmd)), uintptr(unsafe.Pointer(argc)), 0)
+-	argv = (*[8192]*[8192]uint16)(unsafe.Pointer(r0))
++	argv = (**uint16)(unsafe.Pointer(r0))
+ 	if argv == nil {
+ 		err = errnoErr(e1)
+ 	}
+@@ -4017,6 +4041,22 @@ func _VerQueryValue(block unsafe.Pointer, subBlock *uint16, pointerToBufferPoint
+ 	return
+ }
+ 
++func TimeBeginPeriod(period uint32) (err error) {
++	r1, _, e1 := syscall.Syscall(proctimeBeginPeriod.Addr(), 1, uintptr(period), 0, 0)
++	if r1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++func TimeEndPeriod(period uint32) (err error) {
++	r1, _, e1 := syscall.Syscall(proctimeEndPeriod.Addr(), 1, uintptr(period), 0, 0)
++	if r1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func WinVerifyTrustEx(hwnd HWND, actionId *GUID, data *WinTrustData) (ret error) {
+ 	r0, _, _ := syscall.Syscall(procWinVerifyTrustEx.Addr(), 3, uintptr(hwnd), uintptr(unsafe.Pointer(actionId)), uintptr(unsafe.Pointer(data)))
+ 	if r0 != 0 {
+diff --git a/vendor/golang.org/x/text/unicode/norm/trie.go b/vendor/golang.org/x/text/unicode/norm/trie.go
+index 423386b..e4250ae 100644
+--- a/vendor/golang.org/x/text/unicode/norm/trie.go
++++ b/vendor/golang.org/x/text/unicode/norm/trie.go
+@@ -29,7 +29,7 @@ var (
+ 	nfkcData = newNfkcTrie(0)
+ )
+ 
+-// lookupValue determines the type of block n and looks up the value for b.
++// lookup determines the type of block n and looks up the value for b.
+ // For n < t.cutoff, the block is a simple lookup table. Otherwise, the block
+ // is a list of ranges with an accompanying value. Given a matching range r,
+ // the value for b is by r.value + (b - r.lo) * stride.
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 352cad7..a028c0a 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -61,7 +61,46 @@ github.com/prometheus/procfs/internal/util
+ # github.com/spf13/pflag v1.0.5
+ ## explicit; go 1.12
+ github.com/spf13/pflag
+-# golang.org/x/net v0.13.0
++# go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.0
++## explicit; go 1.19
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/internal
++# go.opentelemetry.io/otel v1.15.0
++## explicit; go 1.19
++go.opentelemetry.io/otel
++go.opentelemetry.io/otel/attribute
++go.opentelemetry.io/otel/baggage
++go.opentelemetry.io/otel/codes
++go.opentelemetry.io/otel/internal
++go.opentelemetry.io/otel/internal/attribute
++go.opentelemetry.io/otel/internal/baggage
++go.opentelemetry.io/otel/internal/global
++go.opentelemetry.io/otel/propagation
++go.opentelemetry.io/otel/semconv/v1.17.0
++# go.opentelemetry.io/otel/metric v0.38.0
++## explicit; go 1.19
++go.opentelemetry.io/otel/metric
++go.opentelemetry.io/otel/metric/embedded
++go.opentelemetry.io/otel/metric/global
++go.opentelemetry.io/otel/metric/internal/global
++# go.opentelemetry.io/otel/trace v1.15.0
++## explicit; go 1.19
++go.opentelemetry.io/otel/trace
++# go.uber.org/atomic v1.10.0
++## explicit; go 1.18
++go.uber.org/atomic
++# go.uber.org/multierr v1.11.0
++## explicit; go 1.19
++go.uber.org/multierr
++# go.uber.org/zap v1.19.0
++## explicit; go 1.13
++go.uber.org/zap
++go.uber.org/zap/buffer
++go.uber.org/zap/internal/bufferpool
++go.uber.org/zap/internal/color
++go.uber.org/zap/internal/exit
++go.uber.org/zap/zapcore
++# golang.org/x/net v0.17.0
+ ## explicit; go 1.17
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -69,12 +108,11 @@ golang.org/x/net/http2/hpack
+ golang.org/x/net/idna
+ golang.org/x/net/internal/timeseries
+ golang.org/x/net/trace
+-# golang.org/x/sys v0.10.0
++# golang.org/x/sys v0.13.0
+ ## explicit; go 1.17
+-golang.org/x/sys/internal/unsafeheader
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-# golang.org/x/text v0.11.0
++# golang.org/x/text v0.13.0
+ ## explicit; go 1.17
+ golang.org/x/text/secure/bidirule
+ golang.org/x/text/transform
+-- 
+2.39.1
+

--- a/projects/kubernetes-csi/livenessprobe/1-28/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-28/CHECKSUMS
@@ -1,3 +1,3 @@
-76c4a0a6d54a987744cc1ee11a6a59c75c863db7088ac7a88b6a635ba871024a  _output/1-28/bin/livenessprobe/linux-amd64/livenessprobe
-61349ff8a583832aab8254c3c3ba90c03373324cc6eff7ef1c890811903cc726  _output/1-28/bin/livenessprobe/linux-arm64/livenessprobe
-059722d18e2b0d29632f4a6f760d331f0ba053d6a0dfd758582d2131164b1f0d  _output/1-28/bin/livenessprobe/windows-amd64/livenessprobe.exe
+069068a60fdf7739331586e4ad9f3258690ffe44d066514612dfcc0d8a6c2063  _output/1-28/bin/livenessprobe/linux-amd64/livenessprobe
+d3508a41fee454aea498b9b8841f2b299895a153594b89877a1dac7ed5a56812  _output/1-28/bin/livenessprobe/linux-arm64/livenessprobe
+7c2eda8690b52b3fdf51f1855a6c070afc8bceee41ef2fe8fbdb36b9f07acfc0  _output/1-28/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-28/patches/0001-Fix-CVE-2023-44487-and-CVE-2023-39325-bump-golang.or.patch
+++ b/projects/kubernetes-csi/livenessprobe/1-28/patches/0001-Fix-CVE-2023-44487-and-CVE-2023-39325-bump-golang.or.patch
@@ -1,0 +1,6786 @@
+From 0da68f237a1f971d899df26ee722ddf72905aa15 Mon Sep 17 00:00:00 2001
+From: Jonathan Dobson <jdobson@redhat.com>
+Date: Wed, 18 Oct 2023 14:27:39 -0600
+Subject: [PATCH] Fix CVE-2023-44487 and CVE-2023-39325: bump golang.org/x/net
+
+Signed-off-by: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
+---
+ go.mod                                        |  13 +-
+ go.sum                                        |  31 +-
+ vendor/golang.org/x/net/http2/Dockerfile      |  51 ----
+ vendor/golang.org/x/net/http2/Makefile        |   3 -
+ vendor/golang.org/x/net/http2/server.go       |  86 ++++--
+ vendor/golang.org/x/net/http2/transport.go    |   3 +-
+ .../sys/internal/unsafeheader/unsafeheader.go |  30 --
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |   1 +
+ vendor/golang.org/x/sys/unix/ptrace_darwin.go |   6 -
+ vendor/golang.org/x/sys/unix/ptrace_ios.go    |   6 -
+ vendor/golang.org/x/sys/unix/syscall_aix.go   |   2 -
+ .../golang.org/x/sys/unix/syscall_darwin.go   | 186 ------------
+ .../x/sys/unix/syscall_darwin_amd64.go        |   1 -
+ .../x/sys/unix/syscall_darwin_arm64.go        |   1 -
+ .../x/sys/unix/syscall_dragonfly.go           | 198 -------------
+ .../golang.org/x/sys/unix/syscall_freebsd.go  | 192 -------------
+ vendor/golang.org/x/sys/unix/syscall_linux.go |  77 ++++-
+ .../golang.org/x/sys/unix/syscall_netbsd.go   | 272 +-----------------
+ .../golang.org/x/sys/unix/syscall_openbsd.go  |  74 -----
+ .../golang.org/x/sys/unix/syscall_solaris.go  |  32 ---
+ vendor/golang.org/x/sys/unix/syscall_unix.go  |   3 +
+ .../x/sys/unix/syscall_zos_s390x.go           |   1 -
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  26 ++
+ .../x/sys/unix/zerrors_linux_386.go           |   2 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   2 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   4 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   2 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   2 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   2 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   2 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   2 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   2 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   2 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   2 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   2 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   2 +
+ .../golang.org/x/sys/unix/zsyscall_aix_ppc.go |  22 --
+ .../x/sys/unix/zsyscall_aix_ppc64.go          |  22 --
+ .../x/sys/unix/zsyscall_darwin_amd64.go       |  40 +--
+ .../x/sys/unix/zsyscall_darwin_amd64.s        | 149 ----------
+ .../x/sys/unix/zsyscall_darwin_arm64.go       |  40 +--
+ .../x/sys/unix/zsyscall_darwin_arm64.s        | 149 ----------
+ .../x/sys/unix/zsyscall_dragonfly_amd64.go    |  22 --
+ .../x/sys/unix/zsyscall_freebsd_386.go        |  22 --
+ .../x/sys/unix/zsyscall_freebsd_amd64.go      |  22 --
+ .../x/sys/unix/zsyscall_freebsd_arm.go        |  22 --
+ .../x/sys/unix/zsyscall_freebsd_arm64.go      |  22 --
+ .../x/sys/unix/zsyscall_freebsd_riscv64.go    |  22 --
+ .../x/sys/unix/zsyscall_illumos_amd64.go      |  10 +-
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  42 ++-
+ .../x/sys/unix/zsyscall_netbsd_386.go         |  22 --
+ .../x/sys/unix/zsyscall_netbsd_amd64.go       |  22 --
+ .../x/sys/unix/zsyscall_netbsd_arm.go         |  22 --
+ .../x/sys/unix/zsyscall_netbsd_arm64.go       |  22 --
+ .../x/sys/unix/zsyscall_openbsd_386.go        |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |  22 --
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |  32 +--
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |  32 +--
+ .../x/sys/unix/zsyscall_solaris_amd64.go      | 256 ++++++++---------
+ .../x/sys/unix/zsyscall_zos_s390x.go          |  11 -
+ .../x/sys/unix/zsysnum_linux_386.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   1 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   1 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   1 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   1 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   1 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   1 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  |  23 +-
+ .../x/sys/unix/ztypes_linux_riscv64.go        |  27 ++
+ .../golang.org/x/sys/windows/exec_windows.go  |  89 +++++-
+ .../x/sys/windows/security_windows.go         |  21 +-
+ .../x/sys/windows/syscall_windows.go          |  53 ++--
+ .../golang.org/x/sys/windows/types_windows.go |   7 +
+ .../x/sys/windows/zsyscall_windows.go         |  54 +++-
+ vendor/golang.org/x/text/unicode/norm/trie.go |   2 +-
+ vendor/modules.txt                            |  46 ++-
+ 89 files changed, 698 insertions(+), 2141 deletions(-)
+ delete mode 100644 vendor/golang.org/x/net/http2/Dockerfile
+ delete mode 100644 vendor/golang.org/x/net/http2/Makefile
+ delete mode 100644 vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
+
+diff --git a/go.mod b/go.mod
+index 3c87bf0..1d87210 100644
+--- a/go.mod
++++ b/go.mod
+@@ -23,9 +23,16 @@ require (
+ 	github.com/prometheus/common v0.44.0 // indirect
+ 	github.com/prometheus/procfs v0.10.1 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+-	golang.org/x/net v0.13.0 // indirect
+-	golang.org/x/sys v0.10.0 // indirect
+-	golang.org/x/text v0.11.0 // indirect
++	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.0 // indirect
++	go.opentelemetry.io/otel v1.15.0 // indirect
++	go.opentelemetry.io/otel/metric v0.38.0 // indirect
++	go.opentelemetry.io/otel/trace v1.15.0 // indirect
++	go.uber.org/atomic v1.10.0 // indirect
++	go.uber.org/multierr v1.11.0 // indirect
++	go.uber.org/zap v1.19.0 // indirect
++	golang.org/x/net v0.17.0 // indirect
++	golang.org/x/sys v0.13.0 // indirect
++	golang.org/x/text v0.13.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
+ 	google.golang.org/protobuf v1.31.0 // indirect
+ 	k8s.io/apimachinery v0.28.0 // indirect
+diff --git a/go.sum b/go.sum
+index 038cdf3..d4a9711 100644
+--- a/go.sum
++++ b/go.sum
+@@ -137,17 +137,9 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
+-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+-golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+-golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+-golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+-golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=
+-golang.org/x/net v0.13.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
+-golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+-golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
++golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
++golang.org/x/oauth2 v0.10.0 h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -168,23 +160,14 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220731174439-a90be440212d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
++golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+-golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
+-golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
++golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
++golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+diff --git a/vendor/golang.org/x/net/http2/Dockerfile b/vendor/golang.org/x/net/http2/Dockerfile
+deleted file mode 100644
+index 8512245..0000000
+--- a/vendor/golang.org/x/net/http2/Dockerfile
++++ /dev/null
+@@ -1,51 +0,0 @@
+-#
+-# This Dockerfile builds a recent curl with HTTP/2 client support, using
+-# a recent nghttp2 build.
+-#
+-# See the Makefile for how to tag it. If Docker and that image is found, the
+-# Go tests use this curl binary for integration tests.
+-#
+-
+-FROM ubuntu:trusty
+-
+-RUN apt-get update && \
+-    apt-get upgrade -y && \
+-    apt-get install -y git-core build-essential wget
+-
+-RUN apt-get install -y --no-install-recommends \
+-       autotools-dev libtool pkg-config zlib1g-dev \
+-       libcunit1-dev libssl-dev libxml2-dev libevent-dev \
+-       automake autoconf
+-
+-# The list of packages nghttp2 recommends for h2load:
+-RUN apt-get install -y --no-install-recommends make binutils \
+-        autoconf automake autotools-dev \
+-        libtool pkg-config zlib1g-dev libcunit1-dev libssl-dev libxml2-dev \
+-        libev-dev libevent-dev libjansson-dev libjemalloc-dev \
+-        cython python3.4-dev python-setuptools
+-
+-# Note: setting NGHTTP2_VER before the git clone, so an old git clone isn't cached:
+-ENV NGHTTP2_VER 895da9a
+-RUN cd /root && git clone https://github.com/tatsuhiro-t/nghttp2.git
+-
+-WORKDIR /root/nghttp2
+-RUN git reset --hard $NGHTTP2_VER
+-RUN autoreconf -i
+-RUN automake
+-RUN autoconf
+-RUN ./configure
+-RUN make
+-RUN make install
+-
+-WORKDIR /root
+-RUN wget https://curl.se/download/curl-7.45.0.tar.gz
+-RUN tar -zxvf curl-7.45.0.tar.gz
+-WORKDIR /root/curl-7.45.0
+-RUN ./configure --with-ssl --with-nghttp2=/usr/local
+-RUN make
+-RUN make install
+-RUN ldconfig
+-
+-CMD ["-h"]
+-ENTRYPOINT ["/usr/local/bin/curl"]
+-
+diff --git a/vendor/golang.org/x/net/http2/Makefile b/vendor/golang.org/x/net/http2/Makefile
+deleted file mode 100644
+index 55fd826..0000000
+--- a/vendor/golang.org/x/net/http2/Makefile
++++ /dev/null
+@@ -1,3 +0,0 @@
+-curlimage:
+-	docker build -t gohttp2/curl .
+-
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index 033b6e6..02c88b6 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -581,9 +581,11 @@ type serverConn struct {
+ 	advMaxStreams               uint32 // our SETTINGS_MAX_CONCURRENT_STREAMS advertised the client
+ 	curClientStreams            uint32 // number of open streams initiated by the client
+ 	curPushedStreams            uint32 // number of open streams initiated by server push
++	curHandlers                 uint32 // number of running handler goroutines
+ 	maxClientStreamID           uint32 // max ever seen from client (odd), or 0 if there have been no client requests
+ 	maxPushPromiseID            uint32 // ID of the last push promise (even), or 0 if there have been no pushes
+ 	streams                     map[uint32]*stream
++	unstartedHandlers           []unstartedHandler
+ 	initialStreamSendWindowSize int32
+ 	maxFrameSize                int32
+ 	peerMaxHeaderListSize       uint32            // zero means unknown (default)
+@@ -981,6 +983,8 @@ func (sc *serverConn) serve() {
+ 					return
+ 				case gracefulShutdownMsg:
+ 					sc.startGracefulShutdownInternal()
++				case handlerDoneMsg:
++					sc.handlerDone()
+ 				default:
+ 					panic("unknown timer")
+ 				}
+@@ -1012,14 +1016,6 @@ func (sc *serverConn) serve() {
+ 	}
+ }
+ 
+-func (sc *serverConn) awaitGracefulShutdown(sharedCh <-chan struct{}, privateCh chan struct{}) {
+-	select {
+-	case <-sc.doneServing:
+-	case <-sharedCh:
+-		close(privateCh)
+-	}
+-}
+-
+ type serverMessage int
+ 
+ // Message values sent to serveMsgCh.
+@@ -1028,6 +1024,7 @@ var (
+ 	idleTimerMsg        = new(serverMessage)
+ 	shutdownTimerMsg    = new(serverMessage)
+ 	gracefulShutdownMsg = new(serverMessage)
++	handlerDoneMsg      = new(serverMessage)
+ )
+ 
+ func (sc *serverConn) onSettingsTimer() { sc.sendServeMsg(settingsTimerMsg) }
+@@ -1900,9 +1897,11 @@ func (st *stream) copyTrailersToHandlerRequest() {
+ // onReadTimeout is run on its own goroutine (from time.AfterFunc)
+ // when the stream's ReadTimeout has fired.
+ func (st *stream) onReadTimeout() {
+-	// Wrap the ErrDeadlineExceeded to avoid callers depending on us
+-	// returning the bare error.
+-	st.body.CloseWithError(fmt.Errorf("%w", os.ErrDeadlineExceeded))
++	if st.body != nil {
++		// Wrap the ErrDeadlineExceeded to avoid callers depending on us
++		// returning the bare error.
++		st.body.CloseWithError(fmt.Errorf("%w", os.ErrDeadlineExceeded))
++	}
+ }
+ 
+ // onWriteTimeout is run on its own goroutine (from time.AfterFunc)
+@@ -2020,13 +2019,10 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+ 	if sc.hs.ReadTimeout != 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+-		if st.body != nil {
+-			st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+-		}
++		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+ 
+-	go sc.runHandler(rw, req, handler)
+-	return nil
++	return sc.scheduleHandler(id, rw, req, handler)
+ }
+ 
+ func (sc *serverConn) upgradeRequest(req *http.Request) {
+@@ -2046,6 +2042,10 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
++	// This is the first request on the connection,
++	// so start the handler directly rather than going
++	// through scheduleHandler.
++	sc.curHandlers++
+ 	go sc.runHandler(rw, req, sc.handler.ServeHTTP)
+ }
+ 
+@@ -2286,8 +2286,62 @@ func (sc *serverConn) newResponseWriter(st *stream, req *http.Request) *response
+ 	return &responseWriter{rws: rws}
+ }
+ 
++type unstartedHandler struct {
++	streamID uint32
++	rw       *responseWriter
++	req      *http.Request
++	handler  func(http.ResponseWriter, *http.Request)
++}
++
++// scheduleHandler starts a handler goroutine,
++// or schedules one to start as soon as an existing handler finishes.
++func (sc *serverConn) scheduleHandler(streamID uint32, rw *responseWriter, req *http.Request, handler func(http.ResponseWriter, *http.Request)) error {
++	sc.serveG.check()
++	maxHandlers := sc.advMaxStreams
++	if sc.curHandlers < maxHandlers {
++		sc.curHandlers++
++		go sc.runHandler(rw, req, handler)
++		return nil
++	}
++	if len(sc.unstartedHandlers) > int(4*sc.advMaxStreams) {
++		return sc.countError("too_many_early_resets", ConnectionError(ErrCodeEnhanceYourCalm))
++	}
++	sc.unstartedHandlers = append(sc.unstartedHandlers, unstartedHandler{
++		streamID: streamID,
++		rw:       rw,
++		req:      req,
++		handler:  handler,
++	})
++	return nil
++}
++
++func (sc *serverConn) handlerDone() {
++	sc.serveG.check()
++	sc.curHandlers--
++	i := 0
++	maxHandlers := sc.advMaxStreams
++	for ; i < len(sc.unstartedHandlers); i++ {
++		u := sc.unstartedHandlers[i]
++		if sc.streams[u.streamID] == nil {
++			// This stream was reset before its goroutine had a chance to start.
++			continue
++		}
++		if sc.curHandlers >= maxHandlers {
++			break
++		}
++		sc.curHandlers++
++		go sc.runHandler(u.rw, u.req, u.handler)
++		sc.unstartedHandlers[i] = unstartedHandler{} // don't retain references
++	}
++	sc.unstartedHandlers = sc.unstartedHandlers[i:]
++	if len(sc.unstartedHandlers) == 0 {
++		sc.unstartedHandlers = nil
++	}
++}
++
+ // Run on its own goroutine.
+ func (sc *serverConn) runHandler(rw *responseWriter, req *http.Request, handler func(http.ResponseWriter, *http.Request)) {
++	defer sc.sendServeMsg(handlerDoneMsg)
+ 	didPanic := true
+ 	defer func() {
+ 		rw.rws.stream.cancelCtx()
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index b20c749..7497f56 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -290,8 +290,7 @@ func (t *Transport) initConnPool() {
+ // HTTP/2 server.
+ type ClientConn struct {
+ 	t             *Transport
+-	tconn         net.Conn // usually *tls.Conn, except specialized impls
+-	tconnClosed   bool
++	tconn         net.Conn             // usually *tls.Conn, except specialized impls
+ 	tlsState      *tls.ConnectionState // nil only for specialized impls
+ 	reused        uint32               // whether conn is being reused; atomic
+ 	singleUse     bool                 // whether being used for a single http.Request
+diff --git a/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go b/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
+deleted file mode 100644
+index e07899b..0000000
+--- a/vendor/golang.org/x/sys/internal/unsafeheader/unsafeheader.go
++++ /dev/null
+@@ -1,30 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-// Package unsafeheader contains header declarations for the Go runtime's
+-// slice and string implementations.
+-//
+-// This package allows x/sys to use types equivalent to
+-// reflect.SliceHeader and reflect.StringHeader without introducing
+-// a dependency on the (relatively heavy) "reflect" package.
+-package unsafeheader
+-
+-import (
+-	"unsafe"
+-)
+-
+-// Slice is the runtime representation of a slice.
+-// It cannot be used safely or portably and its representation may change in a later release.
+-type Slice struct {
+-	Data unsafe.Pointer
+-	Len  int
+-	Cap  int
+-}
+-
+-// String is the runtime representation of a string.
+-// It cannot be used safely or portably and its representation may change in a later release.
+-type String struct {
+-	Data unsafe.Pointer
+-	Len  int
+-}
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index 0c4d149..831f9e3 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -583,6 +583,7 @@ ccflags="$@"
+ 		$2 ~ /^PERF_/ ||
+ 		$2 ~ /^SECCOMP_MODE_/ ||
+ 		$2 ~ /^SEEK_/ ||
++		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+ 		$2 ~ /^SYNC_FILE_RANGE_/ ||
+ 		$2 !~ /IOC_MAGIC/ &&
+diff --git a/vendor/golang.org/x/sys/unix/ptrace_darwin.go b/vendor/golang.org/x/sys/unix/ptrace_darwin.go
+index 39dba6c..463c3ef 100644
+--- a/vendor/golang.org/x/sys/unix/ptrace_darwin.go
++++ b/vendor/golang.org/x/sys/unix/ptrace_darwin.go
+@@ -7,12 +7,6 @@
+ 
+ package unix
+ 
+-import "unsafe"
+-
+ func ptrace(request int, pid int, addr uintptr, data uintptr) error {
+ 	return ptrace1(request, pid, addr, data)
+ }
+-
+-func ptracePtr(request int, pid int, addr uintptr, data unsafe.Pointer) error {
+-	return ptrace1Ptr(request, pid, addr, data)
+-}
+diff --git a/vendor/golang.org/x/sys/unix/ptrace_ios.go b/vendor/golang.org/x/sys/unix/ptrace_ios.go
+index 9ea6633..ed0509a 100644
+--- a/vendor/golang.org/x/sys/unix/ptrace_ios.go
++++ b/vendor/golang.org/x/sys/unix/ptrace_ios.go
+@@ -7,12 +7,6 @@
+ 
+ package unix
+ 
+-import "unsafe"
+-
+ func ptrace(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return ENOTSUP
+ }
+-
+-func ptracePtr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	return ENOTSUP
+-}
+diff --git a/vendor/golang.org/x/sys/unix/syscall_aix.go b/vendor/golang.org/x/sys/unix/syscall_aix.go
+index c406ae0..6f77ff5 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_aix.go
++++ b/vendor/golang.org/x/sys/unix/syscall_aix.go
+@@ -487,8 +487,6 @@ func Fsync(fd int) error {
+ //sys	Unlinkat(dirfd int, path string, flags int) (err error)
+ //sys	Ustat(dev int, ubuf *Ustat_t) (err error)
+ //sys	write(fd int, p []byte) (n int, err error)
+-//sys	readlen(fd int, p *byte, np int) (n int, err error) = read
+-//sys	writelen(fd int, p *byte, np int) (n int, err error) = write
+ 
+ //sys	Dup2(oldfd int, newfd int) (err error)
+ //sys	Fadvise(fd int, offset int64, length int64, advice int) (err error) = posix_fadvise64
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin.go b/vendor/golang.org/x/sys/unix/syscall_darwin.go
+index 2069215..3b0bd2d 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin.go
+@@ -638,189 +638,3 @@ func SysctlKinfoProcSlice(name string, args ...int) ([]KinfoProc, error) {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+-
+-/*
+- * Unimplemented
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Ioctl
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// sendfile
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Poll_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go b/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
+index 9fa8798..b37310c 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_amd64.go
+@@ -47,6 +47,5 @@ func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr,
+ //sys	getfsstat(buf unsafe.Pointer, size uintptr, flags int) (n int, err error) = SYS_GETFSSTAT64
+ //sys	Lstat(path string, stat *Stat_t) (err error) = SYS_LSTAT64
+ //sys	ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) = SYS_ptrace
+-//sys	ptrace1Ptr(request int, pid int, addr unsafe.Pointer, data uintptr) (err error) = SYS_ptrace
+ //sys	Stat(path string, stat *Stat_t) (err error) = SYS_STAT64
+ //sys	Statfs(path string, stat *Statfs_t) (err error) = SYS_STATFS64
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go b/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
+index f17b8c5..d51ec99 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_arm64.go
+@@ -47,6 +47,5 @@ func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr,
+ //sys	getfsstat(buf unsafe.Pointer, size uintptr, flags int) (n int, err error) = SYS_GETFSSTAT
+ //sys	Lstat(path string, stat *Stat_t) (err error)
+ //sys	ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) = SYS_ptrace
+-//sys	ptrace1Ptr(request int, pid int, addr unsafe.Pointer, data uintptr) (err error) = SYS_ptrace
+ //sys	Stat(path string, stat *Stat_t) (err error)
+ //sys	Statfs(path string, stat *Statfs_t) (err error)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+index d4ce988..97cb916 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
++++ b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+@@ -343,203 +343,5 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error)
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- * TODO(jsing): Update this list for DragonFly.
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Mount
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Setattrlist
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Getxattr
+-// Fgetxattr
+-// Setxattr
+-// Fsetxattr
+-// Removexattr
+-// Fremovexattr
+-// Listxattr
+-// Flistxattr
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shmat
+-// Shmctl
+-// Shmdt
+-// Shmget
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index afb1010..64d1bb4 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -449,197 +449,5 @@ func Dup3(oldfd, newfd, flags int) error {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error)
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- */
+-// Profil
+-// Sigaction
+-// Sigprocmask
+-// Getlogin
+-// Sigpending
+-// Sigaltstack
+-// Ioctl
+-// Reboot
+-// Execve
+-// Vfork
+-// Sbrk
+-// Sstk
+-// Ovadvise
+-// Mincore
+-// Setitimer
+-// Swapon
+-// Select
+-// Sigsuspend
+-// Readv
+-// Writev
+-// Nfssvc
+-// Getfh
+-// Quotactl
+-// Mount
+-// Csops
+-// Waitid
+-// Add_profil
+-// Kdebug_trace
+-// Sigreturn
+-// Atsocket
+-// Kqueue_from_portset_np
+-// Kqueue_portset
+-// Getattrlist
+-// Setattrlist
+-// Getdents
+-// Getdirentriesattr
+-// Searchfs
+-// Delete
+-// Copyfile
+-// Watchevent
+-// Waitevent
+-// Modwatch
+-// Fsctl
+-// Initgroups
+-// Posix_spawn
+-// Nfsclnt
+-// Fhopen
+-// Minherit
+-// Semsys
+-// Msgsys
+-// Shmsys
+-// Semctl
+-// Semget
+-// Semop
+-// Msgctl
+-// Msgget
+-// Msgsnd
+-// Msgrcv
+-// Shmat
+-// Shmctl
+-// Shmdt
+-// Shmget
+-// Shm_open
+-// Shm_unlink
+-// Sem_open
+-// Sem_close
+-// Sem_unlink
+-// Sem_wait
+-// Sem_trywait
+-// Sem_post
+-// Sem_getvalue
+-// Sem_init
+-// Sem_destroy
+-// Open_extended
+-// Umask_extended
+-// Stat_extended
+-// Lstat_extended
+-// Fstat_extended
+-// Chmod_extended
+-// Fchmod_extended
+-// Access_extended
+-// Settid
+-// Gettid
+-// Setsgroups
+-// Getsgroups
+-// Setwgroups
+-// Getwgroups
+-// Mkfifo_extended
+-// Mkdir_extended
+-// Identitysvc
+-// Shared_region_check_np
+-// Shared_region_map_np
+-// __pthread_mutex_destroy
+-// __pthread_mutex_init
+-// __pthread_mutex_lock
+-// __pthread_mutex_trylock
+-// __pthread_mutex_unlock
+-// __pthread_cond_init
+-// __pthread_cond_destroy
+-// __pthread_cond_broadcast
+-// __pthread_cond_signal
+-// Setsid_with_pid
+-// __pthread_cond_timedwait
+-// Aio_fsync
+-// Aio_return
+-// Aio_suspend
+-// Aio_cancel
+-// Aio_error
+-// Aio_read
+-// Aio_write
+-// Lio_listio
+-// __pthread_cond_wait
+-// Iopolicysys
+-// __pthread_kill
+-// __pthread_sigmask
+-// __sigwait
+-// __disable_threadsignal
+-// __pthread_markcancel
+-// __pthread_canceled
+-// __semwait_signal
+-// Proc_info
+-// Stat64_extended
+-// Lstat64_extended
+-// Fstat64_extended
+-// __pthread_chdir
+-// __pthread_fchdir
+-// Audit
+-// Auditon
+-// Getauid
+-// Setauid
+-// Getaudit
+-// Setaudit
+-// Getaudit_addr
+-// Setaudit_addr
+-// Auditctl
+-// Bsdthread_create
+-// Bsdthread_terminate
+-// Stack_snapshot
+-// Bsdthread_register
+-// Workq_open
+-// Workq_ops
+-// __mac_execve
+-// __mac_syscall
+-// __mac_get_file
+-// __mac_set_file
+-// __mac_get_link
+-// __mac_set_link
+-// __mac_get_proc
+-// __mac_set_proc
+-// __mac_get_fd
+-// __mac_set_fd
+-// __mac_get_pid
+-// __mac_get_lcid
+-// __mac_get_lctx
+-// __mac_set_lctx
+-// Setlcid
+-// Read_nocancel
+-// Write_nocancel
+-// Open_nocancel
+-// Close_nocancel
+-// Wait4_nocancel
+-// Recvmsg_nocancel
+-// Sendmsg_nocancel
+-// Recvfrom_nocancel
+-// Accept_nocancel
+-// Fcntl_nocancel
+-// Select_nocancel
+-// Fsync_nocancel
+-// Connect_nocancel
+-// Sigsuspend_nocancel
+-// Readv_nocancel
+-// Writev_nocancel
+-// Sendto_nocancel
+-// Pread_nocancel
+-// Pwrite_nocancel
+-// Waitid_nocancel
+-// Poll_nocancel
+-// Msgsnd_nocancel
+-// Msgrcv_nocancel
+-// Sem_wait_nocancel
+-// Aio_suspend_nocancel
+-// __sigwait_nocancel
+-// __semwait_signal_nocancel
+-// __mac_mount
+-// __mac_get_mount
+-// __mac_getfsstat
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index 39de5f1..c905ec8 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -693,10 +693,10 @@ type SockaddrALG struct {
+ 
+ func (sa *SockaddrALG) sockaddr() (unsafe.Pointer, _Socklen, error) {
+ 	// Leave room for NUL byte terminator.
+-	if len(sa.Type) > 13 {
++	if len(sa.Type) > len(sa.raw.Type)-1 {
+ 		return nil, 0, EINVAL
+ 	}
+-	if len(sa.Name) > 63 {
++	if len(sa.Name) > len(sa.raw.Name)-1 {
+ 		return nil, 0, EINVAL
+ 	}
+ 
+@@ -704,17 +704,8 @@ func (sa *SockaddrALG) sockaddr() (unsafe.Pointer, _Socklen, error) {
+ 	sa.raw.Feat = sa.Feature
+ 	sa.raw.Mask = sa.Mask
+ 
+-	typ, err := ByteSliceFromString(sa.Type)
+-	if err != nil {
+-		return nil, 0, err
+-	}
+-	name, err := ByteSliceFromString(sa.Name)
+-	if err != nil {
+-		return nil, 0, err
+-	}
+-
+-	copy(sa.raw.Type[:], typ)
+-	copy(sa.raw.Name[:], name)
++	copy(sa.raw.Type[:], sa.Type)
++	copy(sa.raw.Name[:], sa.Name)
+ 
+ 	return unsafe.Pointer(&sa.raw), SizeofSockaddrALG, nil
+ }
+@@ -1988,8 +1979,6 @@ func Signalfd(fd int, sigmask *Sigset_t, flags int) (newfd int, err error) {
+ //sys	Unshare(flags int) (err error)
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	exitThread(code int) (err error) = SYS_EXIT
+-//sys	readlen(fd int, p *byte, np int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, p *byte, np int) (n int, err error) = SYS_WRITE
+ //sys	readv(fd int, iovs []Iovec) (n int, err error) = SYS_READV
+ //sys	writev(fd int, iovs []Iovec) (n int, err error) = SYS_WRITEV
+ //sys	preadv(fd int, iovs []Iovec, offs_l uintptr, offs_h uintptr) (n int, err error) = SYS_PREADV
+@@ -2454,6 +2443,7 @@ func Getresgid() (rgid, egid, sgid int) {
+ 	return int(r), int(e), int(s)
+ }
+ 
++<<<<<<< HEAD
+ /*
+  * Unimplemented
+  */
+@@ -2549,3 +2539,60 @@ func Getresgid() (rgid, egid, sgid int) {
+ // Vhangup
+ // Vserver
+ // _Sysctl
++=======
++// Pselect is a wrapper around the Linux pselect6 system call.
++// This version does not modify the timeout argument.
++func Pselect(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
++	// Per https://man7.org/linux/man-pages/man2/select.2.html#NOTES,
++	// The Linux pselect6() system call modifies its timeout argument.
++	// [Not modifying the argument] is the behavior required by POSIX.1-2001.
++	var mutableTimeout *Timespec
++	if timeout != nil {
++		mutableTimeout = new(Timespec)
++		*mutableTimeout = *timeout
++	}
++
++	// The final argument of the pselect6() system call is not a
++	// sigset_t * pointer, but is instead a structure
++	var kernelMask *sigset_argpack
++	if sigmask != nil {
++		wordBits := 32 << (^uintptr(0) >> 63) // see math.intSize
++
++		// A sigset stores one bit per signal,
++		// offset by 1 (because signal 0 does not exist).
++		// So the number of words needed is ⌈__C_NSIG - 1 / wordBits⌉.
++		sigsetWords := (_C__NSIG - 1 + wordBits - 1) / (wordBits)
++
++		sigsetBytes := uintptr(sigsetWords * (wordBits / 8))
++		kernelMask = &sigset_argpack{
++			ss:    sigmask,
++			ssLen: sigsetBytes,
++		}
++	}
++
++	return pselect6(nfd, r, w, e, mutableTimeout, kernelMask)
++}
++
++//sys	schedSetattr(pid int, attr *SchedAttr, flags uint) (err error)
++//sys	schedGetattr(pid int, attr *SchedAttr, size uint, flags uint) (err error)
++
++// SchedSetAttr is a wrapper for sched_setattr(2) syscall.
++// https://man7.org/linux/man-pages/man2/sched_setattr.2.html
++func SchedSetAttr(pid int, attr *SchedAttr, flags uint) error {
++	if attr == nil {
++		return EINVAL
++	}
++	attr.Size = SizeofSchedAttr
++	return schedSetattr(pid, attr, flags)
++}
++
++// SchedGetAttr is a wrapper for sched_getattr(2) syscall.
++// https://man7.org/linux/man-pages/man2/sched_getattr.2.html
++func SchedGetAttr(pid int, flags uint) (*SchedAttr, error) {
++	attr := &SchedAttr{}
++	if err := schedGetattr(pid, attr, SizeofSchedAttr, flags); err != nil {
++		return nil, err
++	}
++	return attr, nil
++}
++>>>>>>> 48ed37b (CVE-2023-44487: bump golang.org/x/net to v0.17.0)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_netbsd.go b/vendor/golang.org/x/sys/unix/syscall_netbsd.go
+index 018d7d4..8816209 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_netbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_netbsd.go
+@@ -356,266 +356,16 @@ func Statvfs(path string, buf *Statvfs_t) (err error) {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+ 
+-/*
+- * Unimplemented
+- */
+-// ____semctl13
+-// __clone
+-// __fhopen40
+-// __fhstat40
+-// __fhstatvfs140
+-// __fstat30
+-// __getcwd
+-// __getfh30
+-// __getlogin
+-// __lstat30
+-// __mount50
+-// __msgctl13
+-// __msync13
+-// __ntp_gettime30
+-// __posix_chown
+-// __posix_fchown
+-// __posix_lchown
+-// __posix_rename
+-// __setlogin
+-// __shmctl13
+-// __sigaction_sigtramp
+-// __sigaltstack14
+-// __sigpending14
+-// __sigprocmask14
+-// __sigsuspend14
+-// __sigtimedwait
+-// __stat30
+-// __syscall
+-// __vfork14
+-// _ksem_close
+-// _ksem_destroy
+-// _ksem_getvalue
+-// _ksem_init
+-// _ksem_open
+-// _ksem_post
+-// _ksem_trywait
+-// _ksem_unlink
+-// _ksem_wait
+-// _lwp_continue
+-// _lwp_create
+-// _lwp_ctl
+-// _lwp_detach
+-// _lwp_exit
+-// _lwp_getname
+-// _lwp_getprivate
+-// _lwp_kill
+-// _lwp_park
+-// _lwp_self
+-// _lwp_setname
+-// _lwp_setprivate
+-// _lwp_suspend
+-// _lwp_unpark
+-// _lwp_unpark_all
+-// _lwp_wait
+-// _lwp_wakeup
+-// _pset_bind
+-// _sched_getaffinity
+-// _sched_getparam
+-// _sched_setaffinity
+-// _sched_setparam
+-// acct
+-// aio_cancel
+-// aio_error
+-// aio_fsync
+-// aio_read
+-// aio_return
+-// aio_suspend
+-// aio_write
+-// break
+-// clock_getres
+-// clock_gettime
+-// clock_settime
+-// compat_09_ogetdomainname
+-// compat_09_osetdomainname
+-// compat_09_ouname
+-// compat_10_omsgsys
+-// compat_10_osemsys
+-// compat_10_oshmsys
+-// compat_12_fstat12
+-// compat_12_getdirentries
+-// compat_12_lstat12
+-// compat_12_msync
+-// compat_12_oreboot
+-// compat_12_oswapon
+-// compat_12_stat12
+-// compat_13_sigaction13
+-// compat_13_sigaltstack13
+-// compat_13_sigpending13
+-// compat_13_sigprocmask13
+-// compat_13_sigreturn13
+-// compat_13_sigsuspend13
+-// compat_14___semctl
+-// compat_14_msgctl
+-// compat_14_shmctl
+-// compat_16___sigaction14
+-// compat_16___sigreturn14
+-// compat_20_fhstatfs
+-// compat_20_fstatfs
+-// compat_20_getfsstat
+-// compat_20_statfs
+-// compat_30___fhstat30
+-// compat_30___fstat13
+-// compat_30___lstat13
+-// compat_30___stat13
+-// compat_30_fhopen
+-// compat_30_fhstat
+-// compat_30_fhstatvfs1
+-// compat_30_getdents
+-// compat_30_getfh
+-// compat_30_ntp_gettime
+-// compat_30_socket
+-// compat_40_mount
+-// compat_43_fstat43
+-// compat_43_lstat43
+-// compat_43_oaccept
+-// compat_43_ocreat
+-// compat_43_oftruncate
+-// compat_43_ogetdirentries
+-// compat_43_ogetdtablesize
+-// compat_43_ogethostid
+-// compat_43_ogethostname
+-// compat_43_ogetkerninfo
+-// compat_43_ogetpagesize
+-// compat_43_ogetpeername
+-// compat_43_ogetrlimit
+-// compat_43_ogetsockname
+-// compat_43_okillpg
+-// compat_43_olseek
+-// compat_43_ommap
+-// compat_43_oquota
+-// compat_43_orecv
+-// compat_43_orecvfrom
+-// compat_43_orecvmsg
+-// compat_43_osend
+-// compat_43_osendmsg
+-// compat_43_osethostid
+-// compat_43_osethostname
+-// compat_43_osigblock
+-// compat_43_osigsetmask
+-// compat_43_osigstack
+-// compat_43_osigvec
+-// compat_43_otruncate
+-// compat_43_owait
+-// compat_43_stat43
+-// execve
+-// extattr_delete_fd
+-// extattr_delete_file
+-// extattr_delete_link
+-// extattr_get_fd
+-// extattr_get_file
+-// extattr_get_link
+-// extattr_list_fd
+-// extattr_list_file
+-// extattr_list_link
+-// extattr_set_fd
+-// extattr_set_file
+-// extattr_set_link
+-// extattrctl
+-// fchroot
+-// fdatasync
+-// fgetxattr
+-// fktrace
+-// flistxattr
+-// fork
+-// fremovexattr
+-// fsetxattr
+-// fstatvfs1
+-// fsync_range
+-// getcontext
+-// getitimer
+-// getvfsstat
+-// getxattr
+-// ktrace
+-// lchflags
+-// lchmod
+-// lfs_bmapv
+-// lfs_markv
+-// lfs_segclean
+-// lfs_segwait
+-// lgetxattr
+-// lio_listio
+-// listxattr
+-// llistxattr
+-// lremovexattr
+-// lseek
+-// lsetxattr
+-// lutimes
+-// madvise
+-// mincore
+-// minherit
+-// modctl
+-// mq_close
+-// mq_getattr
+-// mq_notify
+-// mq_open
+-// mq_receive
+-// mq_send
+-// mq_setattr
+-// mq_timedreceive
+-// mq_timedsend
+-// mq_unlink
+-// mremap
+-// msgget
+-// msgrcv
+-// msgsnd
+-// nfssvc
+-// ntp_adjtime
+-// pmc_control
+-// pmc_get_info
+-// pollts
+-// preadv
+-// profil
+-// pselect
+-// pset_assign
+-// pset_create
+-// pset_destroy
+-// ptrace
+-// pwritev
+-// quotactl
+-// rasctl
+-// readv
+-// reboot
+-// removexattr
+-// sa_enable
+-// sa_preempt
+-// sa_register
+-// sa_setconcurrency
+-// sa_stacks
+-// sa_yield
+-// sbrk
+-// sched_yield
+-// semconfig
+-// semget
+-// semop
+-// setcontext
+-// setitimer
+-// setxattr
+-// shmat
+-// shmdt
+-// shmget
+-// sstk
+-// statvfs1
+-// swapctl
+-// sysarch
+-// syscall
+-// timer_create
+-// timer_delete
+-// timer_getoverrun
+-// timer_gettime
+-// timer_settime
+-// undelete
+-// utrace
+-// uuidgen
+-// vadvise
+-// vfork
+-// writev
++const (
++	mremapFixed     = MAP_FIXED
++	mremapDontunmap = 0
++	mremapMaymove   = 0
++)
++
++//sys	mremapNetBSD(oldp uintptr, oldsize uintptr, newp uintptr, newsize uintptr, flags int) (xaddr uintptr, err error) = SYS_MREMAP
++
++func mremap(oldaddr uintptr, oldlength uintptr, newlength uintptr, flags int, newaddr uintptr) (uintptr, error) {
++	return mremapNetBSD(oldaddr, oldlength, newaddr, newlength, flags)
++}
+diff --git a/vendor/golang.org/x/sys/unix/syscall_openbsd.go b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+index c5f166a..6f34479 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_openbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+@@ -326,78 +326,4 @@ func Uname(uname *Utsname) error {
+ //sys	write(fd int, p []byte) (n int, err error)
+ //sys	mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (ret uintptr, err error)
+ //sys	munmap(addr uintptr, length uintptr) (err error)
+-//sys	readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+-//sys	writelen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_WRITE
+ //sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+-
+-/*
+- * Unimplemented
+- */
+-// __getcwd
+-// __semctl
+-// __syscall
+-// __sysctl
+-// adjfreq
+-// break
+-// clock_getres
+-// clock_gettime
+-// clock_settime
+-// closefrom
+-// execve
+-// fhopen
+-// fhstat
+-// fhstatfs
+-// fork
+-// futimens
+-// getfh
+-// getgid
+-// getitimer
+-// getlogin
+-// getthrid
+-// ktrace
+-// lfs_bmapv
+-// lfs_markv
+-// lfs_segclean
+-// lfs_segwait
+-// mincore
+-// minherit
+-// mount
+-// mquery
+-// msgctl
+-// msgget
+-// msgrcv
+-// msgsnd
+-// nfssvc
+-// nnpfspioctl
+-// preadv
+-// profil
+-// pwritev
+-// quotactl
+-// readv
+-// reboot
+-// renameat
+-// rfork
+-// sched_yield
+-// semget
+-// semop
+-// setgroups
+-// setitimer
+-// setsockopt
+-// shmat
+-// shmctl
+-// shmdt
+-// shmget
+-// sigaction
+-// sigaltstack
+-// sigpending
+-// sigprocmask
+-// sigreturn
+-// sigsuspend
+-// sysarch
+-// syscall
+-// threxit
+-// thrsigdivert
+-// thrsleep
+-// thrwakeup
+-// vfork
+-// writev
+diff --git a/vendor/golang.org/x/sys/unix/syscall_solaris.go b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+index b600a28..b99cfa1 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
++++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+@@ -698,38 +698,6 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ //sys	setsockopt(s int, level int, name int, val unsafe.Pointer, vallen uintptr) (err error) = libsocket.setsockopt
+ //sys	recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Socklen) (n int, err error) = libsocket.recvfrom
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procread)), 3, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf), 0, 0, 0)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = e1
+-	}
+-	return
+-}
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwrite)), 3, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf), 0, 0, 0)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = e1
+-	}
+-	return
+-}
+-
+-var mapper = &mmapper{
+-	active: make(map[*byte][]byte),
+-	mmap:   mmap,
+-	munmap: munmap,
+-}
+-
+-func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
+-	return mapper.Mmap(fd, offset, length, prot, flags)
+-}
+-
+-func Munmap(b []byte) (err error) {
+-	return mapper.Munmap(b)
+-}
+-
+ // Event Ports
+ 
+ type fileObjCookie struct {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_unix.go b/vendor/golang.org/x/sys/unix/syscall_unix.go
+index 8e48c29..a4b2c98 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_unix.go
++++ b/vendor/golang.org/x/sys/unix/syscall_unix.go
+@@ -541,6 +541,9 @@ func SetNonblock(fd int, nonblocking bool) (err error) {
+ 	if err != nil {
+ 		return err
+ 	}
++	if (flag&O_NONBLOCK != 0) == nonblocking {
++		return nil
++	}
+ 	if nonblocking {
+ 		flag |= O_NONBLOCK
+ 	} else {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+index d3d49ec..799302f 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+@@ -192,7 +192,6 @@ func (cmsg *Cmsghdr) SetLen(length int) {
+ 
+ //sys   fcntl(fd int, cmd int, arg int) (val int, err error)
+ //sys	read(fd int, p []byte) (n int, err error)
+-//sys   readlen(fd int, buf *byte, nbuf int) (n int, err error) = SYS_READ
+ //sys	write(fd int, p []byte) (n int, err error)
+ 
+ //sys	accept(s int, rsa *RawSockaddrAny, addrlen *_Socklen) (fd int, err error) = SYS___ACCEPT_A
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index 3784f40..f9c7f47 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -2421,6 +2421,15 @@ const (
+ 	PR_PAC_GET_ENABLED_KEYS                     = 0x3d
+ 	PR_PAC_RESET_KEYS                           = 0x36
+ 	PR_PAC_SET_ENABLED_KEYS                     = 0x3c
++	PR_RISCV_V_GET_CONTROL                      = 0x46
++	PR_RISCV_V_SET_CONTROL                      = 0x45
++	PR_RISCV_V_VSTATE_CTRL_CUR_MASK             = 0x3
++	PR_RISCV_V_VSTATE_CTRL_DEFAULT              = 0x0
++	PR_RISCV_V_VSTATE_CTRL_INHERIT              = 0x10
++	PR_RISCV_V_VSTATE_CTRL_MASK                 = 0x1f
++	PR_RISCV_V_VSTATE_CTRL_NEXT_MASK            = 0xc
++	PR_RISCV_V_VSTATE_CTRL_OFF                  = 0x1
++	PR_RISCV_V_VSTATE_CTRL_ON                   = 0x2
+ 	PR_SCHED_CORE                               = 0x3e
+ 	PR_SCHED_CORE_CREATE                        = 0x1
+ 	PR_SCHED_CORE_GET                           = 0x0
+@@ -2821,6 +2830,23 @@ const (
+ 	RWF_SUPPORTED                               = 0x1f
+ 	RWF_SYNC                                    = 0x4
+ 	RWF_WRITE_LIFE_NOT_SET                      = 0x0
++	SCHED_BATCH                                 = 0x3
++	SCHED_DEADLINE                              = 0x6
++	SCHED_FIFO                                  = 0x1
++	SCHED_FLAG_ALL                              = 0x7f
++	SCHED_FLAG_DL_OVERRUN                       = 0x4
++	SCHED_FLAG_KEEP_ALL                         = 0x18
++	SCHED_FLAG_KEEP_PARAMS                      = 0x10
++	SCHED_FLAG_KEEP_POLICY                      = 0x8
++	SCHED_FLAG_RECLAIM                          = 0x2
++	SCHED_FLAG_RESET_ON_FORK                    = 0x1
++	SCHED_FLAG_UTIL_CLAMP                       = 0x60
++	SCHED_FLAG_UTIL_CLAMP_MAX                   = 0x40
++	SCHED_FLAG_UTIL_CLAMP_MIN                   = 0x20
++	SCHED_IDLE                                  = 0x5
++	SCHED_NORMAL                                = 0x0
++	SCHED_RESET_ON_FORK                         = 0x40000000
++	SCHED_RR                                    = 0x2
+ 	SCM_CREDENTIALS                             = 0x2
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index a46df0f..c5aeab3 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index 6cd4a3e..6b9fda9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -318,10 +318,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c7ebee2..f015600 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -324,10 +324,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 12a9a13..f760f2a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -314,10 +314,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index f26a164..12f266c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -109,6 +109,8 @@ const (
+ 	IUCLC                            = 0x200
+ 	IXOFF                            = 0x1000
+ 	IXON                             = 0x400
++	LASX_CTX_MAGIC                   = 0x41535801
++	LSX_CTX_MAGIC                    = 0x53580001
+ 	MAP_ANON                         = 0x20
+ 	MAP_ANONYMOUS                    = 0x20
+ 	MAP_DENYWRITE                    = 0x800
+@@ -308,10 +310,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 890bc3c..7fd3806 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 549f26a..c38d426 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index e0365e3..17a5f97 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index fdccce1..b73088d 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -317,10 +317,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x11
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x12
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index b2205c8..80b8d52 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -372,10 +372,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 81aa5ad..8292e16 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -376,10 +376,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index 76807a1..bb1ebb8 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -376,10 +376,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x14
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x15
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index d4a5ab9..28006d4 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -305,10 +305,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 66e65db..75e263b 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -380,10 +380,12 @@ const (
+ 	SO_NOFCS                         = 0x2b
+ 	SO_OOBINLINE                     = 0xa
+ 	SO_PASSCRED                      = 0x10
++	SO_PASSPIDFD                     = 0x4c
+ 	SO_PASSSEC                       = 0x22
+ 	SO_PEEK_OFF                      = 0x2a
+ 	SO_PEERCRED                      = 0x11
+ 	SO_PEERGROUPS                    = 0x3b
++	SO_PEERPIDFD                     = 0x4d
+ 	SO_PEERSEC                       = 0x1f
+ 	SO_PREFER_BUSY_POLL              = 0x45
+ 	SO_PROTOCOL                      = 0x26
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 4898420..5d2d76a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -419,10 +419,12 @@ const (
+ 	SO_NOFCS                         = 0x27
+ 	SO_OOBINLINE                     = 0x100
+ 	SO_PASSCRED                      = 0x2
++	SO_PASSPIDFD                     = 0x55
+ 	SO_PASSSEC                       = 0x1f
+ 	SO_PEEK_OFF                      = 0x26
+ 	SO_PEERCRED                      = 0x40
+ 	SO_PEERGROUPS                    = 0x3d
++	SO_PEERPIDFD                     = 0x56
+ 	SO_PEERSEC                       = 0x1e
+ 	SO_PREFER_BUSY_POLL              = 0x48
+ 	SO_PROTOCOL                      = 0x1028
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
+index 9a25721..d1d1d23 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc.go
+@@ -817,28 +817,6 @@ func write(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, er := C.read(C.int(fd), C.uintptr_t(uintptr(unsafe.Pointer(p))), C.size_t(np))
+-	n = int(r0)
+-	if r0 == -1 && er != nil {
+-		err = er
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, er := C.write(C.int(fd), C.uintptr_t(uintptr(unsafe.Pointer(p))), C.size_t(np))
+-	n = int(r0)
+-	if r0 == -1 && er != nil {
+-		err = er
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	r0, er := C.dup2(C.int(oldfd), C.int(newfd))
+ 	if r0 == -1 && er != nil {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
+index 6de80c2..f99a18a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_aix_ppc64.go
+@@ -762,28 +762,6 @@ func write(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, e1 := callread(fd, uintptr(unsafe.Pointer(p)), np)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, e1 := callwrite(fd, uintptr(unsafe.Pointer(p)), np)
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	_, e1 := calldup2(oldfd, newfd)
+ 	if e1 != 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
+index 4037ccf..1cad561 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
+@@ -725,6 +725,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -733,10 +739,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2410,28 +2412,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_fstat64_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0)
+ 	if e1 != 0 {
+@@ -2521,14 +2501,6 @@ func ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return
+ }
+ 
+-func ptrace1Ptr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	_, _, e1 := syscall_syscall6(libc_ptrace_trampoline_addr, uintptr(request), uintptr(pid), addr, uintptr(data), 0, 0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+ var libc_ptrace_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_ptrace ptrace "/usr/lib/libSystem.B.dylib"
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
+index 4baaed0..8b8bb28 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.s
+@@ -5,703 +5,586 @@
+ 
+ TEXT libc_fdopendir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fdopendir(SB)
+-
+ GLOBL	·libc_fdopendir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fdopendir_trampoline_addr(SB)/8, $libc_fdopendir_trampoline<>(SB)
+ 
+ TEXT libc_getgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgroups(SB)
+-
+ GLOBL	·libc_getgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgroups_trampoline_addr(SB)/8, $libc_getgroups_trampoline<>(SB)
+ 
+ TEXT libc_setgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgroups(SB)
+-
+ GLOBL	·libc_setgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgroups_trampoline_addr(SB)/8, $libc_setgroups_trampoline<>(SB)
+ 
+ TEXT libc_wait4_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_wait4(SB)
+-
+ GLOBL	·libc_wait4_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_wait4_trampoline_addr(SB)/8, $libc_wait4_trampoline<>(SB)
+ 
+ TEXT libc_accept_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_accept(SB)
+-
+ GLOBL	·libc_accept_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_accept_trampoline_addr(SB)/8, $libc_accept_trampoline<>(SB)
+ 
+ TEXT libc_bind_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_bind(SB)
+-
+ GLOBL	·libc_bind_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_bind_trampoline_addr(SB)/8, $libc_bind_trampoline<>(SB)
+ 
+ TEXT libc_connect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_connect(SB)
+-
+ GLOBL	·libc_connect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_connect_trampoline_addr(SB)/8, $libc_connect_trampoline<>(SB)
+ 
+ TEXT libc_socket_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socket(SB)
+-
+ GLOBL	·libc_socket_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socket_trampoline_addr(SB)/8, $libc_socket_trampoline<>(SB)
+ 
+ TEXT libc_getsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockopt(SB)
+-
+ GLOBL	·libc_getsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockopt_trampoline_addr(SB)/8, $libc_getsockopt_trampoline<>(SB)
+ 
+ TEXT libc_setsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsockopt(SB)
+-
+ GLOBL	·libc_setsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsockopt_trampoline_addr(SB)/8, $libc_setsockopt_trampoline<>(SB)
+ 
+ TEXT libc_getpeername_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpeername(SB)
+-
+ GLOBL	·libc_getpeername_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpeername_trampoline_addr(SB)/8, $libc_getpeername_trampoline<>(SB)
+ 
+ TEXT libc_getsockname_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockname(SB)
+-
+ GLOBL	·libc_getsockname_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockname_trampoline_addr(SB)/8, $libc_getsockname_trampoline<>(SB)
+ 
+ TEXT libc_shutdown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shutdown(SB)
+-
+ GLOBL	·libc_shutdown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shutdown_trampoline_addr(SB)/8, $libc_shutdown_trampoline<>(SB)
+ 
+ TEXT libc_socketpair_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socketpair(SB)
+-
+ GLOBL	·libc_socketpair_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socketpair_trampoline_addr(SB)/8, $libc_socketpair_trampoline<>(SB)
+ 
+ TEXT libc_recvfrom_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvfrom(SB)
+-
+ GLOBL	·libc_recvfrom_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvfrom_trampoline_addr(SB)/8, $libc_recvfrom_trampoline<>(SB)
+ 
+ TEXT libc_sendto_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendto(SB)
+-
+ GLOBL	·libc_sendto_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendto_trampoline_addr(SB)/8, $libc_sendto_trampoline<>(SB)
+ 
+ TEXT libc_recvmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvmsg(SB)
+-
+ GLOBL	·libc_recvmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvmsg_trampoline_addr(SB)/8, $libc_recvmsg_trampoline<>(SB)
+ 
+ TEXT libc_sendmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendmsg(SB)
+-
+ GLOBL	·libc_sendmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendmsg_trampoline_addr(SB)/8, $libc_sendmsg_trampoline<>(SB)
+ 
+ TEXT libc_kevent_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kevent(SB)
+-
+ GLOBL	·libc_kevent_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kevent_trampoline_addr(SB)/8, $libc_kevent_trampoline<>(SB)
+ 
+ TEXT libc_utimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimes(SB)
+-
+ GLOBL	·libc_utimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimes_trampoline_addr(SB)/8, $libc_utimes_trampoline<>(SB)
+ 
+ TEXT libc_futimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_futimes(SB)
+-
+ GLOBL	·libc_futimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_futimes_trampoline_addr(SB)/8, $libc_futimes_trampoline<>(SB)
+ 
+ TEXT libc_poll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_poll(SB)
+-
+ GLOBL	·libc_poll_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_poll_trampoline_addr(SB)/8, $libc_poll_trampoline<>(SB)
+ 
+ TEXT libc_madvise_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_madvise(SB)
+-
+ GLOBL	·libc_madvise_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_madvise_trampoline_addr(SB)/8, $libc_madvise_trampoline<>(SB)
+ 
+ TEXT libc_mlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlock(SB)
+-
+ GLOBL	·libc_mlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlock_trampoline_addr(SB)/8, $libc_mlock_trampoline<>(SB)
+ 
+ TEXT libc_mlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlockall(SB)
+-
+ GLOBL	·libc_mlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlockall_trampoline_addr(SB)/8, $libc_mlockall_trampoline<>(SB)
+ 
+ TEXT libc_mprotect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mprotect(SB)
+-
+ GLOBL	·libc_mprotect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mprotect_trampoline_addr(SB)/8, $libc_mprotect_trampoline<>(SB)
+ 
+ TEXT libc_msync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_msync(SB)
+-
+ GLOBL	·libc_msync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_msync_trampoline_addr(SB)/8, $libc_msync_trampoline<>(SB)
+ 
+ TEXT libc_munlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlock(SB)
+-
+ GLOBL	·libc_munlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlock_trampoline_addr(SB)/8, $libc_munlock_trampoline<>(SB)
+ 
+ TEXT libc_munlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlockall(SB)
+-
+ GLOBL	·libc_munlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlockall_trampoline_addr(SB)/8, $libc_munlockall_trampoline<>(SB)
+ 
+ TEXT libc_closedir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_closedir(SB)
+-
+ GLOBL	·libc_closedir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_closedir_trampoline_addr(SB)/8, $libc_closedir_trampoline<>(SB)
+ 
+ TEXT libc_readdir_r_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readdir_r(SB)
+-
+ GLOBL	·libc_readdir_r_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readdir_r_trampoline_addr(SB)/8, $libc_readdir_r_trampoline<>(SB)
+ 
+ TEXT libc_pipe_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pipe(SB)
+-
+ GLOBL	·libc_pipe_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pipe_trampoline_addr(SB)/8, $libc_pipe_trampoline<>(SB)
+ 
+ TEXT libc_getxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getxattr(SB)
+-
+ GLOBL	·libc_getxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getxattr_trampoline_addr(SB)/8, $libc_getxattr_trampoline<>(SB)
+ 
+ TEXT libc_fgetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fgetxattr(SB)
+-
+ GLOBL	·libc_fgetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fgetxattr_trampoline_addr(SB)/8, $libc_fgetxattr_trampoline<>(SB)
+ 
+ TEXT libc_setxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setxattr(SB)
+-
+ GLOBL	·libc_setxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setxattr_trampoline_addr(SB)/8, $libc_setxattr_trampoline<>(SB)
+ 
+ TEXT libc_fsetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsetxattr(SB)
+-
+ GLOBL	·libc_fsetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsetxattr_trampoline_addr(SB)/8, $libc_fsetxattr_trampoline<>(SB)
+ 
+ TEXT libc_removexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_removexattr(SB)
+-
+ GLOBL	·libc_removexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_removexattr_trampoline_addr(SB)/8, $libc_removexattr_trampoline<>(SB)
+ 
+ TEXT libc_fremovexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fremovexattr(SB)
+-
+ GLOBL	·libc_fremovexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fremovexattr_trampoline_addr(SB)/8, $libc_fremovexattr_trampoline<>(SB)
+ 
+ TEXT libc_listxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listxattr(SB)
+-
+ GLOBL	·libc_listxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listxattr_trampoline_addr(SB)/8, $libc_listxattr_trampoline<>(SB)
+ 
+ TEXT libc_flistxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flistxattr(SB)
+-
+ GLOBL	·libc_flistxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flistxattr_trampoline_addr(SB)/8, $libc_flistxattr_trampoline<>(SB)
+ 
+ TEXT libc_utimensat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimensat(SB)
+-
+ GLOBL	·libc_utimensat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimensat_trampoline_addr(SB)/8, $libc_utimensat_trampoline<>(SB)
+ 
+ TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fcntl(SB)
+-
+ GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
+ 
+ TEXT libc_kill_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kill(SB)
+-
+ GLOBL	·libc_kill_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kill_trampoline_addr(SB)/8, $libc_kill_trampoline<>(SB)
+ 
+ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ioctl(SB)
+-
+ GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
+ 
+ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sysctl(SB)
+-
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
+ TEXT libc_sendfile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendfile(SB)
+-
+ GLOBL	·libc_sendfile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendfile_trampoline_addr(SB)/8, $libc_sendfile_trampoline<>(SB)
+ 
+ TEXT libc_shmat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmat(SB)
+-
+ GLOBL	·libc_shmat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmat_trampoline_addr(SB)/8, $libc_shmat_trampoline<>(SB)
+ 
+ TEXT libc_shmctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmctl(SB)
+-
+ GLOBL	·libc_shmctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmctl_trampoline_addr(SB)/8, $libc_shmctl_trampoline<>(SB)
+ 
+ TEXT libc_shmdt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmdt(SB)
+-
+ GLOBL	·libc_shmdt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmdt_trampoline_addr(SB)/8, $libc_shmdt_trampoline<>(SB)
+ 
+ TEXT libc_shmget_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmget(SB)
+-
+ GLOBL	·libc_shmget_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmget_trampoline_addr(SB)/8, $libc_shmget_trampoline<>(SB)
+ 
+ TEXT libc_access_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_access(SB)
+-
+ GLOBL	·libc_access_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_access_trampoline_addr(SB)/8, $libc_access_trampoline<>(SB)
+ 
+ TEXT libc_adjtime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_adjtime(SB)
+-
+ GLOBL	·libc_adjtime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_adjtime_trampoline_addr(SB)/8, $libc_adjtime_trampoline<>(SB)
+ 
+ TEXT libc_chdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chdir(SB)
+-
+ GLOBL	·libc_chdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chdir_trampoline_addr(SB)/8, $libc_chdir_trampoline<>(SB)
+ 
+ TEXT libc_chflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chflags(SB)
+-
+ GLOBL	·libc_chflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chflags_trampoline_addr(SB)/8, $libc_chflags_trampoline<>(SB)
+ 
+ TEXT libc_chmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chmod(SB)
+-
+ GLOBL	·libc_chmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chmod_trampoline_addr(SB)/8, $libc_chmod_trampoline<>(SB)
+ 
+ TEXT libc_chown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chown(SB)
+-
+ GLOBL	·libc_chown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chown_trampoline_addr(SB)/8, $libc_chown_trampoline<>(SB)
+ 
+ TEXT libc_chroot_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chroot(SB)
+-
+ GLOBL	·libc_chroot_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chroot_trampoline_addr(SB)/8, $libc_chroot_trampoline<>(SB)
+ 
+ TEXT libc_clock_gettime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clock_gettime(SB)
+-
+ GLOBL	·libc_clock_gettime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clock_gettime_trampoline_addr(SB)/8, $libc_clock_gettime_trampoline<>(SB)
+ 
+ TEXT libc_close_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_close(SB)
+-
+ GLOBL	·libc_close_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_close_trampoline_addr(SB)/8, $libc_close_trampoline<>(SB)
+ 
+ TEXT libc_clonefile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefile(SB)
+-
+ GLOBL	·libc_clonefile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefile_trampoline_addr(SB)/8, $libc_clonefile_trampoline<>(SB)
+ 
+ TEXT libc_clonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefileat(SB)
+-
+ GLOBL	·libc_clonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefileat_trampoline_addr(SB)/8, $libc_clonefileat_trampoline<>(SB)
+ 
+ TEXT libc_dup_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup(SB)
+-
+ GLOBL	·libc_dup_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup_trampoline_addr(SB)/8, $libc_dup_trampoline<>(SB)
+ 
+ TEXT libc_dup2_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup2(SB)
+-
+ GLOBL	·libc_dup2_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup2_trampoline_addr(SB)/8, $libc_dup2_trampoline<>(SB)
+ 
+ TEXT libc_exchangedata_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exchangedata(SB)
+-
+ GLOBL	·libc_exchangedata_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exchangedata_trampoline_addr(SB)/8, $libc_exchangedata_trampoline<>(SB)
+ 
+ TEXT libc_exit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exit(SB)
+-
+ GLOBL	·libc_exit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exit_trampoline_addr(SB)/8, $libc_exit_trampoline<>(SB)
+ 
+ TEXT libc_faccessat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_faccessat(SB)
+-
+ GLOBL	·libc_faccessat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_faccessat_trampoline_addr(SB)/8, $libc_faccessat_trampoline<>(SB)
+ 
+ TEXT libc_fchdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchdir(SB)
+-
+ GLOBL	·libc_fchdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchdir_trampoline_addr(SB)/8, $libc_fchdir_trampoline<>(SB)
+ 
+ TEXT libc_fchflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchflags(SB)
+-
+ GLOBL	·libc_fchflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchflags_trampoline_addr(SB)/8, $libc_fchflags_trampoline<>(SB)
+ 
+ TEXT libc_fchmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmod(SB)
+-
+ GLOBL	·libc_fchmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmod_trampoline_addr(SB)/8, $libc_fchmod_trampoline<>(SB)
+ 
+ TEXT libc_fchmodat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmodat(SB)
+-
+ GLOBL	·libc_fchmodat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmodat_trampoline_addr(SB)/8, $libc_fchmodat_trampoline<>(SB)
+ 
+ TEXT libc_fchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchown(SB)
+-
+ GLOBL	·libc_fchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchown_trampoline_addr(SB)/8, $libc_fchown_trampoline<>(SB)
+ 
+ TEXT libc_fchownat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchownat(SB)
+-
+ GLOBL	·libc_fchownat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchownat_trampoline_addr(SB)/8, $libc_fchownat_trampoline<>(SB)
+ 
+ TEXT libc_fclonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fclonefileat(SB)
+-
+ GLOBL	·libc_fclonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fclonefileat_trampoline_addr(SB)/8, $libc_fclonefileat_trampoline<>(SB)
+ 
+ TEXT libc_flock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flock(SB)
+-
+ GLOBL	·libc_flock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flock_trampoline_addr(SB)/8, $libc_flock_trampoline<>(SB)
+ 
+ TEXT libc_fpathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fpathconf(SB)
+-
+ GLOBL	·libc_fpathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fpathconf_trampoline_addr(SB)/8, $libc_fpathconf_trampoline<>(SB)
+ 
+ TEXT libc_fsync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsync(SB)
+-
+ GLOBL	·libc_fsync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsync_trampoline_addr(SB)/8, $libc_fsync_trampoline<>(SB)
+ 
+ TEXT libc_ftruncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ftruncate(SB)
+-
+ GLOBL	·libc_ftruncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ftruncate_trampoline_addr(SB)/8, $libc_ftruncate_trampoline<>(SB)
+ 
+ TEXT libc_getcwd_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getcwd(SB)
+-
+ GLOBL	·libc_getcwd_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getcwd_trampoline_addr(SB)/8, $libc_getcwd_trampoline<>(SB)
+ 
+ TEXT libc_getdtablesize_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getdtablesize(SB)
+-
+ GLOBL	·libc_getdtablesize_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getdtablesize_trampoline_addr(SB)/8, $libc_getdtablesize_trampoline<>(SB)
+ 
+ TEXT libc_getegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getegid(SB)
+-
+ GLOBL	·libc_getegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getegid_trampoline_addr(SB)/8, $libc_getegid_trampoline<>(SB)
+ 
+ TEXT libc_geteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_geteuid(SB)
+-
+ GLOBL	·libc_geteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_geteuid_trampoline_addr(SB)/8, $libc_geteuid_trampoline<>(SB)
+ 
+ TEXT libc_getgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgid(SB)
+-
+ GLOBL	·libc_getgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgid_trampoline_addr(SB)/8, $libc_getgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgid(SB)
+-
+ GLOBL	·libc_getpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgid_trampoline_addr(SB)/8, $libc_getpgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgrp_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgrp(SB)
+-
+ GLOBL	·libc_getpgrp_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgrp_trampoline_addr(SB)/8, $libc_getpgrp_trampoline<>(SB)
+ 
+ TEXT libc_getpid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpid(SB)
+-
+ GLOBL	·libc_getpid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpid_trampoline_addr(SB)/8, $libc_getpid_trampoline<>(SB)
+ 
+ TEXT libc_getppid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getppid(SB)
+-
+ GLOBL	·libc_getppid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getppid_trampoline_addr(SB)/8, $libc_getppid_trampoline<>(SB)
+ 
+ TEXT libc_getpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpriority(SB)
+-
+ GLOBL	·libc_getpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpriority_trampoline_addr(SB)/8, $libc_getpriority_trampoline<>(SB)
+ 
+ TEXT libc_getrlimit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrlimit(SB)
+-
+ GLOBL	·libc_getrlimit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrlimit_trampoline_addr(SB)/8, $libc_getrlimit_trampoline<>(SB)
+ 
+ TEXT libc_getrusage_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrusage(SB)
+-
+ GLOBL	·libc_getrusage_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrusage_trampoline_addr(SB)/8, $libc_getrusage_trampoline<>(SB)
+ 
+ TEXT libc_getsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsid(SB)
+-
+ GLOBL	·libc_getsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsid_trampoline_addr(SB)/8, $libc_getsid_trampoline<>(SB)
+ 
+ TEXT libc_gettimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_gettimeofday(SB)
+-
+ GLOBL	·libc_gettimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_gettimeofday_trampoline_addr(SB)/8, $libc_gettimeofday_trampoline<>(SB)
+ 
+ TEXT libc_getuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getuid(SB)
+-
+ GLOBL	·libc_getuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getuid_trampoline_addr(SB)/8, $libc_getuid_trampoline<>(SB)
+ 
+ TEXT libc_issetugid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_issetugid(SB)
+-
+ GLOBL	·libc_issetugid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_issetugid_trampoline_addr(SB)/8, $libc_issetugid_trampoline<>(SB)
+ 
+ TEXT libc_kqueue_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kqueue(SB)
+-
+ GLOBL	·libc_kqueue_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kqueue_trampoline_addr(SB)/8, $libc_kqueue_trampoline<>(SB)
+ 
+ TEXT libc_lchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lchown(SB)
+-
+ GLOBL	·libc_lchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lchown_trampoline_addr(SB)/8, $libc_lchown_trampoline<>(SB)
+ 
+ TEXT libc_link_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_link(SB)
+-
+ GLOBL	·libc_link_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_link_trampoline_addr(SB)/8, $libc_link_trampoline<>(SB)
+ 
+ TEXT libc_linkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_linkat(SB)
+-
+ GLOBL	·libc_linkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_linkat_trampoline_addr(SB)/8, $libc_linkat_trampoline<>(SB)
+ 
+ TEXT libc_listen_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listen(SB)
+-
+ GLOBL	·libc_listen_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listen_trampoline_addr(SB)/8, $libc_listen_trampoline<>(SB)
+ 
+ TEXT libc_mkdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdir(SB)
+-
+ GLOBL	·libc_mkdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdir_trampoline_addr(SB)/8, $libc_mkdir_trampoline<>(SB)
+ 
+ TEXT libc_mkdirat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdirat(SB)
+-
+ GLOBL	·libc_mkdirat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdirat_trampoline_addr(SB)/8, $libc_mkdirat_trampoline<>(SB)
+ 
+ TEXT libc_mkfifo_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkfifo(SB)
+-
+ GLOBL	·libc_mkfifo_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkfifo_trampoline_addr(SB)/8, $libc_mkfifo_trampoline<>(SB)
+ 
+ TEXT libc_mknod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mknod(SB)
+-
+ GLOBL	·libc_mknod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mknod_trampoline_addr(SB)/8, $libc_mknod_trampoline<>(SB)
+ 
+ TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mount(SB)
+-
+ GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mount_trampoline_addr(SB)/8, $libc_mount_trampoline<>(SB)
+ 
+ TEXT libc_open_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_open(SB)
+-
+ GLOBL	·libc_open_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_open_trampoline_addr(SB)/8, $libc_open_trampoline<>(SB)
+ 
+ TEXT libc_openat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_openat(SB)
+-
+ GLOBL	·libc_openat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_openat_trampoline_addr(SB)/8, $libc_openat_trampoline<>(SB)
+ 
+ TEXT libc_pathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pathconf(SB)
+-
+ GLOBL	·libc_pathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pathconf_trampoline_addr(SB)/8, $libc_pathconf_trampoline<>(SB)
+ 
+ TEXT libc_pread_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pread(SB)
+-
+ GLOBL	·libc_pread_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pread_trampoline_addr(SB)/8, $libc_pread_trampoline<>(SB)
+ 
+ TEXT libc_pwrite_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pwrite(SB)
+-
+ GLOBL	·libc_pwrite_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pwrite_trampoline_addr(SB)/8, $libc_pwrite_trampoline<>(SB)
+ 
+ TEXT libc_read_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_read(SB)
+-
+ GLOBL	·libc_read_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_read_trampoline_addr(SB)/8, $libc_read_trampoline<>(SB)
+ 
+ TEXT libc_readlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlink(SB)
+-
+ GLOBL	·libc_readlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlink_trampoline_addr(SB)/8, $libc_readlink_trampoline<>(SB)
+ 
+ TEXT libc_readlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlinkat(SB)
+-
+ GLOBL	·libc_readlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlinkat_trampoline_addr(SB)/8, $libc_readlinkat_trampoline<>(SB)
+ 
+ TEXT libc_rename_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rename(SB)
+-
+ GLOBL	·libc_rename_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rename_trampoline_addr(SB)/8, $libc_rename_trampoline<>(SB)
+ 
+ TEXT libc_renameat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_renameat(SB)
+-
+ GLOBL	·libc_renameat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_renameat_trampoline_addr(SB)/8, $libc_renameat_trampoline<>(SB)
+ 
+ TEXT libc_revoke_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_revoke(SB)
+-
+ GLOBL	·libc_revoke_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_revoke_trampoline_addr(SB)/8, $libc_revoke_trampoline<>(SB)
+ 
+ TEXT libc_rmdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rmdir(SB)
+-
+ GLOBL	·libc_rmdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rmdir_trampoline_addr(SB)/8, $libc_rmdir_trampoline<>(SB)
+ 
+ TEXT libc_lseek_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lseek(SB)
+-
+ GLOBL	·libc_lseek_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lseek_trampoline_addr(SB)/8, $libc_lseek_trampoline<>(SB)
+ 
+ TEXT libc_select_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_select(SB)
+-
+ GLOBL	·libc_select_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_select_trampoline_addr(SB)/8, $libc_select_trampoline<>(SB)
+ 
+@@ -712,192 +595,160 @@ DATA	·libc_setattrlist_trampoline_addr(SB)/8, $libc_setattrlist_trampoline<>(SB
+ 
+ TEXT libc_setegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setegid(SB)
+-
+ GLOBL	·libc_setegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setegid_trampoline_addr(SB)/8, $libc_setegid_trampoline<>(SB)
+ 
+ TEXT libc_seteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_seteuid(SB)
+-
+ GLOBL	·libc_seteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_seteuid_trampoline_addr(SB)/8, $libc_seteuid_trampoline<>(SB)
+ 
+ TEXT libc_setgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgid(SB)
+-
+ GLOBL	·libc_setgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgid_trampoline_addr(SB)/8, $libc_setgid_trampoline<>(SB)
+ 
+ TEXT libc_setlogin_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setlogin(SB)
+-
+ GLOBL	·libc_setlogin_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setlogin_trampoline_addr(SB)/8, $libc_setlogin_trampoline<>(SB)
+ 
+ TEXT libc_setpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpgid(SB)
+-
+ GLOBL	·libc_setpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpgid_trampoline_addr(SB)/8, $libc_setpgid_trampoline<>(SB)
+ 
+ TEXT libc_setpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpriority(SB)
+-
+ GLOBL	·libc_setpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpriority_trampoline_addr(SB)/8, $libc_setpriority_trampoline<>(SB)
+ 
+ TEXT libc_setprivexec_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setprivexec(SB)
+-
+ GLOBL	·libc_setprivexec_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setprivexec_trampoline_addr(SB)/8, $libc_setprivexec_trampoline<>(SB)
+ 
+ TEXT libc_setregid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setregid(SB)
+-
+ GLOBL	·libc_setregid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setregid_trampoline_addr(SB)/8, $libc_setregid_trampoline<>(SB)
+ 
+ TEXT libc_setreuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setreuid(SB)
+-
+ GLOBL	·libc_setreuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setreuid_trampoline_addr(SB)/8, $libc_setreuid_trampoline<>(SB)
+ 
+ TEXT libc_setsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsid(SB)
+-
+ GLOBL	·libc_setsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsid_trampoline_addr(SB)/8, $libc_setsid_trampoline<>(SB)
+ 
+ TEXT libc_settimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_settimeofday(SB)
+-
+ GLOBL	·libc_settimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_settimeofday_trampoline_addr(SB)/8, $libc_settimeofday_trampoline<>(SB)
+ 
+ TEXT libc_setuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setuid(SB)
+-
+ GLOBL	·libc_setuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setuid_trampoline_addr(SB)/8, $libc_setuid_trampoline<>(SB)
+ 
+ TEXT libc_symlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlink(SB)
+-
+ GLOBL	·libc_symlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlink_trampoline_addr(SB)/8, $libc_symlink_trampoline<>(SB)
+ 
+ TEXT libc_symlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlinkat(SB)
+-
+ GLOBL	·libc_symlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlinkat_trampoline_addr(SB)/8, $libc_symlinkat_trampoline<>(SB)
+ 
+ TEXT libc_sync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sync(SB)
+-
+ GLOBL	·libc_sync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sync_trampoline_addr(SB)/8, $libc_sync_trampoline<>(SB)
+ 
+ TEXT libc_truncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_truncate(SB)
+-
+ GLOBL	·libc_truncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_truncate_trampoline_addr(SB)/8, $libc_truncate_trampoline<>(SB)
+ 
+ TEXT libc_umask_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_umask(SB)
+-
+ GLOBL	·libc_umask_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_umask_trampoline_addr(SB)/8, $libc_umask_trampoline<>(SB)
+ 
+ TEXT libc_undelete_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_undelete(SB)
+-
+ GLOBL	·libc_undelete_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_undelete_trampoline_addr(SB)/8, $libc_undelete_trampoline<>(SB)
+ 
+ TEXT libc_unlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlink(SB)
+-
+ GLOBL	·libc_unlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlink_trampoline_addr(SB)/8, $libc_unlink_trampoline<>(SB)
+ 
+ TEXT libc_unlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlinkat(SB)
+-
+ GLOBL	·libc_unlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlinkat_trampoline_addr(SB)/8, $libc_unlinkat_trampoline<>(SB)
+ 
+ TEXT libc_unmount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unmount(SB)
+-
+ GLOBL	·libc_unmount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unmount_trampoline_addr(SB)/8, $libc_unmount_trampoline<>(SB)
+ 
+ TEXT libc_write_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_write(SB)
+-
+ GLOBL	·libc_write_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_write_trampoline_addr(SB)/8, $libc_write_trampoline<>(SB)
+ 
+ TEXT libc_mmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mmap(SB)
+-
+ GLOBL	·libc_mmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mmap_trampoline_addr(SB)/8, $libc_mmap_trampoline<>(SB)
+ 
+ TEXT libc_munmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munmap(SB)
+-
+ GLOBL	·libc_munmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munmap_trampoline_addr(SB)/8, $libc_munmap_trampoline<>(SB)
+ 
+ TEXT libc_fstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstat64(SB)
+-
+ GLOBL	·libc_fstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstat64_trampoline_addr(SB)/8, $libc_fstat64_trampoline<>(SB)
+ 
+ TEXT libc_fstatat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatat64(SB)
+-
+ GLOBL	·libc_fstatat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatat64_trampoline_addr(SB)/8, $libc_fstatat64_trampoline<>(SB)
+ 
+ TEXT libc_fstatfs64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatfs64(SB)
+-
+ GLOBL	·libc_fstatfs64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatfs64_trampoline_addr(SB)/8, $libc_fstatfs64_trampoline<>(SB)
+ 
+ TEXT libc_getfsstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getfsstat64(SB)
+-
+ GLOBL	·libc_getfsstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getfsstat64_trampoline_addr(SB)/8, $libc_getfsstat64_trampoline<>(SB)
+ 
+ TEXT libc_lstat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lstat64(SB)
+-
+ GLOBL	·libc_lstat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lstat64_trampoline_addr(SB)/8, $libc_lstat64_trampoline<>(SB)
+ 
+ TEXT libc_ptrace_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ptrace(SB)
+-
+ GLOBL	·libc_ptrace_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ptrace_trampoline_addr(SB)/8, $libc_ptrace_trampoline<>(SB)
+ 
+ TEXT libc_stat64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_stat64(SB)
+-
+ GLOBL	·libc_stat64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_stat64_trampoline_addr(SB)/8, $libc_stat64_trampoline<>(SB)
+ 
+ TEXT libc_statfs64_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_statfs64(SB)
+-
+ GLOBL	·libc_statfs64_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_statfs64_trampoline_addr(SB)/8, $libc_statfs64_trampoline<>(SB)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
+index 51d6f3f..b18edbd 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
+@@ -725,6 +725,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -733,10 +739,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2410,28 +2412,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_fstat_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0)
+ 	if e1 != 0 {
+@@ -2521,14 +2501,6 @@ func ptrace1(request int, pid int, addr uintptr, data uintptr) (err error) {
+ 	return
+ }
+ 
+-func ptrace1Ptr(request int, pid int, addr uintptr, data unsafe.Pointer) (err error) {
+-	_, _, e1 := syscall_syscall6(libc_ptrace_trampoline_addr, uintptr(request), uintptr(pid), addr, uintptr(data), 0, 0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+ var libc_ptrace_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_ptrace ptrace "/usr/lib/libSystem.B.dylib"
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
+index c3b82c0..08362c1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.s
+@@ -5,703 +5,586 @@
+ 
+ TEXT libc_fdopendir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fdopendir(SB)
+-
+ GLOBL	·libc_fdopendir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fdopendir_trampoline_addr(SB)/8, $libc_fdopendir_trampoline<>(SB)
+ 
+ TEXT libc_getgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgroups(SB)
+-
+ GLOBL	·libc_getgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgroups_trampoline_addr(SB)/8, $libc_getgroups_trampoline<>(SB)
+ 
+ TEXT libc_setgroups_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgroups(SB)
+-
+ GLOBL	·libc_setgroups_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgroups_trampoline_addr(SB)/8, $libc_setgroups_trampoline<>(SB)
+ 
+ TEXT libc_wait4_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_wait4(SB)
+-
+ GLOBL	·libc_wait4_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_wait4_trampoline_addr(SB)/8, $libc_wait4_trampoline<>(SB)
+ 
+ TEXT libc_accept_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_accept(SB)
+-
+ GLOBL	·libc_accept_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_accept_trampoline_addr(SB)/8, $libc_accept_trampoline<>(SB)
+ 
+ TEXT libc_bind_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_bind(SB)
+-
+ GLOBL	·libc_bind_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_bind_trampoline_addr(SB)/8, $libc_bind_trampoline<>(SB)
+ 
+ TEXT libc_connect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_connect(SB)
+-
+ GLOBL	·libc_connect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_connect_trampoline_addr(SB)/8, $libc_connect_trampoline<>(SB)
+ 
+ TEXT libc_socket_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socket(SB)
+-
+ GLOBL	·libc_socket_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socket_trampoline_addr(SB)/8, $libc_socket_trampoline<>(SB)
+ 
+ TEXT libc_getsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockopt(SB)
+-
+ GLOBL	·libc_getsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockopt_trampoline_addr(SB)/8, $libc_getsockopt_trampoline<>(SB)
+ 
+ TEXT libc_setsockopt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsockopt(SB)
+-
+ GLOBL	·libc_setsockopt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsockopt_trampoline_addr(SB)/8, $libc_setsockopt_trampoline<>(SB)
+ 
+ TEXT libc_getpeername_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpeername(SB)
+-
+ GLOBL	·libc_getpeername_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpeername_trampoline_addr(SB)/8, $libc_getpeername_trampoline<>(SB)
+ 
+ TEXT libc_getsockname_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsockname(SB)
+-
+ GLOBL	·libc_getsockname_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsockname_trampoline_addr(SB)/8, $libc_getsockname_trampoline<>(SB)
+ 
+ TEXT libc_shutdown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shutdown(SB)
+-
+ GLOBL	·libc_shutdown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shutdown_trampoline_addr(SB)/8, $libc_shutdown_trampoline<>(SB)
+ 
+ TEXT libc_socketpair_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_socketpair(SB)
+-
+ GLOBL	·libc_socketpair_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_socketpair_trampoline_addr(SB)/8, $libc_socketpair_trampoline<>(SB)
+ 
+ TEXT libc_recvfrom_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvfrom(SB)
+-
+ GLOBL	·libc_recvfrom_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvfrom_trampoline_addr(SB)/8, $libc_recvfrom_trampoline<>(SB)
+ 
+ TEXT libc_sendto_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendto(SB)
+-
+ GLOBL	·libc_sendto_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendto_trampoline_addr(SB)/8, $libc_sendto_trampoline<>(SB)
+ 
+ TEXT libc_recvmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_recvmsg(SB)
+-
+ GLOBL	·libc_recvmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_recvmsg_trampoline_addr(SB)/8, $libc_recvmsg_trampoline<>(SB)
+ 
+ TEXT libc_sendmsg_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendmsg(SB)
+-
+ GLOBL	·libc_sendmsg_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendmsg_trampoline_addr(SB)/8, $libc_sendmsg_trampoline<>(SB)
+ 
+ TEXT libc_kevent_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kevent(SB)
+-
+ GLOBL	·libc_kevent_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kevent_trampoline_addr(SB)/8, $libc_kevent_trampoline<>(SB)
+ 
+ TEXT libc_utimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimes(SB)
+-
+ GLOBL	·libc_utimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimes_trampoline_addr(SB)/8, $libc_utimes_trampoline<>(SB)
+ 
+ TEXT libc_futimes_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_futimes(SB)
+-
+ GLOBL	·libc_futimes_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_futimes_trampoline_addr(SB)/8, $libc_futimes_trampoline<>(SB)
+ 
+ TEXT libc_poll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_poll(SB)
+-
+ GLOBL	·libc_poll_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_poll_trampoline_addr(SB)/8, $libc_poll_trampoline<>(SB)
+ 
+ TEXT libc_madvise_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_madvise(SB)
+-
+ GLOBL	·libc_madvise_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_madvise_trampoline_addr(SB)/8, $libc_madvise_trampoline<>(SB)
+ 
+ TEXT libc_mlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlock(SB)
+-
+ GLOBL	·libc_mlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlock_trampoline_addr(SB)/8, $libc_mlock_trampoline<>(SB)
+ 
+ TEXT libc_mlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mlockall(SB)
+-
+ GLOBL	·libc_mlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mlockall_trampoline_addr(SB)/8, $libc_mlockall_trampoline<>(SB)
+ 
+ TEXT libc_mprotect_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mprotect(SB)
+-
+ GLOBL	·libc_mprotect_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mprotect_trampoline_addr(SB)/8, $libc_mprotect_trampoline<>(SB)
+ 
+ TEXT libc_msync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_msync(SB)
+-
+ GLOBL	·libc_msync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_msync_trampoline_addr(SB)/8, $libc_msync_trampoline<>(SB)
+ 
+ TEXT libc_munlock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlock(SB)
+-
+ GLOBL	·libc_munlock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlock_trampoline_addr(SB)/8, $libc_munlock_trampoline<>(SB)
+ 
+ TEXT libc_munlockall_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munlockall(SB)
+-
+ GLOBL	·libc_munlockall_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munlockall_trampoline_addr(SB)/8, $libc_munlockall_trampoline<>(SB)
+ 
+ TEXT libc_closedir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_closedir(SB)
+-
+ GLOBL	·libc_closedir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_closedir_trampoline_addr(SB)/8, $libc_closedir_trampoline<>(SB)
+ 
+ TEXT libc_readdir_r_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readdir_r(SB)
+-
+ GLOBL	·libc_readdir_r_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readdir_r_trampoline_addr(SB)/8, $libc_readdir_r_trampoline<>(SB)
+ 
+ TEXT libc_pipe_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pipe(SB)
+-
+ GLOBL	·libc_pipe_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pipe_trampoline_addr(SB)/8, $libc_pipe_trampoline<>(SB)
+ 
+ TEXT libc_getxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getxattr(SB)
+-
+ GLOBL	·libc_getxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getxattr_trampoline_addr(SB)/8, $libc_getxattr_trampoline<>(SB)
+ 
+ TEXT libc_fgetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fgetxattr(SB)
+-
+ GLOBL	·libc_fgetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fgetxattr_trampoline_addr(SB)/8, $libc_fgetxattr_trampoline<>(SB)
+ 
+ TEXT libc_setxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setxattr(SB)
+-
+ GLOBL	·libc_setxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setxattr_trampoline_addr(SB)/8, $libc_setxattr_trampoline<>(SB)
+ 
+ TEXT libc_fsetxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsetxattr(SB)
+-
+ GLOBL	·libc_fsetxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsetxattr_trampoline_addr(SB)/8, $libc_fsetxattr_trampoline<>(SB)
+ 
+ TEXT libc_removexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_removexattr(SB)
+-
+ GLOBL	·libc_removexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_removexattr_trampoline_addr(SB)/8, $libc_removexattr_trampoline<>(SB)
+ 
+ TEXT libc_fremovexattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fremovexattr(SB)
+-
+ GLOBL	·libc_fremovexattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fremovexattr_trampoline_addr(SB)/8, $libc_fremovexattr_trampoline<>(SB)
+ 
+ TEXT libc_listxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listxattr(SB)
+-
+ GLOBL	·libc_listxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listxattr_trampoline_addr(SB)/8, $libc_listxattr_trampoline<>(SB)
+ 
+ TEXT libc_flistxattr_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flistxattr(SB)
+-
+ GLOBL	·libc_flistxattr_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flistxattr_trampoline_addr(SB)/8, $libc_flistxattr_trampoline<>(SB)
+ 
+ TEXT libc_utimensat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_utimensat(SB)
+-
+ GLOBL	·libc_utimensat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_utimensat_trampoline_addr(SB)/8, $libc_utimensat_trampoline<>(SB)
+ 
+ TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fcntl(SB)
+-
+ GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
+ 
+ TEXT libc_kill_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kill(SB)
+-
+ GLOBL	·libc_kill_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kill_trampoline_addr(SB)/8, $libc_kill_trampoline<>(SB)
+ 
+ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ioctl(SB)
+-
+ GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
+ 
+ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sysctl(SB)
+-
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
+ TEXT libc_sendfile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sendfile(SB)
+-
+ GLOBL	·libc_sendfile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sendfile_trampoline_addr(SB)/8, $libc_sendfile_trampoline<>(SB)
+ 
+ TEXT libc_shmat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmat(SB)
+-
+ GLOBL	·libc_shmat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmat_trampoline_addr(SB)/8, $libc_shmat_trampoline<>(SB)
+ 
+ TEXT libc_shmctl_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmctl(SB)
+-
+ GLOBL	·libc_shmctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmctl_trampoline_addr(SB)/8, $libc_shmctl_trampoline<>(SB)
+ 
+ TEXT libc_shmdt_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmdt(SB)
+-
+ GLOBL	·libc_shmdt_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmdt_trampoline_addr(SB)/8, $libc_shmdt_trampoline<>(SB)
+ 
+ TEXT libc_shmget_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_shmget(SB)
+-
+ GLOBL	·libc_shmget_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_shmget_trampoline_addr(SB)/8, $libc_shmget_trampoline<>(SB)
+ 
+ TEXT libc_access_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_access(SB)
+-
+ GLOBL	·libc_access_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_access_trampoline_addr(SB)/8, $libc_access_trampoline<>(SB)
+ 
+ TEXT libc_adjtime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_adjtime(SB)
+-
+ GLOBL	·libc_adjtime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_adjtime_trampoline_addr(SB)/8, $libc_adjtime_trampoline<>(SB)
+ 
+ TEXT libc_chdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chdir(SB)
+-
+ GLOBL	·libc_chdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chdir_trampoline_addr(SB)/8, $libc_chdir_trampoline<>(SB)
+ 
+ TEXT libc_chflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chflags(SB)
+-
+ GLOBL	·libc_chflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chflags_trampoline_addr(SB)/8, $libc_chflags_trampoline<>(SB)
+ 
+ TEXT libc_chmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chmod(SB)
+-
+ GLOBL	·libc_chmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chmod_trampoline_addr(SB)/8, $libc_chmod_trampoline<>(SB)
+ 
+ TEXT libc_chown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chown(SB)
+-
+ GLOBL	·libc_chown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chown_trampoline_addr(SB)/8, $libc_chown_trampoline<>(SB)
+ 
+ TEXT libc_chroot_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_chroot(SB)
+-
+ GLOBL	·libc_chroot_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_chroot_trampoline_addr(SB)/8, $libc_chroot_trampoline<>(SB)
+ 
+ TEXT libc_clock_gettime_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clock_gettime(SB)
+-
+ GLOBL	·libc_clock_gettime_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clock_gettime_trampoline_addr(SB)/8, $libc_clock_gettime_trampoline<>(SB)
+ 
+ TEXT libc_close_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_close(SB)
+-
+ GLOBL	·libc_close_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_close_trampoline_addr(SB)/8, $libc_close_trampoline<>(SB)
+ 
+ TEXT libc_clonefile_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefile(SB)
+-
+ GLOBL	·libc_clonefile_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefile_trampoline_addr(SB)/8, $libc_clonefile_trampoline<>(SB)
+ 
+ TEXT libc_clonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_clonefileat(SB)
+-
+ GLOBL	·libc_clonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_clonefileat_trampoline_addr(SB)/8, $libc_clonefileat_trampoline<>(SB)
+ 
+ TEXT libc_dup_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup(SB)
+-
+ GLOBL	·libc_dup_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup_trampoline_addr(SB)/8, $libc_dup_trampoline<>(SB)
+ 
+ TEXT libc_dup2_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_dup2(SB)
+-
+ GLOBL	·libc_dup2_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_dup2_trampoline_addr(SB)/8, $libc_dup2_trampoline<>(SB)
+ 
+ TEXT libc_exchangedata_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exchangedata(SB)
+-
+ GLOBL	·libc_exchangedata_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exchangedata_trampoline_addr(SB)/8, $libc_exchangedata_trampoline<>(SB)
+ 
+ TEXT libc_exit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_exit(SB)
+-
+ GLOBL	·libc_exit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_exit_trampoline_addr(SB)/8, $libc_exit_trampoline<>(SB)
+ 
+ TEXT libc_faccessat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_faccessat(SB)
+-
+ GLOBL	·libc_faccessat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_faccessat_trampoline_addr(SB)/8, $libc_faccessat_trampoline<>(SB)
+ 
+ TEXT libc_fchdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchdir(SB)
+-
+ GLOBL	·libc_fchdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchdir_trampoline_addr(SB)/8, $libc_fchdir_trampoline<>(SB)
+ 
+ TEXT libc_fchflags_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchflags(SB)
+-
+ GLOBL	·libc_fchflags_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchflags_trampoline_addr(SB)/8, $libc_fchflags_trampoline<>(SB)
+ 
+ TEXT libc_fchmod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmod(SB)
+-
+ GLOBL	·libc_fchmod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmod_trampoline_addr(SB)/8, $libc_fchmod_trampoline<>(SB)
+ 
+ TEXT libc_fchmodat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchmodat(SB)
+-
+ GLOBL	·libc_fchmodat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchmodat_trampoline_addr(SB)/8, $libc_fchmodat_trampoline<>(SB)
+ 
+ TEXT libc_fchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchown(SB)
+-
+ GLOBL	·libc_fchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchown_trampoline_addr(SB)/8, $libc_fchown_trampoline<>(SB)
+ 
+ TEXT libc_fchownat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fchownat(SB)
+-
+ GLOBL	·libc_fchownat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fchownat_trampoline_addr(SB)/8, $libc_fchownat_trampoline<>(SB)
+ 
+ TEXT libc_fclonefileat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fclonefileat(SB)
+-
+ GLOBL	·libc_fclonefileat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fclonefileat_trampoline_addr(SB)/8, $libc_fclonefileat_trampoline<>(SB)
+ 
+ TEXT libc_flock_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_flock(SB)
+-
+ GLOBL	·libc_flock_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_flock_trampoline_addr(SB)/8, $libc_flock_trampoline<>(SB)
+ 
+ TEXT libc_fpathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fpathconf(SB)
+-
+ GLOBL	·libc_fpathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fpathconf_trampoline_addr(SB)/8, $libc_fpathconf_trampoline<>(SB)
+ 
+ TEXT libc_fsync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fsync(SB)
+-
+ GLOBL	·libc_fsync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fsync_trampoline_addr(SB)/8, $libc_fsync_trampoline<>(SB)
+ 
+ TEXT libc_ftruncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ftruncate(SB)
+-
+ GLOBL	·libc_ftruncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ftruncate_trampoline_addr(SB)/8, $libc_ftruncate_trampoline<>(SB)
+ 
+ TEXT libc_getcwd_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getcwd(SB)
+-
+ GLOBL	·libc_getcwd_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getcwd_trampoline_addr(SB)/8, $libc_getcwd_trampoline<>(SB)
+ 
+ TEXT libc_getdtablesize_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getdtablesize(SB)
+-
+ GLOBL	·libc_getdtablesize_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getdtablesize_trampoline_addr(SB)/8, $libc_getdtablesize_trampoline<>(SB)
+ 
+ TEXT libc_getegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getegid(SB)
+-
+ GLOBL	·libc_getegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getegid_trampoline_addr(SB)/8, $libc_getegid_trampoline<>(SB)
+ 
+ TEXT libc_geteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_geteuid(SB)
+-
+ GLOBL	·libc_geteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_geteuid_trampoline_addr(SB)/8, $libc_geteuid_trampoline<>(SB)
+ 
+ TEXT libc_getgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getgid(SB)
+-
+ GLOBL	·libc_getgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getgid_trampoline_addr(SB)/8, $libc_getgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgid(SB)
+-
+ GLOBL	·libc_getpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgid_trampoline_addr(SB)/8, $libc_getpgid_trampoline<>(SB)
+ 
+ TEXT libc_getpgrp_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpgrp(SB)
+-
+ GLOBL	·libc_getpgrp_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpgrp_trampoline_addr(SB)/8, $libc_getpgrp_trampoline<>(SB)
+ 
+ TEXT libc_getpid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpid(SB)
+-
+ GLOBL	·libc_getpid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpid_trampoline_addr(SB)/8, $libc_getpid_trampoline<>(SB)
+ 
+ TEXT libc_getppid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getppid(SB)
+-
+ GLOBL	·libc_getppid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getppid_trampoline_addr(SB)/8, $libc_getppid_trampoline<>(SB)
+ 
+ TEXT libc_getpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getpriority(SB)
+-
+ GLOBL	·libc_getpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getpriority_trampoline_addr(SB)/8, $libc_getpriority_trampoline<>(SB)
+ 
+ TEXT libc_getrlimit_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrlimit(SB)
+-
+ GLOBL	·libc_getrlimit_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrlimit_trampoline_addr(SB)/8, $libc_getrlimit_trampoline<>(SB)
+ 
+ TEXT libc_getrusage_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getrusage(SB)
+-
+ GLOBL	·libc_getrusage_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getrusage_trampoline_addr(SB)/8, $libc_getrusage_trampoline<>(SB)
+ 
+ TEXT libc_getsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getsid(SB)
+-
+ GLOBL	·libc_getsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getsid_trampoline_addr(SB)/8, $libc_getsid_trampoline<>(SB)
+ 
+ TEXT libc_gettimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_gettimeofday(SB)
+-
+ GLOBL	·libc_gettimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_gettimeofday_trampoline_addr(SB)/8, $libc_gettimeofday_trampoline<>(SB)
+ 
+ TEXT libc_getuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getuid(SB)
+-
+ GLOBL	·libc_getuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getuid_trampoline_addr(SB)/8, $libc_getuid_trampoline<>(SB)
+ 
+ TEXT libc_issetugid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_issetugid(SB)
+-
+ GLOBL	·libc_issetugid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_issetugid_trampoline_addr(SB)/8, $libc_issetugid_trampoline<>(SB)
+ 
+ TEXT libc_kqueue_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_kqueue(SB)
+-
+ GLOBL	·libc_kqueue_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_kqueue_trampoline_addr(SB)/8, $libc_kqueue_trampoline<>(SB)
+ 
+ TEXT libc_lchown_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lchown(SB)
+-
+ GLOBL	·libc_lchown_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lchown_trampoline_addr(SB)/8, $libc_lchown_trampoline<>(SB)
+ 
+ TEXT libc_link_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_link(SB)
+-
+ GLOBL	·libc_link_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_link_trampoline_addr(SB)/8, $libc_link_trampoline<>(SB)
+ 
+ TEXT libc_linkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_linkat(SB)
+-
+ GLOBL	·libc_linkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_linkat_trampoline_addr(SB)/8, $libc_linkat_trampoline<>(SB)
+ 
+ TEXT libc_listen_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_listen(SB)
+-
+ GLOBL	·libc_listen_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_listen_trampoline_addr(SB)/8, $libc_listen_trampoline<>(SB)
+ 
+ TEXT libc_mkdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdir(SB)
+-
+ GLOBL	·libc_mkdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdir_trampoline_addr(SB)/8, $libc_mkdir_trampoline<>(SB)
+ 
+ TEXT libc_mkdirat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkdirat(SB)
+-
+ GLOBL	·libc_mkdirat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkdirat_trampoline_addr(SB)/8, $libc_mkdirat_trampoline<>(SB)
+ 
+ TEXT libc_mkfifo_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mkfifo(SB)
+-
+ GLOBL	·libc_mkfifo_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mkfifo_trampoline_addr(SB)/8, $libc_mkfifo_trampoline<>(SB)
+ 
+ TEXT libc_mknod_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mknod(SB)
+-
+ GLOBL	·libc_mknod_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mknod_trampoline_addr(SB)/8, $libc_mknod_trampoline<>(SB)
+ 
+ TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mount(SB)
+-
+ GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mount_trampoline_addr(SB)/8, $libc_mount_trampoline<>(SB)
+ 
+ TEXT libc_open_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_open(SB)
+-
+ GLOBL	·libc_open_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_open_trampoline_addr(SB)/8, $libc_open_trampoline<>(SB)
+ 
+ TEXT libc_openat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_openat(SB)
+-
+ GLOBL	·libc_openat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_openat_trampoline_addr(SB)/8, $libc_openat_trampoline<>(SB)
+ 
+ TEXT libc_pathconf_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pathconf(SB)
+-
+ GLOBL	·libc_pathconf_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pathconf_trampoline_addr(SB)/8, $libc_pathconf_trampoline<>(SB)
+ 
+ TEXT libc_pread_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pread(SB)
+-
+ GLOBL	·libc_pread_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pread_trampoline_addr(SB)/8, $libc_pread_trampoline<>(SB)
+ 
+ TEXT libc_pwrite_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_pwrite(SB)
+-
+ GLOBL	·libc_pwrite_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_pwrite_trampoline_addr(SB)/8, $libc_pwrite_trampoline<>(SB)
+ 
+ TEXT libc_read_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_read(SB)
+-
+ GLOBL	·libc_read_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_read_trampoline_addr(SB)/8, $libc_read_trampoline<>(SB)
+ 
+ TEXT libc_readlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlink(SB)
+-
+ GLOBL	·libc_readlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlink_trampoline_addr(SB)/8, $libc_readlink_trampoline<>(SB)
+ 
+ TEXT libc_readlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_readlinkat(SB)
+-
+ GLOBL	·libc_readlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_readlinkat_trampoline_addr(SB)/8, $libc_readlinkat_trampoline<>(SB)
+ 
+ TEXT libc_rename_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rename(SB)
+-
+ GLOBL	·libc_rename_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rename_trampoline_addr(SB)/8, $libc_rename_trampoline<>(SB)
+ 
+ TEXT libc_renameat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_renameat(SB)
+-
+ GLOBL	·libc_renameat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_renameat_trampoline_addr(SB)/8, $libc_renameat_trampoline<>(SB)
+ 
+ TEXT libc_revoke_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_revoke(SB)
+-
+ GLOBL	·libc_revoke_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_revoke_trampoline_addr(SB)/8, $libc_revoke_trampoline<>(SB)
+ 
+ TEXT libc_rmdir_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_rmdir(SB)
+-
+ GLOBL	·libc_rmdir_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_rmdir_trampoline_addr(SB)/8, $libc_rmdir_trampoline<>(SB)
+ 
+ TEXT libc_lseek_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lseek(SB)
+-
+ GLOBL	·libc_lseek_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lseek_trampoline_addr(SB)/8, $libc_lseek_trampoline<>(SB)
+ 
+ TEXT libc_select_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_select(SB)
+-
+ GLOBL	·libc_select_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_select_trampoline_addr(SB)/8, $libc_select_trampoline<>(SB)
+ 
+@@ -712,192 +595,160 @@ DATA	·libc_setattrlist_trampoline_addr(SB)/8, $libc_setattrlist_trampoline<>(SB
+ 
+ TEXT libc_setegid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setegid(SB)
+-
+ GLOBL	·libc_setegid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setegid_trampoline_addr(SB)/8, $libc_setegid_trampoline<>(SB)
+ 
+ TEXT libc_seteuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_seteuid(SB)
+-
+ GLOBL	·libc_seteuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_seteuid_trampoline_addr(SB)/8, $libc_seteuid_trampoline<>(SB)
+ 
+ TEXT libc_setgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setgid(SB)
+-
+ GLOBL	·libc_setgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setgid_trampoline_addr(SB)/8, $libc_setgid_trampoline<>(SB)
+ 
+ TEXT libc_setlogin_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setlogin(SB)
+-
+ GLOBL	·libc_setlogin_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setlogin_trampoline_addr(SB)/8, $libc_setlogin_trampoline<>(SB)
+ 
+ TEXT libc_setpgid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpgid(SB)
+-
+ GLOBL	·libc_setpgid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpgid_trampoline_addr(SB)/8, $libc_setpgid_trampoline<>(SB)
+ 
+ TEXT libc_setpriority_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setpriority(SB)
+-
+ GLOBL	·libc_setpriority_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setpriority_trampoline_addr(SB)/8, $libc_setpriority_trampoline<>(SB)
+ 
+ TEXT libc_setprivexec_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setprivexec(SB)
+-
+ GLOBL	·libc_setprivexec_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setprivexec_trampoline_addr(SB)/8, $libc_setprivexec_trampoline<>(SB)
+ 
+ TEXT libc_setregid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setregid(SB)
+-
+ GLOBL	·libc_setregid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setregid_trampoline_addr(SB)/8, $libc_setregid_trampoline<>(SB)
+ 
+ TEXT libc_setreuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setreuid(SB)
+-
+ GLOBL	·libc_setreuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setreuid_trampoline_addr(SB)/8, $libc_setreuid_trampoline<>(SB)
+ 
+ TEXT libc_setsid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setsid(SB)
+-
+ GLOBL	·libc_setsid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setsid_trampoline_addr(SB)/8, $libc_setsid_trampoline<>(SB)
+ 
+ TEXT libc_settimeofday_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_settimeofday(SB)
+-
+ GLOBL	·libc_settimeofday_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_settimeofday_trampoline_addr(SB)/8, $libc_settimeofday_trampoline<>(SB)
+ 
+ TEXT libc_setuid_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_setuid(SB)
+-
+ GLOBL	·libc_setuid_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_setuid_trampoline_addr(SB)/8, $libc_setuid_trampoline<>(SB)
+ 
+ TEXT libc_symlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlink(SB)
+-
+ GLOBL	·libc_symlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlink_trampoline_addr(SB)/8, $libc_symlink_trampoline<>(SB)
+ 
+ TEXT libc_symlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_symlinkat(SB)
+-
+ GLOBL	·libc_symlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_symlinkat_trampoline_addr(SB)/8, $libc_symlinkat_trampoline<>(SB)
+ 
+ TEXT libc_sync_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_sync(SB)
+-
+ GLOBL	·libc_sync_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sync_trampoline_addr(SB)/8, $libc_sync_trampoline<>(SB)
+ 
+ TEXT libc_truncate_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_truncate(SB)
+-
+ GLOBL	·libc_truncate_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_truncate_trampoline_addr(SB)/8, $libc_truncate_trampoline<>(SB)
+ 
+ TEXT libc_umask_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_umask(SB)
+-
+ GLOBL	·libc_umask_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_umask_trampoline_addr(SB)/8, $libc_umask_trampoline<>(SB)
+ 
+ TEXT libc_undelete_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_undelete(SB)
+-
+ GLOBL	·libc_undelete_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_undelete_trampoline_addr(SB)/8, $libc_undelete_trampoline<>(SB)
+ 
+ TEXT libc_unlink_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlink(SB)
+-
+ GLOBL	·libc_unlink_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlink_trampoline_addr(SB)/8, $libc_unlink_trampoline<>(SB)
+ 
+ TEXT libc_unlinkat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unlinkat(SB)
+-
+ GLOBL	·libc_unlinkat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unlinkat_trampoline_addr(SB)/8, $libc_unlinkat_trampoline<>(SB)
+ 
+ TEXT libc_unmount_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_unmount(SB)
+-
+ GLOBL	·libc_unmount_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_unmount_trampoline_addr(SB)/8, $libc_unmount_trampoline<>(SB)
+ 
+ TEXT libc_write_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_write(SB)
+-
+ GLOBL	·libc_write_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_write_trampoline_addr(SB)/8, $libc_write_trampoline<>(SB)
+ 
+ TEXT libc_mmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_mmap(SB)
+-
+ GLOBL	·libc_mmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_mmap_trampoline_addr(SB)/8, $libc_mmap_trampoline<>(SB)
+ 
+ TEXT libc_munmap_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_munmap(SB)
+-
+ GLOBL	·libc_munmap_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_munmap_trampoline_addr(SB)/8, $libc_munmap_trampoline<>(SB)
+ 
+ TEXT libc_fstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstat(SB)
+-
+ GLOBL	·libc_fstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstat_trampoline_addr(SB)/8, $libc_fstat_trampoline<>(SB)
+ 
+ TEXT libc_fstatat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatat(SB)
+-
+ GLOBL	·libc_fstatat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatat_trampoline_addr(SB)/8, $libc_fstatat_trampoline<>(SB)
+ 
+ TEXT libc_fstatfs_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_fstatfs(SB)
+-
+ GLOBL	·libc_fstatfs_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_fstatfs_trampoline_addr(SB)/8, $libc_fstatfs_trampoline<>(SB)
+ 
+ TEXT libc_getfsstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_getfsstat(SB)
+-
+ GLOBL	·libc_getfsstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_getfsstat_trampoline_addr(SB)/8, $libc_getfsstat_trampoline<>(SB)
+ 
+ TEXT libc_lstat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_lstat(SB)
+-
+ GLOBL	·libc_lstat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_lstat_trampoline_addr(SB)/8, $libc_lstat_trampoline<>(SB)
+ 
+ TEXT libc_ptrace_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ptrace(SB)
+-
+ GLOBL	·libc_ptrace_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_ptrace_trampoline_addr(SB)/8, $libc_ptrace_trampoline<>(SB)
+ 
+ TEXT libc_stat_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_stat(SB)
+-
+ GLOBL	·libc_stat_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_stat_trampoline_addr(SB)/8, $libc_stat_trampoline<>(SB)
+ 
+ TEXT libc_statfs_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_statfs(SB)
+-
+ GLOBL	·libc_statfs_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_statfs_trampoline_addr(SB)/8, $libc_statfs_trampoline<>(SB)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
+index 0eabac7..0c67df6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_dragonfly_amd64.go
+@@ -1642,28 +1642,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
+index ee313eb..e6e05d1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_386.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
+index 4c986e4..7508acc 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_amd64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
+index 5552169..7b56aea 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
+index 67a226f..cc623dc 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_arm64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
+index f0b9dda..5818491 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_freebsd_riscv64.go
+@@ -1862,28 +1862,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func accept4(fd int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (nfd int, err error) {
+ 	r0, _, e1 := Syscall6(SYS_ACCEPT4, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	nfd = int(r0)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
+index b57c705..6be25cd 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_illumos_amd64.go
+@@ -40,7 +40,7 @@ func readv(fd int, iovs []Iovec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procreadv)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -55,7 +55,7 @@ func preadv(fd int, iovs []Iovec, off int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpreadv)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), uintptr(off), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -70,7 +70,7 @@ func writev(fd int, iovs []Iovec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwritev)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -85,7 +85,7 @@ func pwritev(fd int, iovs []Iovec, off int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpwritev)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(iovs)), uintptr(off), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -96,7 +96,7 @@ func accept4(s int, rsa *RawSockaddrAny, addrlen *_Socklen, flags int) (fd int,
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procaccept4)), 4, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), uintptr(flags), 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index 7ceec23..8e5cee2 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -1734,28 +1734,6 @@ func exitThread(code int) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, p *byte, np int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(p)), uintptr(np))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, p *byte, np int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(p)), uintptr(np))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func readv(fd int, iovs []Iovec) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(iovs) > 0 {
+@@ -2197,3 +2175,23 @@ func getresgid(rgid *_C_int, egid *_C_int, sgid *_C_int) {
+ 	RawSyscallNoError(SYS_GETRESGID, uintptr(unsafe.Pointer(rgid)), uintptr(unsafe.Pointer(egid)), uintptr(unsafe.Pointer(sgid)))
+ 	return
+ }
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func schedSetattr(pid int, attr *SchedAttr, flags uint) (err error) {
++	_, _, e1 := Syscall(SYS_SCHED_SETATTR, uintptr(pid), uintptr(unsafe.Pointer(attr)), uintptr(flags))
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func schedGetattr(pid int, attr *SchedAttr, size uint, flags uint) (err error) {
++	_, _, e1 := Syscall6(SYS_SCHED_GETATTR, uintptr(pid), uintptr(unsafe.Pointer(attr)), uintptr(size), uintptr(flags), 0, 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
+index cdb2af5..af06b23 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_386.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
+index 9d25f76..093fcf3 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_amd64.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
+index d3f8035..4a78567 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
+index 887188a..741d8be 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_netbsd_arm64.go
+@@ -1824,28 +1824,6 @@ func munmap(addr uintptr, length uintptr) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := Syscall(SYS_WRITE, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index 9ab9abf..66b3b64 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index 915761e..c5c4cc1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -2213,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index 8e87fdf..93bfbb3 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 12a7a21..a107b8f 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index b19e8aa..c427de5 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index fb99594..60c1a99 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index 32cbbbc..52eba36 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -549,6 +549,12 @@ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	return
+ }
+ 
++var libc_ioctl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	_, _, e1 := syscall_syscall(libc_ioctl_trampoline_addr, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -557,10 +563,6 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+ 	return
+ }
+ 
+-var libc_ioctl_trampoline_addr uintptr
+-
+-//go:cgo_import_dynamic libc_ioctl ioctl "libc.so"
+-
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+ func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+@@ -2211,28 +2213,6 @@ var libc_munmap_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_read_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+-func writelen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(libc_write_trampoline_addr, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error) {
+ 	var _p0 *byte
+ 	_p0, err = BytePtrFromString(path)
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
+index 609d1c5..b401894 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_solaris_amd64.go
+@@ -436,7 +436,7 @@ func pipe(p *[2]_C_int) (n int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procpipe)), 1, uintptr(unsafe.Pointer(p)), 0, 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -446,7 +446,7 @@ func pipe(p *[2]_C_int) (n int, err error) {
+ func pipe2(p *[2]_C_int, flags int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procpipe2)), 2, uintptr(unsafe.Pointer(p)), uintptr(flags), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -456,7 +456,7 @@ func pipe2(p *[2]_C_int, flags int) (err error) {
+ func getsockname(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgetsockname)), 3, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -471,7 +471,7 @@ func Getcwd(buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetcwd)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -482,7 +482,7 @@ func getgroups(ngid int, gid *_Gid_t) (n int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procgetgroups)), 2, uintptr(ngid), uintptr(unsafe.Pointer(gid)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -492,7 +492,7 @@ func getgroups(ngid int, gid *_Gid_t) (n int, err error) {
+ func setgroups(ngid int, gid *_Gid_t) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procsetgroups)), 2, uintptr(ngid), uintptr(unsafe.Pointer(gid)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -503,7 +503,7 @@ func wait4(pid int32, statusp *_C_int, options int, rusage *Rusage) (wpid int32,
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwait4)), 4, uintptr(pid), uintptr(unsafe.Pointer(statusp)), uintptr(options), uintptr(unsafe.Pointer(rusage)), 0, 0)
+ 	wpid = int32(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -518,7 +518,7 @@ func gethostname(buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgethostname)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -533,7 +533,7 @@ func utimes(path string, times *[2]Timeval) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procutimes)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(times)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -548,7 +548,7 @@ func utimensat(fd int, path string, times *[2]Timespec, flag int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procutimensat)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(times)), uintptr(flag), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -559,7 +559,7 @@ func fcntl(fd int, cmd int, arg int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procfcntl)), 3, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -569,7 +569,7 @@ func fcntl(fd int, cmd int, arg int) (val int, err error) {
+ func futimesat(fildes int, path *byte, times *[2]Timeval) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procfutimesat)), 3, uintptr(fildes), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(times)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -580,7 +580,7 @@ func accept(s int, rsa *RawSockaddrAny, addrlen *_Socklen) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procaccept)), 3, uintptr(s), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -591,7 +591,7 @@ func recvmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_recvmsg)), 3, uintptr(s), uintptr(unsafe.Pointer(msg)), uintptr(flags), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -602,7 +602,7 @@ func sendmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_sendmsg)), 3, uintptr(s), uintptr(unsafe.Pointer(msg)), uintptr(flags), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -612,7 +612,7 @@ func sendmsg(s int, msg *Msghdr, flags int) (n int, err error) {
+ func acct(path *byte) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procacct)), 1, uintptr(unsafe.Pointer(path)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -647,7 +647,7 @@ func ioctlRet(fd int, req int, arg uintptr) (ret int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, uintptr(fd), uintptr(req), uintptr(arg), 0, 0, 0)
+ 	ret = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -658,7 +658,7 @@ func ioctlPtrRet(fd int, req int, arg unsafe.Pointer) (ret int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, uintptr(fd), uintptr(req), uintptr(arg), 0, 0, 0)
+ 	ret = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -669,7 +669,7 @@ func poll(fds *PollFd, nfds int, timeout int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpoll)), 3, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(timeout), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -684,7 +684,7 @@ func Access(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procAccess)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -694,7 +694,7 @@ func Access(path string, mode uint32) (err error) {
+ func Adjtime(delta *Timeval, olddelta *Timeval) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procAdjtime)), 2, uintptr(unsafe.Pointer(delta)), uintptr(unsafe.Pointer(olddelta)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -709,7 +709,7 @@ func Chdir(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChdir)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -724,7 +724,7 @@ func Chmod(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChmod)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -739,7 +739,7 @@ func Chown(path string, uid int, gid int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChown)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -754,7 +754,7 @@ func Chroot(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procChroot)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -764,7 +764,7 @@ func Chroot(path string) (err error) {
+ func ClockGettime(clockid int32, time *Timespec) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procClockGettime)), 2, uintptr(clockid), uintptr(unsafe.Pointer(time)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -774,7 +774,7 @@ func ClockGettime(clockid int32, time *Timespec) (err error) {
+ func Close(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procClose)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -790,7 +790,7 @@ func Creat(path string, mode uint32) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procCreat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -801,7 +801,7 @@ func Dup(fd int) (nfd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procDup)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	nfd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -811,7 +811,7 @@ func Dup(fd int) (nfd int, err error) {
+ func Dup2(oldfd int, newfd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procDup2)), 2, uintptr(oldfd), uintptr(newfd), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -833,7 +833,7 @@ func Faccessat(dirfd int, path string, mode uint32, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFaccessat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -843,7 +843,7 @@ func Faccessat(dirfd int, path string, mode uint32, flags int) (err error) {
+ func Fchdir(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchdir)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -853,7 +853,7 @@ func Fchdir(fd int) (err error) {
+ func Fchmod(fd int, mode uint32) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchmod)), 2, uintptr(fd), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -868,7 +868,7 @@ func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchmodat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -878,7 +878,7 @@ func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+ func Fchown(fd int, uid int, gid int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchown)), 3, uintptr(fd), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -893,7 +893,7 @@ func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFchownat)), 5, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), uintptr(flags), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -903,7 +903,7 @@ func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
+ func Fdatasync(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFdatasync)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -913,7 +913,7 @@ func Fdatasync(fd int) (err error) {
+ func Flock(fd int, how int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFlock)), 2, uintptr(fd), uintptr(how), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -924,7 +924,7 @@ func Fpathconf(fd int, name int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFpathconf)), 2, uintptr(fd), uintptr(name), 0, 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -934,7 +934,7 @@ func Fpathconf(fd int, name int) (val int, err error) {
+ func Fstat(fd int, stat *Stat_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstat)), 2, uintptr(fd), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -949,7 +949,7 @@ func Fstatat(fd int, path string, stat *Stat_t, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstatat)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -959,7 +959,7 @@ func Fstatat(fd int, path string, stat *Stat_t, flags int) (err error) {
+ func Fstatvfs(fd int, vfsstat *Statvfs_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFstatvfs)), 2, uintptr(fd), uintptr(unsafe.Pointer(vfsstat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -974,7 +974,7 @@ func Getdents(fd int, buf []byte, basep *uintptr) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetdents)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(basep)), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1001,7 +1001,7 @@ func Getpgid(pid int) (pgid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetpgid)), 1, uintptr(pid), 0, 0, 0, 0, 0)
+ 	pgid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1012,7 +1012,7 @@ func Getpgrp() (pgid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetpgrp)), 0, 0, 0, 0, 0, 0, 0)
+ 	pgid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1047,7 +1047,7 @@ func Getpriority(which int, who int) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procGetpriority)), 2, uintptr(which), uintptr(who), 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1057,7 +1057,7 @@ func Getpriority(which int, who int) (n int, err error) {
+ func Getrlimit(which int, lim *Rlimit) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetrlimit)), 2, uintptr(which), uintptr(unsafe.Pointer(lim)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1067,7 +1067,7 @@ func Getrlimit(which int, lim *Rlimit) (err error) {
+ func Getrusage(who int, rusage *Rusage) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetrusage)), 2, uintptr(who), uintptr(unsafe.Pointer(rusage)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1078,7 +1078,7 @@ func Getsid(pid int) (sid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGetsid)), 1, uintptr(pid), 0, 0, 0, 0, 0)
+ 	sid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1088,7 +1088,7 @@ func Getsid(pid int) (sid int, err error) {
+ func Gettimeofday(tv *Timeval) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procGettimeofday)), 1, uintptr(unsafe.Pointer(tv)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1106,7 +1106,7 @@ func Getuid() (uid int) {
+ func Kill(pid int, signum syscall.Signal) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procKill)), 2, uintptr(pid), uintptr(signum), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1121,7 +1121,7 @@ func Lchown(path string, uid int, gid int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLchown)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(uid), uintptr(gid), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1141,7 +1141,7 @@ func Link(path string, link string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLink)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1151,7 +1151,7 @@ func Link(path string, link string) (err error) {
+ func Listen(s int, backlog int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_llisten)), 2, uintptr(s), uintptr(backlog), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1166,7 +1166,7 @@ func Lstat(path string, stat *Stat_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procLstat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1180,7 +1180,7 @@ func Madvise(b []byte, advice int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMadvise)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(advice), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1195,7 +1195,7 @@ func Mkdir(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkdir)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1210,7 +1210,7 @@ func Mkdirat(dirfd int, path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkdirat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1225,7 +1225,7 @@ func Mkfifo(path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkfifo)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1240,7 +1240,7 @@ func Mkfifoat(dirfd int, path string, mode uint32) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMkfifoat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1255,7 +1255,7 @@ func Mknod(path string, mode uint32, dev int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMknod)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(dev), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1270,7 +1270,7 @@ func Mknodat(dirfd int, path string, mode uint32, dev int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMknodat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(dev), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1284,7 +1284,7 @@ func Mlock(b []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMlock)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1294,7 +1294,7 @@ func Mlock(b []byte) (err error) {
+ func Mlockall(flags int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMlockall)), 1, uintptr(flags), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1308,7 +1308,7 @@ func Mprotect(b []byte, prot int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMprotect)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(prot), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1322,7 +1322,7 @@ func Msync(b []byte, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMsync)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), uintptr(flags), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1336,7 +1336,7 @@ func Munlock(b []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMunlock)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(b)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1346,7 +1346,7 @@ func Munlock(b []byte) (err error) {
+ func Munlockall() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procMunlockall)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1356,7 +1356,7 @@ func Munlockall() (err error) {
+ func Nanosleep(time *Timespec, leftover *Timespec) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procNanosleep)), 2, uintptr(unsafe.Pointer(time)), uintptr(unsafe.Pointer(leftover)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1372,7 +1372,7 @@ func Open(path string, mode int, perm uint32) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procOpen)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(perm), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1388,7 +1388,7 @@ func Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error)
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procOpenat)), 4, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(flags), uintptr(mode), 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1404,7 +1404,7 @@ func Pathconf(path string, name int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procPathconf)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(name), 0, 0, 0, 0)
+ 	val = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1414,7 +1414,7 @@ func Pathconf(path string, name int) (val int, err error) {
+ func Pause() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procPause)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1429,7 +1429,7 @@ func pread(fd int, p []byte, offset int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpread)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(offset), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1444,7 +1444,7 @@ func pwrite(fd int, p []byte, offset int64) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procpwrite)), 4, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(offset), 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1459,7 +1459,7 @@ func read(fd int, p []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procread)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1479,7 +1479,7 @@ func Readlink(path string, buf []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procReadlink)), 3, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), uintptr(len(buf)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1499,7 +1499,7 @@ func Rename(from string, to string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRename)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1519,7 +1519,7 @@ func Renameat(olddirfd int, oldpath string, newdirfd int, newpath string) (err e
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRenameat)), 4, uintptr(olddirfd), uintptr(unsafe.Pointer(_p0)), uintptr(newdirfd), uintptr(unsafe.Pointer(_p1)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1534,7 +1534,7 @@ func Rmdir(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procRmdir)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1545,7 +1545,7 @@ func Seek(fd int, offset int64, whence int) (newoffset int64, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proclseek)), 3, uintptr(fd), uintptr(offset), uintptr(whence), 0, 0, 0)
+ 	newoffset = int64(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1556,7 +1556,7 @@ func Select(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timeval) (n int, err
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSelect)), 5, uintptr(nfd), uintptr(unsafe.Pointer(r)), uintptr(unsafe.Pointer(w)), uintptr(unsafe.Pointer(e)), uintptr(unsafe.Pointer(timeout)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1566,7 +1566,7 @@ func Select(nfd int, r *FdSet, w *FdSet, e *FdSet, timeout *Timeval) (n int, err
+ func Setegid(egid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetegid)), 1, uintptr(egid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1576,7 +1576,7 @@ func Setegid(egid int) (err error) {
+ func Seteuid(euid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSeteuid)), 1, uintptr(euid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1586,7 +1586,7 @@ func Seteuid(euid int) (err error) {
+ func Setgid(gid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetgid)), 1, uintptr(gid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1600,7 +1600,7 @@ func Sethostname(p []byte) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSethostname)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1610,7 +1610,7 @@ func Sethostname(p []byte) (err error) {
+ func Setpgid(pid int, pgid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetpgid)), 2, uintptr(pid), uintptr(pgid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1620,7 +1620,7 @@ func Setpgid(pid int, pgid int) (err error) {
+ func Setpriority(which int, who int, prio int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSetpriority)), 3, uintptr(which), uintptr(who), uintptr(prio), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1630,7 +1630,7 @@ func Setpriority(which int, who int, prio int) (err error) {
+ func Setregid(rgid int, egid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetregid)), 2, uintptr(rgid), uintptr(egid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1640,7 +1640,7 @@ func Setregid(rgid int, egid int) (err error) {
+ func Setreuid(ruid int, euid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetreuid)), 2, uintptr(ruid), uintptr(euid), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1651,7 +1651,7 @@ func Setsid() (pid int, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetsid)), 0, 0, 0, 0, 0, 0, 0)
+ 	pid = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1661,7 +1661,7 @@ func Setsid() (pid int, err error) {
+ func Setuid(uid int) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procSetuid)), 1, uintptr(uid), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1671,7 +1671,7 @@ func Setuid(uid int) (err error) {
+ func Shutdown(s int, how int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procshutdown)), 2, uintptr(s), uintptr(how), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1686,7 +1686,7 @@ func Stat(path string, stat *Stat_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procStat)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(stat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1701,7 +1701,7 @@ func Statvfs(path string, vfsstat *Statvfs_t) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procStatvfs)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(vfsstat)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1721,7 +1721,7 @@ func Symlink(path string, link string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSymlink)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_p1)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1731,7 +1731,7 @@ func Symlink(path string, link string) (err error) {
+ func Sync() (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSync)), 0, 0, 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1742,7 +1742,7 @@ func Sysconf(which int) (n int64, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procSysconf)), 1, uintptr(which), 0, 0, 0, 0, 0)
+ 	n = int64(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1753,7 +1753,7 @@ func Times(tms *Tms) (ticks uintptr, err error) {
+ 	r0, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procTimes)), 1, uintptr(unsafe.Pointer(tms)), 0, 0, 0, 0, 0)
+ 	ticks = uintptr(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1768,7 +1768,7 @@ func Truncate(path string, length int64) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procTruncate)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1778,7 +1778,7 @@ func Truncate(path string, length int64) (err error) {
+ func Fsync(fd int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFsync)), 1, uintptr(fd), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1788,7 +1788,7 @@ func Fsync(fd int) (err error) {
+ func Ftruncate(fd int, length int64) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procFtruncate)), 2, uintptr(fd), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1806,7 +1806,7 @@ func Umask(mask int) (oldmask int) {
+ func Uname(buf *Utsname) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procUname)), 1, uintptr(unsafe.Pointer(buf)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1821,7 +1821,7 @@ func Unmount(target string, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procumount)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(flags), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1836,7 +1836,7 @@ func Unlink(path string) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUnlink)), 1, uintptr(unsafe.Pointer(_p0)), 0, 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1851,7 +1851,7 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUnlinkat)), 3, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(flags), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1861,7 +1861,7 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
+ func Ustat(dev int, ubuf *Ustat_t) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUstat)), 2, uintptr(dev), uintptr(unsafe.Pointer(ubuf)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1876,7 +1876,7 @@ func Utime(path string, buf *Utimbuf) (err error) {
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procUtime)), 2, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(buf)), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1886,7 +1886,7 @@ func Utime(path string, buf *Utimbuf) (err error) {
+ func bind(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_bind)), 3, uintptr(s), uintptr(addr), uintptr(addrlen), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1896,7 +1896,7 @@ func bind(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ func connect(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_connect)), 3, uintptr(s), uintptr(addr), uintptr(addrlen), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1907,7 +1907,7 @@ func mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procmmap)), 6, uintptr(addr), uintptr(length), uintptr(prot), uintptr(flag), uintptr(fd), uintptr(pos))
+ 	ret = uintptr(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1917,7 +1917,7 @@ func mmap(addr uintptr, length uintptr, prot int, flag int, fd int, pos int64) (
+ func munmap(addr uintptr, length uintptr) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procmunmap)), 2, uintptr(addr), uintptr(length), 0, 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1928,7 +1928,7 @@ func sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procsendfile)), 4, uintptr(outfd), uintptr(infd), uintptr(unsafe.Pointer(offset)), uintptr(count), 0, 0)
+ 	written = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1942,7 +1942,7 @@ func sendto(s int, buf []byte, flags int, to unsafe.Pointer, addrlen _Socklen) (
+ 	}
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_sendto)), 6, uintptr(s), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(flags), uintptr(to), uintptr(addrlen))
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1953,7 +1953,7 @@ func socket(domain int, typ int, proto int) (fd int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_socket)), 3, uintptr(domain), uintptr(typ), uintptr(proto), 0, 0, 0)
+ 	fd = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1963,7 +1963,7 @@ func socket(domain int, typ int, proto int) (fd int, err error) {
+ func socketpair(domain int, typ int, proto int, fd *[2]int32) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&proc__xnet_socketpair)), 4, uintptr(domain), uintptr(typ), uintptr(proto), uintptr(unsafe.Pointer(fd)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1978,7 +1978,7 @@ func write(fd int, p []byte) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procwrite)), 3, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1988,7 +1988,7 @@ func write(fd int, p []byte) (n int, err error) {
+ func getsockopt(s int, level int, name int, val unsafe.Pointer, vallen *_Socklen) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&proc__xnet_getsockopt)), 5, uintptr(s), uintptr(level), uintptr(name), uintptr(val), uintptr(unsafe.Pointer(vallen)), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -1998,7 +1998,7 @@ func getsockopt(s int, level int, name int, val unsafe.Pointer, vallen *_Socklen
+ func getpeername(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ 	_, _, e1 := rawSysvicall6(uintptr(unsafe.Pointer(&procgetpeername)), 3, uintptr(fd), uintptr(unsafe.Pointer(rsa)), uintptr(unsafe.Pointer(addrlen)), 0, 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2008,7 +2008,7 @@ func getpeername(fd int, rsa *RawSockaddrAny, addrlen *_Socklen) (err error) {
+ func setsockopt(s int, level int, name int, val unsafe.Pointer, vallen uintptr) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procsetsockopt)), 5, uintptr(s), uintptr(level), uintptr(name), uintptr(val), uintptr(vallen), 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2023,7 +2023,7 @@ func recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Sockl
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procrecvfrom)), 6, uintptr(fd), uintptr(unsafe.Pointer(_p0)), uintptr(len(p)), uintptr(flags), uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(fromlen)))
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2034,7 +2034,7 @@ func port_create() (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_create)), 0, 0, 0, 0, 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2045,7 +2045,7 @@ func port_associate(port int, source int, object uintptr, events int, user *byte
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_associate)), 5, uintptr(port), uintptr(source), uintptr(object), uintptr(events), uintptr(unsafe.Pointer(user)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2056,7 +2056,7 @@ func port_dissociate(port int, source int, object uintptr) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_dissociate)), 3, uintptr(port), uintptr(source), uintptr(object), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2067,7 +2067,7 @@ func port_get(port int, pe *portEvent, timeout *Timespec) (n int, err error) {
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_get)), 3, uintptr(port), uintptr(unsafe.Pointer(pe)), uintptr(unsafe.Pointer(timeout)), 0, 0, 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2078,7 +2078,7 @@ func port_getn(port int, pe *portEvent, max uint32, nget *uint32, timeout *Times
+ 	r0, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procport_getn)), 5, uintptr(port), uintptr(unsafe.Pointer(pe)), uintptr(max), uintptr(unsafe.Pointer(nget)), uintptr(unsafe.Pointer(timeout)), 0)
+ 	n = int(r0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2088,7 +2088,7 @@ func port_getn(port int, pe *portEvent, max uint32, nget *uint32, timeout *Times
+ func putmsg(fd int, clptr *strbuf, dataptr *strbuf, flags int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procputmsg)), 4, uintptr(fd), uintptr(unsafe.Pointer(clptr)), uintptr(unsafe.Pointer(dataptr)), uintptr(flags), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+@@ -2098,7 +2098,7 @@ func putmsg(fd int, clptr *strbuf, dataptr *strbuf, flags int) (err error) {
+ func getmsg(fd int, clptr *strbuf, dataptr *strbuf, flags *int) (err error) {
+ 	_, _, e1 := sysvicall6(uintptr(unsafe.Pointer(&procgetmsg)), 4, uintptr(fd), uintptr(unsafe.Pointer(clptr)), uintptr(unsafe.Pointer(dataptr)), uintptr(unsafe.Pointer(flags)), 0, 0)
+ 	if e1 != 0 {
+-		err = e1
++		err = errnoErr(e1)
+ 	}
+ 	return
+ }
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
+index c316817..1d8fe1d 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_zos_s390x.go
+@@ -40,17 +40,6 @@ func read(fd int, p []byte) (n int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
+-func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
+-	r0, _, e1 := syscall_syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(buf)), uintptr(nbuf))
+-	n = int(r0)
+-	if e1 != 0 {
+-		err = errnoErr(e1)
+-	}
+-	return
+-}
+-
+-// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+-
+ func write(fd int, p []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(p) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index c9c4ad0..9862853 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -447,4 +447,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index 12ff341..8901f0f 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -369,4 +369,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index c3fb5e7..6902c37 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -411,4 +411,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 358c847..a6d3dff 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -314,4 +314,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index 81c4849..b18f3f7 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -308,4 +308,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 202a57e..0302e5e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -431,4 +431,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 4448
+ 	SYS_FUTEX_WAITV                  = 4449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
++	SYS_CACHESTAT                    = 4451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index 1fbceb5..6693ba4 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -361,4 +361,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 5448
+ 	SYS_FUTEX_WAITV             = 5449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
++	SYS_CACHESTAT               = 5451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index b4ffb7a..fd93f49 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -361,4 +361,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 5448
+ 	SYS_FUTEX_WAITV             = 5449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
++	SYS_CACHESTAT               = 5451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index 867985f..760ddca 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -431,4 +431,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 4448
+ 	SYS_FUTEX_WAITV                  = 4449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
++	SYS_CACHESTAT                    = 4451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index a8cce69..cff2b25 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -438,4 +438,5 @@ const (
+ 	SYS_PROCESS_MRELEASE             = 448
+ 	SYS_FUTEX_WAITV                  = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
++	SYS_CACHESTAT                    = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index d44c5b3..a4b2405 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -410,4 +410,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index 4214dd9..aca54b4 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -410,4 +410,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 3e594a8..676245e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -313,4 +313,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index e6ed7d6..022878d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -376,4 +376,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index 92f628e..4100a76 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -389,4 +389,5 @@ const (
+ 	SYS_PROCESS_MRELEASE        = 448
+ 	SYS_FUTEX_WAITV             = 449
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
++	SYS_CACHESTAT               = 451
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index 02e2462..2d93b09 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -1972,7 +1972,7 @@ const (
+ 	NFT_MSG_GETFLOWTABLE              = 0x17
+ 	NFT_MSG_DELFLOWTABLE              = 0x18
+ 	NFT_MSG_GETRULE_RESET             = 0x19
+-	NFT_MSG_MAX                       = 0x21
++	NFT_MSG_MAX                       = 0x22
+ 	NFTA_LIST_UNSPEC                  = 0x0
+ 	NFTA_LIST_ELEM                    = 0x1
+ 	NFTA_HOOK_UNSPEC                  = 0x0
+@@ -4494,7 +4494,7 @@ const (
+ 	NL80211_ATTR_MAC_HINT                                   = 0xc8
+ 	NL80211_ATTR_MAC_MASK                                   = 0xd7
+ 	NL80211_ATTR_MAX_AP_ASSOC_STA                           = 0xca
+-	NL80211_ATTR_MAX                                        = 0x145
++	NL80211_ATTR_MAX                                        = 0x146
+ 	NL80211_ATTR_MAX_CRIT_PROT_DURATION                     = 0xb4
+ 	NL80211_ATTR_MAX_CSA_COUNTERS                           = 0xce
+ 	NL80211_ATTR_MAX_MATCH_SETS                             = 0x85
+@@ -4864,7 +4864,7 @@ const (
+ 	NL80211_CMD_LEAVE_IBSS                                  = 0x2c
+ 	NL80211_CMD_LEAVE_MESH                                  = 0x45
+ 	NL80211_CMD_LEAVE_OCB                                   = 0x6d
+-	NL80211_CMD_MAX                                         = 0x99
++	NL80211_CMD_MAX                                         = 0x9a
+ 	NL80211_CMD_MICHAEL_MIC_FAILURE                         = 0x29
+ 	NL80211_CMD_MODIFY_LINK_STA                             = 0x97
+ 	NL80211_CMD_NAN_MATCH                                   = 0x78
+@@ -5498,7 +5498,7 @@ const (
+ 	NL80211_RATE_INFO_HE_RU_ALLOC_52                        = 0x1
+ 	NL80211_RATE_INFO_HE_RU_ALLOC_996                       = 0x5
+ 	NL80211_RATE_INFO_HE_RU_ALLOC                           = 0x11
+-	NL80211_RATE_INFO_MAX                                   = 0x16
++	NL80211_RATE_INFO_MAX                                   = 0x1d
+ 	NL80211_RATE_INFO_MCS                                   = 0x2
+ 	NL80211_RATE_INFO_SHORT_GI                              = 0x4
+ 	NL80211_RATE_INFO_VHT_MCS                               = 0x6
+@@ -5863,3 +5863,18 @@ const (
+ 	VIRTIO_NET_HDR_GSO_UDP_L4 = 0x5
+ 	VIRTIO_NET_HDR_GSO_ECN    = 0x80
+ )
++
++type SchedAttr struct {
++	Size     uint32
++	Policy   uint32
++	Flags    uint64
++	Nice     int32
++	Priority uint32
++	Runtime  uint64
++	Deadline uint64
++	Period   uint64
++	Util_min uint32
++	Util_max uint32
++}
++
++const SizeofSchedAttr = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+index 9ea54b7..1b4c97c 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+@@ -718,3 +718,30 @@ type SysvShmDesc struct {
+ 	_      uint64
+ 	_      uint64
+ }
++
++type RISCVHWProbePairs struct {
++	Key   int64
++	Value uint64
++}
++
++const (
++	RISCV_HWPROBE_KEY_MVENDORID          = 0x0
++	RISCV_HWPROBE_KEY_MARCHID            = 0x1
++	RISCV_HWPROBE_KEY_MIMPID             = 0x2
++	RISCV_HWPROBE_KEY_BASE_BEHAVIOR      = 0x3
++	RISCV_HWPROBE_BASE_BEHAVIOR_IMA      = 0x1
++	RISCV_HWPROBE_KEY_IMA_EXT_0          = 0x4
++	RISCV_HWPROBE_IMA_FD                 = 0x1
++	RISCV_HWPROBE_IMA_C                  = 0x2
++	RISCV_HWPROBE_IMA_V                  = 0x4
++	RISCV_HWPROBE_EXT_ZBA                = 0x8
++	RISCV_HWPROBE_EXT_ZBB                = 0x10
++	RISCV_HWPROBE_EXT_ZBS                = 0x20
++	RISCV_HWPROBE_KEY_CPUPERF_0          = 0x5
++	RISCV_HWPROBE_MISALIGNED_UNKNOWN     = 0x0
++	RISCV_HWPROBE_MISALIGNED_EMULATED    = 0x1
++	RISCV_HWPROBE_MISALIGNED_SLOW        = 0x2
++	RISCV_HWPROBE_MISALIGNED_FAST        = 0x3
++	RISCV_HWPROBE_MISALIGNED_UNSUPPORTED = 0x4
++	RISCV_HWPROBE_MISALIGNED_MASK        = 0x7
++)
+diff --git a/vendor/golang.org/x/sys/windows/exec_windows.go b/vendor/golang.org/x/sys/windows/exec_windows.go
+index a52e033..9cabbb6 100644
+--- a/vendor/golang.org/x/sys/windows/exec_windows.go
++++ b/vendor/golang.org/x/sys/windows/exec_windows.go
+@@ -22,7 +22,7 @@ import (
+ //     but only if there is space or tab inside s.
+ func EscapeArg(s string) string {
+ 	if len(s) == 0 {
+-		return "\"\""
++		return `""`
+ 	}
+ 	n := len(s)
+ 	hasSpace := false
+@@ -35,7 +35,7 @@ func EscapeArg(s string) string {
+ 		}
+ 	}
+ 	if hasSpace {
+-		n += 2
++		n += 2 // Reserve space for quotes.
+ 	}
+ 	if n == len(s) {
+ 		return s
+@@ -82,20 +82,68 @@ func EscapeArg(s string) string {
+ // in CreateProcess's CommandLine argument, CreateService/ChangeServiceConfig's BinaryPathName argument,
+ // or any program that uses CommandLineToArgv.
+ func ComposeCommandLine(args []string) string {
+-	var commandLine string
+-	for i := range args {
+-		if i > 0 {
+-			commandLine += " "
++	if len(args) == 0 {
++		return ""
++	}
++
++	// Per https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw:
++	// “This function accepts command lines that contain a program name; the
++	// program name can be enclosed in quotation marks or not.”
++	//
++	// Unfortunately, it provides no means of escaping interior quotation marks
++	// within that program name, and we have no way to report them here.
++	prog := args[0]
++	mustQuote := len(prog) == 0
++	for i := 0; i < len(prog); i++ {
++		c := prog[i]
++		if c <= ' ' || (c == '"' && i == 0) {
++			// Force quotes for not only the ASCII space and tab as described in the
++			// MSDN article, but also ASCII control characters.
++			// The documentation for CommandLineToArgvW doesn't say what happens when
++			// the first argument is not a valid program name, but it empirically
++			// seems to drop unquoted control characters.
++			mustQuote = true
++			break
++		}
++	}
++	var commandLine []byte
++	if mustQuote {
++		commandLine = make([]byte, 0, len(prog)+2)
++		commandLine = append(commandLine, '"')
++		for i := 0; i < len(prog); i++ {
++			c := prog[i]
++			if c == '"' {
++				// This quote would interfere with our surrounding quotes.
++				// We have no way to report an error, so just strip out
++				// the offending character instead.
++				continue
++			}
++			commandLine = append(commandLine, c)
+ 		}
+-		commandLine += EscapeArg(args[i])
++		commandLine = append(commandLine, '"')
++	} else {
++		if len(args) == 1 {
++			// args[0] is a valid command line representing itself.
++			// No need to allocate a new slice or string for it.
++			return prog
++		}
++		commandLine = []byte(prog)
+ 	}
+-	return commandLine
++
++	for _, arg := range args[1:] {
++		commandLine = append(commandLine, ' ')
++		// TODO(bcmills): since we're already appending to a slice, it would be nice
++		// to avoid the intermediate allocations of EscapeArg.
++		// Perhaps we can factor out an appendEscapedArg function.
++		commandLine = append(commandLine, EscapeArg(arg)...)
++	}
++	return string(commandLine)
+ }
+ 
+ // DecomposeCommandLine breaks apart its argument command line into unescaped parts using CommandLineToArgv,
+ // as gathered from GetCommandLine, QUERY_SERVICE_CONFIG's BinaryPathName argument, or elsewhere that
+ // command lines are passed around.
+-// DecomposeCommandLine returns error if commandLine contains NUL.
++// DecomposeCommandLine returns an error if commandLine contains NUL.
+ func DecomposeCommandLine(commandLine string) ([]string, error) {
+ 	if len(commandLine) == 0 {
+ 		return []string{}, nil
+@@ -105,18 +153,35 @@ func DecomposeCommandLine(commandLine string) ([]string, error) {
+ 		return nil, errorspkg.New("string with NUL passed to DecomposeCommandLine")
+ 	}
+ 	var argc int32
+-	argv, err := CommandLineToArgv(&utf16CommandLine[0], &argc)
++	argv, err := commandLineToArgv(&utf16CommandLine[0], &argc)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 	defer LocalFree(Handle(unsafe.Pointer(argv)))
++
+ 	var args []string
+-	for _, v := range (*argv)[:argc] {
+-		args = append(args, UTF16ToString((*v)[:]))
++	for _, p := range unsafe.Slice(argv, argc) {
++		args = append(args, UTF16PtrToString(p))
+ 	}
+ 	return args, nil
+ }
+ 
++// CommandLineToArgv parses a Unicode command line string and sets
++// argc to the number of parsed arguments.
++//
++// The returned memory should be freed using a single call to LocalFree.
++//
++// Note that although the return type of CommandLineToArgv indicates 8192
++// entries of up to 8192 characters each, the actual count of parsed arguments
++// may exceed 8192, and the documentation for CommandLineToArgvW does not mention
++// any bound on the lengths of the individual argument strings.
++// (See https://go.dev/issue/63236.)
++func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) {
++	argp, err := commandLineToArgv(cmd, argc)
++	argv = (*[8192]*[8192]uint16)(unsafe.Pointer(argp))
++	return argv, err
++}
++
+ func CloseOnExec(fd Handle) {
+ 	SetHandleInformation(Handle(fd), HANDLE_FLAG_INHERIT, 0)
+ }
+diff --git a/vendor/golang.org/x/sys/windows/security_windows.go b/vendor/golang.org/x/sys/windows/security_windows.go
+index d414ef1..26be94a 100644
+--- a/vendor/golang.org/x/sys/windows/security_windows.go
++++ b/vendor/golang.org/x/sys/windows/security_windows.go
+@@ -7,8 +7,6 @@ package windows
+ import (
+ 	"syscall"
+ 	"unsafe"
+-
+-	"golang.org/x/sys/internal/unsafeheader"
+ )
+ 
+ const (
+@@ -1341,21 +1339,14 @@ func (selfRelativeSD *SECURITY_DESCRIPTOR) copySelfRelativeSecurityDescriptor()
+ 		sdLen = min
+ 	}
+ 
+-	var src []byte
+-	h := (*unsafeheader.Slice)(unsafe.Pointer(&src))
+-	h.Data = unsafe.Pointer(selfRelativeSD)
+-	h.Len = sdLen
+-	h.Cap = sdLen
+-
++	src := unsafe.Slice((*byte)(unsafe.Pointer(selfRelativeSD)), sdLen)
++	// SECURITY_DESCRIPTOR has pointers in it, which means checkptr expects for it to
++	// be aligned properly. When we're copying a Windows-allocated struct to a
++	// Go-allocated one, make sure that the Go allocation is aligned to the
++	// pointer size.
+ 	const psize = int(unsafe.Sizeof(uintptr(0)))
+-
+-	var dst []byte
+-	h = (*unsafeheader.Slice)(unsafe.Pointer(&dst))
+ 	alloc := make([]uintptr, (sdLen+psize-1)/psize)
+-	h.Data = (*unsafeheader.Slice)(unsafe.Pointer(&alloc)).Data
+-	h.Len = sdLen
+-	h.Cap = sdLen
+-
++	dst := unsafe.Slice((*byte)(unsafe.Pointer(&alloc[0])), sdLen)
+ 	copy(dst, src)
+ 	return (*SECURITY_DESCRIPTOR)(unsafe.Pointer(&dst[0]))
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index 9645900..a3cf746 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -15,8 +15,6 @@ import (
+ 	"time"
+ 	"unicode/utf16"
+ 	"unsafe"
+-
+-	"golang.org/x/sys/internal/unsafeheader"
+ )
+ 
+ type Handle uintptr
+@@ -216,7 +214,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	shGetKnownFolderPath(id *KNOWNFOLDERID, flags uint32, token Token, path **uint16) (ret error) = shell32.SHGetKnownFolderPath
+ //sys	TerminateProcess(handle Handle, exitcode uint32) (err error)
+ //sys	GetExitCodeProcess(handle Handle, exitcode *uint32) (err error)
+-//sys	GetStartupInfo(startupInfo *StartupInfo) (err error) = GetStartupInfoW
++//sys	getStartupInfo(startupInfo *StartupInfo) = GetStartupInfoW
+ //sys	GetProcessTimes(handle Handle, creationTime *Filetime, exitTime *Filetime, kernelTime *Filetime, userTime *Filetime) (err error)
+ //sys	DuplicateHandle(hSourceProcessHandle Handle, hSourceHandle Handle, hTargetProcessHandle Handle, lpTargetHandle *Handle, dwDesiredAccess uint32, bInheritHandle bool, dwOptions uint32) (err error)
+ //sys	WaitForSingleObject(handle Handle, waitMilliseconds uint32) (event uint32, err error) [failretval==0xffffffff]
+@@ -240,7 +238,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	SetFileAttributes(name *uint16, attrs uint32) (err error) = kernel32.SetFileAttributesW
+ //sys	GetFileAttributesEx(name *uint16, level uint32, info *byte) (err error) = kernel32.GetFileAttributesExW
+ //sys	GetCommandLine() (cmd *uint16) = kernel32.GetCommandLineW
+-//sys	CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) [failretval==nil] = shell32.CommandLineToArgvW
++//sys	commandLineToArgv(cmd *uint16, argc *int32) (argv **uint16, err error) [failretval==nil] = shell32.CommandLineToArgvW
+ //sys	LocalFree(hmem Handle) (handle Handle, err error) [failretval!=0]
+ //sys	LocalAlloc(flags uint32, length uint32) (ptr uintptr, err error)
+ //sys	SetHandleInformation(handle Handle, mask uint32, flags uint32) (err error)
+@@ -299,12 +297,15 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	RegNotifyChangeKeyValue(key Handle, watchSubtree bool, notifyFilter uint32, event Handle, asynchronous bool) (regerrno error) = advapi32.RegNotifyChangeKeyValue
+ //sys	GetCurrentProcessId() (pid uint32) = kernel32.GetCurrentProcessId
+ //sys	ProcessIdToSessionId(pid uint32, sessionid *uint32) (err error) = kernel32.ProcessIdToSessionId
++//sys	ClosePseudoConsole(console Handle) = kernel32.ClosePseudoConsole
++//sys	createPseudoConsole(size uint32, in Handle, out Handle, flags uint32, pconsole *Handle) (hr error) = kernel32.CreatePseudoConsole
+ //sys	GetConsoleMode(console Handle, mode *uint32) (err error) = kernel32.GetConsoleMode
+ //sys	SetConsoleMode(console Handle, mode uint32) (err error) = kernel32.SetConsoleMode
+ //sys	GetConsoleScreenBufferInfo(console Handle, info *ConsoleScreenBufferInfo) (err error) = kernel32.GetConsoleScreenBufferInfo
+ //sys	setConsoleCursorPosition(console Handle, position uint32) (err error) = kernel32.SetConsoleCursorPosition
+ //sys	WriteConsole(console Handle, buf *uint16, towrite uint32, written *uint32, reserved *byte) (err error) = kernel32.WriteConsoleW
+ //sys	ReadConsole(console Handle, buf *uint16, toread uint32, read *uint32, inputControl *byte) (err error) = kernel32.ReadConsoleW
++//sys	resizePseudoConsole(pconsole Handle, size uint32) (hr error) = kernel32.ResizePseudoConsole
+ //sys	CreateToolhelp32Snapshot(flags uint32, processId uint32) (handle Handle, err error) [failretval==InvalidHandle] = kernel32.CreateToolhelp32Snapshot
+ //sys	Module32First(snapshot Handle, moduleEntry *ModuleEntry32) (err error) = kernel32.Module32FirstW
+ //sys	Module32Next(snapshot Handle, moduleEntry *ModuleEntry32) (err error) = kernel32.Module32NextW
+@@ -437,6 +438,10 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	DwmGetWindowAttribute(hwnd HWND, attribute uint32, value unsafe.Pointer, size uint32) (ret error) = dwmapi.DwmGetWindowAttribute
+ //sys	DwmSetWindowAttribute(hwnd HWND, attribute uint32, value unsafe.Pointer, size uint32) (ret error) = dwmapi.DwmSetWindowAttribute
+ 
++// Windows Multimedia API
++//sys TimeBeginPeriod (period uint32) (err error) [failretval != 0] = winmm.timeBeginPeriod
++//sys TimeEndPeriod (period uint32) (err error) [failretval != 0] = winmm.timeEndPeriod
++
+ // syscall interface implementation for other packages
+ 
+ // GetCurrentProcess returns the handle for the current process.
+@@ -1624,6 +1629,11 @@ func SetConsoleCursorPosition(console Handle, position Coord) error {
+ 	return setConsoleCursorPosition(console, *((*uint32)(unsafe.Pointer(&position))))
+ }
+ 
++func GetStartupInfo(startupInfo *StartupInfo) error {
++	getStartupInfo(startupInfo)
++	return nil
++}
++
+ func (s NTStatus) Errno() syscall.Errno {
+ 	return rtlNtStatusToDosErrorNoTeb(s)
+ }
+@@ -1658,12 +1668,8 @@ func NewNTUnicodeString(s string) (*NTUnicodeString, error) {
+ 
+ // Slice returns a uint16 slice that aliases the data in the NTUnicodeString.
+ func (s *NTUnicodeString) Slice() []uint16 {
+-	var slice []uint16
+-	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&slice))
+-	hdr.Data = unsafe.Pointer(s.Buffer)
+-	hdr.Len = int(s.Length)
+-	hdr.Cap = int(s.MaximumLength)
+-	return slice
++	slice := unsafe.Slice(s.Buffer, s.MaximumLength)
++	return slice[:s.Length]
+ }
+ 
+ func (s *NTUnicodeString) String() string {
+@@ -1686,12 +1692,8 @@ func NewNTString(s string) (*NTString, error) {
+ 
+ // Slice returns a byte slice that aliases the data in the NTString.
+ func (s *NTString) Slice() []byte {
+-	var slice []byte
+-	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&slice))
+-	hdr.Data = unsafe.Pointer(s.Buffer)
+-	hdr.Len = int(s.Length)
+-	hdr.Cap = int(s.MaximumLength)
+-	return slice
++	slice := unsafe.Slice(s.Buffer, s.MaximumLength)
++	return slice[:s.Length]
+ }
+ 
+ func (s *NTString) String() string {
+@@ -1743,10 +1745,7 @@ func LoadResourceData(module, resInfo Handle) (data []byte, err error) {
+ 	if err != nil {
+ 		return
+ 	}
+-	h := (*unsafeheader.Slice)(unsafe.Pointer(&data))
+-	h.Data = unsafe.Pointer(ptr)
+-	h.Len = int(size)
+-	h.Cap = int(size)
++	data = unsafe.Slice((*byte)(unsafe.Pointer(ptr)), size)
+ 	return
+ }
+ 
+@@ -1817,3 +1816,17 @@ type PSAPI_WORKING_SET_EX_INFORMATION struct {
+ 	// A PSAPI_WORKING_SET_EX_BLOCK union that indicates the attributes of the page at VirtualAddress.
+ 	VirtualAttributes PSAPI_WORKING_SET_EX_BLOCK
+ }
++
++// CreatePseudoConsole creates a windows pseudo console.
++func CreatePseudoConsole(size Coord, in Handle, out Handle, flags uint32, pconsole *Handle) error {
++	// We need this wrapper to manually cast Coord to uint32. The autogenerated wrappers only
++	// accept arguments that can be casted to uintptr, and Coord can't.
++	return createPseudoConsole(*((*uint32)(unsafe.Pointer(&size))), in, out, flags, pconsole)
++}
++
++// ResizePseudoConsole resizes the internal buffers of the pseudo console to the width and height specified in `size`.
++func ResizePseudoConsole(pconsole Handle, size Coord) error {
++	// We need this wrapper to manually cast Coord to uint32. The autogenerated wrappers only
++	// accept arguments that can be casted to uintptr, and Coord can't.
++	return resizePseudoConsole(pconsole, *((*uint32)(unsafe.Pointer(&size))))
++}
+diff --git a/vendor/golang.org/x/sys/windows/types_windows.go b/vendor/golang.org/x/sys/windows/types_windows.go
+index 88e62a6..b88dc7c 100644
+--- a/vendor/golang.org/x/sys/windows/types_windows.go
++++ b/vendor/golang.org/x/sys/windows/types_windows.go
+@@ -247,6 +247,7 @@ const (
+ 	PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY = 0x00020007
+ 	PROC_THREAD_ATTRIBUTE_UMS_THREAD        = 0x00030006
+ 	PROC_THREAD_ATTRIBUTE_PROTECTION_LEVEL  = 0x0002000b
++	PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE     = 0x00020016
+ )
+ 
+ const (
+@@ -2139,6 +2140,12 @@ const (
+ 	ENABLE_LVB_GRID_WORLDWIDE          = 0x10
+ )
+ 
++// Pseudo console related constants used for the flags parameter to
++// CreatePseudoConsole. See: https://learn.microsoft.com/en-us/windows/console/createpseudoconsole
++const (
++	PSEUDOCONSOLE_INHERIT_CURSOR = 0x1
++)
++
+ type Coord struct {
+ 	X int16
+ 	Y int16
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index 566dd3e..8b1688d 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -55,6 +55,7 @@ var (
+ 	moduser32   = NewLazySystemDLL("user32.dll")
+ 	moduserenv  = NewLazySystemDLL("userenv.dll")
+ 	modversion  = NewLazySystemDLL("version.dll")
++	modwinmm    = NewLazySystemDLL("winmm.dll")
+ 	modwintrust = NewLazySystemDLL("wintrust.dll")
+ 	modws2_32   = NewLazySystemDLL("ws2_32.dll")
+ 	modwtsapi32 = NewLazySystemDLL("wtsapi32.dll")
+@@ -187,6 +188,7 @@ var (
+ 	procCancelIo                                             = modkernel32.NewProc("CancelIo")
+ 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
+ 	procCloseHandle                                          = modkernel32.NewProc("CloseHandle")
++	procClosePseudoConsole                                   = modkernel32.NewProc("ClosePseudoConsole")
+ 	procConnectNamedPipe                                     = modkernel32.NewProc("ConnectNamedPipe")
+ 	procCreateDirectoryW                                     = modkernel32.NewProc("CreateDirectoryW")
+ 	procCreateEventExW                                       = modkernel32.NewProc("CreateEventExW")
+@@ -201,6 +203,7 @@ var (
+ 	procCreateNamedPipeW                                     = modkernel32.NewProc("CreateNamedPipeW")
+ 	procCreatePipe                                           = modkernel32.NewProc("CreatePipe")
+ 	procCreateProcessW                                       = modkernel32.NewProc("CreateProcessW")
++	procCreatePseudoConsole                                  = modkernel32.NewProc("CreatePseudoConsole")
+ 	procCreateSymbolicLinkW                                  = modkernel32.NewProc("CreateSymbolicLinkW")
+ 	procCreateToolhelp32Snapshot                             = modkernel32.NewProc("CreateToolhelp32Snapshot")
+ 	procDefineDosDeviceW                                     = modkernel32.NewProc("DefineDosDeviceW")
+@@ -327,6 +330,7 @@ var (
+ 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
+ 	procRemoveDirectoryW                                     = modkernel32.NewProc("RemoveDirectoryW")
+ 	procResetEvent                                           = modkernel32.NewProc("ResetEvent")
++	procResizePseudoConsole                                  = modkernel32.NewProc("ResizePseudoConsole")
+ 	procResumeThread                                         = modkernel32.NewProc("ResumeThread")
+ 	procSetCommTimeouts                                      = modkernel32.NewProc("SetCommTimeouts")
+ 	procSetConsoleCursorPosition                             = modkernel32.NewProc("SetConsoleCursorPosition")
+@@ -468,6 +472,8 @@ var (
+ 	procGetFileVersionInfoSizeW                              = modversion.NewProc("GetFileVersionInfoSizeW")
+ 	procGetFileVersionInfoW                                  = modversion.NewProc("GetFileVersionInfoW")
+ 	procVerQueryValueW                                       = modversion.NewProc("VerQueryValueW")
++	proctimeBeginPeriod                                      = modwinmm.NewProc("timeBeginPeriod")
++	proctimeEndPeriod                                        = modwinmm.NewProc("timeEndPeriod")
+ 	procWinVerifyTrustEx                                     = modwintrust.NewProc("WinVerifyTrustEx")
+ 	procFreeAddrInfoW                                        = modws2_32.NewProc("FreeAddrInfoW")
+ 	procGetAddrInfoW                                         = modws2_32.NewProc("GetAddrInfoW")
+@@ -1630,6 +1636,11 @@ func CloseHandle(handle Handle) (err error) {
+ 	return
+ }
+ 
++func ClosePseudoConsole(console Handle) {
++	syscall.Syscall(procClosePseudoConsole.Addr(), 1, uintptr(console), 0, 0)
++	return
++}
++
+ func ConnectNamedPipe(pipe Handle, overlapped *Overlapped) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procConnectNamedPipe.Addr(), 2, uintptr(pipe), uintptr(unsafe.Pointer(overlapped)), 0)
+ 	if r1 == 0 {
+@@ -1759,6 +1770,14 @@ func CreateProcess(appName *uint16, commandLine *uint16, procSecurity *SecurityA
+ 	return
+ }
+ 
++func createPseudoConsole(size uint32, in Handle, out Handle, flags uint32, pconsole *Handle) (hr error) {
++	r0, _, _ := syscall.Syscall6(procCreatePseudoConsole.Addr(), 5, uintptr(size), uintptr(in), uintptr(out), uintptr(flags), uintptr(unsafe.Pointer(pconsole)), 0)
++	if r0 != 0 {
++		hr = syscall.Errno(r0)
++	}
++	return
++}
++
+ func CreateSymbolicLink(symlinkfilename *uint16, targetfilename *uint16, flags uint32) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procCreateSymbolicLinkW.Addr(), 3, uintptr(unsafe.Pointer(symlinkfilename)), uintptr(unsafe.Pointer(targetfilename)), uintptr(flags))
+ 	if r1&0xff == 0 {
+@@ -2367,11 +2386,8 @@ func GetShortPathName(longpath *uint16, shortpath *uint16, buflen uint32) (n uin
+ 	return
+ }
+ 
+-func GetStartupInfo(startupInfo *StartupInfo) (err error) {
+-	r1, _, e1 := syscall.Syscall(procGetStartupInfoW.Addr(), 1, uintptr(unsafe.Pointer(startupInfo)), 0, 0)
+-	if r1 == 0 {
+-		err = errnoErr(e1)
+-	}
++func getStartupInfo(startupInfo *StartupInfo) {
++	syscall.Syscall(procGetStartupInfoW.Addr(), 1, uintptr(unsafe.Pointer(startupInfo)), 0, 0)
+ 	return
+ }
+ 
+@@ -2862,6 +2878,14 @@ func ResetEvent(event Handle) (err error) {
+ 	return
+ }
+ 
++func resizePseudoConsole(pconsole Handle, size uint32) (hr error) {
++	r0, _, _ := syscall.Syscall(procResizePseudoConsole.Addr(), 2, uintptr(pconsole), uintptr(size), 0)
++	if r0 != 0 {
++		hr = syscall.Errno(r0)
++	}
++	return
++}
++
+ func ResumeThread(thread Handle) (ret uint32, err error) {
+ 	r0, _, e1 := syscall.Syscall(procResumeThread.Addr(), 1, uintptr(thread), 0, 0)
+ 	ret = uint32(r0)
+@@ -3820,9 +3844,9 @@ func setupUninstallOEMInf(infFileName *uint16, flags SUOI, reserved uintptr) (er
+ 	return
+ }
+ 
+-func CommandLineToArgv(cmd *uint16, argc *int32) (argv *[8192]*[8192]uint16, err error) {
++func commandLineToArgv(cmd *uint16, argc *int32) (argv **uint16, err error) {
+ 	r0, _, e1 := syscall.Syscall(procCommandLineToArgvW.Addr(), 2, uintptr(unsafe.Pointer(cmd)), uintptr(unsafe.Pointer(argc)), 0)
+-	argv = (*[8192]*[8192]uint16)(unsafe.Pointer(r0))
++	argv = (**uint16)(unsafe.Pointer(r0))
+ 	if argv == nil {
+ 		err = errnoErr(e1)
+ 	}
+@@ -4017,6 +4041,22 @@ func _VerQueryValue(block unsafe.Pointer, subBlock *uint16, pointerToBufferPoint
+ 	return
+ }
+ 
++func TimeBeginPeriod(period uint32) (err error) {
++	r1, _, e1 := syscall.Syscall(proctimeBeginPeriod.Addr(), 1, uintptr(period), 0, 0)
++	if r1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++func TimeEndPeriod(period uint32) (err error) {
++	r1, _, e1 := syscall.Syscall(proctimeEndPeriod.Addr(), 1, uintptr(period), 0, 0)
++	if r1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func WinVerifyTrustEx(hwnd HWND, actionId *GUID, data *WinTrustData) (ret error) {
+ 	r0, _, _ := syscall.Syscall(procWinVerifyTrustEx.Addr(), 3, uintptr(hwnd), uintptr(unsafe.Pointer(actionId)), uintptr(unsafe.Pointer(data)))
+ 	if r0 != 0 {
+diff --git a/vendor/golang.org/x/text/unicode/norm/trie.go b/vendor/golang.org/x/text/unicode/norm/trie.go
+index 423386b..e4250ae 100644
+--- a/vendor/golang.org/x/text/unicode/norm/trie.go
++++ b/vendor/golang.org/x/text/unicode/norm/trie.go
+@@ -29,7 +29,7 @@ var (
+ 	nfkcData = newNfkcTrie(0)
+ )
+ 
+-// lookupValue determines the type of block n and looks up the value for b.
++// lookup determines the type of block n and looks up the value for b.
+ // For n < t.cutoff, the block is a simple lookup table. Otherwise, the block
+ // is a list of ranges with an accompanying value. Given a matching range r,
+ // the value for b is by r.value + (b - r.lo) * stride.
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 352cad7..a028c0a 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -61,7 +61,46 @@ github.com/prometheus/procfs/internal/util
+ # github.com/spf13/pflag v1.0.5
+ ## explicit; go 1.12
+ github.com/spf13/pflag
+-# golang.org/x/net v0.13.0
++# go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.0
++## explicit; go 1.19
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/internal
++# go.opentelemetry.io/otel v1.15.0
++## explicit; go 1.19
++go.opentelemetry.io/otel
++go.opentelemetry.io/otel/attribute
++go.opentelemetry.io/otel/baggage
++go.opentelemetry.io/otel/codes
++go.opentelemetry.io/otel/internal
++go.opentelemetry.io/otel/internal/attribute
++go.opentelemetry.io/otel/internal/baggage
++go.opentelemetry.io/otel/internal/global
++go.opentelemetry.io/otel/propagation
++go.opentelemetry.io/otel/semconv/v1.17.0
++# go.opentelemetry.io/otel/metric v0.38.0
++## explicit; go 1.19
++go.opentelemetry.io/otel/metric
++go.opentelemetry.io/otel/metric/embedded
++go.opentelemetry.io/otel/metric/global
++go.opentelemetry.io/otel/metric/internal/global
++# go.opentelemetry.io/otel/trace v1.15.0
++## explicit; go 1.19
++go.opentelemetry.io/otel/trace
++# go.uber.org/atomic v1.10.0
++## explicit; go 1.18
++go.uber.org/atomic
++# go.uber.org/multierr v1.11.0
++## explicit; go 1.19
++go.uber.org/multierr
++# go.uber.org/zap v1.19.0
++## explicit; go 1.13
++go.uber.org/zap
++go.uber.org/zap/buffer
++go.uber.org/zap/internal/bufferpool
++go.uber.org/zap/internal/color
++go.uber.org/zap/internal/exit
++go.uber.org/zap/zapcore
++# golang.org/x/net v0.17.0
+ ## explicit; go 1.17
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -69,12 +108,11 @@ golang.org/x/net/http2/hpack
+ golang.org/x/net/idna
+ golang.org/x/net/internal/timeseries
+ golang.org/x/net/trace
+-# golang.org/x/sys v0.10.0
++# golang.org/x/sys v0.13.0
+ ## explicit; go 1.17
+-golang.org/x/sys/internal/unsafeheader
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-# golang.org/x/text v0.11.0
++# golang.org/x/text v0.13.0
+ ## explicit; go 1.17
+ golang.org/x/text/secure/bidirule
+ golang.org/x/text/transform
+-- 
+2.39.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes CVE-2023-39325, CVE-2023-44487. When upstream include these changes in the latest release we can drop this patch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
