### PR TITLE
Update local build commands and scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ stop-docker-builder:
 
 .PHONY: run-buildkit-and-registry
 run-buildkit-and-registry:
-	docker run -d --name buildkitd --net host --privileged moby/buildkit:v0.9.3-rootless
+	docker run -d --name buildkitd --net host --privileged moby/buildkit:v0.12.3
 	docker run -d --name registry  --net host registry:2
 
 .PHONY: stop-buildkit-and-registry

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -101,7 +101,7 @@ function build::gather_licenses() {
   # data about each dependency to generate the amazon approved attribution.txt files
   # go-deps is needed for module versions
   # go-licenses are all the dependencies found from the module(s) that were passed in via patterns
-  build::common::echo_and_run go list -deps=true -json ./... | jq -s ''  > "${outputdir}/attribution/go-deps.json"
+  build::common::echo_and_run go list -deps=true -json ./... | jq -s '.'  > "${outputdir}/attribution/go-deps.json"
 
   # go-licenses can be a bit noisy with its output and lot of it can be confusing 
   # the following messages are safe to ignore since we do not need the license url for our process

--- a/build/lib/update_checksums.sh
+++ b/build/lib/update_checksums.sh
@@ -31,8 +31,13 @@ CHECKSUMS_FILE=$PROJECT_ROOT/CHECKSUMS
 
 rm -f $CHECKSUMS_FILE
 for file in $(find ${OUTPUT_BIN_DIR} -type f | sort); do
+  if [ "$(uname)" == "Darwin" ]; then
+    filepath=$(grealpath --relative-base=$MAKE_ROOT $file)
+    sha256sum $filepath >>$CHECKSUMS_FILE
+  else
     filepath=$(realpath --relative-base=$MAKE_ROOT $file)
     sha256sum $filepath >> $CHECKSUMS_FILE
+  fi
 done
 
 echo "*************** CHECKSUMS ***************"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
macOS uses a different `realpath` that doesn't work with the `--relative-base` flag. `grealpath` fixes the error and returns the same values.
newer versions of `jq` treat `''` and `'.'` differently, but older versions treat them identically. `'.'` allows this to work with newer local versions of `jq`.
updating the `run-buildkit-and-registry` make command to run the same values as what is in prow so local testing mimics tests more closely.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
