### PR TITLE
Add labeler for v1.29 projects

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,41 +1,44 @@
-documentation: 
-- 'docs/**/*'
+documentation:
+  - "docs/**/*"
 
 project:
-- 'projects/**/GIT_TAG'
-- 'projects/**/GOLANG_VERSION'
+  - "projects/**/GIT_TAG"
+  - "projects/**/GOLANG_VERSION"
 
 patch:
-- '**/*.patch'
+  - "**/*.patch"
 
 release:
-- 'release/**/*'
-- 'docs/contents/releases/**/*'
+  - "release/**/*"
+  - "docs/contents/releases/**/*"
 
 PROD-release:
-- 'release/*/production/RELEASE'
+  - "release/*/production/RELEASE"
 
 DEV-release:
-- 'release/*/development/RELEASE'
+  - "release/*/development/RELEASE"
 
 do-not-merge/hold:
-- 'release/**/*'
-- 'docs/contents/releases/**/*'
+  - "release/**/*"
+  - "docs/contents/releases/**/*"
 
 base-img-pkg-update:
-- 'EKS_DISTRO_BASE_TAG_FILE'
+  - "EKS_DISTRO_BASE_TAG_FILE"
 
 v1.24:
-- '**/1-24/**/*'
+  - "**/1-24/**/*"
 
 v1.25:
-- '**/1-25/**/*'
+  - "**/1-25/**/*"
 
 v1.26:
-- '**/1-26/**/*'
+  - "**/1-26/**/*"
 
 v1.27:
-- '**/1-27/**/*'
+  - "**/1-27/**/*"
 
 v1.28:
-- '**/1-28/**/*'
+  - "**/1-28/**/*"
+
+v1.29:
+  - "**/1-29/**/*"


### PR DESCRIPTION
*Issue #, if available:*
#2555 
*Description of changes:*
Add labeler for `v1.29` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
