### PR TITLE
Fix attribution.sh to pass bash value to make

### DIFF
--- a/build/update-attribution-files/make_attribution.sh
+++ b/build/update-attribution-files/make_attribution.sh
@@ -56,8 +56,8 @@ else
         export RELEASE_BRANCH="$release"
         GIT_TAG="$(cat $PROJECT_ROOT/$release/GIT_TAG)"
 
-        if ! ( cat release/K8_SUPPORTED_RELEASE_BRANCHES | grep -q $release >/dev/null 2>&1 )  || [[ $(basename "$PROJECT") == "kubernetes" ]] || [[ $(basename "$PROJECT") == "release" ]]; then
-            if cat release/K8_SUPPORTED_RELEASE_BRANCHES | grep -q $LAST_RELEASE_BRANCH >/dev/null 2>&1 || [ "$GIT_TAG" != "$LAST_GIT_TAG" ] || [ $TARGET == "update-go-mods" ]; then
+        if ! ( $(cat release/K8_SUPPORTED_RELEASE_BRANCHES | grep -q $release) >/dev/null 2>&1 )  || [[ $(basename "$PROJECT") == "kubernetes" ]] || [[ $(basename "$PROJECT") == "release" ]]; then
+            if $(cat release/K8_SUPPORTED_RELEASE_BRANCHES | grep -q $LAST_RELEASE_BRANCH) >/dev/null 2>&1 || [ "$GIT_TAG" != "$LAST_GIT_TAG" ] || [ $TARGET == "update-go-mods" ]; then
                 # clean before regenerating to ensure there are no intermediate files left around
                 make -C $PROJECT_ROOT clean clean-go-cache
                 build::attribution::generate $release


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* in #2642 the `cat` commands were not wrapped by `$` thus, is not passing the value to common.mk. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
