### PR TITLE
Patch CoreDns 1.29 to fix CVE-2023-49295

### DIFF
--- a/projects/coredns/coredns/1-29/CHECKSUMS
+++ b/projects/coredns/coredns/1-29/CHECKSUMS
@@ -1,2 +1,2 @@
-6716e8fde40ae946704b296e1bc8a9625dd2e476a93c76eaf0a93b970ac560d0  _output/1-29/bin/coredns/linux-amd64/coredns
-8d9ab954c989c8b971519beaaf101d8a0490a8f62b1e69a34adad5bec4abf673  _output/1-29/bin/coredns/linux-arm64/coredns
+867745abcb6b9bef76733d263e86e17c6a01aaba0de8f5ba92dbec3234470bc2  _output/1-29/bin/coredns/linux-amd64/coredns
+28daecbb2b565d47b44e469b8ad2c575086100430367149ceb7fa7afafe23dd6  _output/1-29/bin/coredns/linux-arm64/coredns

--- a/projects/coredns/coredns/1-29/patches/0004-Bump-quic-go-to-0.40.1-to-resolve-CVE-2023-49295.patch
+++ b/projects/coredns/coredns/1-29/patches/0004-Bump-quic-go-to-0.40.1-to-resolve-CVE-2023-49295.patch
@@ -1,0 +1,105 @@
+From 8cc5e915b66d4ea0221b33b6b0f1d5625520ea58 Mon Sep 17 00:00:00 2001
+From: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
+Date: Wed, 17 Jan 2024 08:52:51 -0800
+Subject: [PATCH] Bump quic-go to 0.40.1 to resolve CVE-2023-49295
+
+Signed-off-by: Sajia Zafreen <sajiazafreen@u.boisestate.edu>
+---
+ go.mod |  8 ++++----
+ go.sum | 15 ++++++++-------
+ 2 files changed, 12 insertions(+), 11 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 59c73745..aaeb2060 100644
+--- a/go.mod
++++ b/go.mod
+@@ -24,7 +24,7 @@ require (
+ 	github.com/prometheus/client_golang v1.16.0
+ 	github.com/prometheus/client_model v0.4.0
+ 	github.com/prometheus/common v0.44.0
+-	github.com/quic-go/quic-go v0.37.4
++	github.com/quic-go/quic-go v0.40.1
+ 	go.etcd.io/etcd/api/v3 v3.5.9
+ 	go.etcd.io/etcd/client/v3 v3.5.9
+ 	golang.org/x/crypto v0.17.0
+@@ -76,7 +76,6 @@ require (
+ 	github.com/gogo/protobuf v1.3.2 // indirect
+ 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+ 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+-	github.com/golang/mock v1.6.0 // indirect
+ 	github.com/golang/protobuf v1.5.3 // indirect
+ 	github.com/google/gnostic v0.5.7-v3refs // indirect
+ 	github.com/google/go-cmp v0.5.9 // indirect
+@@ -102,19 +101,20 @@ require (
+ 	github.com/philhofer/fwd v1.1.2 // indirect
+ 	github.com/pkg/errors v0.9.1 // indirect
+ 	github.com/prometheus/procfs v0.10.1 // indirect
+-	github.com/quic-go/qtls-go1-20 v0.3.1 // indirect
++	github.com/quic-go/qtls-go1-20 v0.4.1 // indirect
+ 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+ 	github.com/tinylib/msgp v1.1.8 // indirect
+ 	go.etcd.io/etcd/client/pkg/v3 v3.5.9 // indirect
+ 	go.opencensus.io v0.24.0 // indirect
+ 	go.uber.org/atomic v1.11.0 // indirect
++	go.uber.org/mock v0.3.0 // indirect
+ 	go.uber.org/multierr v1.6.0 // indirect
+ 	go.uber.org/zap v1.17.0 // indirect
+ 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
+ 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
+ 	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db // indirect
+-	golang.org/x/mod v0.10.0 // indirect
++	golang.org/x/mod v0.11.0 // indirect
+ 	golang.org/x/net v0.17.0 // indirect
+ 	golang.org/x/oauth2 v0.13.0 // indirect
+ 	golang.org/x/term v0.15.0 // indirect
+diff --git a/go.sum b/go.sum
+index 12f6e5b3..eeac1695 100644
+--- a/go.sum
++++ b/go.sum
+@@ -120,7 +120,6 @@ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4er
+ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+-github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+ github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+@@ -234,10 +233,10 @@ github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdO
+ github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
+ github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
+ github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
+-github.com/quic-go/qtls-go1-20 v0.3.1 h1:O4BLOM3hwfVF3AcktIylQXyl7Yi2iBNVy5QsV+ySxbg=
+-github.com/quic-go/qtls-go1-20 v0.3.1/go.mod h1:X9Nh97ZL80Z+bX/gUXMbipO6OxdiDi58b/fMC9mAL+k=
+-github.com/quic-go/quic-go v0.37.4 h1:ke8B73yMCWGq9MfrCCAw0Uzdm7GaViC3i39dsIdDlH4=
+-github.com/quic-go/quic-go v0.37.4/go.mod h1:YsbH1r4mSHPJcLF4k4zruUkLBqctEMBDR6VPvcYjIsU=
++github.com/quic-go/qtls-go1-20 v0.4.1 h1:D33340mCNDAIKBqXuAvexTNMUByrYmFYVfKfDN5nfFs=
++github.com/quic-go/qtls-go1-20 v0.4.1/go.mod h1:X9Nh97ZL80Z+bX/gUXMbipO6OxdiDi58b/fMC9mAL+k=
++github.com/quic-go/quic-go v0.40.1 h1:X3AGzUNFs0jVuO3esAGnTfvdgvL4fq655WaOi1snv1Q=
++github.com/quic-go/quic-go v0.40.1/go.mod h1:PeN7kuVJ4xZbxSv/4OX6S1USOX8MJvydwpTx31vx60c=
+ github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052 h1:Qp27Idfgi6ACvFQat5+VJvlYToylpM/hcyLBI3WaKPA=
+ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+ github.com/secure-systems-lab/go-securesystemslib v0.7.0 h1:OwvJ5jQf9LnIAS83waAjPbcMsODrTQUpJ02eNLUoxBg=
+@@ -279,6 +278,8 @@ go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+ go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
+ go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+ go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
++go.uber.org/mock v0.3.0 h1:3mUxI1No2/60yUYax92Pt8eNOEecx2D3lcXZh2NEZJo=
++go.uber.org/mock v0.3.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
+ go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
+ go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
+ go.uber.org/zap v1.17.0 h1:MTjgFu6ZLKvY6Pvaqk97GlxNBuMpV4Hy/3P6tRGlI2U=
+@@ -309,8 +310,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+ golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+-golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
+-golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
++golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
++golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+-- 
+2.39.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes CVE-2023-49295


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
