### PR TITLE
Patch protobuf to resolve CVE-2024-24786 for Liveness-Probe

### DIFF
--- a/projects/kubernetes-csi/livenessprobe/1-25/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-25/CHECKSUMS
@@ -1,3 +1,3 @@
-d6969295d34e8eff3c87c9d9ace64f4817b5163a175d8be4384238266757ac28  _output/1-25/bin/livenessprobe/linux-amd64/livenessprobe
-23dd70fa11a9c2e0c83eccd1b4c8eecdf5d7c7ba55f8c50b6a3a88545b2998b6  _output/1-25/bin/livenessprobe/linux-arm64/livenessprobe
-d981c39b4089a15067100c9408f44898dc9d5c332716bd904c29dc44cd019b59  _output/1-25/bin/livenessprobe/windows-amd64/livenessprobe.exe
+f22ddc72b7428124f72945a6a6ffae35f17ecf71ebe35e1cbb356048bf216b20  _output/1-25/bin/livenessprobe/linux-amd64/livenessprobe
+d855e1a5d85f62483f89761693933b4a08cc98aa465248a23b4d98bd0c677885  _output/1-25/bin/livenessprobe/linux-arm64/livenessprobe
+062bdd08c21daf93a62469e7e09a88e4c514082cc9e0baa7de260ff1ee4d09eb  _output/1-25/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-25/patches/0001-Bump-protobuf-to-resolve-CVE-2024-24786-for-Liveness.patch
+++ b/projects/kubernetes-csi/livenessprobe/1-25/patches/0001-Bump-protobuf-to-resolve-CVE-2024-24786-for-Liveness.patch
@@ -1,0 +1,8141 @@
+From 787b5e4818b71783774e36f358a57150abad5983 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Mon, 18 Mar 2024 17:37:01 +0000
+Subject: [PATCH] Bump protobuf to resolve CVE-2024-24786 for Liveness-Probe
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |    4 +-
+ go.sum                                        |   12 +-
+ .../golang/protobuf/jsonpb/decode.go          |    1 +
+ .../golang/protobuf/jsonpb/encode.go          |    1 +
+ .../protoc-gen-go/descriptor/descriptor.pb.go |  128 +-
+ .../github.com/golang/protobuf/ptypes/any.go  |    7 +-
+ .../protobuf/encoding/protojson/decode.go     |   38 +-
+ .../protobuf/encoding/protojson/doc.go        |    2 +-
+ .../protobuf/encoding/protojson/encode.go     |   39 +-
+ .../encoding/protojson/well_known_types.go    |   59 +-
+ .../protobuf/encoding/prototext/decode.go     |    8 +-
+ .../protobuf/encoding/prototext/encode.go     |    4 +-
+ .../protobuf/encoding/protowire/wire.go       |   28 +-
+ .../protobuf/internal/descfmt/stringer.go     |  183 +-
+ .../internal/editiondefaults/defaults.go      |   12 +
+ .../editiondefaults/editions_defaults.binpb   |    4 +
+ .../protobuf/internal/encoding/json/decode.go |    2 +-
+ .../protobuf/internal/filedesc/desc.go        |  102 +-
+ .../protobuf/internal/filedesc/desc_init.go   |   52 +
+ .../protobuf/internal/filedesc/desc_lazy.go   |   28 +
+ .../protobuf/internal/filedesc/editions.go    |  142 +
+ .../protobuf/internal/genid/descriptor_gen.go |  364 ++-
+ .../internal/genid/go_features_gen.go         |   31 +
+ .../protobuf/internal/genid/struct_gen.go     |    5 +
+ .../protobuf/internal/genid/type_gen.go       |   38 +
+ .../protobuf/internal/impl/codec_extension.go |   22 +-
+ .../protobuf/internal/impl/codec_gen.go       |  113 +-
+ .../protobuf/internal/impl/codec_tables.go    |    2 +-
+ .../protobuf/internal/impl/legacy_message.go  |   19 +-
+ .../protobuf/internal/impl/message.go         |   17 +-
+ .../internal/impl/message_reflect_field.go    |    2 +-
+ .../protobuf/internal/impl/pointer_reflect.go |   36 +
+ .../protobuf/internal/impl/pointer_unsafe.go  |   40 +
+ .../protobuf/internal/strs/strings.go         |    2 +-
+ ...ings_unsafe.go => strings_unsafe_go120.go} |    4 +-
+ .../internal/strs/strings_unsafe_go121.go     |   74 +
+ .../protobuf/internal/version/version.go      |    2 +-
+ .../protobuf/proto/decode.go                  |    2 +-
+ .../google.golang.org/protobuf/proto/doc.go   |   58 +-
+ .../protobuf/proto/encode.go                  |    2 +-
+ .../protobuf/proto/extension.go               |    2 +-
+ .../google.golang.org/protobuf/proto/merge.go |    2 +-
+ .../google.golang.org/protobuf/proto/proto.go |   18 +-
+ .../protobuf/reflect/protodesc/desc.go        |   29 +-
+ .../protobuf/reflect/protodesc/desc_init.go   |   56 +
+ .../reflect/protodesc/desc_resolve.go         |    4 +-
+ .../reflect/protodesc/desc_validate.go        |    6 +-
+ .../protobuf/reflect/protodesc/editions.go    |  148 +
+ .../protobuf/reflect/protodesc/proto.go       |   18 +-
+ .../protobuf/reflect/protoreflect/proto.go    |   85 +-
+ .../reflect/protoreflect/source_gen.go        |   64 +-
+ .../protobuf/reflect/protoreflect/type.go     |   44 +-
+ .../protobuf/reflect/protoreflect/value.go    |   24 +-
+ .../reflect/protoreflect/value_equal.go       |    8 +-
+ .../reflect/protoreflect/value_union.go       |   44 +-
+ ...{value_unsafe.go => value_unsafe_go120.go} |    4 +-
+ .../protoreflect/value_unsafe_go121.go        |   87 +
+ .../reflect/protoregistry/registry.go         |   24 +-
+ .../types/descriptorpb/descriptor.pb.go       | 2475 ++++++++++++-----
+ .../types/gofeaturespb/go_features.pb.go      |  177 ++
+ .../types/gofeaturespb/go_features.proto      |   28 +
+ .../protobuf/types/known/anypb/any.pb.go      |    3 +-
+ vendor/modules.txt                            |   10 +-
+ 63 files changed, 3921 insertions(+), 1128 deletions(-)
+ create mode 100644 vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+ create mode 100644 vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+ create mode 100644 vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+ create mode 100644 vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+ rename vendor/google.golang.org/protobuf/internal/strs/{strings_unsafe.go => strings_unsafe_go120.go} (96%)
+ create mode 100644 vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+ create mode 100644 vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+ rename vendor/google.golang.org/protobuf/reflect/protoreflect/{value_unsafe.go => value_unsafe_go120.go} (97%)
+ create mode 100644 vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+ create mode 100644 vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+ create mode 100644 vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+
+diff --git a/go.mod b/go.mod
+index 66f1999..1e1128d 100644
+--- a/go.mod
++++ b/go.mod
+@@ -19,7 +19,7 @@ require (
+ 	github.com/go-logr/stdr v1.2.2 // indirect
+ 	github.com/go-logr/zapr v1.2.3 // indirect
+ 	github.com/gogo/protobuf v1.3.2 // indirect
+-	github.com/golang/protobuf v1.5.3 // indirect
++	github.com/golang/protobuf v1.5.4 // indirect
+ 	github.com/google/go-cmp v0.6.0 // indirect
+ 	github.com/google/gofuzz v1.2.0 // indirect
+ 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+@@ -46,7 +46,7 @@ require (
+ 	golang.org/x/text v0.14.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
+ 	google.golang.org/grpc v1.60.1 // indirect
+-	google.golang.org/protobuf v1.31.0 // indirect
++	google.golang.org/protobuf v1.33.0 // indirect
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+ 	gopkg.in/yaml.v2 v2.4.0 // indirect
+ 	k8s.io/apimachinery v0.29.0 // indirect
+diff --git a/go.sum b/go.sum
+index 37e6f06..8d87ecd 100644
+--- a/go.sum
++++ b/go.sum
+@@ -33,10 +33,8 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
+ github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+ github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
++github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
++github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+@@ -169,10 +167,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 h1:
+ google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17/go.mod h1:oQ5rr10WTTMvP4A36n8JpR1OrO1BEiV4f78CneXZxkA=
+ google.golang.org/grpc v1.60.1 h1:26+wFr+cNqSGFcOXcabYC0lUVJVRa2Sb2ortSK7VrEU=
+ google.golang.org/grpc v1.60.1/go.mod h1:OlCHIeLYqSSsLi6i49B5QGdzaMZK9+M7LXN2FKz4eGM=
+-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
++google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
++google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+diff --git a/vendor/github.com/golang/protobuf/jsonpb/decode.go b/vendor/github.com/golang/protobuf/jsonpb/decode.go
+index 6c16c25..c6f66f1 100644
+--- a/vendor/github.com/golang/protobuf/jsonpb/decode.go
++++ b/vendor/github.com/golang/protobuf/jsonpb/decode.go
+@@ -56,6 +56,7 @@ type Unmarshaler struct {
+ // implement JSONPBMarshaler so that the custom format can be produced.
+ //
+ // The JSON unmarshaling must follow the JSON to proto specification:
++//
+ //	https://developers.google.com/protocol-buffers/docs/proto3#json
+ //
+ // Deprecated: Custom types should implement protobuf reflection instead.
+diff --git a/vendor/github.com/golang/protobuf/jsonpb/encode.go b/vendor/github.com/golang/protobuf/jsonpb/encode.go
+index 685c80a..e9438a9 100644
+--- a/vendor/github.com/golang/protobuf/jsonpb/encode.go
++++ b/vendor/github.com/golang/protobuf/jsonpb/encode.go
+@@ -55,6 +55,7 @@ type Marshaler struct {
+ // implement JSONPBUnmarshaler so that the custom format can be parsed.
+ //
+ // The JSON marshaling must follow the proto to JSON specification:
++//
+ //	https://developers.google.com/protocol-buffers/docs/proto3#json
+ //
+ // Deprecated: Custom types should implement protobuf reflection instead.
+diff --git a/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go b/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
+index 63dc057..a5a1386 100644
+--- a/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
++++ b/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
+@@ -12,6 +12,31 @@ import (
+ 
+ // Symbols defined in public import of google/protobuf/descriptor.proto.
+ 
++type Edition = descriptorpb.Edition
++
++const Edition_EDITION_UNKNOWN = descriptorpb.Edition_EDITION_UNKNOWN
++const Edition_EDITION_PROTO2 = descriptorpb.Edition_EDITION_PROTO2
++const Edition_EDITION_PROTO3 = descriptorpb.Edition_EDITION_PROTO3
++const Edition_EDITION_2023 = descriptorpb.Edition_EDITION_2023
++const Edition_EDITION_2024 = descriptorpb.Edition_EDITION_2024
++const Edition_EDITION_1_TEST_ONLY = descriptorpb.Edition_EDITION_1_TEST_ONLY
++const Edition_EDITION_2_TEST_ONLY = descriptorpb.Edition_EDITION_2_TEST_ONLY
++const Edition_EDITION_99997_TEST_ONLY = descriptorpb.Edition_EDITION_99997_TEST_ONLY
++const Edition_EDITION_99998_TEST_ONLY = descriptorpb.Edition_EDITION_99998_TEST_ONLY
++const Edition_EDITION_99999_TEST_ONLY = descriptorpb.Edition_EDITION_99999_TEST_ONLY
++const Edition_EDITION_MAX = descriptorpb.Edition_EDITION_MAX
++
++var Edition_name = descriptorpb.Edition_name
++var Edition_value = descriptorpb.Edition_value
++
++type ExtensionRangeOptions_VerificationState = descriptorpb.ExtensionRangeOptions_VerificationState
++
++const ExtensionRangeOptions_DECLARATION = descriptorpb.ExtensionRangeOptions_DECLARATION
++const ExtensionRangeOptions_UNVERIFIED = descriptorpb.ExtensionRangeOptions_UNVERIFIED
++
++var ExtensionRangeOptions_VerificationState_name = descriptorpb.ExtensionRangeOptions_VerificationState_name
++var ExtensionRangeOptions_VerificationState_value = descriptorpb.ExtensionRangeOptions_VerificationState_value
++
+ type FieldDescriptorProto_Type = descriptorpb.FieldDescriptorProto_Type
+ 
+ const FieldDescriptorProto_TYPE_DOUBLE = descriptorpb.FieldDescriptorProto_TYPE_DOUBLE
+@@ -39,8 +64,8 @@ var FieldDescriptorProto_Type_value = descriptorpb.FieldDescriptorProto_Type_val
+ type FieldDescriptorProto_Label = descriptorpb.FieldDescriptorProto_Label
+ 
+ const FieldDescriptorProto_LABEL_OPTIONAL = descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL
+-const FieldDescriptorProto_LABEL_REQUIRED = descriptorpb.FieldDescriptorProto_LABEL_REQUIRED
+ const FieldDescriptorProto_LABEL_REPEATED = descriptorpb.FieldDescriptorProto_LABEL_REPEATED
++const FieldDescriptorProto_LABEL_REQUIRED = descriptorpb.FieldDescriptorProto_LABEL_REQUIRED
+ 
+ var FieldDescriptorProto_Label_name = descriptorpb.FieldDescriptorProto_Label_name
+ var FieldDescriptorProto_Label_value = descriptorpb.FieldDescriptorProto_Label_value
+@@ -72,6 +97,31 @@ const FieldOptions_JS_NUMBER = descriptorpb.FieldOptions_JS_NUMBER
+ var FieldOptions_JSType_name = descriptorpb.FieldOptions_JSType_name
+ var FieldOptions_JSType_value = descriptorpb.FieldOptions_JSType_value
+ 
++type FieldOptions_OptionRetention = descriptorpb.FieldOptions_OptionRetention
++
++const FieldOptions_RETENTION_UNKNOWN = descriptorpb.FieldOptions_RETENTION_UNKNOWN
++const FieldOptions_RETENTION_RUNTIME = descriptorpb.FieldOptions_RETENTION_RUNTIME
++const FieldOptions_RETENTION_SOURCE = descriptorpb.FieldOptions_RETENTION_SOURCE
++
++var FieldOptions_OptionRetention_name = descriptorpb.FieldOptions_OptionRetention_name
++var FieldOptions_OptionRetention_value = descriptorpb.FieldOptions_OptionRetention_value
++
++type FieldOptions_OptionTargetType = descriptorpb.FieldOptions_OptionTargetType
++
++const FieldOptions_TARGET_TYPE_UNKNOWN = descriptorpb.FieldOptions_TARGET_TYPE_UNKNOWN
++const FieldOptions_TARGET_TYPE_FILE = descriptorpb.FieldOptions_TARGET_TYPE_FILE
++const FieldOptions_TARGET_TYPE_EXTENSION_RANGE = descriptorpb.FieldOptions_TARGET_TYPE_EXTENSION_RANGE
++const FieldOptions_TARGET_TYPE_MESSAGE = descriptorpb.FieldOptions_TARGET_TYPE_MESSAGE
++const FieldOptions_TARGET_TYPE_FIELD = descriptorpb.FieldOptions_TARGET_TYPE_FIELD
++const FieldOptions_TARGET_TYPE_ONEOF = descriptorpb.FieldOptions_TARGET_TYPE_ONEOF
++const FieldOptions_TARGET_TYPE_ENUM = descriptorpb.FieldOptions_TARGET_TYPE_ENUM
++const FieldOptions_TARGET_TYPE_ENUM_ENTRY = descriptorpb.FieldOptions_TARGET_TYPE_ENUM_ENTRY
++const FieldOptions_TARGET_TYPE_SERVICE = descriptorpb.FieldOptions_TARGET_TYPE_SERVICE
++const FieldOptions_TARGET_TYPE_METHOD = descriptorpb.FieldOptions_TARGET_TYPE_METHOD
++
++var FieldOptions_OptionTargetType_name = descriptorpb.FieldOptions_OptionTargetType_name
++var FieldOptions_OptionTargetType_value = descriptorpb.FieldOptions_OptionTargetType_value
++
+ type MethodOptions_IdempotencyLevel = descriptorpb.MethodOptions_IdempotencyLevel
+ 
+ const MethodOptions_IDEMPOTENCY_UNKNOWN = descriptorpb.MethodOptions_IDEMPOTENCY_UNKNOWN
+@@ -81,10 +131,77 @@ const MethodOptions_IDEMPOTENT = descriptorpb.MethodOptions_IDEMPOTENT
+ var MethodOptions_IdempotencyLevel_name = descriptorpb.MethodOptions_IdempotencyLevel_name
+ var MethodOptions_IdempotencyLevel_value = descriptorpb.MethodOptions_IdempotencyLevel_value
+ 
++type FeatureSet_FieldPresence = descriptorpb.FeatureSet_FieldPresence
++
++const FeatureSet_FIELD_PRESENCE_UNKNOWN = descriptorpb.FeatureSet_FIELD_PRESENCE_UNKNOWN
++const FeatureSet_EXPLICIT = descriptorpb.FeatureSet_EXPLICIT
++const FeatureSet_IMPLICIT = descriptorpb.FeatureSet_IMPLICIT
++const FeatureSet_LEGACY_REQUIRED = descriptorpb.FeatureSet_LEGACY_REQUIRED
++
++var FeatureSet_FieldPresence_name = descriptorpb.FeatureSet_FieldPresence_name
++var FeatureSet_FieldPresence_value = descriptorpb.FeatureSet_FieldPresence_value
++
++type FeatureSet_EnumType = descriptorpb.FeatureSet_EnumType
++
++const FeatureSet_ENUM_TYPE_UNKNOWN = descriptorpb.FeatureSet_ENUM_TYPE_UNKNOWN
++const FeatureSet_OPEN = descriptorpb.FeatureSet_OPEN
++const FeatureSet_CLOSED = descriptorpb.FeatureSet_CLOSED
++
++var FeatureSet_EnumType_name = descriptorpb.FeatureSet_EnumType_name
++var FeatureSet_EnumType_value = descriptorpb.FeatureSet_EnumType_value
++
++type FeatureSet_RepeatedFieldEncoding = descriptorpb.FeatureSet_RepeatedFieldEncoding
++
++const FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN = descriptorpb.FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN
++const FeatureSet_PACKED = descriptorpb.FeatureSet_PACKED
++const FeatureSet_EXPANDED = descriptorpb.FeatureSet_EXPANDED
++
++var FeatureSet_RepeatedFieldEncoding_name = descriptorpb.FeatureSet_RepeatedFieldEncoding_name
++var FeatureSet_RepeatedFieldEncoding_value = descriptorpb.FeatureSet_RepeatedFieldEncoding_value
++
++type FeatureSet_Utf8Validation = descriptorpb.FeatureSet_Utf8Validation
++
++const FeatureSet_UTF8_VALIDATION_UNKNOWN = descriptorpb.FeatureSet_UTF8_VALIDATION_UNKNOWN
++const FeatureSet_VERIFY = descriptorpb.FeatureSet_VERIFY
++const FeatureSet_NONE = descriptorpb.FeatureSet_NONE
++
++var FeatureSet_Utf8Validation_name = descriptorpb.FeatureSet_Utf8Validation_name
++var FeatureSet_Utf8Validation_value = descriptorpb.FeatureSet_Utf8Validation_value
++
++type FeatureSet_MessageEncoding = descriptorpb.FeatureSet_MessageEncoding
++
++const FeatureSet_MESSAGE_ENCODING_UNKNOWN = descriptorpb.FeatureSet_MESSAGE_ENCODING_UNKNOWN
++const FeatureSet_LENGTH_PREFIXED = descriptorpb.FeatureSet_LENGTH_PREFIXED
++const FeatureSet_DELIMITED = descriptorpb.FeatureSet_DELIMITED
++
++var FeatureSet_MessageEncoding_name = descriptorpb.FeatureSet_MessageEncoding_name
++var FeatureSet_MessageEncoding_value = descriptorpb.FeatureSet_MessageEncoding_value
++
++type FeatureSet_JsonFormat = descriptorpb.FeatureSet_JsonFormat
++
++const FeatureSet_JSON_FORMAT_UNKNOWN = descriptorpb.FeatureSet_JSON_FORMAT_UNKNOWN
++const FeatureSet_ALLOW = descriptorpb.FeatureSet_ALLOW
++const FeatureSet_LEGACY_BEST_EFFORT = descriptorpb.FeatureSet_LEGACY_BEST_EFFORT
++
++var FeatureSet_JsonFormat_name = descriptorpb.FeatureSet_JsonFormat_name
++var FeatureSet_JsonFormat_value = descriptorpb.FeatureSet_JsonFormat_value
++
++type GeneratedCodeInfo_Annotation_Semantic = descriptorpb.GeneratedCodeInfo_Annotation_Semantic
++
++const GeneratedCodeInfo_Annotation_NONE = descriptorpb.GeneratedCodeInfo_Annotation_NONE
++const GeneratedCodeInfo_Annotation_SET = descriptorpb.GeneratedCodeInfo_Annotation_SET
++const GeneratedCodeInfo_Annotation_ALIAS = descriptorpb.GeneratedCodeInfo_Annotation_ALIAS
++
++var GeneratedCodeInfo_Annotation_Semantic_name = descriptorpb.GeneratedCodeInfo_Annotation_Semantic_name
++var GeneratedCodeInfo_Annotation_Semantic_value = descriptorpb.GeneratedCodeInfo_Annotation_Semantic_value
++
+ type FileDescriptorSet = descriptorpb.FileDescriptorSet
+ type FileDescriptorProto = descriptorpb.FileDescriptorProto
+ type DescriptorProto = descriptorpb.DescriptorProto
+ type ExtensionRangeOptions = descriptorpb.ExtensionRangeOptions
++
++const Default_ExtensionRangeOptions_Verification = descriptorpb.Default_ExtensionRangeOptions_Verification
++
+ type FieldDescriptorProto = descriptorpb.FieldDescriptorProto
+ type OneofDescriptorProto = descriptorpb.OneofDescriptorProto
+ type EnumDescriptorProto = descriptorpb.EnumDescriptorProto
+@@ -103,7 +220,6 @@ const Default_FileOptions_OptimizeFor = descriptorpb.Default_FileOptions_Optimiz
+ const Default_FileOptions_CcGenericServices = descriptorpb.Default_FileOptions_CcGenericServices
+ const Default_FileOptions_JavaGenericServices = descriptorpb.Default_FileOptions_JavaGenericServices
+ const Default_FileOptions_PyGenericServices = descriptorpb.Default_FileOptions_PyGenericServices
+-const Default_FileOptions_PhpGenericServices = descriptorpb.Default_FileOptions_PhpGenericServices
+ const Default_FileOptions_Deprecated = descriptorpb.Default_FileOptions_Deprecated
+ const Default_FileOptions_CcEnableArenas = descriptorpb.Default_FileOptions_CcEnableArenas
+ 
+@@ -118,8 +234,10 @@ type FieldOptions = descriptorpb.FieldOptions
+ const Default_FieldOptions_Ctype = descriptorpb.Default_FieldOptions_Ctype
+ const Default_FieldOptions_Jstype = descriptorpb.Default_FieldOptions_Jstype
+ const Default_FieldOptions_Lazy = descriptorpb.Default_FieldOptions_Lazy
++const Default_FieldOptions_UnverifiedLazy = descriptorpb.Default_FieldOptions_UnverifiedLazy
+ const Default_FieldOptions_Deprecated = descriptorpb.Default_FieldOptions_Deprecated
+ const Default_FieldOptions_Weak = descriptorpb.Default_FieldOptions_Weak
++const Default_FieldOptions_DebugRedact = descriptorpb.Default_FieldOptions_DebugRedact
+ 
+ type OneofOptions = descriptorpb.OneofOptions
+ type EnumOptions = descriptorpb.EnumOptions
+@@ -129,6 +247,7 @@ const Default_EnumOptions_Deprecated = descriptorpb.Default_EnumOptions_Deprecat
+ type EnumValueOptions = descriptorpb.EnumValueOptions
+ 
+ const Default_EnumValueOptions_Deprecated = descriptorpb.Default_EnumValueOptions_Deprecated
++const Default_EnumValueOptions_DebugRedact = descriptorpb.Default_EnumValueOptions_DebugRedact
+ 
+ type ServiceOptions = descriptorpb.ServiceOptions
+ 
+@@ -140,12 +259,17 @@ const Default_MethodOptions_Deprecated = descriptorpb.Default_MethodOptions_Depr
+ const Default_MethodOptions_IdempotencyLevel = descriptorpb.Default_MethodOptions_IdempotencyLevel
+ 
+ type UninterpretedOption = descriptorpb.UninterpretedOption
++type FeatureSet = descriptorpb.FeatureSet
++type FeatureSetDefaults = descriptorpb.FeatureSetDefaults
+ type SourceCodeInfo = descriptorpb.SourceCodeInfo
+ type GeneratedCodeInfo = descriptorpb.GeneratedCodeInfo
+ type DescriptorProto_ExtensionRange = descriptorpb.DescriptorProto_ExtensionRange
+ type DescriptorProto_ReservedRange = descriptorpb.DescriptorProto_ReservedRange
++type ExtensionRangeOptions_Declaration = descriptorpb.ExtensionRangeOptions_Declaration
+ type EnumDescriptorProto_EnumReservedRange = descriptorpb.EnumDescriptorProto_EnumReservedRange
++type FieldOptions_EditionDefault = descriptorpb.FieldOptions_EditionDefault
+ type UninterpretedOption_NamePart = descriptorpb.UninterpretedOption_NamePart
++type FeatureSetDefaults_FeatureSetEditionDefault = descriptorpb.FeatureSetDefaults_FeatureSetEditionDefault
+ type SourceCodeInfo_Location = descriptorpb.SourceCodeInfo_Location
+ type GeneratedCodeInfo_Annotation = descriptorpb.GeneratedCodeInfo_Annotation
+ 
+diff --git a/vendor/github.com/golang/protobuf/ptypes/any.go b/vendor/github.com/golang/protobuf/ptypes/any.go
+index 85f9f57..fdff3fd 100644
+--- a/vendor/github.com/golang/protobuf/ptypes/any.go
++++ b/vendor/github.com/golang/protobuf/ptypes/any.go
+@@ -127,9 +127,10 @@ func Is(any *anypb.Any, m proto.Message) bool {
+ // The allocated message is stored in the embedded proto.Message.
+ //
+ // Example:
+-//   var x ptypes.DynamicAny
+-//   if err := ptypes.UnmarshalAny(a, &x); err != nil { ... }
+-//   fmt.Printf("unmarshaled message: %v", x.Message)
++//
++//	var x ptypes.DynamicAny
++//	if err := ptypes.UnmarshalAny(a, &x); err != nil { ... }
++//	fmt.Printf("unmarshaled message: %v", x.Message)
+ //
+ // Deprecated: Use the any.UnmarshalNew method instead to unmarshal
+ // the any message contents into a new instance of the underlying message.
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/decode.go b/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
+index 5f28148..f479023 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
+@@ -11,6 +11,7 @@ import (
+ 	"strconv"
+ 	"strings"
+ 
++	"google.golang.org/protobuf/encoding/protowire"
+ 	"google.golang.org/protobuf/internal/encoding/json"
+ 	"google.golang.org/protobuf/internal/encoding/messageset"
+ 	"google.golang.org/protobuf/internal/errors"
+@@ -23,7 +24,7 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
+-// Unmarshal reads the given []byte into the given proto.Message.
++// Unmarshal reads the given []byte into the given [proto.Message].
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func Unmarshal(b []byte, m proto.Message) error {
+ 	return UnmarshalOptions{}.Unmarshal(b, m)
+@@ -37,7 +38,7 @@ type UnmarshalOptions struct {
+ 	// required fields will not return an error.
+ 	AllowPartial bool
+ 
+-	// If DiscardUnknown is set, unknown fields are ignored.
++	// If DiscardUnknown is set, unknown fields and enum name values are ignored.
+ 	DiscardUnknown bool
+ 
+ 	// Resolver is used for looking up types when unmarshaling
+@@ -47,9 +48,13 @@ type UnmarshalOptions struct {
+ 		protoregistry.MessageTypeResolver
+ 		protoregistry.ExtensionTypeResolver
+ 	}
++
++	// RecursionLimit limits how deeply messages may be nested.
++	// If zero, a default limit is applied.
++	RecursionLimit int
+ }
+ 
+-// Unmarshal reads the given []byte and populates the given proto.Message
++// Unmarshal reads the given []byte and populates the given [proto.Message]
+ // using options in the UnmarshalOptions object.
+ // It will clear the message first before setting the fields.
+ // If it returns an error, the given message may be partially set.
+@@ -67,6 +72,9 @@ func (o UnmarshalOptions) unmarshal(b []byte, m proto.Message) error {
+ 	if o.Resolver == nil {
+ 		o.Resolver = protoregistry.GlobalTypes
+ 	}
++	if o.RecursionLimit == 0 {
++		o.RecursionLimit = protowire.DefaultRecursionLimit
++	}
+ 
+ 	dec := decoder{json.NewDecoder(b), o}
+ 	if err := dec.unmarshalMessage(m.ProtoReflect(), false); err != nil {
+@@ -114,6 +122,10 @@ func (d decoder) syntaxError(pos int, f string, x ...interface{}) error {
+ 
+ // unmarshalMessage unmarshals a message into the given protoreflect.Message.
+ func (d decoder) unmarshalMessage(m protoreflect.Message, skipTypeURL bool) error {
++	d.opts.RecursionLimit--
++	if d.opts.RecursionLimit < 0 {
++		return errors.New("exceeded max recursion depth")
++	}
+ 	if unmarshal := wellKnownTypeUnmarshaler(m.Descriptor().FullName()); unmarshal != nil {
+ 		return unmarshal(d, m)
+ 	}
+@@ -266,7 +278,9 @@ func (d decoder) unmarshalSingular(m protoreflect.Message, fd protoreflect.Field
+ 	if err != nil {
+ 		return err
+ 	}
+-	m.Set(fd, val)
++	if val.IsValid() {
++		m.Set(fd, val)
++	}
+ 	return nil
+ }
+ 
+@@ -329,7 +343,7 @@ func (d decoder) unmarshalScalar(fd protoreflect.FieldDescriptor) (protoreflect.
+ 		}
+ 
+ 	case protoreflect.EnumKind:
+-		if v, ok := unmarshalEnum(tok, fd); ok {
++		if v, ok := unmarshalEnum(tok, fd, d.opts.DiscardUnknown); ok {
+ 			return v, nil
+ 		}
+ 
+@@ -474,7 +488,7 @@ func unmarshalBytes(tok json.Token) (protoreflect.Value, bool) {
+ 	return protoreflect.ValueOfBytes(b), true
+ }
+ 
+-func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor) (protoreflect.Value, bool) {
++func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor, discardUnknown bool) (protoreflect.Value, bool) {
+ 	switch tok.Kind() {
+ 	case json.String:
+ 		// Lookup EnumNumber based on name.
+@@ -482,6 +496,9 @@ func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor) (protoreflec
+ 		if enumVal := fd.Enum().Values().ByName(protoreflect.Name(s)); enumVal != nil {
+ 			return protoreflect.ValueOfEnum(enumVal.Number()), true
+ 		}
++		if discardUnknown {
++			return protoreflect.Value{}, true
++		}
+ 
+ 	case json.Number:
+ 		if n, ok := tok.Int(32); ok {
+@@ -542,7 +559,9 @@ func (d decoder) unmarshalList(list protoreflect.List, fd protoreflect.FieldDesc
+ 			if err != nil {
+ 				return err
+ 			}
+-			list.Append(val)
++			if val.IsValid() {
++				list.Append(val)
++			}
+ 		}
+ 	}
+ 
+@@ -609,8 +628,9 @@ Loop:
+ 		if err != nil {
+ 			return err
+ 		}
+-
+-		mmap.Set(pkey, pval)
++		if pval.IsValid() {
++			mmap.Set(pkey, pval)
++		}
+ 	}
+ 
+ 	return nil
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/doc.go b/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
+index 21d5d2c..ae71007 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
+@@ -6,6 +6,6 @@
+ // format. It follows the guide at
+ // https://protobuf.dev/programming-guides/proto3#json.
+ //
+-// This package produces a different output than the standard "encoding/json"
++// This package produces a different output than the standard [encoding/json]
+ // package, which does not operate correctly on protocol buffer messages.
+ package protojson
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/encode.go b/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
+index 66b9587..3f75098 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
+@@ -31,7 +31,7 @@ func Format(m proto.Message) string {
+ 	return MarshalOptions{Multiline: true}.Format(m)
+ }
+ 
+-// Marshal writes the given proto.Message in JSON format using default options.
++// Marshal writes the given [proto.Message] in JSON format using default options.
+ // Do not depend on the output being stable. It may change over time across
+ // different versions of the program.
+ func Marshal(m proto.Message) ([]byte, error) {
+@@ -81,6 +81,25 @@ type MarshalOptions struct {
+ 	//  ╚═══════╧════════════════════════════╝
+ 	EmitUnpopulated bool
+ 
++	// EmitDefaultValues specifies whether to emit default-valued primitive fields,
++	// empty lists, and empty maps. The fields affected are as follows:
++	//  ╔═══════╤════════════════════════════════════════╗
++	//  ║ JSON  │ Protobuf field                         ║
++	//  ╠═══════╪════════════════════════════════════════╣
++	//  ║ false │ non-optional scalar boolean fields     ║
++	//  ║ 0     │ non-optional scalar numeric fields     ║
++	//  ║ ""    │ non-optional scalar string/byte fields ║
++	//  ║ []    │ empty repeated fields                  ║
++	//  ║ {}    │ empty map fields                       ║
++	//  ╚═══════╧════════════════════════════════════════╝
++	//
++	// Behaves similarly to EmitUnpopulated, but does not emit "null"-value fields,
++	// i.e. presence-sensing fields that are omitted will remain omitted to preserve
++	// presence-sensing.
++	// EmitUnpopulated takes precedence over EmitDefaultValues since the former generates
++	// a strict superset of the latter.
++	EmitDefaultValues bool
++
+ 	// Resolver is used for looking up types when expanding google.protobuf.Any
+ 	// messages. If nil, this defaults to using protoregistry.GlobalTypes.
+ 	Resolver interface {
+@@ -102,7 +121,7 @@ func (o MarshalOptions) Format(m proto.Message) string {
+ 	return string(b)
+ }
+ 
+-// Marshal marshals the given proto.Message in the JSON format using options in
++// Marshal marshals the given [proto.Message] in the JSON format using options in
+ // MarshalOptions. Do not depend on the output being stable. It may change over
+ // time across different versions of the program.
+ func (o MarshalOptions) Marshal(m proto.Message) ([]byte, error) {
+@@ -178,7 +197,11 @@ func (m typeURLFieldRanger) Range(f func(protoreflect.FieldDescriptor, protorefl
+ 
+ // unpopulatedFieldRanger wraps a protoreflect.Message and modifies its Range
+ // method to additionally iterate over unpopulated fields.
+-type unpopulatedFieldRanger struct{ protoreflect.Message }
++type unpopulatedFieldRanger struct {
++	protoreflect.Message
++
++	skipNull bool
++}
+ 
+ func (m unpopulatedFieldRanger) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+ 	fds := m.Descriptor().Fields()
+@@ -192,6 +215,9 @@ func (m unpopulatedFieldRanger) Range(f func(protoreflect.FieldDescriptor, proto
+ 		isProto2Scalar := fd.Syntax() == protoreflect.Proto2 && fd.Default().IsValid()
+ 		isSingularMessage := fd.Cardinality() != protoreflect.Repeated && fd.Message() != nil
+ 		if isProto2Scalar || isSingularMessage {
++			if m.skipNull {
++				continue
++			}
+ 			v = protoreflect.Value{} // use invalid value to emit null
+ 		}
+ 		if !f(fd, v) {
+@@ -217,8 +243,11 @@ func (e encoder) marshalMessage(m protoreflect.Message, typeURL string) error {
+ 	defer e.EndObject()
+ 
+ 	var fields order.FieldRanger = m
+-	if e.opts.EmitUnpopulated {
+-		fields = unpopulatedFieldRanger{m}
++	switch {
++	case e.opts.EmitUnpopulated:
++		fields = unpopulatedFieldRanger{Message: m, skipNull: false}
++	case e.opts.EmitDefaultValues:
++		fields = unpopulatedFieldRanger{Message: m, skipNull: true}
+ 	}
+ 	if typeURL != "" {
+ 		fields = typeURLFieldRanger{fields, typeURL}
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+index 6c37d41..4b177c8 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+@@ -176,7 +176,7 @@ func (d decoder) unmarshalAny(m protoreflect.Message) error {
+ 	// Use another decoder to parse the unread bytes for @type field. This
+ 	// avoids advancing a read from current decoder because the current JSON
+ 	// object may contain the fields of the embedded type.
+-	dec := decoder{d.Clone(), UnmarshalOptions{}}
++	dec := decoder{d.Clone(), UnmarshalOptions{RecursionLimit: d.opts.RecursionLimit}}
+ 	tok, err := findTypeURL(dec)
+ 	switch err {
+ 	case errEmptyObject:
+@@ -308,48 +308,29 @@ Loop:
+ // array) in order to advance the read to the next JSON value. It relies on
+ // the decoder returning an error if the types are not in valid sequence.
+ func (d decoder) skipJSONValue() error {
+-	tok, err := d.Read()
+-	if err != nil {
+-		return err
+-	}
+-	// Only need to continue reading for objects and arrays.
+-	switch tok.Kind() {
+-	case json.ObjectOpen:
+-		for {
+-			tok, err := d.Read()
+-			if err != nil {
+-				return err
+-			}
+-			switch tok.Kind() {
+-			case json.ObjectClose:
+-				return nil
+-			case json.Name:
+-				// Skip object field value.
+-				if err := d.skipJSONValue(); err != nil {
+-					return err
+-				}
+-			}
++	var open int
++	for {
++		tok, err := d.Read()
++		if err != nil {
++			return err
+ 		}
+-
+-	case json.ArrayOpen:
+-		for {
+-			tok, err := d.Peek()
+-			if err != nil {
+-				return err
+-			}
+-			switch tok.Kind() {
+-			case json.ArrayClose:
+-				d.Read()
+-				return nil
+-			default:
+-				// Skip array item.
+-				if err := d.skipJSONValue(); err != nil {
+-					return err
+-				}
++		switch tok.Kind() {
++		case json.ObjectClose, json.ArrayClose:
++			open--
++		case json.ObjectOpen, json.ArrayOpen:
++			open++
++			if open > d.opts.RecursionLimit {
++				return errors.New("exceeded max recursion depth")
+ 			}
++		case json.EOF:
++			// This can only happen if there's a bug in Decoder.Read.
++			// Avoid an infinite loop if this does happen.
++			return errors.New("unexpected EOF")
++		}
++		if open == 0 {
++			return nil
+ 		}
+ 	}
+-	return nil
+ }
+ 
+ // unmarshalAnyValue unmarshals the given custom-type message from the JSON
+diff --git a/vendor/google.golang.org/protobuf/encoding/prototext/decode.go b/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
+index 4921b2d..a45f112 100644
+--- a/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
++++ b/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
+@@ -21,7 +21,7 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
+-// Unmarshal reads the given []byte into the given proto.Message.
++// Unmarshal reads the given []byte into the given [proto.Message].
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func Unmarshal(b []byte, m proto.Message) error {
+ 	return UnmarshalOptions{}.Unmarshal(b, m)
+@@ -51,7 +51,7 @@ type UnmarshalOptions struct {
+ 	}
+ }
+ 
+-// Unmarshal reads the given []byte and populates the given proto.Message
++// Unmarshal reads the given []byte and populates the given [proto.Message]
+ // using options in the UnmarshalOptions object.
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func (o UnmarshalOptions) Unmarshal(b []byte, m proto.Message) error {
+@@ -739,7 +739,9 @@ func (d decoder) skipValue() error {
+ 			case text.ListClose:
+ 				return nil
+ 			case text.MessageOpen:
+-				return d.skipMessageValue()
++				if err := d.skipMessageValue(); err != nil {
++					return err
++				}
+ 			default:
+ 				// Skip items. This will not validate whether skipped values are
+ 				// of the same type or not, same behavior as C++
+diff --git a/vendor/google.golang.org/protobuf/encoding/prototext/encode.go b/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
+index 722a7b4..95967e8 100644
+--- a/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
++++ b/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
+@@ -33,7 +33,7 @@ func Format(m proto.Message) string {
+ 	return MarshalOptions{Multiline: true}.Format(m)
+ }
+ 
+-// Marshal writes the given proto.Message in textproto format using default
++// Marshal writes the given [proto.Message] in textproto format using default
+ // options. Do not depend on the output being stable. It may change over time
+ // across different versions of the program.
+ func Marshal(m proto.Message) ([]byte, error) {
+@@ -97,7 +97,7 @@ func (o MarshalOptions) Format(m proto.Message) string {
+ 	return string(b)
+ }
+ 
+-// Marshal writes the given proto.Message in textproto format using options in
++// Marshal writes the given [proto.Message] in textproto format using options in
+ // MarshalOptions object. Do not depend on the output being stable. It may
+ // change over time across different versions of the program.
+ func (o MarshalOptions) Marshal(m proto.Message) ([]byte, error) {
+diff --git a/vendor/google.golang.org/protobuf/encoding/protowire/wire.go b/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
+index f4b4686..e942bc9 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
++++ b/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
+@@ -6,7 +6,7 @@
+ // See https://protobuf.dev/programming-guides/encoding.
+ //
+ // For marshaling and unmarshaling entire protobuf messages,
+-// use the "google.golang.org/protobuf/proto" package instead.
++// use the [google.golang.org/protobuf/proto] package instead.
+ package protowire
+ 
+ import (
+@@ -87,7 +87,7 @@ func ParseError(n int) error {
+ 
+ // ConsumeField parses an entire field record (both tag and value) and returns
+ // the field number, the wire type, and the total length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ //
+ // The total length includes the tag header and the end group marker (if the
+ // field is a group).
+@@ -104,8 +104,8 @@ func ConsumeField(b []byte) (Number, Type, int) {
+ }
+ 
+ // ConsumeFieldValue parses a field value and returns its length.
+-// This assumes that the field Number and wire Type have already been parsed.
+-// This returns a negative length upon an error (see ParseError).
++// This assumes that the field [Number] and wire [Type] have already been parsed.
++// This returns a negative length upon an error (see [ParseError]).
+ //
+ // When parsing a group, the length includes the end group marker and
+ // the end group is verified to match the starting field number.
+@@ -164,7 +164,7 @@ func AppendTag(b []byte, num Number, typ Type) []byte {
+ }
+ 
+ // ConsumeTag parses b as a varint-encoded tag, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeTag(b []byte) (Number, Type, int) {
+ 	v, n := ConsumeVarint(b)
+ 	if n < 0 {
+@@ -263,7 +263,7 @@ func AppendVarint(b []byte, v uint64) []byte {
+ }
+ 
+ // ConsumeVarint parses b as a varint-encoded uint64, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeVarint(b []byte) (v uint64, n int) {
+ 	var y uint64
+ 	if len(b) <= 0 {
+@@ -384,7 +384,7 @@ func AppendFixed32(b []byte, v uint32) []byte {
+ }
+ 
+ // ConsumeFixed32 parses b as a little-endian uint32, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeFixed32(b []byte) (v uint32, n int) {
+ 	if len(b) < 4 {
+ 		return 0, errCodeTruncated
+@@ -412,7 +412,7 @@ func AppendFixed64(b []byte, v uint64) []byte {
+ }
+ 
+ // ConsumeFixed64 parses b as a little-endian uint64, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeFixed64(b []byte) (v uint64, n int) {
+ 	if len(b) < 8 {
+ 		return 0, errCodeTruncated
+@@ -432,7 +432,7 @@ func AppendBytes(b []byte, v []byte) []byte {
+ }
+ 
+ // ConsumeBytes parses b as a length-prefixed bytes value, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeBytes(b []byte) (v []byte, n int) {
+ 	m, n := ConsumeVarint(b)
+ 	if n < 0 {
+@@ -456,7 +456,7 @@ func AppendString(b []byte, v string) []byte {
+ }
+ 
+ // ConsumeString parses b as a length-prefixed bytes value, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeString(b []byte) (v string, n int) {
+ 	bb, n := ConsumeBytes(b)
+ 	return string(bb), n
+@@ -471,7 +471,7 @@ func AppendGroup(b []byte, num Number, v []byte) []byte {
+ // ConsumeGroup parses b as a group value until the trailing end group marker,
+ // and verifies that the end marker matches the provided num. The value v
+ // does not contain the end marker, while the length does contain the end marker.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeGroup(num Number, b []byte) (v []byte, n int) {
+ 	n = ConsumeFieldValue(num, StartGroupType, b)
+ 	if n < 0 {
+@@ -495,8 +495,8 @@ func SizeGroup(num Number, n int) int {
+ 	return n + SizeTag(num)
+ }
+ 
+-// DecodeTag decodes the field Number and wire Type from its unified form.
+-// The Number is -1 if the decoded field number overflows int32.
++// DecodeTag decodes the field [Number] and wire [Type] from its unified form.
++// The [Number] is -1 if the decoded field number overflows int32.
+ // Other than overflow, this does not check for field number validity.
+ func DecodeTag(x uint64) (Number, Type) {
+ 	// NOTE: MessageSet allows for larger field numbers than normal.
+@@ -506,7 +506,7 @@ func DecodeTag(x uint64) (Number, Type) {
+ 	return Number(x >> 3), Type(x & 7)
+ }
+ 
+-// EncodeTag encodes the field Number and wire Type into its unified form.
++// EncodeTag encodes the field [Number] and wire [Type] into its unified form.
+ func EncodeTag(num Number, typ Type) uint64 {
+ 	return uint64(num)<<3 | uint64(typ&7)
+ }
+diff --git a/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go b/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
+index db5248e..a45625c 100644
+--- a/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
++++ b/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
+@@ -83,7 +83,13 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
+ 	case protoreflect.FileImports:
+ 		for i := 0; i < vs.Len(); i++ {
+ 			var rs records
+-			rs.Append(reflect.ValueOf(vs.Get(i)), "Path", "Package", "IsPublic", "IsWeak")
++			rv := reflect.ValueOf(vs.Get(i))
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("IsPublic"), "IsPublic"},
++				{rv.MethodByName("IsWeak"), "IsWeak"},
++			}...)
+ 			ss = append(ss, "{"+rs.Join()+"}")
+ 		}
+ 		return start + joinStrings(ss, allowMulti) + end
+@@ -92,34 +98,26 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
+ 		for i := 0; i < vs.Len(); i++ {
+ 			m := reflect.ValueOf(vs).MethodByName("Get")
+ 			v := m.Call([]reflect.Value{reflect.ValueOf(i)})[0].Interface()
+-			ss = append(ss, formatDescOpt(v.(protoreflect.Descriptor), false, allowMulti && !isEnumValue))
++			ss = append(ss, formatDescOpt(v.(protoreflect.Descriptor), false, allowMulti && !isEnumValue, nil))
+ 		}
+ 		return start + joinStrings(ss, allowMulti && isEnumValue) + end
+ 	}
+ }
+ 
+-// descriptorAccessors is a list of accessors to print for each descriptor.
+-//
+-// Do not print all accessors since some contain redundant information,
+-// while others are pointers that we do not want to follow since the descriptor
+-// is actually a cyclic graph.
+-//
+-// Using a list allows us to print the accessors in a sensible order.
+-var descriptorAccessors = map[reflect.Type][]string{
+-	reflect.TypeOf((*protoreflect.FileDescriptor)(nil)).Elem():      {"Path", "Package", "Imports", "Messages", "Enums", "Extensions", "Services"},
+-	reflect.TypeOf((*protoreflect.MessageDescriptor)(nil)).Elem():   {"IsMapEntry", "Fields", "Oneofs", "ReservedNames", "ReservedRanges", "RequiredNumbers", "ExtensionRanges", "Messages", "Enums", "Extensions"},
+-	reflect.TypeOf((*protoreflect.FieldDescriptor)(nil)).Elem():     {"Number", "Cardinality", "Kind", "HasJSONName", "JSONName", "HasPresence", "IsExtension", "IsPacked", "IsWeak", "IsList", "IsMap", "MapKey", "MapValue", "HasDefault", "Default", "ContainingOneof", "ContainingMessage", "Message", "Enum"},
+-	reflect.TypeOf((*protoreflect.OneofDescriptor)(nil)).Elem():     {"Fields"}, // not directly used; must keep in sync with formatDescOpt
+-	reflect.TypeOf((*protoreflect.EnumDescriptor)(nil)).Elem():      {"Values", "ReservedNames", "ReservedRanges"},
+-	reflect.TypeOf((*protoreflect.EnumValueDescriptor)(nil)).Elem(): {"Number"},
+-	reflect.TypeOf((*protoreflect.ServiceDescriptor)(nil)).Elem():   {"Methods"},
+-	reflect.TypeOf((*protoreflect.MethodDescriptor)(nil)).Elem():    {"Input", "Output", "IsStreamingClient", "IsStreamingServer"},
++type methodAndName struct {
++	method reflect.Value
++	name   string
+ }
+ 
+ func FormatDesc(s fmt.State, r rune, t protoreflect.Descriptor) {
+-	io.WriteString(s, formatDescOpt(t, true, r == 'v' && (s.Flag('+') || s.Flag('#'))))
++	io.WriteString(s, formatDescOpt(t, true, r == 'v' && (s.Flag('+') || s.Flag('#')), nil))
+ }
+-func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
++
++func InternalFormatDescOptForTesting(t protoreflect.Descriptor, isRoot, allowMulti bool, record func(string)) string {
++	return formatDescOpt(t, isRoot, allowMulti, record)
++}
++
++func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool, record func(string)) string {
+ 	rv := reflect.ValueOf(t)
+ 	rt := rv.MethodByName("ProtoType").Type().In(0)
+ 
+@@ -129,26 +127,60 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 	}
+ 
+ 	_, isFile := t.(protoreflect.FileDescriptor)
+-	rs := records{allowMulti: allowMulti}
++	rs := records{
++		allowMulti: allowMulti,
++		record:     record,
++	}
+ 	if t.IsPlaceholder() {
+ 		if isFile {
+-			rs.Append(rv, "Path", "Package", "IsPlaceholder")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
++			}...)
+ 		} else {
+-			rs.Append(rv, "FullName", "IsPlaceholder")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("FullName"), "FullName"},
++				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
++			}...)
+ 		}
+ 	} else {
+ 		switch {
+ 		case isFile:
+-			rs.Append(rv, "Syntax")
++			rs.Append(rv, methodAndName{rv.MethodByName("Syntax"), "Syntax"})
+ 		case isRoot:
+-			rs.Append(rv, "Syntax", "FullName")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Syntax"), "Syntax"},
++				{rv.MethodByName("FullName"), "FullName"},
++			}...)
+ 		default:
+-			rs.Append(rv, "Name")
++			rs.Append(rv, methodAndName{rv.MethodByName("Name"), "Name"})
+ 		}
+ 		switch t := t.(type) {
+ 		case protoreflect.FieldDescriptor:
+-			for _, s := range descriptorAccessors[rt] {
+-				switch s {
++			accessors := []methodAndName{
++				{rv.MethodByName("Number"), "Number"},
++				{rv.MethodByName("Cardinality"), "Cardinality"},
++				{rv.MethodByName("Kind"), "Kind"},
++				{rv.MethodByName("HasJSONName"), "HasJSONName"},
++				{rv.MethodByName("JSONName"), "JSONName"},
++				{rv.MethodByName("HasPresence"), "HasPresence"},
++				{rv.MethodByName("IsExtension"), "IsExtension"},
++				{rv.MethodByName("IsPacked"), "IsPacked"},
++				{rv.MethodByName("IsWeak"), "IsWeak"},
++				{rv.MethodByName("IsList"), "IsList"},
++				{rv.MethodByName("IsMap"), "IsMap"},
++				{rv.MethodByName("MapKey"), "MapKey"},
++				{rv.MethodByName("MapValue"), "MapValue"},
++				{rv.MethodByName("HasDefault"), "HasDefault"},
++				{rv.MethodByName("Default"), "Default"},
++				{rv.MethodByName("ContainingOneof"), "ContainingOneof"},
++				{rv.MethodByName("ContainingMessage"), "ContainingMessage"},
++				{rv.MethodByName("Message"), "Message"},
++				{rv.MethodByName("Enum"), "Enum"},
++			}
++			for _, s := range accessors {
++				switch s.name {
+ 				case "MapKey":
+ 					if k := t.MapKey(); k != nil {
+ 						rs.recs = append(rs.recs, [2]string{"MapKey", k.Kind().String()})
+@@ -157,20 +189,20 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 					if v := t.MapValue(); v != nil {
+ 						switch v.Kind() {
+ 						case protoreflect.EnumKind:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", string(v.Enum().FullName())})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", string(v.Enum().FullName())})
+ 						case protoreflect.MessageKind, protoreflect.GroupKind:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", string(v.Message().FullName())})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", string(v.Message().FullName())})
+ 						default:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", v.Kind().String()})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", v.Kind().String()})
+ 						}
+ 					}
+ 				case "ContainingOneof":
+ 					if od := t.ContainingOneof(); od != nil {
+-						rs.recs = append(rs.recs, [2]string{"Oneof", string(od.Name())})
++						rs.AppendRecs("ContainingOneof", [2]string{"Oneof", string(od.Name())})
+ 					}
+ 				case "ContainingMessage":
+ 					if t.IsExtension() {
+-						rs.recs = append(rs.recs, [2]string{"Extendee", string(t.ContainingMessage().FullName())})
++						rs.AppendRecs("ContainingMessage", [2]string{"Extendee", string(t.ContainingMessage().FullName())})
+ 					}
+ 				case "Message":
+ 					if !t.IsMap() {
+@@ -187,13 +219,61 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 				ss = append(ss, string(fs.Get(i).Name()))
+ 			}
+ 			if len(ss) > 0 {
+-				rs.recs = append(rs.recs, [2]string{"Fields", "[" + joinStrings(ss, false) + "]"})
++				rs.AppendRecs("Fields", [2]string{"Fields", "[" + joinStrings(ss, false) + "]"})
+ 			}
+-		default:
+-			rs.Append(rv, descriptorAccessors[rt]...)
++
++		case protoreflect.FileDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("Imports"), "Imports"},
++				{rv.MethodByName("Messages"), "Messages"},
++				{rv.MethodByName("Enums"), "Enums"},
++				{rv.MethodByName("Extensions"), "Extensions"},
++				{rv.MethodByName("Services"), "Services"},
++			}...)
++
++		case protoreflect.MessageDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("IsMapEntry"), "IsMapEntry"},
++				{rv.MethodByName("Fields"), "Fields"},
++				{rv.MethodByName("Oneofs"), "Oneofs"},
++				{rv.MethodByName("ReservedNames"), "ReservedNames"},
++				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
++				{rv.MethodByName("RequiredNumbers"), "RequiredNumbers"},
++				{rv.MethodByName("ExtensionRanges"), "ExtensionRanges"},
++				{rv.MethodByName("Messages"), "Messages"},
++				{rv.MethodByName("Enums"), "Enums"},
++				{rv.MethodByName("Extensions"), "Extensions"},
++			}...)
++
++		case protoreflect.EnumDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Values"), "Values"},
++				{rv.MethodByName("ReservedNames"), "ReservedNames"},
++				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
++			}...)
++
++		case protoreflect.EnumValueDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Number"), "Number"},
++			}...)
++
++		case protoreflect.ServiceDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Methods"), "Methods"},
++			}...)
++
++		case protoreflect.MethodDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Input"), "Input"},
++				{rv.MethodByName("Output"), "Output"},
++				{rv.MethodByName("IsStreamingClient"), "IsStreamingClient"},
++				{rv.MethodByName("IsStreamingServer"), "IsStreamingServer"},
++			}...)
+ 		}
+-		if rv.MethodByName("GoType").IsValid() {
+-			rs.Append(rv, "GoType")
++		if m := rv.MethodByName("GoType"); m.IsValid() {
++			rs.Append(rv, methodAndName{m, "GoType"})
+ 		}
+ 	}
+ 	return start + rs.Join() + end
+@@ -202,19 +282,34 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ type records struct {
+ 	recs       [][2]string
+ 	allowMulti bool
++
++	// record is a function that will be called for every Append() or
++	// AppendRecs() call, to be used for testing with the
++	// InternalFormatDescOptForTesting function.
++	record func(string)
+ }
+ 
+-func (rs *records) Append(v reflect.Value, accessors ...string) {
++func (rs *records) AppendRecs(fieldName string, newRecs [2]string) {
++	if rs.record != nil {
++		rs.record(fieldName)
++	}
++	rs.recs = append(rs.recs, newRecs)
++}
++
++func (rs *records) Append(v reflect.Value, accessors ...methodAndName) {
+ 	for _, a := range accessors {
++		if rs.record != nil {
++			rs.record(a.name)
++		}
+ 		var rv reflect.Value
+-		if m := v.MethodByName(a); m.IsValid() {
+-			rv = m.Call(nil)[0]
++		if a.method.IsValid() {
++			rv = a.method.Call(nil)[0]
+ 		}
+ 		if v.Kind() == reflect.Struct && !rv.IsValid() {
+-			rv = v.FieldByName(a)
++			rv = v.FieldByName(a.name)
+ 		}
+ 		if !rv.IsValid() {
+-			panic(fmt.Sprintf("unknown accessor: %v.%s", v.Type(), a))
++			panic(fmt.Sprintf("unknown accessor: %v.%s", v.Type(), a.name))
+ 		}
+ 		if _, ok := rv.Interface().(protoreflect.Value); ok {
+ 			rv = rv.MethodByName("Interface").Call(nil)[0]
+@@ -261,7 +356,7 @@ func (rs *records) Append(v reflect.Value, accessors ...string) {
+ 		default:
+ 			s = fmt.Sprint(v)
+ 		}
+-		rs.recs = append(rs.recs, [2]string{a, s})
++		rs.recs = append(rs.recs, [2]string{a.name, s})
+ 	}
+ }
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go b/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+new file mode 100644
+index 0000000..14656b6
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+@@ -0,0 +1,12 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Package editiondefaults contains the binary representation of the editions
++// defaults.
++package editiondefaults
++
++import _ "embed"
++
++//go:embed editions_defaults.binpb
++var Defaults []byte
+diff --git a/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb b/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+new file mode 100644
+index 0000000..18f0756
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+@@ -0,0 +1,4 @@
++
++ (0�
++ (0�
++ (0� �(�
+\ No newline at end of file
+diff --git a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+index d043a6e..d2b3ac0 100644
+--- a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
++++ b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+@@ -121,7 +121,7 @@ func (d *Decoder) Read() (Token, error) {
+ 
+ 	case ObjectClose:
+ 		if len(d.openStack) == 0 ||
+-			d.lastToken.kind == comma ||
++			d.lastToken.kind&(Name|comma) != 0 ||
+ 			d.openStack[len(d.openStack)-1] != ObjectOpen {
+ 			return Token{}, d.newSyntaxError(tok.pos, unexpectedFmt, tok.RawString())
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+index 7c3689b..8826bcf 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+@@ -21,11 +21,26 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
++// Edition is an Enum for proto2.Edition
++type Edition int32
++
++// These values align with the value of Enum in descriptor.proto which allows
++// direct conversion between the proto enum and this enum.
++const (
++	EditionUnknown     Edition = 0
++	EditionProto2      Edition = 998
++	EditionProto3      Edition = 999
++	Edition2023        Edition = 1000
++	EditionUnsupported Edition = 100000
++)
++
+ // The types in this file may have a suffix:
+ //	• L0: Contains fields common to all descriptors (except File) and
+ //	must be initialized up front.
+ //	• L1: Contains fields specific to a descriptor and
+-//	must be initialized up front.
++//	must be initialized up front. If the associated proto uses Editions, the
++//  Editions features must always be resolved. If not explicitly set, the
++//  appropriate default must be resolved and set.
+ //	• L2: Contains fields that are lazily initialized when constructing
+ //	from the raw file descriptor. When constructing as a literal, the L2
+ //	fields must be initialized up front.
+@@ -44,6 +59,7 @@ type (
+ 	}
+ 	FileL1 struct {
+ 		Syntax  protoreflect.Syntax
++		Edition Edition // Only used if Syntax == Editions
+ 		Path    string
+ 		Package protoreflect.FullName
+ 
+@@ -51,12 +67,41 @@ type (
+ 		Messages   Messages
+ 		Extensions Extensions
+ 		Services   Services
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	FileL2 struct {
+ 		Options   func() protoreflect.ProtoMessage
+ 		Imports   FileImports
+ 		Locations SourceLocations
+ 	}
++
++	EditionFeatures struct {
++		// IsFieldPresence is true if field_presence is EXPLICIT
++		// https://protobuf.dev/editions/features/#field_presence
++		IsFieldPresence bool
++		// IsFieldPresence is true if field_presence is LEGACY_REQUIRED
++		// https://protobuf.dev/editions/features/#field_presence
++		IsLegacyRequired bool
++		// IsOpenEnum is true if enum_type is OPEN
++		// https://protobuf.dev/editions/features/#enum_type
++		IsOpenEnum bool
++		// IsPacked is true if repeated_field_encoding is PACKED
++		// https://protobuf.dev/editions/features/#repeated_field_encoding
++		IsPacked bool
++		// IsUTF8Validated is true if utf_validation is VERIFY
++		// https://protobuf.dev/editions/features/#utf8_validation
++		IsUTF8Validated bool
++		// IsDelimitedEncoded is true if message_encoding is DELIMITED
++		// https://protobuf.dev/editions/features/#message_encoding
++		IsDelimitedEncoded bool
++		// IsJSONCompliant is true if json_format is ALLOW
++		// https://protobuf.dev/editions/features/#json_format
++		IsJSONCompliant bool
++		// GenerateLegacyUnmarshalJSON determines if the plugin generates the
++		// UnmarshalJSON([]byte) error method for enums.
++		GenerateLegacyUnmarshalJSON bool
++	}
+ )
+ 
+ func (fd *File) ParentFile() protoreflect.FileDescriptor { return fd }
+@@ -117,6 +162,8 @@ type (
+ 	}
+ 	EnumL1 struct {
+ 		eagerValues bool // controls whether EnumL2.Values is already populated
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	EnumL2 struct {
+ 		Options        func() protoreflect.ProtoMessage
+@@ -178,6 +225,8 @@ type (
+ 		Extensions   Extensions
+ 		IsMapEntry   bool // promoted from google.protobuf.MessageOptions
+ 		IsMessageSet bool // promoted from google.protobuf.MessageOptions
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	MessageL2 struct {
+ 		Options               func() protoreflect.ProtoMessage
+@@ -210,6 +259,8 @@ type (
+ 		ContainingOneof  protoreflect.OneofDescriptor // must be consistent with Message.Oneofs.Fields
+ 		Enum             protoreflect.EnumDescriptor
+ 		Message          protoreflect.MessageDescriptor
++
++		EditionFeatures EditionFeatures
+ 	}
+ 
+ 	Oneof struct {
+@@ -219,6 +270,8 @@ type (
+ 	OneofL1 struct {
+ 		Options func() protoreflect.ProtoMessage
+ 		Fields  OneofFields // must be consistent with Message.Fields.ContainingOneof
++
++		EditionFeatures EditionFeatures
+ 	}
+ )
+ 
+@@ -268,23 +321,36 @@ func (fd *Field) Options() protoreflect.ProtoMessage {
+ }
+ func (fd *Field) Number() protoreflect.FieldNumber      { return fd.L1.Number }
+ func (fd *Field) Cardinality() protoreflect.Cardinality { return fd.L1.Cardinality }
+-func (fd *Field) Kind() protoreflect.Kind               { return fd.L1.Kind }
+-func (fd *Field) HasJSONName() bool                     { return fd.L1.StringName.hasJSON }
+-func (fd *Field) JSONName() string                      { return fd.L1.StringName.getJSON(fd) }
+-func (fd *Field) TextName() string                      { return fd.L1.StringName.getText(fd) }
++func (fd *Field) Kind() protoreflect.Kind {
++	return fd.L1.Kind
++}
++func (fd *Field) HasJSONName() bool { return fd.L1.StringName.hasJSON }
++func (fd *Field) JSONName() string  { return fd.L1.StringName.getJSON(fd) }
++func (fd *Field) TextName() string  { return fd.L1.StringName.getText(fd) }
+ func (fd *Field) HasPresence() bool {
+-	return fd.L1.Cardinality != protoreflect.Repeated && (fd.L0.ParentFile.L1.Syntax == protoreflect.Proto2 || fd.L1.Message != nil || fd.L1.ContainingOneof != nil)
++	if fd.L1.Cardinality == protoreflect.Repeated {
++		return false
++	}
++	explicitFieldPresence := fd.Syntax() == protoreflect.Editions && fd.L1.EditionFeatures.IsFieldPresence
++	return fd.Syntax() == protoreflect.Proto2 || explicitFieldPresence || fd.L1.Message != nil || fd.L1.ContainingOneof != nil
+ }
+ func (fd *Field) HasOptionalKeyword() bool {
+ 	return (fd.L0.ParentFile.L1.Syntax == protoreflect.Proto2 && fd.L1.Cardinality == protoreflect.Optional && fd.L1.ContainingOneof == nil) || fd.L1.IsProto3Optional
+ }
+ func (fd *Field) IsPacked() bool {
+-	if !fd.L1.HasPacked && fd.L0.ParentFile.L1.Syntax != protoreflect.Proto2 && fd.L1.Cardinality == protoreflect.Repeated {
+-		switch fd.L1.Kind {
+-		case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
+-		default:
+-			return true
+-		}
++	if fd.L1.Cardinality != protoreflect.Repeated {
++		return false
++	}
++	switch fd.L1.Kind {
++	case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
++		return false
++	}
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Editions {
++		return fd.L1.EditionFeatures.IsPacked
++	}
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Proto3 {
++		// proto3 repeated fields are packed by default.
++		return !fd.L1.HasPacked || fd.L1.IsPacked
+ 	}
+ 	return fd.L1.IsPacked
+ }
+@@ -333,6 +399,9 @@ func (fd *Field) ProtoType(protoreflect.FieldDescriptor) {}
+ // WARNING: This method is exempt from the compatibility promise and may be
+ // removed in the future without warning.
+ func (fd *Field) EnforceUTF8() bool {
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Editions {
++		return fd.L1.EditionFeatures.IsUTF8Validated
++	}
+ 	if fd.L1.HasEnforceUTF8 {
+ 		return fd.L1.EnforceUTF8
+ 	}
+@@ -359,10 +428,11 @@ type (
+ 		L2 *ExtensionL2 // protected by fileDesc.once
+ 	}
+ 	ExtensionL1 struct {
+-		Number      protoreflect.FieldNumber
+-		Extendee    protoreflect.MessageDescriptor
+-		Cardinality protoreflect.Cardinality
+-		Kind        protoreflect.Kind
++		Number          protoreflect.FieldNumber
++		Extendee        protoreflect.MessageDescriptor
++		Cardinality     protoreflect.Cardinality
++		Kind            protoreflect.Kind
++		EditionFeatures EditionFeatures
+ 	}
+ 	ExtensionL2 struct {
+ 		Options          func() protoreflect.ProtoMessage
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
+index 4a1584c..237e64f 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
+@@ -5,6 +5,7 @@
+ package filedesc
+ 
+ import (
++	"fmt"
+ 	"sync"
+ 
+ 	"google.golang.org/protobuf/encoding/protowire"
+@@ -98,6 +99,7 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 	var prevField protoreflect.FieldNumber
+ 	var numEnums, numMessages, numExtensions, numServices int
+ 	var posEnums, posMessages, posExtensions, posServices int
++	var options []byte
+ 	b0 := b
+ 	for len(b) > 0 {
+ 		num, typ, n := protowire.ConsumeTag(b)
+@@ -113,6 +115,8 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 					fd.L1.Syntax = protoreflect.Proto2
+ 				case "proto3":
+ 					fd.L1.Syntax = protoreflect.Proto3
++				case "editions":
++					fd.L1.Syntax = protoreflect.Editions
+ 				default:
+ 					panic("invalid syntax")
+ 				}
+@@ -120,6 +124,8 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 				fd.L1.Path = sb.MakeString(v)
+ 			case genid.FileDescriptorProto_Package_field_number:
+ 				fd.L1.Package = protoreflect.FullName(sb.MakeString(v))
++			case genid.FileDescriptorProto_Options_field_number:
++				options = v
+ 			case genid.FileDescriptorProto_EnumType_field_number:
+ 				if prevField != genid.FileDescriptorProto_EnumType_field_number {
+ 					if numEnums > 0 {
+@@ -154,6 +160,13 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 				numServices++
+ 			}
+ 			prevField = num
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FileDescriptorProto_Edition_field_number:
++				fd.L1.Edition = Edition(v)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+@@ -166,6 +179,15 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 		fd.L1.Syntax = protoreflect.Proto2
+ 	}
+ 
++	if fd.L1.Syntax == protoreflect.Editions {
++		fd.L1.EditionFeatures = getFeaturesFor(fd.L1.Edition)
++	}
++
++	// Parse editions features from options if any
++	if options != nil {
++		fd.unmarshalSeedOptions(options)
++	}
++
+ 	// Must allocate all declarations before parsing each descriptor type
+ 	// to ensure we handled all descriptors in "flattened ordering".
+ 	if numEnums > 0 {
+@@ -219,6 +241,28 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 	}
+ }
+ 
++func (fd *File) unmarshalSeedOptions(b []byte) {
++	for b := b; len(b) > 0; {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FileOptions_Features_field_number:
++				if fd.Syntax() != protoreflect.Editions {
++					panic(fmt.Sprintf("invalid descriptor: using edition features in a proto with syntax %s", fd.Syntax()))
++				}
++				fd.L1.EditionFeatures = unmarshalFeatureSet(v, fd.L1.EditionFeatures)
++			}
++		default:
++			m := protowire.ConsumeFieldValue(num, typ, b)
++			b = b[m:]
++		}
++	}
++}
++
+ func (ed *Enum) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protoreflect.Descriptor, i int) {
+ 	ed.L0.ParentFile = pf
+ 	ed.L0.Parent = pd
+@@ -275,6 +319,7 @@ func (md *Message) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protor
+ 	md.L0.ParentFile = pf
+ 	md.L0.Parent = pd
+ 	md.L0.Index = i
++	md.L1.EditionFeatures = featuresFromParentDesc(md.Parent())
+ 
+ 	var prevField protoreflect.FieldNumber
+ 	var numEnums, numMessages, numExtensions int
+@@ -380,6 +425,13 @@ func (md *Message) unmarshalSeedOptions(b []byte) {
+ 			case genid.MessageOptions_MessageSetWireFormat_field_number:
+ 				md.L1.IsMessageSet = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.MessageOptions_Features_field_number:
++				md.L1.EditionFeatures = unmarshalFeatureSet(v, md.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+index 736a19a..482a61c 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+@@ -414,6 +414,7 @@ func (fd *Field) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ 	fd.L0.ParentFile = pf
+ 	fd.L0.Parent = pd
+ 	fd.L0.Index = i
++	fd.L1.EditionFeatures = featuresFromParentDesc(fd.Parent())
+ 
+ 	var rawTypeName []byte
+ 	var rawOptions []byte
+@@ -465,6 +466,12 @@ func (fd *Field) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ 			b = b[m:]
+ 		}
+ 	}
++	if fd.Syntax() == protoreflect.Editions && fd.L1.Kind == protoreflect.MessageKind && fd.L1.EditionFeatures.IsDelimitedEncoded {
++		fd.L1.Kind = protoreflect.GroupKind
++	}
++	if fd.Syntax() == protoreflect.Editions && fd.L1.EditionFeatures.IsLegacyRequired {
++		fd.L1.Cardinality = protoreflect.Required
++	}
+ 	if rawTypeName != nil {
+ 		name := makeFullName(sb, rawTypeName)
+ 		switch fd.L1.Kind {
+@@ -497,6 +504,13 @@ func (fd *Field) unmarshalOptions(b []byte) {
+ 				fd.L1.HasEnforceUTF8 = true
+ 				fd.L1.EnforceUTF8 = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FieldOptions_Features_field_number:
++				fd.L1.EditionFeatures = unmarshalFeatureSet(v, fd.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+@@ -534,6 +548,7 @@ func (od *Oneof) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ func (xd *Extension) unmarshalFull(b []byte, sb *strs.Builder) {
+ 	var rawTypeName []byte
+ 	var rawOptions []byte
++	xd.L1.EditionFeatures = featuresFromParentDesc(xd.L1.Extendee)
+ 	xd.L2 = new(ExtensionL2)
+ 	for len(b) > 0 {
+ 		num, typ, n := protowire.ConsumeTag(b)
+@@ -565,6 +580,12 @@ func (xd *Extension) unmarshalFull(b []byte, sb *strs.Builder) {
+ 			b = b[m:]
+ 		}
+ 	}
++	if xd.Syntax() == protoreflect.Editions && xd.L1.Kind == protoreflect.MessageKind && xd.L1.EditionFeatures.IsDelimitedEncoded {
++		xd.L1.Kind = protoreflect.GroupKind
++	}
++	if xd.Syntax() == protoreflect.Editions && xd.L1.EditionFeatures.IsLegacyRequired {
++		xd.L1.Cardinality = protoreflect.Required
++	}
+ 	if rawTypeName != nil {
+ 		name := makeFullName(sb, rawTypeName)
+ 		switch xd.L1.Kind {
+@@ -589,6 +610,13 @@ func (xd *Extension) unmarshalOptions(b []byte) {
+ 			case genid.FieldOptions_Packed_field_number:
+ 				xd.L2.IsPacked = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FieldOptions_Features_field_number:
++				xd.L1.EditionFeatures = unmarshalFeatureSet(v, xd.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/editions.go b/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+new file mode 100644
+index 0000000..0375a49
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+@@ -0,0 +1,142 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package filedesc
++
++import (
++	"fmt"
++
++	"google.golang.org/protobuf/encoding/protowire"
++	"google.golang.org/protobuf/internal/editiondefaults"
++	"google.golang.org/protobuf/internal/genid"
++	"google.golang.org/protobuf/reflect/protoreflect"
++)
++
++var defaultsCache = make(map[Edition]EditionFeatures)
++
++func init() {
++	unmarshalEditionDefaults(editiondefaults.Defaults)
++}
++
++func unmarshalGoFeature(b []byte, parent EditionFeatures) EditionFeatures {
++	for len(b) > 0 {
++		num, _, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch num {
++		case genid.GoFeatures_LegacyUnmarshalJsonEnum_field_number:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			parent.GenerateLegacyUnmarshalJSON = protowire.DecodeBool(v)
++		default:
++			panic(fmt.Sprintf("unkown field number %d while unmarshalling GoFeatures", num))
++		}
++	}
++	return parent
++}
++
++func unmarshalFeatureSet(b []byte, parent EditionFeatures) EditionFeatures {
++	for len(b) > 0 {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSet_FieldPresence_field_number:
++				parent.IsFieldPresence = v == genid.FeatureSet_EXPLICIT_enum_value || v == genid.FeatureSet_LEGACY_REQUIRED_enum_value
++				parent.IsLegacyRequired = v == genid.FeatureSet_LEGACY_REQUIRED_enum_value
++			case genid.FeatureSet_EnumType_field_number:
++				parent.IsOpenEnum = v == genid.FeatureSet_OPEN_enum_value
++			case genid.FeatureSet_RepeatedFieldEncoding_field_number:
++				parent.IsPacked = v == genid.FeatureSet_PACKED_enum_value
++			case genid.FeatureSet_Utf8Validation_field_number:
++				parent.IsUTF8Validated = v == genid.FeatureSet_VERIFY_enum_value
++			case genid.FeatureSet_MessageEncoding_field_number:
++				parent.IsDelimitedEncoded = v == genid.FeatureSet_DELIMITED_enum_value
++			case genid.FeatureSet_JsonFormat_field_number:
++				parent.IsJSONCompliant = v == genid.FeatureSet_ALLOW_enum_value
++			default:
++				panic(fmt.Sprintf("unkown field number %d while unmarshalling FeatureSet", num))
++			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.GoFeatures_LegacyUnmarshalJsonEnum_field_number:
++				parent = unmarshalGoFeature(v, parent)
++			}
++		}
++	}
++
++	return parent
++}
++
++func featuresFromParentDesc(parentDesc protoreflect.Descriptor) EditionFeatures {
++	var parentFS EditionFeatures
++	switch p := parentDesc.(type) {
++	case *File:
++		parentFS = p.L1.EditionFeatures
++	case *Message:
++		parentFS = p.L1.EditionFeatures
++	default:
++		panic(fmt.Sprintf("unknown parent type %T", parentDesc))
++	}
++	return parentFS
++}
++
++func unmarshalEditionDefault(b []byte) {
++	var ed Edition
++	var fs EditionFeatures
++	for len(b) > 0 {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_number:
++				ed = Edition(v)
++			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSetDefaults_FeatureSetEditionDefault_Features_field_number:
++				fs = unmarshalFeatureSet(v, fs)
++			}
++		}
++	}
++	defaultsCache[ed] = fs
++}
++
++func unmarshalEditionDefaults(b []byte) {
++	for len(b) > 0 {
++		num, _, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch num {
++		case genid.FeatureSetDefaults_Defaults_field_number:
++			def, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			unmarshalEditionDefault(def)
++		case genid.FeatureSetDefaults_MinimumEdition_field_number,
++			genid.FeatureSetDefaults_MaximumEdition_field_number:
++			// We don't care about the minimum and maximum editions. If the
++			// edition we are looking for later on is not in the cache we know
++			// it is outside of the range between minimum and maximum edition.
++			_, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++		default:
++			panic(fmt.Sprintf("unkown field number %d while unmarshalling EditionDefault", num))
++		}
++	}
++}
++
++func getFeaturesFor(ed Edition) EditionFeatures {
++	if def, ok := defaultsCache[ed]; ok {
++		return def
++	}
++	panic(fmt.Sprintf("unsupported edition: %v", ed))
++}
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+index 136f1b2..40272c8 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+@@ -12,6 +12,27 @@ import (
+ 
+ const File_google_protobuf_descriptor_proto = "google/protobuf/descriptor.proto"
+ 
++// Full and short names for google.protobuf.Edition.
++const (
++	Edition_enum_fullname = "google.protobuf.Edition"
++	Edition_enum_name     = "Edition"
++)
++
++// Enum values for google.protobuf.Edition.
++const (
++	Edition_EDITION_UNKNOWN_enum_value         = 0
++	Edition_EDITION_PROTO2_enum_value          = 998
++	Edition_EDITION_PROTO3_enum_value          = 999
++	Edition_EDITION_2023_enum_value            = 1000
++	Edition_EDITION_2024_enum_value            = 1001
++	Edition_EDITION_1_TEST_ONLY_enum_value     = 1
++	Edition_EDITION_2_TEST_ONLY_enum_value     = 2
++	Edition_EDITION_99997_TEST_ONLY_enum_value = 99997
++	Edition_EDITION_99998_TEST_ONLY_enum_value = 99998
++	Edition_EDITION_99999_TEST_ONLY_enum_value = 99999
++	Edition_EDITION_MAX_enum_value             = 2147483647
++)
++
+ // Names for google.protobuf.FileDescriptorSet.
+ const (
+ 	FileDescriptorSet_message_name     protoreflect.Name     = "FileDescriptorSet"
+@@ -81,7 +102,7 @@ const (
+ 	FileDescriptorProto_Options_field_number          protoreflect.FieldNumber = 8
+ 	FileDescriptorProto_SourceCodeInfo_field_number   protoreflect.FieldNumber = 9
+ 	FileDescriptorProto_Syntax_field_number           protoreflect.FieldNumber = 12
+-	FileDescriptorProto_Edition_field_number          protoreflect.FieldNumber = 13
++	FileDescriptorProto_Edition_field_number          protoreflect.FieldNumber = 14
+ )
+ 
+ // Names for google.protobuf.DescriptorProto.
+@@ -184,10 +205,12 @@ const (
+ const (
+ 	ExtensionRangeOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 	ExtensionRangeOptions_Declaration_field_name         protoreflect.Name = "declaration"
++	ExtensionRangeOptions_Features_field_name            protoreflect.Name = "features"
+ 	ExtensionRangeOptions_Verification_field_name        protoreflect.Name = "verification"
+ 
+ 	ExtensionRangeOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.uninterpreted_option"
+ 	ExtensionRangeOptions_Declaration_field_fullname         protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.declaration"
++	ExtensionRangeOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.features"
+ 	ExtensionRangeOptions_Verification_field_fullname        protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.verification"
+ )
+ 
+@@ -195,6 +218,7 @@ const (
+ const (
+ 	ExtensionRangeOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ 	ExtensionRangeOptions_Declaration_field_number         protoreflect.FieldNumber = 2
++	ExtensionRangeOptions_Features_field_number            protoreflect.FieldNumber = 50
+ 	ExtensionRangeOptions_Verification_field_number        protoreflect.FieldNumber = 3
+ )
+ 
+@@ -204,6 +228,12 @@ const (
+ 	ExtensionRangeOptions_VerificationState_enum_name     = "VerificationState"
+ )
+ 
++// Enum values for google.protobuf.ExtensionRangeOptions.VerificationState.
++const (
++	ExtensionRangeOptions_DECLARATION_enum_value = 0
++	ExtensionRangeOptions_UNVERIFIED_enum_value  = 1
++)
++
+ // Names for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+ 	ExtensionRangeOptions_Declaration_message_name     protoreflect.Name     = "Declaration"
+@@ -212,29 +242,26 @@ const (
+ 
+ // Field names for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+-	ExtensionRangeOptions_Declaration_Number_field_name     protoreflect.Name = "number"
+-	ExtensionRangeOptions_Declaration_FullName_field_name   protoreflect.Name = "full_name"
+-	ExtensionRangeOptions_Declaration_Type_field_name       protoreflect.Name = "type"
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_name protoreflect.Name = "is_repeated"
+-	ExtensionRangeOptions_Declaration_Reserved_field_name   protoreflect.Name = "reserved"
+-	ExtensionRangeOptions_Declaration_Repeated_field_name   protoreflect.Name = "repeated"
++	ExtensionRangeOptions_Declaration_Number_field_name   protoreflect.Name = "number"
++	ExtensionRangeOptions_Declaration_FullName_field_name protoreflect.Name = "full_name"
++	ExtensionRangeOptions_Declaration_Type_field_name     protoreflect.Name = "type"
++	ExtensionRangeOptions_Declaration_Reserved_field_name protoreflect.Name = "reserved"
++	ExtensionRangeOptions_Declaration_Repeated_field_name protoreflect.Name = "repeated"
+ 
+-	ExtensionRangeOptions_Declaration_Number_field_fullname     protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.number"
+-	ExtensionRangeOptions_Declaration_FullName_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.full_name"
+-	ExtensionRangeOptions_Declaration_Type_field_fullname       protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.type"
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.is_repeated"
+-	ExtensionRangeOptions_Declaration_Reserved_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.reserved"
+-	ExtensionRangeOptions_Declaration_Repeated_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.repeated"
++	ExtensionRangeOptions_Declaration_Number_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.number"
++	ExtensionRangeOptions_Declaration_FullName_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.full_name"
++	ExtensionRangeOptions_Declaration_Type_field_fullname     protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.type"
++	ExtensionRangeOptions_Declaration_Reserved_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.reserved"
++	ExtensionRangeOptions_Declaration_Repeated_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.repeated"
+ )
+ 
+ // Field numbers for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+-	ExtensionRangeOptions_Declaration_Number_field_number     protoreflect.FieldNumber = 1
+-	ExtensionRangeOptions_Declaration_FullName_field_number   protoreflect.FieldNumber = 2
+-	ExtensionRangeOptions_Declaration_Type_field_number       protoreflect.FieldNumber = 3
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_number protoreflect.FieldNumber = 4
+-	ExtensionRangeOptions_Declaration_Reserved_field_number   protoreflect.FieldNumber = 5
+-	ExtensionRangeOptions_Declaration_Repeated_field_number   protoreflect.FieldNumber = 6
++	ExtensionRangeOptions_Declaration_Number_field_number   protoreflect.FieldNumber = 1
++	ExtensionRangeOptions_Declaration_FullName_field_number protoreflect.FieldNumber = 2
++	ExtensionRangeOptions_Declaration_Type_field_number     protoreflect.FieldNumber = 3
++	ExtensionRangeOptions_Declaration_Reserved_field_number protoreflect.FieldNumber = 5
++	ExtensionRangeOptions_Declaration_Repeated_field_number protoreflect.FieldNumber = 6
+ )
+ 
+ // Names for google.protobuf.FieldDescriptorProto.
+@@ -291,12 +318,41 @@ const (
+ 	FieldDescriptorProto_Type_enum_name     = "Type"
+ )
+ 
++// Enum values for google.protobuf.FieldDescriptorProto.Type.
++const (
++	FieldDescriptorProto_TYPE_DOUBLE_enum_value   = 1
++	FieldDescriptorProto_TYPE_FLOAT_enum_value    = 2
++	FieldDescriptorProto_TYPE_INT64_enum_value    = 3
++	FieldDescriptorProto_TYPE_UINT64_enum_value   = 4
++	FieldDescriptorProto_TYPE_INT32_enum_value    = 5
++	FieldDescriptorProto_TYPE_FIXED64_enum_value  = 6
++	FieldDescriptorProto_TYPE_FIXED32_enum_value  = 7
++	FieldDescriptorProto_TYPE_BOOL_enum_value     = 8
++	FieldDescriptorProto_TYPE_STRING_enum_value   = 9
++	FieldDescriptorProto_TYPE_GROUP_enum_value    = 10
++	FieldDescriptorProto_TYPE_MESSAGE_enum_value  = 11
++	FieldDescriptorProto_TYPE_BYTES_enum_value    = 12
++	FieldDescriptorProto_TYPE_UINT32_enum_value   = 13
++	FieldDescriptorProto_TYPE_ENUM_enum_value     = 14
++	FieldDescriptorProto_TYPE_SFIXED32_enum_value = 15
++	FieldDescriptorProto_TYPE_SFIXED64_enum_value = 16
++	FieldDescriptorProto_TYPE_SINT32_enum_value   = 17
++	FieldDescriptorProto_TYPE_SINT64_enum_value   = 18
++)
++
+ // Full and short names for google.protobuf.FieldDescriptorProto.Label.
+ const (
+ 	FieldDescriptorProto_Label_enum_fullname = "google.protobuf.FieldDescriptorProto.Label"
+ 	FieldDescriptorProto_Label_enum_name     = "Label"
+ )
+ 
++// Enum values for google.protobuf.FieldDescriptorProto.Label.
++const (
++	FieldDescriptorProto_LABEL_OPTIONAL_enum_value = 1
++	FieldDescriptorProto_LABEL_REPEATED_enum_value = 3
++	FieldDescriptorProto_LABEL_REQUIRED_enum_value = 2
++)
++
+ // Names for google.protobuf.OneofDescriptorProto.
+ const (
+ 	OneofDescriptorProto_message_name     protoreflect.Name     = "OneofDescriptorProto"
+@@ -468,7 +524,6 @@ const (
+ 	FileOptions_CcGenericServices_field_name         protoreflect.Name = "cc_generic_services"
+ 	FileOptions_JavaGenericServices_field_name       protoreflect.Name = "java_generic_services"
+ 	FileOptions_PyGenericServices_field_name         protoreflect.Name = "py_generic_services"
+-	FileOptions_PhpGenericServices_field_name        protoreflect.Name = "php_generic_services"
+ 	FileOptions_Deprecated_field_name                protoreflect.Name = "deprecated"
+ 	FileOptions_CcEnableArenas_field_name            protoreflect.Name = "cc_enable_arenas"
+ 	FileOptions_ObjcClassPrefix_field_name           protoreflect.Name = "objc_class_prefix"
+@@ -478,6 +533,7 @@ const (
+ 	FileOptions_PhpNamespace_field_name              protoreflect.Name = "php_namespace"
+ 	FileOptions_PhpMetadataNamespace_field_name      protoreflect.Name = "php_metadata_namespace"
+ 	FileOptions_RubyPackage_field_name               protoreflect.Name = "ruby_package"
++	FileOptions_Features_field_name                  protoreflect.Name = "features"
+ 	FileOptions_UninterpretedOption_field_name       protoreflect.Name = "uninterpreted_option"
+ 
+ 	FileOptions_JavaPackage_field_fullname               protoreflect.FullName = "google.protobuf.FileOptions.java_package"
+@@ -490,7 +546,6 @@ const (
+ 	FileOptions_CcGenericServices_field_fullname         protoreflect.FullName = "google.protobuf.FileOptions.cc_generic_services"
+ 	FileOptions_JavaGenericServices_field_fullname       protoreflect.FullName = "google.protobuf.FileOptions.java_generic_services"
+ 	FileOptions_PyGenericServices_field_fullname         protoreflect.FullName = "google.protobuf.FileOptions.py_generic_services"
+-	FileOptions_PhpGenericServices_field_fullname        protoreflect.FullName = "google.protobuf.FileOptions.php_generic_services"
+ 	FileOptions_Deprecated_field_fullname                protoreflect.FullName = "google.protobuf.FileOptions.deprecated"
+ 	FileOptions_CcEnableArenas_field_fullname            protoreflect.FullName = "google.protobuf.FileOptions.cc_enable_arenas"
+ 	FileOptions_ObjcClassPrefix_field_fullname           protoreflect.FullName = "google.protobuf.FileOptions.objc_class_prefix"
+@@ -500,6 +555,7 @@ const (
+ 	FileOptions_PhpNamespace_field_fullname              protoreflect.FullName = "google.protobuf.FileOptions.php_namespace"
+ 	FileOptions_PhpMetadataNamespace_field_fullname      protoreflect.FullName = "google.protobuf.FileOptions.php_metadata_namespace"
+ 	FileOptions_RubyPackage_field_fullname               protoreflect.FullName = "google.protobuf.FileOptions.ruby_package"
++	FileOptions_Features_field_fullname                  protoreflect.FullName = "google.protobuf.FileOptions.features"
+ 	FileOptions_UninterpretedOption_field_fullname       protoreflect.FullName = "google.protobuf.FileOptions.uninterpreted_option"
+ )
+ 
+@@ -515,7 +571,6 @@ const (
+ 	FileOptions_CcGenericServices_field_number         protoreflect.FieldNumber = 16
+ 	FileOptions_JavaGenericServices_field_number       protoreflect.FieldNumber = 17
+ 	FileOptions_PyGenericServices_field_number         protoreflect.FieldNumber = 18
+-	FileOptions_PhpGenericServices_field_number        protoreflect.FieldNumber = 42
+ 	FileOptions_Deprecated_field_number                protoreflect.FieldNumber = 23
+ 	FileOptions_CcEnableArenas_field_number            protoreflect.FieldNumber = 31
+ 	FileOptions_ObjcClassPrefix_field_number           protoreflect.FieldNumber = 36
+@@ -525,6 +580,7 @@ const (
+ 	FileOptions_PhpNamespace_field_number              protoreflect.FieldNumber = 41
+ 	FileOptions_PhpMetadataNamespace_field_number      protoreflect.FieldNumber = 44
+ 	FileOptions_RubyPackage_field_number               protoreflect.FieldNumber = 45
++	FileOptions_Features_field_number                  protoreflect.FieldNumber = 50
+ 	FileOptions_UninterpretedOption_field_number       protoreflect.FieldNumber = 999
+ )
+ 
+@@ -534,6 +590,13 @@ const (
+ 	FileOptions_OptimizeMode_enum_name     = "OptimizeMode"
+ )
+ 
++// Enum values for google.protobuf.FileOptions.OptimizeMode.
++const (
++	FileOptions_SPEED_enum_value        = 1
++	FileOptions_CODE_SIZE_enum_value    = 2
++	FileOptions_LITE_RUNTIME_enum_value = 3
++)
++
+ // Names for google.protobuf.MessageOptions.
+ const (
+ 	MessageOptions_message_name     protoreflect.Name     = "MessageOptions"
+@@ -547,6 +610,7 @@ const (
+ 	MessageOptions_Deprecated_field_name                         protoreflect.Name = "deprecated"
+ 	MessageOptions_MapEntry_field_name                           protoreflect.Name = "map_entry"
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_name protoreflect.Name = "deprecated_legacy_json_field_conflicts"
++	MessageOptions_Features_field_name                           protoreflect.Name = "features"
+ 	MessageOptions_UninterpretedOption_field_name                protoreflect.Name = "uninterpreted_option"
+ 
+ 	MessageOptions_MessageSetWireFormat_field_fullname               protoreflect.FullName = "google.protobuf.MessageOptions.message_set_wire_format"
+@@ -554,6 +618,7 @@ const (
+ 	MessageOptions_Deprecated_field_fullname                         protoreflect.FullName = "google.protobuf.MessageOptions.deprecated"
+ 	MessageOptions_MapEntry_field_fullname                           protoreflect.FullName = "google.protobuf.MessageOptions.map_entry"
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_fullname protoreflect.FullName = "google.protobuf.MessageOptions.deprecated_legacy_json_field_conflicts"
++	MessageOptions_Features_field_fullname                           protoreflect.FullName = "google.protobuf.MessageOptions.features"
+ 	MessageOptions_UninterpretedOption_field_fullname                protoreflect.FullName = "google.protobuf.MessageOptions.uninterpreted_option"
+ )
+ 
+@@ -564,6 +629,7 @@ const (
+ 	MessageOptions_Deprecated_field_number                         protoreflect.FieldNumber = 3
+ 	MessageOptions_MapEntry_field_number                           protoreflect.FieldNumber = 7
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_number protoreflect.FieldNumber = 11
++	MessageOptions_Features_field_number                           protoreflect.FieldNumber = 12
+ 	MessageOptions_UninterpretedOption_field_number                protoreflect.FieldNumber = 999
+ )
+ 
+@@ -584,8 +650,9 @@ const (
+ 	FieldOptions_Weak_field_name                protoreflect.Name = "weak"
+ 	FieldOptions_DebugRedact_field_name         protoreflect.Name = "debug_redact"
+ 	FieldOptions_Retention_field_name           protoreflect.Name = "retention"
+-	FieldOptions_Target_field_name              protoreflect.Name = "target"
+ 	FieldOptions_Targets_field_name             protoreflect.Name = "targets"
++	FieldOptions_EditionDefaults_field_name     protoreflect.Name = "edition_defaults"
++	FieldOptions_Features_field_name            protoreflect.Name = "features"
+ 	FieldOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	FieldOptions_Ctype_field_fullname               protoreflect.FullName = "google.protobuf.FieldOptions.ctype"
+@@ -597,8 +664,9 @@ const (
+ 	FieldOptions_Weak_field_fullname                protoreflect.FullName = "google.protobuf.FieldOptions.weak"
+ 	FieldOptions_DebugRedact_field_fullname         protoreflect.FullName = "google.protobuf.FieldOptions.debug_redact"
+ 	FieldOptions_Retention_field_fullname           protoreflect.FullName = "google.protobuf.FieldOptions.retention"
+-	FieldOptions_Target_field_fullname              protoreflect.FullName = "google.protobuf.FieldOptions.target"
+ 	FieldOptions_Targets_field_fullname             protoreflect.FullName = "google.protobuf.FieldOptions.targets"
++	FieldOptions_EditionDefaults_field_fullname     protoreflect.FullName = "google.protobuf.FieldOptions.edition_defaults"
++	FieldOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.FieldOptions.features"
+ 	FieldOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.FieldOptions.uninterpreted_option"
+ )
+ 
+@@ -613,8 +681,9 @@ const (
+ 	FieldOptions_Weak_field_number                protoreflect.FieldNumber = 10
+ 	FieldOptions_DebugRedact_field_number         protoreflect.FieldNumber = 16
+ 	FieldOptions_Retention_field_number           protoreflect.FieldNumber = 17
+-	FieldOptions_Target_field_number              protoreflect.FieldNumber = 18
+ 	FieldOptions_Targets_field_number             protoreflect.FieldNumber = 19
++	FieldOptions_EditionDefaults_field_number     protoreflect.FieldNumber = 20
++	FieldOptions_Features_field_number            protoreflect.FieldNumber = 21
+ 	FieldOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -624,24 +693,80 @@ const (
+ 	FieldOptions_CType_enum_name     = "CType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.CType.
++const (
++	FieldOptions_STRING_enum_value       = 0
++	FieldOptions_CORD_enum_value         = 1
++	FieldOptions_STRING_PIECE_enum_value = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.JSType.
+ const (
+ 	FieldOptions_JSType_enum_fullname = "google.protobuf.FieldOptions.JSType"
+ 	FieldOptions_JSType_enum_name     = "JSType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.JSType.
++const (
++	FieldOptions_JS_NORMAL_enum_value = 0
++	FieldOptions_JS_STRING_enum_value = 1
++	FieldOptions_JS_NUMBER_enum_value = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.OptionRetention.
+ const (
+ 	FieldOptions_OptionRetention_enum_fullname = "google.protobuf.FieldOptions.OptionRetention"
+ 	FieldOptions_OptionRetention_enum_name     = "OptionRetention"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.OptionRetention.
++const (
++	FieldOptions_RETENTION_UNKNOWN_enum_value = 0
++	FieldOptions_RETENTION_RUNTIME_enum_value = 1
++	FieldOptions_RETENTION_SOURCE_enum_value  = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.OptionTargetType.
+ const (
+ 	FieldOptions_OptionTargetType_enum_fullname = "google.protobuf.FieldOptions.OptionTargetType"
+ 	FieldOptions_OptionTargetType_enum_name     = "OptionTargetType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.OptionTargetType.
++const (
++	FieldOptions_TARGET_TYPE_UNKNOWN_enum_value         = 0
++	FieldOptions_TARGET_TYPE_FILE_enum_value            = 1
++	FieldOptions_TARGET_TYPE_EXTENSION_RANGE_enum_value = 2
++	FieldOptions_TARGET_TYPE_MESSAGE_enum_value         = 3
++	FieldOptions_TARGET_TYPE_FIELD_enum_value           = 4
++	FieldOptions_TARGET_TYPE_ONEOF_enum_value           = 5
++	FieldOptions_TARGET_TYPE_ENUM_enum_value            = 6
++	FieldOptions_TARGET_TYPE_ENUM_ENTRY_enum_value      = 7
++	FieldOptions_TARGET_TYPE_SERVICE_enum_value         = 8
++	FieldOptions_TARGET_TYPE_METHOD_enum_value          = 9
++)
++
++// Names for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_message_name     protoreflect.Name     = "EditionDefault"
++	FieldOptions_EditionDefault_message_fullname protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault"
++)
++
++// Field names for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_Edition_field_name protoreflect.Name = "edition"
++	FieldOptions_EditionDefault_Value_field_name   protoreflect.Name = "value"
++
++	FieldOptions_EditionDefault_Edition_field_fullname protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault.edition"
++	FieldOptions_EditionDefault_Value_field_fullname   protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault.value"
++)
++
++// Field numbers for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_Edition_field_number protoreflect.FieldNumber = 3
++	FieldOptions_EditionDefault_Value_field_number   protoreflect.FieldNumber = 2
++)
++
+ // Names for google.protobuf.OneofOptions.
+ const (
+ 	OneofOptions_message_name     protoreflect.Name     = "OneofOptions"
+@@ -650,13 +775,16 @@ const (
+ 
+ // Field names for google.protobuf.OneofOptions.
+ const (
++	OneofOptions_Features_field_name            protoreflect.Name = "features"
+ 	OneofOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
++	OneofOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.OneofOptions.features"
+ 	OneofOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.OneofOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.OneofOptions.
+ const (
++	OneofOptions_Features_field_number            protoreflect.FieldNumber = 1
+ 	OneofOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -671,11 +799,13 @@ const (
+ 	EnumOptions_AllowAlias_field_name                         protoreflect.Name = "allow_alias"
+ 	EnumOptions_Deprecated_field_name                         protoreflect.Name = "deprecated"
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_name protoreflect.Name = "deprecated_legacy_json_field_conflicts"
++	EnumOptions_Features_field_name                           protoreflect.Name = "features"
+ 	EnumOptions_UninterpretedOption_field_name                protoreflect.Name = "uninterpreted_option"
+ 
+ 	EnumOptions_AllowAlias_field_fullname                         protoreflect.FullName = "google.protobuf.EnumOptions.allow_alias"
+ 	EnumOptions_Deprecated_field_fullname                         protoreflect.FullName = "google.protobuf.EnumOptions.deprecated"
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_fullname protoreflect.FullName = "google.protobuf.EnumOptions.deprecated_legacy_json_field_conflicts"
++	EnumOptions_Features_field_fullname                           protoreflect.FullName = "google.protobuf.EnumOptions.features"
+ 	EnumOptions_UninterpretedOption_field_fullname                protoreflect.FullName = "google.protobuf.EnumOptions.uninterpreted_option"
+ )
+ 
+@@ -684,6 +814,7 @@ const (
+ 	EnumOptions_AllowAlias_field_number                         protoreflect.FieldNumber = 2
+ 	EnumOptions_Deprecated_field_number                         protoreflect.FieldNumber = 3
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_number protoreflect.FieldNumber = 6
++	EnumOptions_Features_field_number                           protoreflect.FieldNumber = 7
+ 	EnumOptions_UninterpretedOption_field_number                protoreflect.FieldNumber = 999
+ )
+ 
+@@ -696,15 +827,21 @@ const (
+ // Field names for google.protobuf.EnumValueOptions.
+ const (
+ 	EnumValueOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
++	EnumValueOptions_Features_field_name            protoreflect.Name = "features"
++	EnumValueOptions_DebugRedact_field_name         protoreflect.Name = "debug_redact"
+ 	EnumValueOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	EnumValueOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.EnumValueOptions.deprecated"
++	EnumValueOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.EnumValueOptions.features"
++	EnumValueOptions_DebugRedact_field_fullname         protoreflect.FullName = "google.protobuf.EnumValueOptions.debug_redact"
+ 	EnumValueOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.EnumValueOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.EnumValueOptions.
+ const (
+ 	EnumValueOptions_Deprecated_field_number          protoreflect.FieldNumber = 1
++	EnumValueOptions_Features_field_number            protoreflect.FieldNumber = 2
++	EnumValueOptions_DebugRedact_field_number         protoreflect.FieldNumber = 3
+ 	EnumValueOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -716,15 +853,18 @@ const (
+ 
+ // Field names for google.protobuf.ServiceOptions.
+ const (
++	ServiceOptions_Features_field_name            protoreflect.Name = "features"
+ 	ServiceOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
+ 	ServiceOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
++	ServiceOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.ServiceOptions.features"
+ 	ServiceOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.ServiceOptions.deprecated"
+ 	ServiceOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.ServiceOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.ServiceOptions.
+ const (
++	ServiceOptions_Features_field_number            protoreflect.FieldNumber = 34
+ 	ServiceOptions_Deprecated_field_number          protoreflect.FieldNumber = 33
+ 	ServiceOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+@@ -739,10 +879,12 @@ const (
+ const (
+ 	MethodOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
+ 	MethodOptions_IdempotencyLevel_field_name    protoreflect.Name = "idempotency_level"
++	MethodOptions_Features_field_name            protoreflect.Name = "features"
+ 	MethodOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	MethodOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.MethodOptions.deprecated"
+ 	MethodOptions_IdempotencyLevel_field_fullname    protoreflect.FullName = "google.protobuf.MethodOptions.idempotency_level"
++	MethodOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.MethodOptions.features"
+ 	MethodOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.MethodOptions.uninterpreted_option"
+ )
+ 
+@@ -750,6 +892,7 @@ const (
+ const (
+ 	MethodOptions_Deprecated_field_number          protoreflect.FieldNumber = 33
+ 	MethodOptions_IdempotencyLevel_field_number    protoreflect.FieldNumber = 34
++	MethodOptions_Features_field_number            protoreflect.FieldNumber = 35
+ 	MethodOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -759,6 +902,13 @@ const (
+ 	MethodOptions_IdempotencyLevel_enum_name     = "IdempotencyLevel"
+ )
+ 
++// Enum values for google.protobuf.MethodOptions.IdempotencyLevel.
++const (
++	MethodOptions_IDEMPOTENCY_UNKNOWN_enum_value = 0
++	MethodOptions_NO_SIDE_EFFECTS_enum_value     = 1
++	MethodOptions_IDEMPOTENT_enum_value          = 2
++)
++
+ // Names for google.protobuf.UninterpretedOption.
+ const (
+ 	UninterpretedOption_message_name     protoreflect.Name     = "UninterpretedOption"
+@@ -816,6 +966,163 @@ const (
+ 	UninterpretedOption_NamePart_IsExtension_field_number protoreflect.FieldNumber = 2
+ )
+ 
++// Names for google.protobuf.FeatureSet.
++const (
++	FeatureSet_message_name     protoreflect.Name     = "FeatureSet"
++	FeatureSet_message_fullname protoreflect.FullName = "google.protobuf.FeatureSet"
++)
++
++// Field names for google.protobuf.FeatureSet.
++const (
++	FeatureSet_FieldPresence_field_name         protoreflect.Name = "field_presence"
++	FeatureSet_EnumType_field_name              protoreflect.Name = "enum_type"
++	FeatureSet_RepeatedFieldEncoding_field_name protoreflect.Name = "repeated_field_encoding"
++	FeatureSet_Utf8Validation_field_name        protoreflect.Name = "utf8_validation"
++	FeatureSet_MessageEncoding_field_name       protoreflect.Name = "message_encoding"
++	FeatureSet_JsonFormat_field_name            protoreflect.Name = "json_format"
++
++	FeatureSet_FieldPresence_field_fullname         protoreflect.FullName = "google.protobuf.FeatureSet.field_presence"
++	FeatureSet_EnumType_field_fullname              protoreflect.FullName = "google.protobuf.FeatureSet.enum_type"
++	FeatureSet_RepeatedFieldEncoding_field_fullname protoreflect.FullName = "google.protobuf.FeatureSet.repeated_field_encoding"
++	FeatureSet_Utf8Validation_field_fullname        protoreflect.FullName = "google.protobuf.FeatureSet.utf8_validation"
++	FeatureSet_MessageEncoding_field_fullname       protoreflect.FullName = "google.protobuf.FeatureSet.message_encoding"
++	FeatureSet_JsonFormat_field_fullname            protoreflect.FullName = "google.protobuf.FeatureSet.json_format"
++)
++
++// Field numbers for google.protobuf.FeatureSet.
++const (
++	FeatureSet_FieldPresence_field_number         protoreflect.FieldNumber = 1
++	FeatureSet_EnumType_field_number              protoreflect.FieldNumber = 2
++	FeatureSet_RepeatedFieldEncoding_field_number protoreflect.FieldNumber = 3
++	FeatureSet_Utf8Validation_field_number        protoreflect.FieldNumber = 4
++	FeatureSet_MessageEncoding_field_number       protoreflect.FieldNumber = 5
++	FeatureSet_JsonFormat_field_number            protoreflect.FieldNumber = 6
++)
++
++// Full and short names for google.protobuf.FeatureSet.FieldPresence.
++const (
++	FeatureSet_FieldPresence_enum_fullname = "google.protobuf.FeatureSet.FieldPresence"
++	FeatureSet_FieldPresence_enum_name     = "FieldPresence"
++)
++
++// Enum values for google.protobuf.FeatureSet.FieldPresence.
++const (
++	FeatureSet_FIELD_PRESENCE_UNKNOWN_enum_value = 0
++	FeatureSet_EXPLICIT_enum_value               = 1
++	FeatureSet_IMPLICIT_enum_value               = 2
++	FeatureSet_LEGACY_REQUIRED_enum_value        = 3
++)
++
++// Full and short names for google.protobuf.FeatureSet.EnumType.
++const (
++	FeatureSet_EnumType_enum_fullname = "google.protobuf.FeatureSet.EnumType"
++	FeatureSet_EnumType_enum_name     = "EnumType"
++)
++
++// Enum values for google.protobuf.FeatureSet.EnumType.
++const (
++	FeatureSet_ENUM_TYPE_UNKNOWN_enum_value = 0
++	FeatureSet_OPEN_enum_value              = 1
++	FeatureSet_CLOSED_enum_value            = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.RepeatedFieldEncoding.
++const (
++	FeatureSet_RepeatedFieldEncoding_enum_fullname = "google.protobuf.FeatureSet.RepeatedFieldEncoding"
++	FeatureSet_RepeatedFieldEncoding_enum_name     = "RepeatedFieldEncoding"
++)
++
++// Enum values for google.protobuf.FeatureSet.RepeatedFieldEncoding.
++const (
++	FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN_enum_value = 0
++	FeatureSet_PACKED_enum_value                          = 1
++	FeatureSet_EXPANDED_enum_value                        = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.Utf8Validation.
++const (
++	FeatureSet_Utf8Validation_enum_fullname = "google.protobuf.FeatureSet.Utf8Validation"
++	FeatureSet_Utf8Validation_enum_name     = "Utf8Validation"
++)
++
++// Enum values for google.protobuf.FeatureSet.Utf8Validation.
++const (
++	FeatureSet_UTF8_VALIDATION_UNKNOWN_enum_value = 0
++	FeatureSet_VERIFY_enum_value                  = 2
++	FeatureSet_NONE_enum_value                    = 3
++)
++
++// Full and short names for google.protobuf.FeatureSet.MessageEncoding.
++const (
++	FeatureSet_MessageEncoding_enum_fullname = "google.protobuf.FeatureSet.MessageEncoding"
++	FeatureSet_MessageEncoding_enum_name     = "MessageEncoding"
++)
++
++// Enum values for google.protobuf.FeatureSet.MessageEncoding.
++const (
++	FeatureSet_MESSAGE_ENCODING_UNKNOWN_enum_value = 0
++	FeatureSet_LENGTH_PREFIXED_enum_value          = 1
++	FeatureSet_DELIMITED_enum_value                = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.JsonFormat.
++const (
++	FeatureSet_JsonFormat_enum_fullname = "google.protobuf.FeatureSet.JsonFormat"
++	FeatureSet_JsonFormat_enum_name     = "JsonFormat"
++)
++
++// Enum values for google.protobuf.FeatureSet.JsonFormat.
++const (
++	FeatureSet_JSON_FORMAT_UNKNOWN_enum_value = 0
++	FeatureSet_ALLOW_enum_value               = 1
++	FeatureSet_LEGACY_BEST_EFFORT_enum_value  = 2
++)
++
++// Names for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_message_name     protoreflect.Name     = "FeatureSetDefaults"
++	FeatureSetDefaults_message_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults"
++)
++
++// Field names for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_Defaults_field_name       protoreflect.Name = "defaults"
++	FeatureSetDefaults_MinimumEdition_field_name protoreflect.Name = "minimum_edition"
++	FeatureSetDefaults_MaximumEdition_field_name protoreflect.Name = "maximum_edition"
++
++	FeatureSetDefaults_Defaults_field_fullname       protoreflect.FullName = "google.protobuf.FeatureSetDefaults.defaults"
++	FeatureSetDefaults_MinimumEdition_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.minimum_edition"
++	FeatureSetDefaults_MaximumEdition_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.maximum_edition"
++)
++
++// Field numbers for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_Defaults_field_number       protoreflect.FieldNumber = 1
++	FeatureSetDefaults_MinimumEdition_field_number protoreflect.FieldNumber = 4
++	FeatureSetDefaults_MaximumEdition_field_number protoreflect.FieldNumber = 5
++)
++
++// Names for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_message_name     protoreflect.Name     = "FeatureSetEditionDefault"
++	FeatureSetDefaults_FeatureSetEditionDefault_message_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault"
++)
++
++// Field names for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_name  protoreflect.Name = "edition"
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_name protoreflect.Name = "features"
++
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_fullname  protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.edition"
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.features"
++)
++
++// Field numbers for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_number  protoreflect.FieldNumber = 3
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_number protoreflect.FieldNumber = 2
++)
++
+ // Names for google.protobuf.SourceCodeInfo.
+ const (
+ 	SourceCodeInfo_message_name     protoreflect.Name     = "SourceCodeInfo"
+@@ -917,3 +1224,10 @@ const (
+ 	GeneratedCodeInfo_Annotation_Semantic_enum_fullname = "google.protobuf.GeneratedCodeInfo.Annotation.Semantic"
+ 	GeneratedCodeInfo_Annotation_Semantic_enum_name     = "Semantic"
+ )
++
++// Enum values for google.protobuf.GeneratedCodeInfo.Annotation.Semantic.
++const (
++	GeneratedCodeInfo_Annotation_NONE_enum_value  = 0
++	GeneratedCodeInfo_Annotation_SET_enum_value   = 1
++	GeneratedCodeInfo_Annotation_ALIAS_enum_value = 2
++)
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go b/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+new file mode 100644
+index 0000000..fd9015e
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+@@ -0,0 +1,31 @@
++// Copyright 2019 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Code generated by generate-protos. DO NOT EDIT.
++
++package genid
++
++import (
++	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
++)
++
++const File_reflect_protodesc_proto_go_features_proto = "reflect/protodesc/proto/go_features.proto"
++
++// Names for google.protobuf.GoFeatures.
++const (
++	GoFeatures_message_name     protoreflect.Name     = "GoFeatures"
++	GoFeatures_message_fullname protoreflect.FullName = "google.protobuf.GoFeatures"
++)
++
++// Field names for google.protobuf.GoFeatures.
++const (
++	GoFeatures_LegacyUnmarshalJsonEnum_field_name protoreflect.Name = "legacy_unmarshal_json_enum"
++
++	GoFeatures_LegacyUnmarshalJsonEnum_field_fullname protoreflect.FullName = "google.protobuf.GoFeatures.legacy_unmarshal_json_enum"
++)
++
++// Field numbers for google.protobuf.GoFeatures.
++const (
++	GoFeatures_LegacyUnmarshalJsonEnum_field_number protoreflect.FieldNumber = 1
++)
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go b/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
+index 1a38944..ad6f80c 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
+@@ -18,6 +18,11 @@ const (
+ 	NullValue_enum_name     = "NullValue"
+ )
+ 
++// Enum values for google.protobuf.NullValue.
++const (
++	NullValue_NULL_VALUE_enum_value = 0
++)
++
+ // Names for google.protobuf.Struct.
+ const (
+ 	Struct_message_name     protoreflect.Name     = "Struct"
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/type_gen.go b/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
+index e0f75fe..49bc73e 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
+@@ -18,6 +18,13 @@ const (
+ 	Syntax_enum_name     = "Syntax"
+ )
+ 
++// Enum values for google.protobuf.Syntax.
++const (
++	Syntax_SYNTAX_PROTO2_enum_value   = 0
++	Syntax_SYNTAX_PROTO3_enum_value   = 1
++	Syntax_SYNTAX_EDITIONS_enum_value = 2
++)
++
+ // Names for google.protobuf.Type.
+ const (
+ 	Type_message_name     protoreflect.Name     = "Type"
+@@ -105,12 +112,43 @@ const (
+ 	Field_Kind_enum_name     = "Kind"
+ )
+ 
++// Enum values for google.protobuf.Field.Kind.
++const (
++	Field_TYPE_UNKNOWN_enum_value  = 0
++	Field_TYPE_DOUBLE_enum_value   = 1
++	Field_TYPE_FLOAT_enum_value    = 2
++	Field_TYPE_INT64_enum_value    = 3
++	Field_TYPE_UINT64_enum_value   = 4
++	Field_TYPE_INT32_enum_value    = 5
++	Field_TYPE_FIXED64_enum_value  = 6
++	Field_TYPE_FIXED32_enum_value  = 7
++	Field_TYPE_BOOL_enum_value     = 8
++	Field_TYPE_STRING_enum_value   = 9
++	Field_TYPE_GROUP_enum_value    = 10
++	Field_TYPE_MESSAGE_enum_value  = 11
++	Field_TYPE_BYTES_enum_value    = 12
++	Field_TYPE_UINT32_enum_value   = 13
++	Field_TYPE_ENUM_enum_value     = 14
++	Field_TYPE_SFIXED32_enum_value = 15
++	Field_TYPE_SFIXED64_enum_value = 16
++	Field_TYPE_SINT32_enum_value   = 17
++	Field_TYPE_SINT64_enum_value   = 18
++)
++
+ // Full and short names for google.protobuf.Field.Cardinality.
+ const (
+ 	Field_Cardinality_enum_fullname = "google.protobuf.Field.Cardinality"
+ 	Field_Cardinality_enum_name     = "Cardinality"
+ )
+ 
++// Enum values for google.protobuf.Field.Cardinality.
++const (
++	Field_CARDINALITY_UNKNOWN_enum_value  = 0
++	Field_CARDINALITY_OPTIONAL_enum_value = 1
++	Field_CARDINALITY_REQUIRED_enum_value = 2
++	Field_CARDINALITY_REPEATED_enum_value = 3
++)
++
+ // Names for google.protobuf.Enum.
+ const (
+ 	Enum_message_name     protoreflect.Name     = "Enum"
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go b/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
+index e74cefd..2b8f122 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
+@@ -21,26 +21,18 @@ type extensionFieldInfo struct {
+ 	validation          validationInfo
+ }
+ 
+-var legacyExtensionFieldInfoCache sync.Map // map[protoreflect.ExtensionType]*extensionFieldInfo
+-
+ func getExtensionFieldInfo(xt protoreflect.ExtensionType) *extensionFieldInfo {
+ 	if xi, ok := xt.(*ExtensionInfo); ok {
+ 		xi.lazyInit()
+ 		return xi.info
+ 	}
+-	return legacyLoadExtensionFieldInfo(xt)
+-}
+-
+-// legacyLoadExtensionFieldInfo dynamically loads a *ExtensionInfo for xt.
+-func legacyLoadExtensionFieldInfo(xt protoreflect.ExtensionType) *extensionFieldInfo {
+-	if xi, ok := legacyExtensionFieldInfoCache.Load(xt); ok {
+-		return xi.(*extensionFieldInfo)
+-	}
+-	e := makeExtensionFieldInfo(xt.TypeDescriptor())
+-	if e, ok := legacyMessageTypeCache.LoadOrStore(xt, e); ok {
+-		return e.(*extensionFieldInfo)
+-	}
+-	return e
++	// Ideally we'd cache the resulting *extensionFieldInfo so we don't have to
++	// recompute this metadata repeatedly. But without support for something like
++	// weak references, such a cache would pin temporary values (like dynamic
++	// extension types, constructed for the duration of a user request) to the
++	// heap forever, causing memory usage of the cache to grow unbounded.
++	// See discussion in https://github.com/golang/protobuf/issues/1521.
++	return makeExtensionFieldInfo(xt.TypeDescriptor())
+ }
+ 
+ func makeExtensionFieldInfo(xd protoreflect.ExtensionDescriptor) *extensionFieldInfo {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go b/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
+index 1a509b6..f55dc01 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
+@@ -162,11 +162,20 @@ func appendBoolSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptions
+ func consumeBoolSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.BoolSlice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growBoolSlice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -732,11 +741,20 @@ func appendInt32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeInt32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1138,11 +1156,20 @@ func appendSint32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeSint32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1544,11 +1571,20 @@ func appendUint32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeUint32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growUint32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1950,11 +1986,20 @@ func appendInt64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeInt64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -2356,11 +2401,20 @@ func appendSint64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeSint64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -2762,11 +2816,20 @@ func appendUint64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeUint64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growUint64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -3145,11 +3208,15 @@ func appendSfixed32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpt
+ func consumeSfixed32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -3461,11 +3528,15 @@ func appendFixed32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpti
+ func consumeFixed32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growUint32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -3777,11 +3848,15 @@ func appendFloatSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeFloatSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Float32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growFloat32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -4093,11 +4168,15 @@ func appendSfixed64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpt
+ func consumeSfixed64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+@@ -4409,11 +4488,15 @@ func appendFixed64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpti
+ func consumeFixed64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growUint64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+@@ -4725,11 +4808,15 @@ func appendDoubleSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeDoubleSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Float64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growFloat64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go b/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
+index 576dcf3..1307775 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
+@@ -197,7 +197,7 @@ func fieldCoder(fd protoreflect.FieldDescriptor, ft reflect.Type) (*MessageInfo,
+ 		return getMessageInfo(ft), makeMessageFieldCoder(fd, ft)
+ 	case fd.Kind() == protoreflect.GroupKind:
+ 		return getMessageInfo(ft), makeGroupFieldCoder(fd, ft)
+-	case fd.Syntax() == protoreflect.Proto3 && fd.ContainingOneof() == nil:
++	case !fd.HasPresence() && fd.ContainingOneof() == nil:
+ 		// Populated oneof fields always encode even if set to the zero value,
+ 		// which normally are not encoded in proto3.
+ 		switch fd.Kind() {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go b/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
+index 61c483f..2ab2c62 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
+@@ -206,13 +206,18 @@ func aberrantLoadMessageDescReentrant(t reflect.Type, name protoreflect.FullName
+ 
+ 	// Obtain a list of oneof wrapper types.
+ 	var oneofWrappers []reflect.Type
+-	for _, method := range []string{"XXX_OneofFuncs", "XXX_OneofWrappers"} {
+-		if fn, ok := t.MethodByName(method); ok {
+-			for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
+-				if vs, ok := v.Interface().([]interface{}); ok {
+-					for _, v := range vs {
+-						oneofWrappers = append(oneofWrappers, reflect.TypeOf(v))
+-					}
++	methods := make([]reflect.Method, 0, 2)
++	if m, ok := t.MethodByName("XXX_OneofFuncs"); ok {
++		methods = append(methods, m)
++	}
++	if m, ok := t.MethodByName("XXX_OneofWrappers"); ok {
++		methods = append(methods, m)
++	}
++	for _, fn := range methods {
++		for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
++			if vs, ok := v.Interface().([]interface{}); ok {
++				for _, v := range vs {
++					oneofWrappers = append(oneofWrappers, reflect.TypeOf(v))
+ 				}
+ 			}
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/message.go b/vendor/google.golang.org/protobuf/internal/impl/message.go
+index 4f5fb67..629bacd 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/message.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/message.go
+@@ -192,12 +192,17 @@ fieldLoop:
+ 
+ 	// Derive a mapping of oneof wrappers to fields.
+ 	oneofWrappers := mi.OneofWrappers
+-	for _, method := range []string{"XXX_OneofFuncs", "XXX_OneofWrappers"} {
+-		if fn, ok := reflect.PtrTo(t).MethodByName(method); ok {
+-			for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
+-				if vs, ok := v.Interface().([]interface{}); ok {
+-					oneofWrappers = vs
+-				}
++	methods := make([]reflect.Method, 0, 2)
++	if m, ok := reflect.PtrTo(t).MethodByName("XXX_OneofFuncs"); ok {
++		methods = append(methods, m)
++	}
++	if m, ok := reflect.PtrTo(t).MethodByName("XXX_OneofWrappers"); ok {
++		methods = append(methods, m)
++	}
++	for _, fn := range methods {
++		for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
++			if vs, ok := v.Interface().([]interface{}); ok {
++				oneofWrappers = vs
+ 			}
+ 		}
+ 	}
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go b/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
+index 5e736c6..986322b 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
+@@ -538,6 +538,6 @@ func isZero(v reflect.Value) bool {
+ 		}
+ 		return true
+ 	default:
+-		panic(&reflect.ValueError{"reflect.Value.IsZero", v.Kind()})
++		panic(&reflect.ValueError{Method: "reflect.Value.IsZero", Kind: v.Kind()})
+ 	}
+ }
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go b/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
+index 4c491bd..517e944 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
+@@ -159,6 +159,42 @@ func (p pointer) SetPointer(v pointer) {
+ 	p.v.Elem().Set(v.v)
+ }
+ 
++func growSlice(p pointer, addCap int) {
++	// TODO: Once we only support Go 1.20 and newer, use reflect.Grow.
++	in := p.v.Elem()
++	out := reflect.MakeSlice(in.Type(), in.Len(), in.Len()+addCap)
++	reflect.Copy(out, in)
++	p.v.Elem().Set(out)
++}
++
++func (p pointer) growBoolSlice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growInt32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growUint32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growInt64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growUint64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growFloat64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growFloat32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
+ func (Export) MessageStateOf(p Pointer) *messageState     { panic("not supported") }
+ func (ms *messageState) pointer() pointer                 { panic("not supported") }
+ func (ms *messageState) messageInfo() *MessageInfo        { panic("not supported") }
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go b/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
+index ee0e057..4b020e3 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
+@@ -138,6 +138,46 @@ func (p pointer) SetPointer(v pointer) {
+ 	*(*unsafe.Pointer)(p.p) = (unsafe.Pointer)(v.p)
+ }
+ 
++func (p pointer) growBoolSlice(addCap int) {
++	sp := p.BoolSlice()
++	s := make([]bool, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growInt32Slice(addCap int) {
++	sp := p.Int32Slice()
++	s := make([]int32, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growUint32Slice(addCap int) {
++	p.growInt32Slice(addCap)
++}
++
++func (p pointer) growFloat32Slice(addCap int) {
++	p.growInt32Slice(addCap)
++}
++
++func (p pointer) growInt64Slice(addCap int) {
++	sp := p.Int64Slice()
++	s := make([]int64, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growUint64Slice(addCap int) {
++	p.growInt64Slice(addCap)
++}
++
++func (p pointer) growFloat64Slice(addCap int) {
++	p.growInt64Slice(addCap)
++}
++
+ // Static check that MessageState does not exceed the size of a pointer.
+ const _ = uint(unsafe.Sizeof(unsafe.Pointer(nil)) - unsafe.Sizeof(MessageState{}))
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings.go b/vendor/google.golang.org/protobuf/internal/strs/strings.go
+index 0b74e76..a6e7df2 100644
+--- a/vendor/google.golang.org/protobuf/internal/strs/strings.go
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings.go
+@@ -17,7 +17,7 @@ import (
+ 
+ // EnforceUTF8 reports whether to enforce strict UTF-8 validation.
+ func EnforceUTF8(fd protoreflect.FieldDescriptor) bool {
+-	if flags.ProtoLegacy {
++	if flags.ProtoLegacy || fd.Syntax() == protoreflect.Editions {
+ 		if fd, ok := fd.(interface{ EnforceUTF8() bool }); ok {
+ 			return fd.EnforceUTF8()
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+similarity index 96%
+rename from vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
+rename to vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+index 61a84d3..a008acd 100644
+--- a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !purego && !appengine
+-// +build !purego,!appengine
++//go:build !purego && !appengine && !go1.21
++// +build !purego,!appengine,!go1.21
+ 
+ package strs
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+new file mode 100644
+index 0000000..60166f2
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+@@ -0,0 +1,74 @@
++// Copyright 2018 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !purego && !appengine && go1.21
++// +build !purego,!appengine,go1.21
++
++package strs
++
++import (
++	"unsafe"
++
++	"google.golang.org/protobuf/reflect/protoreflect"
++)
++
++// UnsafeString returns an unsafe string reference of b.
++// The caller must treat the input slice as immutable.
++//
++// WARNING: Use carefully. The returned result must not leak to the end user
++// unless the input slice is provably immutable.
++func UnsafeString(b []byte) string {
++	return unsafe.String(unsafe.SliceData(b), len(b))
++}
++
++// UnsafeBytes returns an unsafe bytes slice reference of s.
++// The caller must treat returned slice as immutable.
++//
++// WARNING: Use carefully. The returned result must not leak to the end user.
++func UnsafeBytes(s string) []byte {
++	return unsafe.Slice(unsafe.StringData(s), len(s))
++}
++
++// Builder builds a set of strings with shared lifetime.
++// This differs from strings.Builder, which is for building a single string.
++type Builder struct {
++	buf []byte
++}
++
++// AppendFullName is equivalent to protoreflect.FullName.Append,
++// but optimized for large batches where each name has a shared lifetime.
++func (sb *Builder) AppendFullName(prefix protoreflect.FullName, name protoreflect.Name) protoreflect.FullName {
++	n := len(prefix) + len(".") + len(name)
++	if len(prefix) == 0 {
++		n -= len(".")
++	}
++	sb.grow(n)
++	sb.buf = append(sb.buf, prefix...)
++	sb.buf = append(sb.buf, '.')
++	sb.buf = append(sb.buf, name...)
++	return protoreflect.FullName(sb.last(n))
++}
++
++// MakeString is equivalent to string(b), but optimized for large batches
++// with a shared lifetime.
++func (sb *Builder) MakeString(b []byte) string {
++	sb.grow(len(b))
++	sb.buf = append(sb.buf, b...)
++	return sb.last(len(b))
++}
++
++func (sb *Builder) grow(n int) {
++	if cap(sb.buf)-len(sb.buf) >= n {
++		return
++	}
++
++	// Unlike strings.Builder, we do not need to copy over the contents
++	// of the old buffer since our builder provides no API for
++	// retrieving previously created strings.
++	sb.buf = make([]byte, 0, 2*(cap(sb.buf)+n))
++}
++
++func (sb *Builder) last(n int) string {
++	return UnsafeString(sb.buf[len(sb.buf)-n:])
++}
+diff --git a/vendor/google.golang.org/protobuf/internal/version/version.go b/vendor/google.golang.org/protobuf/internal/version/version.go
+index 0999f29..a50fcfb 100644
+--- a/vendor/google.golang.org/protobuf/internal/version/version.go
++++ b/vendor/google.golang.org/protobuf/internal/version/version.go
+@@ -51,7 +51,7 @@ import (
+ //  10. Send out the CL for review and submit it.
+ const (
+ 	Major      = 1
+-	Minor      = 31
++	Minor      = 33
+ 	Patch      = 0
+ 	PreRelease = ""
+ )
+diff --git a/vendor/google.golang.org/protobuf/proto/decode.go b/vendor/google.golang.org/protobuf/proto/decode.go
+index 48d4794..e5b03b5 100644
+--- a/vendor/google.golang.org/protobuf/proto/decode.go
++++ b/vendor/google.golang.org/protobuf/proto/decode.go
+@@ -69,7 +69,7 @@ func (o UnmarshalOptions) Unmarshal(b []byte, m Message) error {
+ // UnmarshalState parses a wire-format message and places the result in m.
+ //
+ // This method permits fine-grained control over the unmarshaler.
+-// Most users should use Unmarshal instead.
++// Most users should use [Unmarshal] instead.
+ func (o UnmarshalOptions) UnmarshalState(in protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+ 	if o.RecursionLimit == 0 {
+ 		o.RecursionLimit = protowire.DefaultRecursionLimit
+diff --git a/vendor/google.golang.org/protobuf/proto/doc.go b/vendor/google.golang.org/protobuf/proto/doc.go
+index ec71e71..80ed16a 100644
+--- a/vendor/google.golang.org/protobuf/proto/doc.go
++++ b/vendor/google.golang.org/protobuf/proto/doc.go
+@@ -18,27 +18,27 @@
+ // This package contains functions to convert to and from the wire format,
+ // an efficient binary serialization of protocol buffers.
+ //
+-// • Size reports the size of a message in the wire format.
++//   - [Size] reports the size of a message in the wire format.
+ //
+-// • Marshal converts a message to the wire format.
+-// The MarshalOptions type provides more control over wire marshaling.
++//   - [Marshal] converts a message to the wire format.
++//     The [MarshalOptions] type provides more control over wire marshaling.
+ //
+-// • Unmarshal converts a message from the wire format.
+-// The UnmarshalOptions type provides more control over wire unmarshaling.
++//   - [Unmarshal] converts a message from the wire format.
++//     The [UnmarshalOptions] type provides more control over wire unmarshaling.
+ //
+ // # Basic message operations
+ //
+-// • Clone makes a deep copy of a message.
++//   - [Clone] makes a deep copy of a message.
+ //
+-// • Merge merges the content of a message into another.
++//   - [Merge] merges the content of a message into another.
+ //
+-// • Equal compares two messages. For more control over comparisons
+-// and detailed reporting of differences, see package
+-// "google.golang.org/protobuf/testing/protocmp".
++//   - [Equal] compares two messages. For more control over comparisons
++//     and detailed reporting of differences, see package
++//     [google.golang.org/protobuf/testing/protocmp].
+ //
+-// • Reset clears the content of a message.
++//   - [Reset] clears the content of a message.
+ //
+-// • CheckInitialized reports whether all required fields in a message are set.
++//   - [CheckInitialized] reports whether all required fields in a message are set.
+ //
+ // # Optional scalar constructors
+ //
+@@ -46,9 +46,9 @@
+ // as pointers to a value. For example, an optional string field has the
+ // Go type *string.
+ //
+-// • Bool, Int32, Int64, Uint32, Uint64, Float32, Float64, and String
+-// take a value and return a pointer to a new instance of it,
+-// to simplify construction of optional field values.
++//   - [Bool], [Int32], [Int64], [Uint32], [Uint64], [Float32], [Float64], and [String]
++//     take a value and return a pointer to a new instance of it,
++//     to simplify construction of optional field values.
+ //
+ // Generated enum types usually have an Enum method which performs the
+ // same operation.
+@@ -57,29 +57,29 @@
+ //
+ // # Extension accessors
+ //
+-// • HasExtension, GetExtension, SetExtension, and ClearExtension
+-// access extension field values in a protocol buffer message.
++//   - [HasExtension], [GetExtension], [SetExtension], and [ClearExtension]
++//     access extension field values in a protocol buffer message.
+ //
+ // Extension fields are only supported in proto2.
+ //
+ // # Related packages
+ //
+-// • Package "google.golang.org/protobuf/encoding/protojson" converts messages to
+-// and from JSON.
++//   - Package [google.golang.org/protobuf/encoding/protojson] converts messages to
++//     and from JSON.
+ //
+-// • Package "google.golang.org/protobuf/encoding/prototext" converts messages to
+-// and from the text format.
++//   - Package [google.golang.org/protobuf/encoding/prototext] converts messages to
++//     and from the text format.
+ //
+-// • Package "google.golang.org/protobuf/reflect/protoreflect" provides a
+-// reflection interface for protocol buffer data types.
++//   - Package [google.golang.org/protobuf/reflect/protoreflect] provides a
++//     reflection interface for protocol buffer data types.
+ //
+-// • Package "google.golang.org/protobuf/testing/protocmp" provides features
+-// to compare protocol buffer messages with the "github.com/google/go-cmp/cmp"
+-// package.
++//   - Package [google.golang.org/protobuf/testing/protocmp] provides features
++//     to compare protocol buffer messages with the [github.com/google/go-cmp/cmp]
++//     package.
+ //
+-// • Package "google.golang.org/protobuf/types/dynamicpb" provides a dynamic
+-// message type, suitable for working with messages where the protocol buffer
+-// type is only known at runtime.
++//   - Package [google.golang.org/protobuf/types/dynamicpb] provides a dynamic
++//     message type, suitable for working with messages where the protocol buffer
++//     type is only known at runtime.
+ //
+ // This module contains additional packages for more specialized use cases.
+ // Consult the individual package documentation for details.
+diff --git a/vendor/google.golang.org/protobuf/proto/encode.go b/vendor/google.golang.org/protobuf/proto/encode.go
+index bf7f816..4fed202 100644
+--- a/vendor/google.golang.org/protobuf/proto/encode.go
++++ b/vendor/google.golang.org/protobuf/proto/encode.go
+@@ -129,7 +129,7 @@ func (o MarshalOptions) MarshalAppend(b []byte, m Message) ([]byte, error) {
+ // MarshalState returns the wire-format encoding of a message.
+ //
+ // This method permits fine-grained control over the marshaler.
+-// Most users should use Marshal instead.
++// Most users should use [Marshal] instead.
+ func (o MarshalOptions) MarshalState(in protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+ 	return o.marshal(in.Buf, in.Message)
+ }
+diff --git a/vendor/google.golang.org/protobuf/proto/extension.go b/vendor/google.golang.org/protobuf/proto/extension.go
+index 5f293cd..17899a3 100644
+--- a/vendor/google.golang.org/protobuf/proto/extension.go
++++ b/vendor/google.golang.org/protobuf/proto/extension.go
+@@ -26,7 +26,7 @@ func HasExtension(m Message, xt protoreflect.ExtensionType) bool {
+ }
+ 
+ // ClearExtension clears an extension field such that subsequent
+-// HasExtension calls return false.
++// [HasExtension] calls return false.
+ // It panics if m is invalid or if xt does not extend m.
+ func ClearExtension(m Message, xt protoreflect.ExtensionType) {
+ 	m.ProtoReflect().Clear(xt.TypeDescriptor())
+diff --git a/vendor/google.golang.org/protobuf/proto/merge.go b/vendor/google.golang.org/protobuf/proto/merge.go
+index d761ab3..3c6fe57 100644
+--- a/vendor/google.golang.org/protobuf/proto/merge.go
++++ b/vendor/google.golang.org/protobuf/proto/merge.go
+@@ -21,7 +21,7 @@ import (
+ // The unknown fields of src are appended to the unknown fields of dst.
+ //
+ // It is semantically equivalent to unmarshaling the encoded form of src
+-// into dst with the UnmarshalOptions.Merge option specified.
++// into dst with the [UnmarshalOptions.Merge] option specified.
+ func Merge(dst, src Message) {
+ 	// TODO: Should nil src be treated as semantically equivalent to a
+ 	// untyped, read-only, empty message? What about a nil dst?
+diff --git a/vendor/google.golang.org/protobuf/proto/proto.go b/vendor/google.golang.org/protobuf/proto/proto.go
+index 1f0d183..7543ee6 100644
+--- a/vendor/google.golang.org/protobuf/proto/proto.go
++++ b/vendor/google.golang.org/protobuf/proto/proto.go
+@@ -15,18 +15,20 @@ import (
+ // protobuf module that accept a Message, except where otherwise specified.
+ //
+ // This is the v2 interface definition for protobuf messages.
+-// The v1 interface definition is "github.com/golang/protobuf/proto".Message.
++// The v1 interface definition is [github.com/golang/protobuf/proto.Message].
+ //
+-// To convert a v1 message to a v2 message,
+-// use "github.com/golang/protobuf/proto".MessageV2.
+-// To convert a v2 message to a v1 message,
+-// use "github.com/golang/protobuf/proto".MessageV1.
++//   - To convert a v1 message to a v2 message,
++//     use [google.golang.org/protobuf/protoadapt.MessageV2Of].
++//   - To convert a v2 message to a v1 message,
++//     use [google.golang.org/protobuf/protoadapt.MessageV1Of].
+ type Message = protoreflect.ProtoMessage
+ 
+-// Error matches all errors produced by packages in the protobuf module.
++// Error matches all errors produced by packages in the protobuf module
++// according to [errors.Is].
+ //
+-// That is, errors.Is(err, Error) reports whether an error is produced
+-// by this module.
++// Example usage:
++//
++//	if errors.Is(err, proto.Error) { ... }
+ var Error error
+ 
+ func init() {
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+index e4dfb12..baa0cc6 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+@@ -3,11 +3,11 @@
+ // license that can be found in the LICENSE file.
+ 
+ // Package protodesc provides functionality for converting
+-// FileDescriptorProto messages to/from protoreflect.FileDescriptor values.
++// FileDescriptorProto messages to/from [protoreflect.FileDescriptor] values.
+ //
+ // The google.protobuf.FileDescriptorProto is a protobuf message that describes
+ // the type information for a .proto file in a form that is easily serializable.
+-// The protoreflect.FileDescriptor is a more structured representation of
++// The [protoreflect.FileDescriptor] is a more structured representation of
+ // the FileDescriptorProto message where references and remote dependencies
+ // can be directly followed.
+ package protodesc
+@@ -24,11 +24,11 @@ import (
+ 	"google.golang.org/protobuf/types/descriptorpb"
+ )
+ 
+-// Resolver is the resolver used by NewFile to resolve dependencies.
++// Resolver is the resolver used by [NewFile] to resolve dependencies.
+ // The enums and messages provided must belong to some parent file,
+ // which is also registered.
+ //
+-// It is implemented by protoregistry.Files.
++// It is implemented by [protoregistry.Files].
+ type Resolver interface {
+ 	FindFileByPath(string) (protoreflect.FileDescriptor, error)
+ 	FindDescriptorByName(protoreflect.FullName) (protoreflect.Descriptor, error)
+@@ -61,19 +61,19 @@ type FileOptions struct {
+ 	AllowUnresolvable bool
+ }
+ 
+-// NewFile creates a new protoreflect.FileDescriptor from the provided
+-// file descriptor message. See FileOptions.New for more information.
++// NewFile creates a new [protoreflect.FileDescriptor] from the provided
++// file descriptor message. See [FileOptions.New] for more information.
+ func NewFile(fd *descriptorpb.FileDescriptorProto, r Resolver) (protoreflect.FileDescriptor, error) {
+ 	return FileOptions{}.New(fd, r)
+ }
+ 
+-// NewFiles creates a new protoregistry.Files from the provided
+-// FileDescriptorSet message. See FileOptions.NewFiles for more information.
++// NewFiles creates a new [protoregistry.Files] from the provided
++// FileDescriptorSet message. See [FileOptions.NewFiles] for more information.
+ func NewFiles(fd *descriptorpb.FileDescriptorSet) (*protoregistry.Files, error) {
+ 	return FileOptions{}.NewFiles(fd)
+ }
+ 
+-// New creates a new protoreflect.FileDescriptor from the provided
++// New creates a new [protoreflect.FileDescriptor] from the provided
+ // file descriptor message. The file must represent a valid proto file according
+ // to protobuf semantics. The returned descriptor is a deep copy of the input.
+ //
+@@ -93,9 +93,15 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
+ 		f.L1.Syntax = protoreflect.Proto2
+ 	case "proto3":
+ 		f.L1.Syntax = protoreflect.Proto3
++	case "editions":
++		f.L1.Syntax = protoreflect.Editions
++		f.L1.Edition = fromEditionProto(fd.GetEdition())
+ 	default:
+ 		return nil, errors.New("invalid syntax: %q", fd.GetSyntax())
+ 	}
++	if f.L1.Syntax == protoreflect.Editions && (fd.GetEdition() < SupportedEditionsMinimum || fd.GetEdition() > SupportedEditionsMaximum) {
++		return nil, errors.New("use of edition %v not yet supported by the Go Protobuf runtime", fd.GetEdition())
++	}
+ 	f.L1.Path = fd.GetName()
+ 	if f.L1.Path == "" {
+ 		return nil, errors.New("file path must be populated")
+@@ -108,6 +114,9 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
+ 		opts = proto.Clone(opts).(*descriptorpb.FileOptions)
+ 		f.L2.Options = func() protoreflect.ProtoMessage { return opts }
+ 	}
++	if f.L1.Syntax == protoreflect.Editions {
++		initFileDescFromFeatureSet(f, fd.GetOptions().GetFeatures())
++	}
+ 
+ 	f.L2.Imports = make(filedesc.FileImports, len(fd.GetDependency()))
+ 	for _, i := range fd.GetPublicDependency() {
+@@ -231,7 +240,7 @@ func (is importSet) importPublic(imps protoreflect.FileImports) {
+ 	}
+ }
+ 
+-// NewFiles creates a new protoregistry.Files from the provided
++// NewFiles creates a new [protoregistry.Files] from the provided
+ // FileDescriptorSet message. The descriptor set must include only
+ // valid files according to protobuf semantics. The returned descriptors
+ // are a deep copy of the input.
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
+index 37efda1..b327816 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
+@@ -28,6 +28,7 @@ func (r descsByName) initEnumDeclarations(eds []*descriptorpb.EnumDescriptorProt
+ 			opts = proto.Clone(opts).(*descriptorpb.EnumOptions)
+ 			e.L2.Options = func() protoreflect.ProtoMessage { return opts }
+ 		}
++		e.L1.EditionFeatures = mergeEditionFeatures(parent, ed.GetOptions().GetFeatures())
+ 		for _, s := range ed.GetReservedName() {
+ 			e.L2.ReservedNames.List = append(e.L2.ReservedNames.List, protoreflect.Name(s))
+ 		}
+@@ -68,6 +69,9 @@ func (r descsByName) initMessagesDeclarations(mds []*descriptorpb.DescriptorProt
+ 		if m.L0, err = r.makeBase(m, parent, md.GetName(), i, sb); err != nil {
+ 			return nil, err
+ 		}
++		if m.Base.L0.ParentFile.Syntax() == protoreflect.Editions {
++			m.L1.EditionFeatures = mergeEditionFeatures(parent, md.GetOptions().GetFeatures())
++		}
+ 		if opts := md.GetOptions(); opts != nil {
+ 			opts = proto.Clone(opts).(*descriptorpb.MessageOptions)
+ 			m.L2.Options = func() protoreflect.ProtoMessage { return opts }
+@@ -114,6 +118,27 @@ func (r descsByName) initMessagesDeclarations(mds []*descriptorpb.DescriptorProt
+ 	return ms, nil
+ }
+ 
++// canBePacked returns whether the field can use packed encoding:
++// https://protobuf.dev/programming-guides/encoding/#packed
++func canBePacked(fd *descriptorpb.FieldDescriptorProto) bool {
++	if fd.GetLabel() != descriptorpb.FieldDescriptorProto_LABEL_REPEATED {
++		return false // not a repeated field
++	}
++
++	switch protoreflect.Kind(fd.GetType()) {
++	case protoreflect.MessageKind, protoreflect.GroupKind:
++		return false // not a scalar type field
++
++	case protoreflect.StringKind, protoreflect.BytesKind:
++		// string and bytes can explicitly not be declared as packed,
++		// see https://protobuf.dev/programming-guides/encoding/#packed
++		return false
++
++	default:
++		return true
++	}
++}
++
+ func (r descsByName) initFieldsFromDescriptorProto(fds []*descriptorpb.FieldDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (fs []filedesc.Field, err error) {
+ 	fs = make([]filedesc.Field, len(fds)) // allocate up-front to ensure stable pointers
+ 	for i, fd := range fds {
+@@ -137,6 +162,34 @@ func (r descsByName) initFieldsFromDescriptorProto(fds []*descriptorpb.FieldDesc
+ 		if fd.JsonName != nil {
+ 			f.L1.StringName.InitJSON(fd.GetJsonName())
+ 		}
++
++		if f.Base.L0.ParentFile.Syntax() == protoreflect.Editions {
++			f.L1.EditionFeatures = mergeEditionFeatures(parent, fd.GetOptions().GetFeatures())
++
++			if f.L1.EditionFeatures.IsLegacyRequired {
++				f.L1.Cardinality = protoreflect.Required
++			}
++			// We reuse the existing field because the old option `[packed =
++			// true]` is mutually exclusive with the editions feature.
++			if canBePacked(fd) {
++				f.L1.HasPacked = true
++				f.L1.IsPacked = f.L1.EditionFeatures.IsPacked
++			}
++
++			// We pretend this option is always explicitly set because the only
++			// use of HasEnforceUTF8 is to determine whether to use EnforceUTF8
++			// or to return the appropriate default.
++			// When using editions we either parse the option or resolve the
++			// appropriate default here (instead of later when this option is
++			// requested from the descriptor).
++			// In proto2/proto3 syntax HasEnforceUTF8 might be false.
++			f.L1.HasEnforceUTF8 = true
++			f.L1.EnforceUTF8 = f.L1.EditionFeatures.IsUTF8Validated
++
++			if f.L1.Kind == protoreflect.MessageKind && f.L1.EditionFeatures.IsDelimitedEncoded {
++				f.L1.Kind = protoreflect.GroupKind
++			}
++		}
+ 	}
+ 	return fs, nil
+ }
+@@ -151,6 +204,9 @@ func (r descsByName) initOneofsFromDescriptorProto(ods []*descriptorpb.OneofDesc
+ 		if opts := od.GetOptions(); opts != nil {
+ 			opts = proto.Clone(opts).(*descriptorpb.OneofOptions)
+ 			o.L1.Options = func() protoreflect.ProtoMessage { return opts }
++			if parent.Syntax() == protoreflect.Editions {
++				o.L1.EditionFeatures = mergeEditionFeatures(parent, opts.GetFeatures())
++			}
+ 		}
+ 	}
+ 	return os, nil
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
+index 27d7e35..254ca58 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
+@@ -276,8 +276,8 @@ func unmarshalDefault(s string, fd protoreflect.FieldDescriptor, allowUnresolvab
+ 	} else if err != nil {
+ 		return v, ev, err
+ 	}
+-	if fd.Syntax() == protoreflect.Proto3 {
+-		return v, ev, errors.New("cannot be specified under proto3 semantics")
++	if !fd.HasPresence() {
++		return v, ev, errors.New("cannot be specified with implicit field presence")
+ 	}
+ 	if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind || fd.Cardinality() == protoreflect.Repeated {
+ 		return v, ev, errors.New("cannot be specified on composite types")
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
+index 9af1d56..e4dcaf8 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
+@@ -107,7 +107,7 @@ func validateMessageDeclarations(ms []filedesc.Message, mds []*descriptorpb.Desc
+ 		if isMessageSet && !flags.ProtoLegacy {
+ 			return errors.New("message %q is a MessageSet, which is a legacy proto1 feature that is no longer supported", m.FullName())
+ 		}
+-		if isMessageSet && (m.Syntax() != protoreflect.Proto2 || m.Fields().Len() > 0 || m.ExtensionRanges().Len() == 0) {
++		if isMessageSet && (m.Syntax() == protoreflect.Proto3 || m.Fields().Len() > 0 || m.ExtensionRanges().Len() == 0) {
+ 			return errors.New("message %q is an invalid proto1 MessageSet", m.FullName())
+ 		}
+ 		if m.Syntax() == protoreflect.Proto3 {
+@@ -314,8 +314,8 @@ func checkValidGroup(fd protoreflect.FieldDescriptor) error {
+ 	switch {
+ 	case fd.Kind() != protoreflect.GroupKind:
+ 		return nil
+-	case fd.Syntax() != protoreflect.Proto2:
+-		return errors.New("invalid under proto2 semantics")
++	case fd.Syntax() == protoreflect.Proto3:
++		return errors.New("invalid under proto3 semantics")
+ 	case md == nil || md.IsPlaceholder():
+ 		return errors.New("message must be resolvable")
+ 	case fd.FullName().Parent() != md.FullName().Parent():
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go b/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+new file mode 100644
+index 0000000..2a6b29d
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+@@ -0,0 +1,148 @@
++// Copyright 2019 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package protodesc
++
++import (
++	"fmt"
++	"os"
++	"sync"
++
++	"google.golang.org/protobuf/internal/editiondefaults"
++	"google.golang.org/protobuf/internal/filedesc"
++	"google.golang.org/protobuf/proto"
++	"google.golang.org/protobuf/reflect/protoreflect"
++	"google.golang.org/protobuf/types/descriptorpb"
++	gofeaturespb "google.golang.org/protobuf/types/gofeaturespb"
++)
++
++const (
++	SupportedEditionsMinimum = descriptorpb.Edition_EDITION_PROTO2
++	SupportedEditionsMaximum = descriptorpb.Edition_EDITION_2023
++)
++
++var defaults = &descriptorpb.FeatureSetDefaults{}
++var defaultsCacheMu sync.Mutex
++var defaultsCache = make(map[filedesc.Edition]*descriptorpb.FeatureSet)
++
++func init() {
++	err := proto.Unmarshal(editiondefaults.Defaults, defaults)
++	if err != nil {
++		fmt.Fprintf(os.Stderr, "unmarshal editions defaults: %v\n", err)
++		os.Exit(1)
++	}
++}
++
++func fromEditionProto(epb descriptorpb.Edition) filedesc.Edition {
++	return filedesc.Edition(epb)
++}
++
++func toEditionProto(ed filedesc.Edition) descriptorpb.Edition {
++	switch ed {
++	case filedesc.EditionUnknown:
++		return descriptorpb.Edition_EDITION_UNKNOWN
++	case filedesc.EditionProto2:
++		return descriptorpb.Edition_EDITION_PROTO2
++	case filedesc.EditionProto3:
++		return descriptorpb.Edition_EDITION_PROTO3
++	case filedesc.Edition2023:
++		return descriptorpb.Edition_EDITION_2023
++	default:
++		panic(fmt.Sprintf("unknown value for edition: %v", ed))
++	}
++}
++
++func getFeatureSetFor(ed filedesc.Edition) *descriptorpb.FeatureSet {
++	defaultsCacheMu.Lock()
++	defer defaultsCacheMu.Unlock()
++	if def, ok := defaultsCache[ed]; ok {
++		return def
++	}
++	edpb := toEditionProto(ed)
++	if defaults.GetMinimumEdition() > edpb || defaults.GetMaximumEdition() < edpb {
++		// This should never happen protodesc.(FileOptions).New would fail when
++		// initializing the file descriptor.
++		// This most likely means the embedded defaults were not updated.
++		fmt.Fprintf(os.Stderr, "internal error: unsupported edition %v (did you forget to update the embedded defaults (i.e. the bootstrap descriptor proto)?)\n", edpb)
++		os.Exit(1)
++	}
++	fs := defaults.GetDefaults()[0].GetFeatures()
++	// Using a linear search for now.
++	// Editions are guaranteed to be sorted and thus we could use a binary search.
++	// Given that there are only a handful of editions (with one more per year)
++	// there is not much reason to use a binary search.
++	for _, def := range defaults.GetDefaults() {
++		if def.GetEdition() <= edpb {
++			fs = def.GetFeatures()
++		} else {
++			break
++		}
++	}
++	defaultsCache[ed] = fs
++	return fs
++}
++
++// mergeEditionFeatures merges the parent and child feature sets. This function
++// should be used when initializing Go descriptors from descriptor protos which
++// is why the parent is a filedesc.EditionsFeatures (Go representation) while
++// the child is a descriptorproto.FeatureSet (protoc representation).
++// Any feature set by the child overwrites what is set by the parent.
++func mergeEditionFeatures(parentDesc protoreflect.Descriptor, child *descriptorpb.FeatureSet) filedesc.EditionFeatures {
++	var parentFS filedesc.EditionFeatures
++	switch p := parentDesc.(type) {
++	case *filedesc.File:
++		parentFS = p.L1.EditionFeatures
++	case *filedesc.Message:
++		parentFS = p.L1.EditionFeatures
++	default:
++		panic(fmt.Sprintf("unknown parent type %T", parentDesc))
++	}
++	if child == nil {
++		return parentFS
++	}
++	if fp := child.FieldPresence; fp != nil {
++		parentFS.IsFieldPresence = *fp == descriptorpb.FeatureSet_LEGACY_REQUIRED ||
++			*fp == descriptorpb.FeatureSet_EXPLICIT
++		parentFS.IsLegacyRequired = *fp == descriptorpb.FeatureSet_LEGACY_REQUIRED
++	}
++	if et := child.EnumType; et != nil {
++		parentFS.IsOpenEnum = *et == descriptorpb.FeatureSet_OPEN
++	}
++
++	if rfe := child.RepeatedFieldEncoding; rfe != nil {
++		parentFS.IsPacked = *rfe == descriptorpb.FeatureSet_PACKED
++	}
++
++	if utf8val := child.Utf8Validation; utf8val != nil {
++		parentFS.IsUTF8Validated = *utf8val == descriptorpb.FeatureSet_VERIFY
++	}
++
++	if me := child.MessageEncoding; me != nil {
++		parentFS.IsDelimitedEncoded = *me == descriptorpb.FeatureSet_DELIMITED
++	}
++
++	if jf := child.JsonFormat; jf != nil {
++		parentFS.IsJSONCompliant = *jf == descriptorpb.FeatureSet_ALLOW
++	}
++
++	if goFeatures, ok := proto.GetExtension(child, gofeaturespb.E_Go).(*gofeaturespb.GoFeatures); ok && goFeatures != nil {
++		if luje := goFeatures.LegacyUnmarshalJsonEnum; luje != nil {
++			parentFS.GenerateLegacyUnmarshalJSON = *luje
++		}
++	}
++
++	return parentFS
++}
++
++// initFileDescFromFeatureSet initializes editions related fields in fd based
++// on fs. If fs is nil it is assumed to be an empty featureset and all fields
++// will be initialized with the appropriate default. fd.L1.Edition must be set
++// before calling this function.
++func initFileDescFromFeatureSet(fd *filedesc.File, fs *descriptorpb.FeatureSet) {
++	dfs := getFeatureSetFor(fd.L1.Edition)
++	// initialize the featureset with the defaults
++	fd.L1.EditionFeatures = mergeEditionFeatures(fd, dfs)
++	// overwrite any options explicitly specified
++	fd.L1.EditionFeatures = mergeEditionFeatures(fd, fs)
++}
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go b/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
+index a7c5cef..9d6e054 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
+@@ -16,7 +16,7 @@ import (
+ 	"google.golang.org/protobuf/types/descriptorpb"
+ )
+ 
+-// ToFileDescriptorProto copies a protoreflect.FileDescriptor into a
++// ToFileDescriptorProto copies a [protoreflect.FileDescriptor] into a
+ // google.protobuf.FileDescriptorProto message.
+ func ToFileDescriptorProto(file protoreflect.FileDescriptor) *descriptorpb.FileDescriptorProto {
+ 	p := &descriptorpb.FileDescriptorProto{
+@@ -70,13 +70,13 @@ func ToFileDescriptorProto(file protoreflect.FileDescriptor) *descriptorpb.FileD
+ 	for i, exts := 0, file.Extensions(); i < exts.Len(); i++ {
+ 		p.Extension = append(p.Extension, ToFieldDescriptorProto(exts.Get(i)))
+ 	}
+-	if syntax := file.Syntax(); syntax != protoreflect.Proto2 {
++	if syntax := file.Syntax(); syntax != protoreflect.Proto2 && syntax.IsValid() {
+ 		p.Syntax = proto.String(file.Syntax().String())
+ 	}
+ 	return p
+ }
+ 
+-// ToDescriptorProto copies a protoreflect.MessageDescriptor into a
++// ToDescriptorProto copies a [protoreflect.MessageDescriptor] into a
+ // google.protobuf.DescriptorProto message.
+ func ToDescriptorProto(message protoreflect.MessageDescriptor) *descriptorpb.DescriptorProto {
+ 	p := &descriptorpb.DescriptorProto{
+@@ -119,7 +119,7 @@ func ToDescriptorProto(message protoreflect.MessageDescriptor) *descriptorpb.Des
+ 	return p
+ }
+ 
+-// ToFieldDescriptorProto copies a protoreflect.FieldDescriptor into a
++// ToFieldDescriptorProto copies a [protoreflect.FieldDescriptor] into a
+ // google.protobuf.FieldDescriptorProto message.
+ func ToFieldDescriptorProto(field protoreflect.FieldDescriptor) *descriptorpb.FieldDescriptorProto {
+ 	p := &descriptorpb.FieldDescriptorProto{
+@@ -168,7 +168,7 @@ func ToFieldDescriptorProto(field protoreflect.FieldDescriptor) *descriptorpb.Fi
+ 	return p
+ }
+ 
+-// ToOneofDescriptorProto copies a protoreflect.OneofDescriptor into a
++// ToOneofDescriptorProto copies a [protoreflect.OneofDescriptor] into a
+ // google.protobuf.OneofDescriptorProto message.
+ func ToOneofDescriptorProto(oneof protoreflect.OneofDescriptor) *descriptorpb.OneofDescriptorProto {
+ 	return &descriptorpb.OneofDescriptorProto{
+@@ -177,7 +177,7 @@ func ToOneofDescriptorProto(oneof protoreflect.OneofDescriptor) *descriptorpb.On
+ 	}
+ }
+ 
+-// ToEnumDescriptorProto copies a protoreflect.EnumDescriptor into a
++// ToEnumDescriptorProto copies a [protoreflect.EnumDescriptor] into a
+ // google.protobuf.EnumDescriptorProto message.
+ func ToEnumDescriptorProto(enum protoreflect.EnumDescriptor) *descriptorpb.EnumDescriptorProto {
+ 	p := &descriptorpb.EnumDescriptorProto{
+@@ -200,7 +200,7 @@ func ToEnumDescriptorProto(enum protoreflect.EnumDescriptor) *descriptorpb.EnumD
+ 	return p
+ }
+ 
+-// ToEnumValueDescriptorProto copies a protoreflect.EnumValueDescriptor into a
++// ToEnumValueDescriptorProto copies a [protoreflect.EnumValueDescriptor] into a
+ // google.protobuf.EnumValueDescriptorProto message.
+ func ToEnumValueDescriptorProto(value protoreflect.EnumValueDescriptor) *descriptorpb.EnumValueDescriptorProto {
+ 	return &descriptorpb.EnumValueDescriptorProto{
+@@ -210,7 +210,7 @@ func ToEnumValueDescriptorProto(value protoreflect.EnumValueDescriptor) *descrip
+ 	}
+ }
+ 
+-// ToServiceDescriptorProto copies a protoreflect.ServiceDescriptor into a
++// ToServiceDescriptorProto copies a [protoreflect.ServiceDescriptor] into a
+ // google.protobuf.ServiceDescriptorProto message.
+ func ToServiceDescriptorProto(service protoreflect.ServiceDescriptor) *descriptorpb.ServiceDescriptorProto {
+ 	p := &descriptorpb.ServiceDescriptorProto{
+@@ -223,7 +223,7 @@ func ToServiceDescriptorProto(service protoreflect.ServiceDescriptor) *descripto
+ 	return p
+ }
+ 
+-// ToMethodDescriptorProto copies a protoreflect.MethodDescriptor into a
++// ToMethodDescriptorProto copies a [protoreflect.MethodDescriptor] into a
+ // google.protobuf.MethodDescriptorProto message.
+ func ToMethodDescriptorProto(method protoreflect.MethodDescriptor) *descriptorpb.MethodDescriptorProto {
+ 	p := &descriptorpb.MethodDescriptorProto{
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
+index 55aa149..00b01fb 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
+@@ -10,46 +10,46 @@
+ //
+ // # Protocol Buffer Descriptors
+ //
+-// Protobuf descriptors (e.g., EnumDescriptor or MessageDescriptor)
++// Protobuf descriptors (e.g., [EnumDescriptor] or [MessageDescriptor])
+ // are immutable objects that represent protobuf type information.
+ // They are wrappers around the messages declared in descriptor.proto.
+ // Protobuf descriptors alone lack any information regarding Go types.
+ //
+-// Enums and messages generated by this module implement Enum and ProtoMessage,
++// Enums and messages generated by this module implement [Enum] and [ProtoMessage],
+ // where the Descriptor and ProtoReflect.Descriptor accessors respectively
+ // return the protobuf descriptor for the values.
+ //
+ // The protobuf descriptor interfaces are not meant to be implemented by
+ // user code since they might need to be extended in the future to support
+ // additions to the protobuf language.
+-// The "google.golang.org/protobuf/reflect/protodesc" package converts between
++// The [google.golang.org/protobuf/reflect/protodesc] package converts between
+ // google.protobuf.DescriptorProto messages and protobuf descriptors.
+ //
+ // # Go Type Descriptors
+ //
+-// A type descriptor (e.g., EnumType or MessageType) is a constructor for
++// A type descriptor (e.g., [EnumType] or [MessageType]) is a constructor for
+ // a concrete Go type that represents the associated protobuf descriptor.
+ // There is commonly a one-to-one relationship between protobuf descriptors and
+ // Go type descriptors, but it can potentially be a one-to-many relationship.
+ //
+-// Enums and messages generated by this module implement Enum and ProtoMessage,
++// Enums and messages generated by this module implement [Enum] and [ProtoMessage],
+ // where the Type and ProtoReflect.Type accessors respectively
+ // return the protobuf descriptor for the values.
+ //
+-// The "google.golang.org/protobuf/types/dynamicpb" package can be used to
++// The [google.golang.org/protobuf/types/dynamicpb] package can be used to
+ // create Go type descriptors from protobuf descriptors.
+ //
+ // # Value Interfaces
+ //
+-// The Enum and Message interfaces provide a reflective view over an
++// The [Enum] and [Message] interfaces provide a reflective view over an
+ // enum or message instance. For enums, it provides the ability to retrieve
+ // the enum value number for any concrete enum type. For messages, it provides
+ // the ability to access or manipulate fields of the message.
+ //
+-// To convert a proto.Message to a protoreflect.Message, use the
++// To convert a [google.golang.org/protobuf/proto.Message] to a [protoreflect.Message], use the
+ // former's ProtoReflect method. Since the ProtoReflect method is new to the
+ // v2 message interface, it may not be present on older message implementations.
+-// The "github.com/golang/protobuf/proto".MessageReflect function can be used
++// The [github.com/golang/protobuf/proto.MessageReflect] function can be used
+ // to obtain a reflective view on older messages.
+ //
+ // # Relationships
+@@ -71,12 +71,12 @@
+ //	      │                                 │
+ //	      └────────────────── Type() ───────┘
+ //
+-// • An EnumType describes a concrete Go enum type.
++// • An [EnumType] describes a concrete Go enum type.
+ // It has an EnumDescriptor and can construct an Enum instance.
+ //
+-// • An EnumDescriptor describes an abstract protobuf enum type.
++// • An [EnumDescriptor] describes an abstract protobuf enum type.
+ //
+-// • An Enum is a concrete enum instance. Generated enums implement Enum.
++// • An [Enum] is a concrete enum instance. Generated enums implement Enum.
+ //
+ //	  ┌──────────────── New() ─────────────────┐
+ //	  │                                        │
+@@ -90,24 +90,26 @@
+ //	       │                                    │
+ //	       └─────────────────── Type() ─────────┘
+ //
+-// • A MessageType describes a concrete Go message type.
+-// It has a MessageDescriptor and can construct a Message instance.
+-// Just as how Go's reflect.Type is a reflective description of a Go type,
+-// a MessageType is a reflective description of a Go type for a protobuf message.
++// • A [MessageType] describes a concrete Go message type.
++// It has a [MessageDescriptor] and can construct a [Message] instance.
++// Just as how Go's [reflect.Type] is a reflective description of a Go type,
++// a [MessageType] is a reflective description of a Go type for a protobuf message.
+ //
+-// • A MessageDescriptor describes an abstract protobuf message type.
+-// It has no understanding of Go types. In order to construct a MessageType
+-// from just a MessageDescriptor, you can consider looking up the message type
+-// in the global registry using protoregistry.GlobalTypes.FindMessageByName
+-// or constructing a dynamic MessageType using dynamicpb.NewMessageType.
++// • A [MessageDescriptor] describes an abstract protobuf message type.
++// It has no understanding of Go types. In order to construct a [MessageType]
++// from just a [MessageDescriptor], you can consider looking up the message type
++// in the global registry using the FindMessageByName method on
++// [google.golang.org/protobuf/reflect/protoregistry.GlobalTypes]
++// or constructing a dynamic [MessageType] using
++// [google.golang.org/protobuf/types/dynamicpb.NewMessageType].
+ //
+-// • A Message is a reflective view over a concrete message instance.
+-// Generated messages implement ProtoMessage, which can convert to a Message.
+-// Just as how Go's reflect.Value is a reflective view over a Go value,
+-// a Message is a reflective view over a concrete protobuf message instance.
+-// Using Go reflection as an analogy, the ProtoReflect method is similar to
+-// calling reflect.ValueOf, and the Message.Interface method is similar to
+-// calling reflect.Value.Interface.
++// • A [Message] is a reflective view over a concrete message instance.
++// Generated messages implement [ProtoMessage], which can convert to a [Message].
++// Just as how Go's [reflect.Value] is a reflective view over a Go value,
++// a [Message] is a reflective view over a concrete protobuf message instance.
++// Using Go reflection as an analogy, the [ProtoMessage.ProtoReflect] method is similar to
++// calling [reflect.ValueOf], and the [Message.Interface] method is similar to
++// calling [reflect.Value.Interface].
+ //
+ //	      ┌── TypeDescriptor() ──┐    ┌───── Descriptor() ─────┐
+ //	      │                      V    │                        V
+@@ -119,15 +121,15 @@
+ //	                                 │                          │
+ //	                                 └────── implements ────────┘
+ //
+-// • An ExtensionType describes a concrete Go implementation of an extension.
+-// It has an ExtensionTypeDescriptor and can convert to/from
+-// abstract Values and Go values.
++// • An [ExtensionType] describes a concrete Go implementation of an extension.
++// It has an [ExtensionTypeDescriptor] and can convert to/from
++// an abstract [Value] and a Go value.
+ //
+-// • An ExtensionTypeDescriptor is an ExtensionDescriptor
+-// which also has an ExtensionType.
++// • An [ExtensionTypeDescriptor] is an [ExtensionDescriptor]
++// which also has an [ExtensionType].
+ //
+-// • An ExtensionDescriptor describes an abstract protobuf extension field and
+-// may not always be an ExtensionTypeDescriptor.
++// • An [ExtensionDescriptor] describes an abstract protobuf extension field and
++// may not always be an [ExtensionTypeDescriptor].
+ package protoreflect
+ 
+ import (
+@@ -142,7 +144,7 @@ type doNotImplement pragma.DoNotImplement
+ 
+ // ProtoMessage is the top-level interface that all proto messages implement.
+ // This is declared in the protoreflect package to avoid a cyclic dependency;
+-// use the proto.Message type instead, which aliases this type.
++// use the [google.golang.org/protobuf/proto.Message] type instead, which aliases this type.
+ type ProtoMessage interface{ ProtoReflect() Message }
+ 
+ // Syntax is the language version of the proto file.
+@@ -151,8 +153,9 @@ type Syntax syntax
+ type syntax int8 // keep exact type opaque as the int type may change
+ 
+ const (
+-	Proto2 Syntax = 2
+-	Proto3 Syntax = 3
++	Proto2   Syntax = 2
++	Proto3   Syntax = 3
++	Editions Syntax = 4
+ )
+ 
+ // IsValid reports whether the syntax is valid.
+@@ -172,6 +175,8 @@ func (s Syntax) String() string {
+ 		return "proto2"
+ 	case Proto3:
+ 		return "proto3"
++	case Editions:
++		return "editions"
+ 	default:
+ 		return fmt.Sprintf("<unknown:%d>", s)
+ 	}
+@@ -436,7 +441,7 @@ type Names interface {
+ // FullName is a qualified name that uniquely identifies a proto declaration.
+ // A qualified name is the concatenation of the proto package along with the
+ // fully-declared name (i.e., name of parent preceding the name of the child),
+-// with a '.' delimiter placed between each Name.
++// with a '.' delimiter placed between each [Name].
+ //
+ // This should not have any leading or trailing dots.
+ type FullName string // e.g., "google.protobuf.Field.Kind"
+@@ -480,7 +485,7 @@ func isLetterDigit(c byte) bool {
+ }
+ 
+ // Name returns the short name, which is the last identifier segment.
+-// A single segment FullName is the Name itself.
++// A single segment FullName is the [Name] itself.
+ func (n FullName) Name() Name {
+ 	if i := strings.LastIndexByte(string(n), '.'); i >= 0 {
+ 		return Name(n[i+1:])
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
+index 717b106..7dcc2ff 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
+@@ -35,7 +35,7 @@ func (p *SourcePath) appendFileDescriptorProto(b []byte) []byte {
+ 		b = p.appendSingularField(b, "source_code_info", (*SourcePath).appendSourceCodeInfo)
+ 	case 12:
+ 		b = p.appendSingularField(b, "syntax", nil)
+-	case 13:
++	case 14:
+ 		b = p.appendSingularField(b, "edition", nil)
+ 	}
+ 	return b
+@@ -160,8 +160,6 @@ func (p *SourcePath) appendFileOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "java_generic_services", nil)
+ 	case 18:
+ 		b = p.appendSingularField(b, "py_generic_services", nil)
+-	case 42:
+-		b = p.appendSingularField(b, "php_generic_services", nil)
+ 	case 23:
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 31:
+@@ -180,6 +178,8 @@ func (p *SourcePath) appendFileOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "php_metadata_namespace", nil)
+ 	case 45:
+ 		b = p.appendSingularField(b, "ruby_package", nil)
++	case 50:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -240,6 +240,8 @@ func (p *SourcePath) appendMessageOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "map_entry", nil)
+ 	case 11:
+ 		b = p.appendSingularField(b, "deprecated_legacy_json_field_conflicts", nil)
++	case 12:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -285,6 +287,8 @@ func (p *SourcePath) appendEnumOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 6:
+ 		b = p.appendSingularField(b, "deprecated_legacy_json_field_conflicts", nil)
++	case 7:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -330,6 +334,8 @@ func (p *SourcePath) appendServiceOptions(b []byte) []byte {
+ 		return b
+ 	}
+ 	switch (*p)[0] {
++	case 34:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 33:
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 999:
+@@ -361,16 +367,39 @@ func (p *SourcePath) appendFieldOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "debug_redact", nil)
+ 	case 17:
+ 		b = p.appendSingularField(b, "retention", nil)
+-	case 18:
+-		b = p.appendSingularField(b, "target", nil)
+ 	case 19:
+ 		b = p.appendRepeatedField(b, "targets", nil)
++	case 20:
++		b = p.appendRepeatedField(b, "edition_defaults", (*SourcePath).appendFieldOptions_EditionDefault)
++	case 21:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+ 	return b
+ }
+ 
++func (p *SourcePath) appendFeatureSet(b []byte) []byte {
++	if len(*p) == 0 {
++		return b
++	}
++	switch (*p)[0] {
++	case 1:
++		b = p.appendSingularField(b, "field_presence", nil)
++	case 2:
++		b = p.appendSingularField(b, "enum_type", nil)
++	case 3:
++		b = p.appendSingularField(b, "repeated_field_encoding", nil)
++	case 4:
++		b = p.appendSingularField(b, "utf8_validation", nil)
++	case 5:
++		b = p.appendSingularField(b, "message_encoding", nil)
++	case 6:
++		b = p.appendSingularField(b, "json_format", nil)
++	}
++	return b
++}
++
+ func (p *SourcePath) appendUninterpretedOption(b []byte) []byte {
+ 	if len(*p) == 0 {
+ 		return b
+@@ -422,6 +451,8 @@ func (p *SourcePath) appendExtensionRangeOptions(b []byte) []byte {
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	case 2:
+ 		b = p.appendRepeatedField(b, "declaration", (*SourcePath).appendExtensionRangeOptions_Declaration)
++	case 50:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 3:
+ 		b = p.appendSingularField(b, "verification", nil)
+ 	}
+@@ -433,6 +464,8 @@ func (p *SourcePath) appendOneofOptions(b []byte) []byte {
+ 		return b
+ 	}
+ 	switch (*p)[0] {
++	case 1:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -446,6 +479,10 @@ func (p *SourcePath) appendEnumValueOptions(b []byte) []byte {
+ 	switch (*p)[0] {
+ 	case 1:
+ 		b = p.appendSingularField(b, "deprecated", nil)
++	case 2:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
++	case 3:
++		b = p.appendSingularField(b, "debug_redact", nil)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -461,12 +498,27 @@ func (p *SourcePath) appendMethodOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 34:
+ 		b = p.appendSingularField(b, "idempotency_level", nil)
++	case 35:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+ 	return b
+ }
+ 
++func (p *SourcePath) appendFieldOptions_EditionDefault(b []byte) []byte {
++	if len(*p) == 0 {
++		return b
++	}
++	switch (*p)[0] {
++	case 3:
++		b = p.appendSingularField(b, "edition", nil)
++	case 2:
++		b = p.appendSingularField(b, "value", nil)
++	}
++	return b
++}
++
+ func (p *SourcePath) appendUninterpretedOption_NamePart(b []byte) []byte {
+ 	if len(*p) == 0 {
+ 		return b
+@@ -491,8 +543,6 @@ func (p *SourcePath) appendExtensionRangeOptions_Declaration(b []byte) []byte {
+ 		b = p.appendSingularField(b, "full_name", nil)
+ 	case 3:
+ 		b = p.appendSingularField(b, "type", nil)
+-	case 4:
+-		b = p.appendSingularField(b, "is_repeated", nil)
+ 	case 5:
+ 		b = p.appendSingularField(b, "reserved", nil)
+ 	case 6:
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
+index 3867470..60ff62b 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
+@@ -12,7 +12,7 @@ package protoreflect
+ // exactly identical. However, it is possible for the same semantically
+ // identical proto type to be represented by multiple type descriptors.
+ //
+-// For example, suppose we have t1 and t2 which are both MessageDescriptors.
++// For example, suppose we have t1 and t2 which are both an [MessageDescriptor].
+ // If t1 == t2, then the types are definitely equal and all accessors return
+ // the same information. However, if t1 != t2, then it is still possible that
+ // they still represent the same proto type (e.g., t1.FullName == t2.FullName).
+@@ -115,7 +115,7 @@ type Descriptor interface {
+ // corresponds with the google.protobuf.FileDescriptorProto message.
+ //
+ // Top-level declarations:
+-// EnumDescriptor, MessageDescriptor, FieldDescriptor, and/or ServiceDescriptor.
++// [EnumDescriptor], [MessageDescriptor], [FieldDescriptor], and/or [ServiceDescriptor].
+ type FileDescriptor interface {
+ 	Descriptor // Descriptor.FullName is identical to Package
+ 
+@@ -180,8 +180,8 @@ type FileImport struct {
+ // corresponds with the google.protobuf.DescriptorProto message.
+ //
+ // Nested declarations:
+-// FieldDescriptor, OneofDescriptor, FieldDescriptor, EnumDescriptor,
+-// and/or MessageDescriptor.
++// [FieldDescriptor], [OneofDescriptor], [FieldDescriptor], [EnumDescriptor],
++// and/or [MessageDescriptor].
+ type MessageDescriptor interface {
+ 	Descriptor
+ 
+@@ -214,7 +214,7 @@ type MessageDescriptor interface {
+ 	ExtensionRanges() FieldRanges
+ 	// ExtensionRangeOptions returns the ith extension range options.
+ 	//
+-	// To avoid a dependency cycle, this method returns a proto.Message value,
++	// To avoid a dependency cycle, this method returns a proto.Message] value,
+ 	// which always contains a google.protobuf.ExtensionRangeOptions message.
+ 	// This method returns a typed nil-pointer if no options are present.
+ 	// The caller must import the descriptorpb package to use this.
+@@ -231,9 +231,9 @@ type MessageDescriptor interface {
+ }
+ type isMessageDescriptor interface{ ProtoType(MessageDescriptor) }
+ 
+-// MessageType encapsulates a MessageDescriptor with a concrete Go implementation.
++// MessageType encapsulates a [MessageDescriptor] with a concrete Go implementation.
+ // It is recommended that implementations of this interface also implement the
+-// MessageFieldTypes interface.
++// [MessageFieldTypes] interface.
+ type MessageType interface {
+ 	// New returns a newly allocated empty message.
+ 	// It may return nil for synthetic messages representing a map entry.
+@@ -249,19 +249,19 @@ type MessageType interface {
+ 	Descriptor() MessageDescriptor
+ }
+ 
+-// MessageFieldTypes extends a MessageType by providing type information
++// MessageFieldTypes extends a [MessageType] by providing type information
+ // regarding enums and messages referenced by the message fields.
+ type MessageFieldTypes interface {
+ 	MessageType
+ 
+-	// Enum returns the EnumType for the ith field in Descriptor.Fields.
++	// Enum returns the EnumType for the ith field in MessageDescriptor.Fields.
+ 	// It returns nil if the ith field is not an enum kind.
+ 	// It panics if out of bounds.
+ 	//
+ 	// Invariant: mt.Enum(i).Descriptor() == mt.Descriptor().Fields(i).Enum()
+ 	Enum(i int) EnumType
+ 
+-	// Message returns the MessageType for the ith field in Descriptor.Fields.
++	// Message returns the MessageType for the ith field in MessageDescriptor.Fields.
+ 	// It returns nil if the ith field is not a message or group kind.
+ 	// It panics if out of bounds.
+ 	//
+@@ -286,8 +286,8 @@ type MessageDescriptors interface {
+ // corresponds with the google.protobuf.FieldDescriptorProto message.
+ //
+ // It is used for both normal fields defined within the parent message
+-// (e.g., MessageDescriptor.Fields) and fields that extend some remote message
+-// (e.g., FileDescriptor.Extensions or MessageDescriptor.Extensions).
++// (e.g., [MessageDescriptor.Fields]) and fields that extend some remote message
++// (e.g., [FileDescriptor.Extensions] or [MessageDescriptor.Extensions]).
+ type FieldDescriptor interface {
+ 	Descriptor
+ 
+@@ -344,7 +344,7 @@ type FieldDescriptor interface {
+ 	// IsMap reports whether this field represents a map,
+ 	// where the value type for the associated field is a Map.
+ 	// It is equivalent to checking whether Cardinality is Repeated,
+-	// that the Kind is MessageKind, and that Message.IsMapEntry reports true.
++	// that the Kind is MessageKind, and that MessageDescriptor.IsMapEntry reports true.
+ 	IsMap() bool
+ 
+ 	// MapKey returns the field descriptor for the key in the map entry.
+@@ -419,7 +419,7 @@ type OneofDescriptor interface {
+ 
+ 	// IsSynthetic reports whether this is a synthetic oneof created to support
+ 	// proto3 optional semantics. If true, Fields contains exactly one field
+-	// with HasOptionalKeyword specified.
++	// with FieldDescriptor.HasOptionalKeyword specified.
+ 	IsSynthetic() bool
+ 
+ 	// Fields is a list of fields belonging to this oneof.
+@@ -442,10 +442,10 @@ type OneofDescriptors interface {
+ 	doNotImplement
+ }
+ 
+-// ExtensionDescriptor is an alias of FieldDescriptor for documentation.
++// ExtensionDescriptor is an alias of [FieldDescriptor] for documentation.
+ type ExtensionDescriptor = FieldDescriptor
+ 
+-// ExtensionTypeDescriptor is an ExtensionDescriptor with an associated ExtensionType.
++// ExtensionTypeDescriptor is an [ExtensionDescriptor] with an associated [ExtensionType].
+ type ExtensionTypeDescriptor interface {
+ 	ExtensionDescriptor
+ 
+@@ -470,12 +470,12 @@ type ExtensionDescriptors interface {
+ 	doNotImplement
+ }
+ 
+-// ExtensionType encapsulates an ExtensionDescriptor with a concrete
++// ExtensionType encapsulates an [ExtensionDescriptor] with a concrete
+ // Go implementation. The nested field descriptor must be for a extension field.
+ //
+ // While a normal field is a member of the parent message that it is declared
+-// within (see Descriptor.Parent), an extension field is a member of some other
+-// target message (see ExtensionDescriptor.Extendee) and may have no
++// within (see [Descriptor.Parent]), an extension field is a member of some other
++// target message (see [FieldDescriptor.ContainingMessage]) and may have no
+ // relationship with the parent. However, the full name of an extension field is
+ // relative to the parent that it is declared within.
+ //
+@@ -532,7 +532,7 @@ type ExtensionType interface {
+ // corresponds with the google.protobuf.EnumDescriptorProto message.
+ //
+ // Nested declarations:
+-// EnumValueDescriptor.
++// [EnumValueDescriptor].
+ type EnumDescriptor interface {
+ 	Descriptor
+ 
+@@ -548,7 +548,7 @@ type EnumDescriptor interface {
+ }
+ type isEnumDescriptor interface{ ProtoType(EnumDescriptor) }
+ 
+-// EnumType encapsulates an EnumDescriptor with a concrete Go implementation.
++// EnumType encapsulates an [EnumDescriptor] with a concrete Go implementation.
+ type EnumType interface {
+ 	// New returns an instance of this enum type with its value set to n.
+ 	New(n EnumNumber) Enum
+@@ -610,7 +610,7 @@ type EnumValueDescriptors interface {
+ // ServiceDescriptor describes a service and
+ // corresponds with the google.protobuf.ServiceDescriptorProto message.
+ //
+-// Nested declarations: MethodDescriptor.
++// Nested declarations: [MethodDescriptor].
+ type ServiceDescriptor interface {
+ 	Descriptor
+ 
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
+index 37601b7..a7b0d06 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
+@@ -27,16 +27,16 @@ type Enum interface {
+ // Message is a reflective interface for a concrete message value,
+ // encapsulating both type and value information for the message.
+ //
+-// Accessor/mutators for individual fields are keyed by FieldDescriptor.
++// Accessor/mutators for individual fields are keyed by [FieldDescriptor].
+ // For non-extension fields, the descriptor must exactly match the
+ // field known by the parent message.
+-// For extension fields, the descriptor must implement ExtensionTypeDescriptor,
+-// extend the parent message (i.e., have the same message FullName), and
++// For extension fields, the descriptor must implement [ExtensionTypeDescriptor],
++// extend the parent message (i.e., have the same message [FullName]), and
+ // be within the parent's extension range.
+ //
+-// Each field Value can be a scalar or a composite type (Message, List, or Map).
+-// See Value for the Go types associated with a FieldDescriptor.
+-// Providing a Value that is invalid or of an incorrect type panics.
++// Each field [Value] can be a scalar or a composite type ([Message], [List], or [Map]).
++// See [Value] for the Go types associated with a [FieldDescriptor].
++// Providing a [Value] that is invalid or of an incorrect type panics.
+ type Message interface {
+ 	// Descriptor returns message descriptor, which contains only the protobuf
+ 	// type information for the message.
+@@ -152,7 +152,7 @@ type Message interface {
+ 	// This method may return nil.
+ 	//
+ 	// The returned methods type is identical to
+-	// "google.golang.org/protobuf/runtime/protoiface".Methods.
++	// google.golang.org/protobuf/runtime/protoiface.Methods.
+ 	// Consult the protoiface package documentation for details.
+ 	ProtoMethods() *methods
+ }
+@@ -175,8 +175,8 @@ func (b RawFields) IsValid() bool {
+ }
+ 
+ // List is a zero-indexed, ordered list.
+-// The element Value type is determined by FieldDescriptor.Kind.
+-// Providing a Value that is invalid or of an incorrect type panics.
++// The element [Value] type is determined by [FieldDescriptor.Kind].
++// Providing a [Value] that is invalid or of an incorrect type panics.
+ type List interface {
+ 	// Len reports the number of entries in the List.
+ 	// Get, Set, and Truncate panic with out of bound indexes.
+@@ -226,9 +226,9 @@ type List interface {
+ }
+ 
+ // Map is an unordered, associative map.
+-// The entry MapKey type is determined by FieldDescriptor.MapKey.Kind.
+-// The entry Value type is determined by FieldDescriptor.MapValue.Kind.
+-// Providing a MapKey or Value that is invalid or of an incorrect type panics.
++// The entry [MapKey] type is determined by [FieldDescriptor.MapKey].Kind.
++// The entry [Value] type is determined by [FieldDescriptor.MapValue].Kind.
++// Providing a [MapKey] or [Value] that is invalid or of an incorrect type panics.
+ type Map interface {
+ 	// Len reports the number of elements in the map.
+ 	Len() int
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
+index 5916525..654599d 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
+@@ -24,19 +24,19 @@ import (
+ //     Unlike the == operator, a NaN is equal to another NaN.
+ //
+ //   - Enums are equal if they contain the same number.
+-//     Since Value does not contain an enum descriptor,
++//     Since [Value] does not contain an enum descriptor,
+ //     enum values do not consider the type of the enum.
+ //
+ //   - Other scalar values are equal if they contain the same value.
+ //
+-//   - Message values are equal if they belong to the same message descriptor,
++//   - [Message] values are equal if they belong to the same message descriptor,
+ //     have the same set of populated known and extension field values,
+ //     and the same set of unknown fields values.
+ //
+-//   - Lists are equal if they are the same length and
++//   - [List] values are equal if they are the same length and
+ //     each corresponding element is equal.
+ //
+-//   - Maps are equal if they have the same set of keys and
++//   - [Map] values are equal if they have the same set of keys and
+ //     the corresponding value for each key is equal.
+ func (v1 Value) Equal(v2 Value) bool {
+ 	return equalValue(v1, v2)
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
+index 08e5ef7..1603097 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
+@@ -11,7 +11,7 @@ import (
+ 
+ // Value is a union where only one Go type may be set at a time.
+ // The Value is used to represent all possible values a field may take.
+-// The following shows which Go type is used to represent each proto Kind:
++// The following shows which Go type is used to represent each proto [Kind]:
+ //
+ //	╔════════════╤═════════════════════════════════════╗
+ //	║ Go type    │ Protobuf kind                       ║
+@@ -31,22 +31,22 @@ import (
+ //
+ // Multiple protobuf Kinds may be represented by a single Go type if the type
+ // can losslessly represent the information for the proto kind. For example,
+-// Int64Kind, Sint64Kind, and Sfixed64Kind are all represented by int64,
++// [Int64Kind], [Sint64Kind], and [Sfixed64Kind] are all represented by int64,
+ // but use different integer encoding methods.
+ //
+-// The List or Map types are used if the field cardinality is repeated.
+-// A field is a List if FieldDescriptor.IsList reports true.
+-// A field is a Map if FieldDescriptor.IsMap reports true.
++// The [List] or [Map] types are used if the field cardinality is repeated.
++// A field is a [List] if [FieldDescriptor.IsList] reports true.
++// A field is a [Map] if [FieldDescriptor.IsMap] reports true.
+ //
+ // Converting to/from a Value and a concrete Go value panics on type mismatch.
+-// For example, ValueOf("hello").Int() panics because this attempts to
++// For example, [ValueOf]("hello").Int() panics because this attempts to
+ // retrieve an int64 from a string.
+ //
+-// List, Map, and Message Values are called "composite" values.
++// [List], [Map], and [Message] Values are called "composite" values.
+ //
+ // A composite Value may alias (reference) memory at some location,
+ // such that changes to the Value updates the that location.
+-// A composite value acquired with a Mutable method, such as Message.Mutable,
++// A composite value acquired with a Mutable method, such as [Message.Mutable],
+ // always references the source object.
+ //
+ // For example:
+@@ -65,7 +65,7 @@ import (
+ //	// appending to the List here may or may not modify the message.
+ //	list.Append(protoreflect.ValueOfInt32(0))
+ //
+-// Some operations, such as Message.Get, may return an "empty, read-only"
++// Some operations, such as [Message.Get], may return an "empty, read-only"
+ // composite Value. Modifying an empty, read-only value panics.
+ type Value value
+ 
+@@ -306,7 +306,7 @@ func (v Value) Float() float64 {
+ 	}
+ }
+ 
+-// String returns v as a string. Since this method implements fmt.Stringer,
++// String returns v as a string. Since this method implements [fmt.Stringer],
+ // this returns the formatted string value for any non-string type.
+ func (v Value) String() string {
+ 	switch v.typ {
+@@ -327,7 +327,7 @@ func (v Value) Bytes() []byte {
+ 	}
+ }
+ 
+-// Enum returns v as a EnumNumber and panics if the type is not a EnumNumber.
++// Enum returns v as a [EnumNumber] and panics if the type is not a [EnumNumber].
+ func (v Value) Enum() EnumNumber {
+ 	switch v.typ {
+ 	case enumType:
+@@ -337,7 +337,7 @@ func (v Value) Enum() EnumNumber {
+ 	}
+ }
+ 
+-// Message returns v as a Message and panics if the type is not a Message.
++// Message returns v as a [Message] and panics if the type is not a [Message].
+ func (v Value) Message() Message {
+ 	switch vi := v.getIface().(type) {
+ 	case Message:
+@@ -347,7 +347,7 @@ func (v Value) Message() Message {
+ 	}
+ }
+ 
+-// List returns v as a List and panics if the type is not a List.
++// List returns v as a [List] and panics if the type is not a [List].
+ func (v Value) List() List {
+ 	switch vi := v.getIface().(type) {
+ 	case List:
+@@ -357,7 +357,7 @@ func (v Value) List() List {
+ 	}
+ }
+ 
+-// Map returns v as a Map and panics if the type is not a Map.
++// Map returns v as a [Map] and panics if the type is not a [Map].
+ func (v Value) Map() Map {
+ 	switch vi := v.getIface().(type) {
+ 	case Map:
+@@ -367,7 +367,7 @@ func (v Value) Map() Map {
+ 	}
+ }
+ 
+-// MapKey returns v as a MapKey and panics for invalid MapKey types.
++// MapKey returns v as a [MapKey] and panics for invalid [MapKey] types.
+ func (v Value) MapKey() MapKey {
+ 	switch v.typ {
+ 	case boolType, int32Type, int64Type, uint32Type, uint64Type, stringType:
+@@ -378,8 +378,8 @@ func (v Value) MapKey() MapKey {
+ }
+ 
+ // MapKey is used to index maps, where the Go type of the MapKey must match
+-// the specified key Kind (see MessageDescriptor.IsMapEntry).
+-// The following shows what Go type is used to represent each proto Kind:
++// the specified key [Kind] (see [MessageDescriptor.IsMapEntry]).
++// The following shows what Go type is used to represent each proto [Kind]:
+ //
+ //	╔═════════╤═════════════════════════════════════╗
+ //	║ Go type │ Protobuf kind                       ║
+@@ -392,13 +392,13 @@ func (v Value) MapKey() MapKey {
+ //	║ string  │ StringKind                          ║
+ //	╚═════════╧═════════════════════════════════════╝
+ //
+-// A MapKey is constructed and accessed through a Value:
++// A MapKey is constructed and accessed through a [Value]:
+ //
+ //	k := ValueOf("hash").MapKey() // convert string to MapKey
+ //	s := k.String()               // convert MapKey to string
+ //
+-// The MapKey is a strict subset of valid types used in Value;
+-// converting a Value to a MapKey with an invalid type panics.
++// The MapKey is a strict subset of valid types used in [Value];
++// converting a [Value] to a MapKey with an invalid type panics.
+ type MapKey value
+ 
+ // IsValid reports whether k is populated with a value.
+@@ -426,13 +426,13 @@ func (k MapKey) Uint() uint64 {
+ 	return Value(k).Uint()
+ }
+ 
+-// String returns k as a string. Since this method implements fmt.Stringer,
++// String returns k as a string. Since this method implements [fmt.Stringer],
+ // this returns the formatted string value for any non-string type.
+ func (k MapKey) String() string {
+ 	return Value(k).String()
+ }
+ 
+-// Value returns k as a Value.
++// Value returns k as a [Value].
+ func (k MapKey) Value() Value {
+ 	return Value(k)
+ }
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+similarity index 97%
+rename from vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
+rename to vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+index 702ddf2..b1fdbe3 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !purego && !appengine
+-// +build !purego,!appengine
++//go:build !purego && !appengine && !go1.21
++// +build !purego,!appengine,!go1.21
+ 
+ package protoreflect
+ 
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+new file mode 100644
+index 0000000..4354701
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+@@ -0,0 +1,87 @@
++// Copyright 2018 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !purego && !appengine && go1.21
++// +build !purego,!appengine,go1.21
++
++package protoreflect
++
++import (
++	"unsafe"
++
++	"google.golang.org/protobuf/internal/pragma"
++)
++
++type (
++	ifaceHeader struct {
++		_    [0]interface{} // if interfaces have greater alignment than unsafe.Pointer, this will enforce it.
++		Type unsafe.Pointer
++		Data unsafe.Pointer
++	}
++)
++
++var (
++	nilType     = typeOf(nil)
++	boolType    = typeOf(*new(bool))
++	int32Type   = typeOf(*new(int32))
++	int64Type   = typeOf(*new(int64))
++	uint32Type  = typeOf(*new(uint32))
++	uint64Type  = typeOf(*new(uint64))
++	float32Type = typeOf(*new(float32))
++	float64Type = typeOf(*new(float64))
++	stringType  = typeOf(*new(string))
++	bytesType   = typeOf(*new([]byte))
++	enumType    = typeOf(*new(EnumNumber))
++)
++
++// typeOf returns a pointer to the Go type information.
++// The pointer is comparable and equal if and only if the types are identical.
++func typeOf(t interface{}) unsafe.Pointer {
++	return (*ifaceHeader)(unsafe.Pointer(&t)).Type
++}
++
++// value is a union where only one type can be represented at a time.
++// The struct is 24B large on 64-bit systems and requires the minimum storage
++// necessary to represent each possible type.
++//
++// The Go GC needs to be able to scan variables containing pointers.
++// As such, pointers and non-pointers cannot be intermixed.
++type value struct {
++	pragma.DoNotCompare // 0B
++
++	// typ stores the type of the value as a pointer to the Go type.
++	typ unsafe.Pointer // 8B
++
++	// ptr stores the data pointer for a String, Bytes, or interface value.
++	ptr unsafe.Pointer // 8B
++
++	// num stores a Bool, Int32, Int64, Uint32, Uint64, Float32, Float64, or
++	// Enum value as a raw uint64.
++	//
++	// It is also used to store the length of a String or Bytes value;
++	// the capacity is ignored.
++	num uint64 // 8B
++}
++
++func valueOfString(v string) Value {
++	return Value{typ: stringType, ptr: unsafe.Pointer(unsafe.StringData(v)), num: uint64(len(v))}
++}
++func valueOfBytes(v []byte) Value {
++	return Value{typ: bytesType, ptr: unsafe.Pointer(unsafe.SliceData(v)), num: uint64(len(v))}
++}
++func valueOfIface(v interface{}) Value {
++	p := (*ifaceHeader)(unsafe.Pointer(&v))
++	return Value{typ: p.Type, ptr: p.Data}
++}
++
++func (v Value) getString() string {
++	return unsafe.String((*byte)(v.ptr), v.num)
++}
++func (v Value) getBytes() []byte {
++	return unsafe.Slice((*byte)(v.ptr), v.num)
++}
++func (v Value) getIface() (x interface{}) {
++	*(*ifaceHeader)(unsafe.Pointer(&x)) = ifaceHeader{Type: v.typ, Data: v.ptr}
++	return x
++}
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go b/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
+index aeb5597..6267dc5 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
+@@ -5,12 +5,12 @@
+ // Package protoregistry provides data structures to register and lookup
+ // protobuf descriptor types.
+ //
+-// The Files registry contains file descriptors and provides the ability
++// The [Files] registry contains file descriptors and provides the ability
+ // to iterate over the files or lookup a specific descriptor within the files.
+-// Files only contains protobuf descriptors and has no understanding of Go
++// [Files] only contains protobuf descriptors and has no understanding of Go
+ // type information that may be associated with each descriptor.
+ //
+-// The Types registry contains descriptor types for which there is a known
++// The [Types] registry contains descriptor types for which there is a known
+ // Go type associated with that descriptor. It provides the ability to iterate
+ // over the registered types or lookup a type by name.
+ package protoregistry
+@@ -218,7 +218,7 @@ func (r *Files) checkGenProtoConflict(path string) {
+ 
+ // FindDescriptorByName looks up a descriptor by the full name.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Files) FindDescriptorByName(name protoreflect.FullName) (protoreflect.Descriptor, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -310,7 +310,7 @@ func (s *nameSuffix) Pop() (name protoreflect.Name) {
+ 
+ // FindFileByPath looks up a file by the path.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ // This returns an error if multiple files have the same path.
+ func (r *Files) FindFileByPath(path string) (protoreflect.FileDescriptor, error) {
+ 	if r == nil {
+@@ -431,7 +431,7 @@ func rangeTopLevelDescriptors(fd protoreflect.FileDescriptor, f func(protoreflec
+ // A compliant implementation must deterministically return the same type
+ // if no error is encountered.
+ //
+-// The Types type implements this interface.
++// The [Types] type implements this interface.
+ type MessageTypeResolver interface {
+ 	// FindMessageByName looks up a message by its full name.
+ 	// E.g., "google.protobuf.Any"
+@@ -451,7 +451,7 @@ type MessageTypeResolver interface {
+ // A compliant implementation must deterministically return the same type
+ // if no error is encountered.
+ //
+-// The Types type implements this interface.
++// The [Types] type implements this interface.
+ type ExtensionTypeResolver interface {
+ 	// FindExtensionByName looks up a extension field by the field's full name.
+ 	// Note that this is the full name of the field as determined by
+@@ -590,7 +590,7 @@ func (r *Types) register(kind string, desc protoreflect.Descriptor, typ interfac
+ // FindEnumByName looks up an enum by its full name.
+ // E.g., "google.protobuf.Field.Kind".
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -611,7 +611,7 @@ func (r *Types) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumTyp
+ // FindMessageByName looks up a message by its full name,
+ // e.g. "google.protobuf.Any".
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -632,7 +632,7 @@ func (r *Types) FindMessageByName(message protoreflect.FullName) (protoreflect.M
+ // FindMessageByURL looks up a message by a URL identifier.
+ // See documentation on google.protobuf.Any.type_url for the URL format.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+ 	// This function is similar to FindMessageByName but
+ 	// truncates anything before and including '/' in the URL.
+@@ -662,7 +662,7 @@ func (r *Types) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+ // where the extension is declared and is unrelated to the full name of the
+ // message being extended.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -703,7 +703,7 @@ func (r *Types) FindExtensionByName(field protoreflect.FullName) (protoreflect.E
+ // FindExtensionByNumber looks up a extension field by the field number
+ // within some parent message, identified by full name.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+diff --git a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+index 04c00f7..78624cf 100644
+--- a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
++++ b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+@@ -48,6 +48,103 @@ import (
+ 	sync "sync"
+ )
+ 
++// The full set of known editions.
++type Edition int32
++
++const (
++	// A placeholder for an unknown edition value.
++	Edition_EDITION_UNKNOWN Edition = 0
++	// Legacy syntax "editions".  These pre-date editions, but behave much like
++	// distinct editions.  These can't be used to specify the edition of proto
++	// files, but feature definitions must supply proto2/proto3 defaults for
++	// backwards compatibility.
++	Edition_EDITION_PROTO2 Edition = 998
++	Edition_EDITION_PROTO3 Edition = 999
++	// Editions that have been released.  The specific values are arbitrary and
++	// should not be depended on, but they will always be time-ordered for easy
++	// comparison.
++	Edition_EDITION_2023 Edition = 1000
++	Edition_EDITION_2024 Edition = 1001
++	// Placeholder editions for testing feature resolution.  These should not be
++	// used or relyed on outside of tests.
++	Edition_EDITION_1_TEST_ONLY     Edition = 1
++	Edition_EDITION_2_TEST_ONLY     Edition = 2
++	Edition_EDITION_99997_TEST_ONLY Edition = 99997
++	Edition_EDITION_99998_TEST_ONLY Edition = 99998
++	Edition_EDITION_99999_TEST_ONLY Edition = 99999
++	// Placeholder for specifying unbounded edition support.  This should only
++	// ever be used by plugins that can expect to never require any changes to
++	// support a new edition.
++	Edition_EDITION_MAX Edition = 2147483647
++)
++
++// Enum value maps for Edition.
++var (
++	Edition_name = map[int32]string{
++		0:          "EDITION_UNKNOWN",
++		998:        "EDITION_PROTO2",
++		999:        "EDITION_PROTO3",
++		1000:       "EDITION_2023",
++		1001:       "EDITION_2024",
++		1:          "EDITION_1_TEST_ONLY",
++		2:          "EDITION_2_TEST_ONLY",
++		99997:      "EDITION_99997_TEST_ONLY",
++		99998:      "EDITION_99998_TEST_ONLY",
++		99999:      "EDITION_99999_TEST_ONLY",
++		2147483647: "EDITION_MAX",
++	}
++	Edition_value = map[string]int32{
++		"EDITION_UNKNOWN":         0,
++		"EDITION_PROTO2":          998,
++		"EDITION_PROTO3":          999,
++		"EDITION_2023":            1000,
++		"EDITION_2024":            1001,
++		"EDITION_1_TEST_ONLY":     1,
++		"EDITION_2_TEST_ONLY":     2,
++		"EDITION_99997_TEST_ONLY": 99997,
++		"EDITION_99998_TEST_ONLY": 99998,
++		"EDITION_99999_TEST_ONLY": 99999,
++		"EDITION_MAX":             2147483647,
++	}
++)
++
++func (x Edition) Enum() *Edition {
++	p := new(Edition)
++	*p = x
++	return p
++}
++
++func (x Edition) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (Edition) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[0].Descriptor()
++}
++
++func (Edition) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[0]
++}
++
++func (x Edition) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *Edition) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = Edition(num)
++	return nil
++}
++
++// Deprecated: Use Edition.Descriptor instead.
++func (Edition) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{0}
++}
++
+ // The verification state of the extension range.
+ type ExtensionRangeOptions_VerificationState int32
+ 
+@@ -80,11 +177,11 @@ func (x ExtensionRangeOptions_VerificationState) String() string {
+ }
+ 
+ func (ExtensionRangeOptions_VerificationState) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[0].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[1].Descriptor()
+ }
+ 
+ func (ExtensionRangeOptions_VerificationState) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[0]
++	return &file_google_protobuf_descriptor_proto_enumTypes[1]
+ }
+ 
+ func (x ExtensionRangeOptions_VerificationState) Number() protoreflect.EnumNumber {
+@@ -125,9 +222,10 @@ const (
+ 	FieldDescriptorProto_TYPE_BOOL    FieldDescriptorProto_Type = 8
+ 	FieldDescriptorProto_TYPE_STRING  FieldDescriptorProto_Type = 9
+ 	// Tag-delimited aggregate.
+-	// Group type is deprecated and not supported in proto3. However, Proto3
++	// Group type is deprecated and not supported after google.protobuf. However, Proto3
+ 	// implementations should still be able to parse the group wire format and
+-	// treat group fields as unknown fields.
++	// treat group fields as unknown fields.  In Editions, the group wire format
++	// can be enabled via the `message_encoding` feature.
+ 	FieldDescriptorProto_TYPE_GROUP   FieldDescriptorProto_Type = 10
+ 	FieldDescriptorProto_TYPE_MESSAGE FieldDescriptorProto_Type = 11 // Length-delimited aggregate.
+ 	// New in version 2.
+@@ -195,11 +293,11 @@ func (x FieldDescriptorProto_Type) String() string {
+ }
+ 
+ func (FieldDescriptorProto_Type) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[1].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[2].Descriptor()
+ }
+ 
+ func (FieldDescriptorProto_Type) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[1]
++	return &file_google_protobuf_descriptor_proto_enumTypes[2]
+ }
+ 
+ func (x FieldDescriptorProto_Type) Number() protoreflect.EnumNumber {
+@@ -226,21 +324,24 @@ type FieldDescriptorProto_Label int32
+ const (
+ 	// 0 is reserved for errors
+ 	FieldDescriptorProto_LABEL_OPTIONAL FieldDescriptorProto_Label = 1
+-	FieldDescriptorProto_LABEL_REQUIRED FieldDescriptorProto_Label = 2
+ 	FieldDescriptorProto_LABEL_REPEATED FieldDescriptorProto_Label = 3
++	// The required label is only allowed in google.protobuf.  In proto3 and Editions
++	// it's explicitly prohibited.  In Editions, the `field_presence` feature
++	// can be used to get this behavior.
++	FieldDescriptorProto_LABEL_REQUIRED FieldDescriptorProto_Label = 2
+ )
+ 
+ // Enum value maps for FieldDescriptorProto_Label.
+ var (
+ 	FieldDescriptorProto_Label_name = map[int32]string{
+ 		1: "LABEL_OPTIONAL",
+-		2: "LABEL_REQUIRED",
+ 		3: "LABEL_REPEATED",
++		2: "LABEL_REQUIRED",
+ 	}
+ 	FieldDescriptorProto_Label_value = map[string]int32{
+ 		"LABEL_OPTIONAL": 1,
+-		"LABEL_REQUIRED": 2,
+ 		"LABEL_REPEATED": 3,
++		"LABEL_REQUIRED": 2,
+ 	}
+ )
+ 
+@@ -255,11 +356,11 @@ func (x FieldDescriptorProto_Label) String() string {
+ }
+ 
+ func (FieldDescriptorProto_Label) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[2].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[3].Descriptor()
+ }
+ 
+ func (FieldDescriptorProto_Label) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[2]
++	return &file_google_protobuf_descriptor_proto_enumTypes[3]
+ }
+ 
+ func (x FieldDescriptorProto_Label) Number() protoreflect.EnumNumber {
+@@ -316,11 +417,11 @@ func (x FileOptions_OptimizeMode) String() string {
+ }
+ 
+ func (FileOptions_OptimizeMode) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[3].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[4].Descriptor()
+ }
+ 
+ func (FileOptions_OptimizeMode) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[3]
++	return &file_google_protobuf_descriptor_proto_enumTypes[4]
+ }
+ 
+ func (x FileOptions_OptimizeMode) Number() protoreflect.EnumNumber {
+@@ -382,11 +483,11 @@ func (x FieldOptions_CType) String() string {
+ }
+ 
+ func (FieldOptions_CType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[4].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[5].Descriptor()
+ }
+ 
+ func (FieldOptions_CType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[4]
++	return &file_google_protobuf_descriptor_proto_enumTypes[5]
+ }
+ 
+ func (x FieldOptions_CType) Number() protoreflect.EnumNumber {
+@@ -444,11 +545,11 @@ func (x FieldOptions_JSType) String() string {
+ }
+ 
+ func (FieldOptions_JSType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[5].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[6].Descriptor()
+ }
+ 
+ func (FieldOptions_JSType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[5]
++	return &file_google_protobuf_descriptor_proto_enumTypes[6]
+ }
+ 
+ func (x FieldOptions_JSType) Number() protoreflect.EnumNumber {
+@@ -506,11 +607,11 @@ func (x FieldOptions_OptionRetention) String() string {
+ }
+ 
+ func (FieldOptions_OptionRetention) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[6].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[7].Descriptor()
+ }
+ 
+ func (FieldOptions_OptionRetention) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[6]
++	return &file_google_protobuf_descriptor_proto_enumTypes[7]
+ }
+ 
+ func (x FieldOptions_OptionRetention) Number() protoreflect.EnumNumber {
+@@ -590,11 +691,11 @@ func (x FieldOptions_OptionTargetType) String() string {
+ }
+ 
+ func (FieldOptions_OptionTargetType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[7].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[8].Descriptor()
+ }
+ 
+ func (FieldOptions_OptionTargetType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[7]
++	return &file_google_protobuf_descriptor_proto_enumTypes[8]
+ }
+ 
+ func (x FieldOptions_OptionTargetType) Number() protoreflect.EnumNumber {
+@@ -652,11 +753,11 @@ func (x MethodOptions_IdempotencyLevel) String() string {
+ }
+ 
+ func (MethodOptions_IdempotencyLevel) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[8].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[9].Descriptor()
+ }
+ 
+ func (MethodOptions_IdempotencyLevel) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[8]
++	return &file_google_protobuf_descriptor_proto_enumTypes[9]
+ }
+ 
+ func (x MethodOptions_IdempotencyLevel) Number() protoreflect.EnumNumber {
+@@ -678,6 +779,363 @@ func (MethodOptions_IdempotencyLevel) EnumDescriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{17, 0}
+ }
+ 
++type FeatureSet_FieldPresence int32
++
++const (
++	FeatureSet_FIELD_PRESENCE_UNKNOWN FeatureSet_FieldPresence = 0
++	FeatureSet_EXPLICIT               FeatureSet_FieldPresence = 1
++	FeatureSet_IMPLICIT               FeatureSet_FieldPresence = 2
++	FeatureSet_LEGACY_REQUIRED        FeatureSet_FieldPresence = 3
++)
++
++// Enum value maps for FeatureSet_FieldPresence.
++var (
++	FeatureSet_FieldPresence_name = map[int32]string{
++		0: "FIELD_PRESENCE_UNKNOWN",
++		1: "EXPLICIT",
++		2: "IMPLICIT",
++		3: "LEGACY_REQUIRED",
++	}
++	FeatureSet_FieldPresence_value = map[string]int32{
++		"FIELD_PRESENCE_UNKNOWN": 0,
++		"EXPLICIT":               1,
++		"IMPLICIT":               2,
++		"LEGACY_REQUIRED":        3,
++	}
++)
++
++func (x FeatureSet_FieldPresence) Enum() *FeatureSet_FieldPresence {
++	p := new(FeatureSet_FieldPresence)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_FieldPresence) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_FieldPresence) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[10].Descriptor()
++}
++
++func (FeatureSet_FieldPresence) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[10]
++}
++
++func (x FeatureSet_FieldPresence) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_FieldPresence) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_FieldPresence(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_FieldPresence.Descriptor instead.
++func (FeatureSet_FieldPresence) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 0}
++}
++
++type FeatureSet_EnumType int32
++
++const (
++	FeatureSet_ENUM_TYPE_UNKNOWN FeatureSet_EnumType = 0
++	FeatureSet_OPEN              FeatureSet_EnumType = 1
++	FeatureSet_CLOSED            FeatureSet_EnumType = 2
++)
++
++// Enum value maps for FeatureSet_EnumType.
++var (
++	FeatureSet_EnumType_name = map[int32]string{
++		0: "ENUM_TYPE_UNKNOWN",
++		1: "OPEN",
++		2: "CLOSED",
++	}
++	FeatureSet_EnumType_value = map[string]int32{
++		"ENUM_TYPE_UNKNOWN": 0,
++		"OPEN":              1,
++		"CLOSED":            2,
++	}
++)
++
++func (x FeatureSet_EnumType) Enum() *FeatureSet_EnumType {
++	p := new(FeatureSet_EnumType)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_EnumType) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_EnumType) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[11].Descriptor()
++}
++
++func (FeatureSet_EnumType) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[11]
++}
++
++func (x FeatureSet_EnumType) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_EnumType) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_EnumType(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_EnumType.Descriptor instead.
++func (FeatureSet_EnumType) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 1}
++}
++
++type FeatureSet_RepeatedFieldEncoding int32
++
++const (
++	FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN FeatureSet_RepeatedFieldEncoding = 0
++	FeatureSet_PACKED                          FeatureSet_RepeatedFieldEncoding = 1
++	FeatureSet_EXPANDED                        FeatureSet_RepeatedFieldEncoding = 2
++)
++
++// Enum value maps for FeatureSet_RepeatedFieldEncoding.
++var (
++	FeatureSet_RepeatedFieldEncoding_name = map[int32]string{
++		0: "REPEATED_FIELD_ENCODING_UNKNOWN",
++		1: "PACKED",
++		2: "EXPANDED",
++	}
++	FeatureSet_RepeatedFieldEncoding_value = map[string]int32{
++		"REPEATED_FIELD_ENCODING_UNKNOWN": 0,
++		"PACKED":                          1,
++		"EXPANDED":                        2,
++	}
++)
++
++func (x FeatureSet_RepeatedFieldEncoding) Enum() *FeatureSet_RepeatedFieldEncoding {
++	p := new(FeatureSet_RepeatedFieldEncoding)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_RepeatedFieldEncoding) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_RepeatedFieldEncoding) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[12].Descriptor()
++}
++
++func (FeatureSet_RepeatedFieldEncoding) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[12]
++}
++
++func (x FeatureSet_RepeatedFieldEncoding) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_RepeatedFieldEncoding) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_RepeatedFieldEncoding(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_RepeatedFieldEncoding.Descriptor instead.
++func (FeatureSet_RepeatedFieldEncoding) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 2}
++}
++
++type FeatureSet_Utf8Validation int32
++
++const (
++	FeatureSet_UTF8_VALIDATION_UNKNOWN FeatureSet_Utf8Validation = 0
++	FeatureSet_VERIFY                  FeatureSet_Utf8Validation = 2
++	FeatureSet_NONE                    FeatureSet_Utf8Validation = 3
++)
++
++// Enum value maps for FeatureSet_Utf8Validation.
++var (
++	FeatureSet_Utf8Validation_name = map[int32]string{
++		0: "UTF8_VALIDATION_UNKNOWN",
++		2: "VERIFY",
++		3: "NONE",
++	}
++	FeatureSet_Utf8Validation_value = map[string]int32{
++		"UTF8_VALIDATION_UNKNOWN": 0,
++		"VERIFY":                  2,
++		"NONE":                    3,
++	}
++)
++
++func (x FeatureSet_Utf8Validation) Enum() *FeatureSet_Utf8Validation {
++	p := new(FeatureSet_Utf8Validation)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_Utf8Validation) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_Utf8Validation) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[13].Descriptor()
++}
++
++func (FeatureSet_Utf8Validation) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[13]
++}
++
++func (x FeatureSet_Utf8Validation) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_Utf8Validation) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_Utf8Validation(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_Utf8Validation.Descriptor instead.
++func (FeatureSet_Utf8Validation) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 3}
++}
++
++type FeatureSet_MessageEncoding int32
++
++const (
++	FeatureSet_MESSAGE_ENCODING_UNKNOWN FeatureSet_MessageEncoding = 0
++	FeatureSet_LENGTH_PREFIXED          FeatureSet_MessageEncoding = 1
++	FeatureSet_DELIMITED                FeatureSet_MessageEncoding = 2
++)
++
++// Enum value maps for FeatureSet_MessageEncoding.
++var (
++	FeatureSet_MessageEncoding_name = map[int32]string{
++		0: "MESSAGE_ENCODING_UNKNOWN",
++		1: "LENGTH_PREFIXED",
++		2: "DELIMITED",
++	}
++	FeatureSet_MessageEncoding_value = map[string]int32{
++		"MESSAGE_ENCODING_UNKNOWN": 0,
++		"LENGTH_PREFIXED":          1,
++		"DELIMITED":                2,
++	}
++)
++
++func (x FeatureSet_MessageEncoding) Enum() *FeatureSet_MessageEncoding {
++	p := new(FeatureSet_MessageEncoding)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_MessageEncoding) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_MessageEncoding) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[14].Descriptor()
++}
++
++func (FeatureSet_MessageEncoding) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[14]
++}
++
++func (x FeatureSet_MessageEncoding) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_MessageEncoding) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_MessageEncoding(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_MessageEncoding.Descriptor instead.
++func (FeatureSet_MessageEncoding) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 4}
++}
++
++type FeatureSet_JsonFormat int32
++
++const (
++	FeatureSet_JSON_FORMAT_UNKNOWN FeatureSet_JsonFormat = 0
++	FeatureSet_ALLOW               FeatureSet_JsonFormat = 1
++	FeatureSet_LEGACY_BEST_EFFORT  FeatureSet_JsonFormat = 2
++)
++
++// Enum value maps for FeatureSet_JsonFormat.
++var (
++	FeatureSet_JsonFormat_name = map[int32]string{
++		0: "JSON_FORMAT_UNKNOWN",
++		1: "ALLOW",
++		2: "LEGACY_BEST_EFFORT",
++	}
++	FeatureSet_JsonFormat_value = map[string]int32{
++		"JSON_FORMAT_UNKNOWN": 0,
++		"ALLOW":               1,
++		"LEGACY_BEST_EFFORT":  2,
++	}
++)
++
++func (x FeatureSet_JsonFormat) Enum() *FeatureSet_JsonFormat {
++	p := new(FeatureSet_JsonFormat)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_JsonFormat) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_JsonFormat) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[15].Descriptor()
++}
++
++func (FeatureSet_JsonFormat) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[15]
++}
++
++func (x FeatureSet_JsonFormat) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_JsonFormat) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_JsonFormat(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_JsonFormat.Descriptor instead.
++func (FeatureSet_JsonFormat) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 5}
++}
++
+ // Represents the identified object's effect on the element in the original
+ // .proto file.
+ type GeneratedCodeInfo_Annotation_Semantic int32
+@@ -716,11 +1174,11 @@ func (x GeneratedCodeInfo_Annotation_Semantic) String() string {
+ }
+ 
+ func (GeneratedCodeInfo_Annotation_Semantic) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[9].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[16].Descriptor()
+ }
+ 
+ func (GeneratedCodeInfo_Annotation_Semantic) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[9]
++	return &file_google_protobuf_descriptor_proto_enumTypes[16]
+ }
+ 
+ func (x GeneratedCodeInfo_Annotation_Semantic) Number() protoreflect.EnumNumber {
+@@ -739,7 +1197,7 @@ func (x *GeneratedCodeInfo_Annotation_Semantic) UnmarshalJSON(b []byte) error {
+ 
+ // Deprecated: Use GeneratedCodeInfo_Annotation_Semantic.Descriptor instead.
+ func (GeneratedCodeInfo_Annotation_Semantic) EnumDescriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22, 0, 0}
+ }
+ 
+ // The protocol compiler can output a FileDescriptorSet containing the .proto
+@@ -822,8 +1280,8 @@ type FileDescriptorProto struct {
+ 	//
+ 	// If `edition` is present, this value must be "editions".
+ 	Syntax *string `protobuf:"bytes,12,opt,name=syntax" json:"syntax,omitempty"`
+-	// The edition of the proto file, which is an opaque string.
+-	Edition *string `protobuf:"bytes,13,opt,name=edition" json:"edition,omitempty"`
++	// The edition of the proto file.
++	Edition *Edition `protobuf:"varint,14,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
+ }
+ 
+ func (x *FileDescriptorProto) Reset() {
+@@ -942,11 +1400,11 @@ func (x *FileDescriptorProto) GetSyntax() string {
+ 	return ""
+ }
+ 
+-func (x *FileDescriptorProto) GetEdition() string {
++func (x *FileDescriptorProto) GetEdition() Edition {
+ 	if x != nil && x.Edition != nil {
+ 		return *x.Edition
+ 	}
+-	return ""
++	return Edition_EDITION_UNKNOWN
+ }
+ 
+ // Describes a message type.
+@@ -1079,13 +1537,14 @@ type ExtensionRangeOptions struct {
+ 
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+-	// go/protobuf-stripping-extension-declarations
+-	// Like Metadata, but we use a repeated field to hold all extension
+-	// declarations. This should avoid the size increases of transforming a large
+-	// extension range into small ranges in generated binaries.
++	// For external users: DO NOT USE. We are in the process of open sourcing
++	// extension declaration and executing internal cleanups before it can be
++	// used externally.
+ 	Declaration []*ExtensionRangeOptions_Declaration `protobuf:"bytes,2,rep,name=declaration" json:"declaration,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,50,opt,name=features" json:"features,omitempty"`
+ 	// The verification state of the range.
+-	// TODO(b/278783756): flip the default to DECLARATION once all empty ranges
++	// TODO: flip the default to DECLARATION once all empty ranges
+ 	// are marked as UNVERIFIED.
+ 	Verification *ExtensionRangeOptions_VerificationState `protobuf:"varint,3,opt,name=verification,enum=google.protobuf.ExtensionRangeOptions_VerificationState,def=1" json:"verification,omitempty"`
+ }
+@@ -1141,6 +1600,13 @@ func (x *ExtensionRangeOptions) GetDeclaration() []*ExtensionRangeOptions_Declar
+ 	return nil
+ }
+ 
++func (x *ExtensionRangeOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *ExtensionRangeOptions) GetVerification() ExtensionRangeOptions_VerificationState {
+ 	if x != nil && x.Verification != nil {
+ 		return *x.Verification
+@@ -1186,12 +1652,12 @@ type FieldDescriptorProto struct {
+ 	// If true, this is a proto3 "optional". When a proto3 field is optional, it
+ 	// tracks presence regardless of field type.
+ 	//
+-	// When proto3_optional is true, this field must be belong to a oneof to
+-	// signal to old proto3 clients that presence is tracked for this field. This
+-	// oneof is known as a "synthetic" oneof, and this field must be its sole
+-	// member (each proto3 optional field gets its own synthetic oneof). Synthetic
+-	// oneofs exist in the descriptor only, and do not generate any API. Synthetic
+-	// oneofs must be ordered after all "real" oneofs.
++	// When proto3_optional is true, this field must belong to a oneof to signal
++	// to old proto3 clients that presence is tracked for this field. This oneof
++	// is known as a "synthetic" oneof, and this field must be its sole member
++	// (each proto3 optional field gets its own synthetic oneof). Synthetic oneofs
++	// exist in the descriptor only, and do not generate any API. Synthetic oneofs
++	// must be ordered after all "real" oneofs.
+ 	//
+ 	// For message fields, proto3_optional doesn't create any semantic change,
+ 	// since non-repeated message fields always track presence. However it still
+@@ -1738,7 +2204,6 @@ type FileOptions struct {
+ 	CcGenericServices   *bool `protobuf:"varint,16,opt,name=cc_generic_services,json=ccGenericServices,def=0" json:"cc_generic_services,omitempty"`
+ 	JavaGenericServices *bool `protobuf:"varint,17,opt,name=java_generic_services,json=javaGenericServices,def=0" json:"java_generic_services,omitempty"`
+ 	PyGenericServices   *bool `protobuf:"varint,18,opt,name=py_generic_services,json=pyGenericServices,def=0" json:"py_generic_services,omitempty"`
+-	PhpGenericServices  *bool `protobuf:"varint,42,opt,name=php_generic_services,json=phpGenericServices,def=0" json:"php_generic_services,omitempty"`
+ 	// Is this file deprecated?
+ 	// Depending on the target platform, this can emit Deprecated annotations
+ 	// for everything in the file, or it will be completely ignored; in the very
+@@ -1772,6 +2237,8 @@ type FileOptions struct {
+ 	// is empty. When this option is not set, the package name will be used for
+ 	// determining the ruby package.
+ 	RubyPackage *string `protobuf:"bytes,45,opt,name=ruby_package,json=rubyPackage" json:"ruby_package,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,50,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here.
+ 	// See the documentation for the "Options" section above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+@@ -1785,7 +2252,6 @@ const (
+ 	Default_FileOptions_CcGenericServices   = bool(false)
+ 	Default_FileOptions_JavaGenericServices = bool(false)
+ 	Default_FileOptions_PyGenericServices   = bool(false)
+-	Default_FileOptions_PhpGenericServices  = bool(false)
+ 	Default_FileOptions_Deprecated          = bool(false)
+ 	Default_FileOptions_CcEnableArenas      = bool(true)
+ )
+@@ -1893,13 +2359,6 @@ func (x *FileOptions) GetPyGenericServices() bool {
+ 	return Default_FileOptions_PyGenericServices
+ }
+ 
+-func (x *FileOptions) GetPhpGenericServices() bool {
+-	if x != nil && x.PhpGenericServices != nil {
+-		return *x.PhpGenericServices
+-	}
+-	return Default_FileOptions_PhpGenericServices
+-}
+-
+ func (x *FileOptions) GetDeprecated() bool {
+ 	if x != nil && x.Deprecated != nil {
+ 		return *x.Deprecated
+@@ -1963,6 +2422,13 @@ func (x *FileOptions) GetRubyPackage() string {
+ 	return ""
+ }
+ 
++func (x *FileOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *FileOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2006,10 +2472,6 @@ type MessageOptions struct {
+ 	// for the message, or it will be completely ignored; in the very least,
+ 	// this is a formalization for deprecating messages.
+ 	Deprecated *bool `protobuf:"varint,3,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
+-	// NOTE: Do not set the option in .proto files. Always use the maps syntax
+-	// instead. The option should only be implicitly set by the proto compiler
+-	// parser.
+-	//
+ 	// Whether the message is an automatically generated map entry type for the
+ 	// maps field.
+ 	//
+@@ -2030,6 +2492,10 @@ type MessageOptions struct {
+ 	// use a native map in the target language to hold the keys and values.
+ 	// The reflection APIs in such implementations still need to work as
+ 	// if the field is a repeated message field.
++	//
++	// NOTE: Do not set the option in .proto files. Always use the maps syntax
++	// instead. The option should only be implicitly set by the proto compiler
++	// parser.
+ 	MapEntry *bool `protobuf:"varint,7,opt,name=map_entry,json=mapEntry" json:"map_entry,omitempty"`
+ 	// Enable the legacy handling of JSON field name conflicts.  This lowercases
+ 	// and strips underscored from the fields before comparison in proto3 only.
+@@ -2039,11 +2505,13 @@ type MessageOptions struct {
+ 	// This should only be used as a temporary measure against broken builds due
+ 	// to the change in behavior for JSON field name conflicts.
+ 	//
+-	// TODO(b/261750190) This is legacy behavior we plan to remove once downstream
++	// TODO This is legacy behavior we plan to remove once downstream
+ 	// teams have had time to migrate.
+ 	//
+ 	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+ 	DeprecatedLegacyJsonFieldConflicts *bool `protobuf:"varint,11,opt,name=deprecated_legacy_json_field_conflicts,json=deprecatedLegacyJsonFieldConflicts" json:"deprecated_legacy_json_field_conflicts,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,12,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2123,6 +2591,13 @@ func (x *MessageOptions) GetDeprecatedLegacyJsonFieldConflicts() bool {
+ 	return false
+ }
+ 
++func (x *MessageOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *MessageOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2147,7 +2622,9 @@ type FieldOptions struct {
+ 	// a more efficient representation on the wire. Rather than repeatedly
+ 	// writing the tag and type for each element, the entire array is encoded as
+ 	// a single length-delimited blob. In proto3, only explicit setting it to
+-	// false will avoid using packed encoding.
++	// false will avoid using packed encoding.  This option is prohibited in
++	// Editions, but the `repeated_field_encoding` feature can be used to control
++	// the behavior.
+ 	Packed *bool `protobuf:"varint,2,opt,name=packed" json:"packed,omitempty"`
+ 	// The jstype option determines the JavaScript type used for values of the
+ 	// field.  The option is permitted only for 64 bit integral and fixed types
+@@ -2178,19 +2655,11 @@ type FieldOptions struct {
+ 	// call from multiple threads concurrently, while non-const methods continue
+ 	// to require exclusive access.
+ 	//
+-	// Note that implementations may choose not to check required fields within
+-	// a lazy sub-message.  That is, calling IsInitialized() on the outer message
+-	// may return true even if the inner message has missing required fields.
+-	// This is necessary because otherwise the inner message would have to be
+-	// parsed in order to perform the check, defeating the purpose of lazy
+-	// parsing.  An implementation which chooses not to check required fields
+-	// must be consistent about it.  That is, for any particular sub-message, the
+-	// implementation must either *always* check its required fields, or *never*
+-	// check its required fields, regardless of whether or not the message has
+-	// been parsed.
+-	//
+-	// As of May 2022, lazy verifies the contents of the byte stream during
+-	// parsing.  An invalid byte stream will cause the overall parsing to fail.
++	// Note that lazy message fields are still eagerly verified to check
++	// ill-formed wireformat or missing required fields. Calling IsInitialized()
++	// on the outer message would fail if the inner message has missing required
++	// fields. Failed verification would result in parsing failure (except when
++	// uninitialized messages are acceptable).
+ 	Lazy *bool `protobuf:"varint,5,opt,name=lazy,def=0" json:"lazy,omitempty"`
+ 	// unverified_lazy does no correctness checks on the byte stream. This should
+ 	// only be used where lazy with verification is prohibitive for performance
+@@ -2205,11 +2674,12 @@ type FieldOptions struct {
+ 	Weak *bool `protobuf:"varint,10,opt,name=weak,def=0" json:"weak,omitempty"`
+ 	// Indicate that the field value should not be printed out when using debug
+ 	// formats, e.g. when the field contains sensitive credentials.
+-	DebugRedact *bool                         `protobuf:"varint,16,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
+-	Retention   *FieldOptions_OptionRetention `protobuf:"varint,17,opt,name=retention,enum=google.protobuf.FieldOptions_OptionRetention" json:"retention,omitempty"`
+-	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-	Target  *FieldOptions_OptionTargetType  `protobuf:"varint,18,opt,name=target,enum=google.protobuf.FieldOptions_OptionTargetType" json:"target,omitempty"`
+-	Targets []FieldOptions_OptionTargetType `protobuf:"varint,19,rep,name=targets,enum=google.protobuf.FieldOptions_OptionTargetType" json:"targets,omitempty"`
++	DebugRedact     *bool                           `protobuf:"varint,16,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
++	Retention       *FieldOptions_OptionRetention   `protobuf:"varint,17,opt,name=retention,enum=google.protobuf.FieldOptions_OptionRetention" json:"retention,omitempty"`
++	Targets         []FieldOptions_OptionTargetType `protobuf:"varint,19,rep,name=targets,enum=google.protobuf.FieldOptions_OptionTargetType" json:"targets,omitempty"`
++	EditionDefaults []*FieldOptions_EditionDefault  `protobuf:"bytes,20,rep,name=edition_defaults,json=editionDefaults" json:"edition_defaults,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,21,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2320,17 +2790,23 @@ func (x *FieldOptions) GetRetention() FieldOptions_OptionRetention {
+ 	return FieldOptions_RETENTION_UNKNOWN
+ }
+ 
+-// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-func (x *FieldOptions) GetTarget() FieldOptions_OptionTargetType {
+-	if x != nil && x.Target != nil {
+-		return *x.Target
++func (x *FieldOptions) GetTargets() []FieldOptions_OptionTargetType {
++	if x != nil {
++		return x.Targets
+ 	}
+-	return FieldOptions_TARGET_TYPE_UNKNOWN
++	return nil
+ }
+ 
+-func (x *FieldOptions) GetTargets() []FieldOptions_OptionTargetType {
++func (x *FieldOptions) GetEditionDefaults() []*FieldOptions_EditionDefault {
+ 	if x != nil {
+-		return x.Targets
++		return x.EditionDefaults
++	}
++	return nil
++}
++
++func (x *FieldOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
+ 	}
+ 	return nil
+ }
+@@ -2348,6 +2824,8 @@ type OneofOptions struct {
+ 	unknownFields   protoimpl.UnknownFields
+ 	extensionFields protoimpl.ExtensionFields
+ 
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,1,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2384,6 +2862,13 @@ func (*OneofOptions) Descriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{13}
+ }
+ 
++func (x *OneofOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *OneofOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2409,11 +2894,13 @@ type EnumOptions struct {
+ 	// and strips underscored from the fields before comparison in proto3 only.
+ 	// The new behavior takes `json_name` into account and applies to proto2 as
+ 	// well.
+-	// TODO(b/261750190) Remove this legacy behavior once downstream teams have
++	// TODO Remove this legacy behavior once downstream teams have
+ 	// had time to migrate.
+ 	//
+ 	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+ 	DeprecatedLegacyJsonFieldConflicts *bool `protobuf:"varint,6,opt,name=deprecated_legacy_json_field_conflicts,json=deprecatedLegacyJsonFieldConflicts" json:"deprecated_legacy_json_field_conflicts,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,7,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2477,6 +2964,13 @@ func (x *EnumOptions) GetDeprecatedLegacyJsonFieldConflicts() bool {
+ 	return false
+ }
+ 
++func (x *EnumOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *EnumOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2495,13 +2989,20 @@ type EnumValueOptions struct {
+ 	// for the enum value, or it will be completely ignored; in the very least,
+ 	// this is a formalization for deprecating enum values.
+ 	Deprecated *bool `protobuf:"varint,1,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,2,opt,name=features" json:"features,omitempty"`
++	// Indicate that fields annotated with this enum value should not be printed
++	// out when using debug formats, e.g. when the field contains sensitive
++	// credentials.
++	DebugRedact *bool `protobuf:"varint,3,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+ 
+ // Default values for EnumValueOptions fields.
+ const (
+-	Default_EnumValueOptions_Deprecated = bool(false)
++	Default_EnumValueOptions_Deprecated  = bool(false)
++	Default_EnumValueOptions_DebugRedact = bool(false)
+ )
+ 
+ func (x *EnumValueOptions) Reset() {
+@@ -2543,6 +3044,20 @@ func (x *EnumValueOptions) GetDeprecated() bool {
+ 	return Default_EnumValueOptions_Deprecated
+ }
+ 
++func (x *EnumValueOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
++func (x *EnumValueOptions) GetDebugRedact() bool {
++	if x != nil && x.DebugRedact != nil {
++		return *x.DebugRedact
++	}
++	return Default_EnumValueOptions_DebugRedact
++}
++
+ func (x *EnumValueOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2556,6 +3071,8 @@ type ServiceOptions struct {
+ 	unknownFields   protoimpl.UnknownFields
+ 	extensionFields protoimpl.ExtensionFields
+ 
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,34,opt,name=features" json:"features,omitempty"`
+ 	// Is this service deprecated?
+ 	// Depending on the target platform, this can emit Deprecated annotations
+ 	// for the service, or it will be completely ignored; in the very least,
+@@ -2602,6 +3119,13 @@ func (*ServiceOptions) Descriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{16}
+ }
+ 
++func (x *ServiceOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *ServiceOptions) GetDeprecated() bool {
+ 	if x != nil && x.Deprecated != nil {
+ 		return *x.Deprecated
+@@ -2628,6 +3152,8 @@ type MethodOptions struct {
+ 	// this is a formalization for deprecating methods.
+ 	Deprecated       *bool                           `protobuf:"varint,33,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
+ 	IdempotencyLevel *MethodOptions_IdempotencyLevel `protobuf:"varint,34,opt,name=idempotency_level,json=idempotencyLevel,enum=google.protobuf.MethodOptions_IdempotencyLevel,def=0" json:"idempotency_level,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,35,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2684,6 +3210,13 @@ func (x *MethodOptions) GetIdempotencyLevel() MethodOptions_IdempotencyLevel {
+ 	return Default_MethodOptions_IdempotencyLevel
+ }
+ 
++func (x *MethodOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *MethodOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2770,28 +3303,193 @@ func (x *UninterpretedOption) GetNegativeIntValue() int64 {
+ 	if x != nil && x.NegativeIntValue != nil {
+ 		return *x.NegativeIntValue
+ 	}
+-	return 0
++	return 0
++}
++
++func (x *UninterpretedOption) GetDoubleValue() float64 {
++	if x != nil && x.DoubleValue != nil {
++		return *x.DoubleValue
++	}
++	return 0
++}
++
++func (x *UninterpretedOption) GetStringValue() []byte {
++	if x != nil {
++		return x.StringValue
++	}
++	return nil
++}
++
++func (x *UninterpretedOption) GetAggregateValue() string {
++	if x != nil && x.AggregateValue != nil {
++		return *x.AggregateValue
++	}
++	return ""
++}
++
++// TODO Enums in C++ gencode (and potentially other languages) are
++// not well scoped.  This means that each of the feature enums below can clash
++// with each other.  The short names we've chosen maximize call-site
++// readability, but leave us very open to this scenario.  A future feature will
++// be designed and implemented to handle this, hopefully before we ever hit a
++// conflict here.
++type FeatureSet struct {
++	state           protoimpl.MessageState
++	sizeCache       protoimpl.SizeCache
++	unknownFields   protoimpl.UnknownFields
++	extensionFields protoimpl.ExtensionFields
++
++	FieldPresence         *FeatureSet_FieldPresence         `protobuf:"varint,1,opt,name=field_presence,json=fieldPresence,enum=google.protobuf.FeatureSet_FieldPresence" json:"field_presence,omitempty"`
++	EnumType              *FeatureSet_EnumType              `protobuf:"varint,2,opt,name=enum_type,json=enumType,enum=google.protobuf.FeatureSet_EnumType" json:"enum_type,omitempty"`
++	RepeatedFieldEncoding *FeatureSet_RepeatedFieldEncoding `protobuf:"varint,3,opt,name=repeated_field_encoding,json=repeatedFieldEncoding,enum=google.protobuf.FeatureSet_RepeatedFieldEncoding" json:"repeated_field_encoding,omitempty"`
++	Utf8Validation        *FeatureSet_Utf8Validation        `protobuf:"varint,4,opt,name=utf8_validation,json=utf8Validation,enum=google.protobuf.FeatureSet_Utf8Validation" json:"utf8_validation,omitempty"`
++	MessageEncoding       *FeatureSet_MessageEncoding       `protobuf:"varint,5,opt,name=message_encoding,json=messageEncoding,enum=google.protobuf.FeatureSet_MessageEncoding" json:"message_encoding,omitempty"`
++	JsonFormat            *FeatureSet_JsonFormat            `protobuf:"varint,6,opt,name=json_format,json=jsonFormat,enum=google.protobuf.FeatureSet_JsonFormat" json:"json_format,omitempty"`
++}
++
++func (x *FeatureSet) Reset() {
++	*x = FeatureSet{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSet) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSet) ProtoMessage() {}
++
++func (x *FeatureSet) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FeatureSet.ProtoReflect.Descriptor instead.
++func (*FeatureSet) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19}
++}
++
++func (x *FeatureSet) GetFieldPresence() FeatureSet_FieldPresence {
++	if x != nil && x.FieldPresence != nil {
++		return *x.FieldPresence
++	}
++	return FeatureSet_FIELD_PRESENCE_UNKNOWN
++}
++
++func (x *FeatureSet) GetEnumType() FeatureSet_EnumType {
++	if x != nil && x.EnumType != nil {
++		return *x.EnumType
++	}
++	return FeatureSet_ENUM_TYPE_UNKNOWN
++}
++
++func (x *FeatureSet) GetRepeatedFieldEncoding() FeatureSet_RepeatedFieldEncoding {
++	if x != nil && x.RepeatedFieldEncoding != nil {
++		return *x.RepeatedFieldEncoding
++	}
++	return FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN
++}
++
++func (x *FeatureSet) GetUtf8Validation() FeatureSet_Utf8Validation {
++	if x != nil && x.Utf8Validation != nil {
++		return *x.Utf8Validation
++	}
++	return FeatureSet_UTF8_VALIDATION_UNKNOWN
++}
++
++func (x *FeatureSet) GetMessageEncoding() FeatureSet_MessageEncoding {
++	if x != nil && x.MessageEncoding != nil {
++		return *x.MessageEncoding
++	}
++	return FeatureSet_MESSAGE_ENCODING_UNKNOWN
++}
++
++func (x *FeatureSet) GetJsonFormat() FeatureSet_JsonFormat {
++	if x != nil && x.JsonFormat != nil {
++		return *x.JsonFormat
++	}
++	return FeatureSet_JSON_FORMAT_UNKNOWN
++}
++
++// A compiled specification for the defaults of a set of features.  These
++// messages are generated from FeatureSet extensions and can be used to seed
++// feature resolution. The resolution with this object becomes a simple search
++// for the closest matching edition, followed by proto merges.
++type FeatureSetDefaults struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Defaults []*FeatureSetDefaults_FeatureSetEditionDefault `protobuf:"bytes,1,rep,name=defaults" json:"defaults,omitempty"`
++	// The minimum supported edition (inclusive) when this was constructed.
++	// Editions before this will not have defaults.
++	MinimumEdition *Edition `protobuf:"varint,4,opt,name=minimum_edition,json=minimumEdition,enum=google.protobuf.Edition" json:"minimum_edition,omitempty"`
++	// The maximum known edition (inclusive) when this was constructed. Editions
++	// after this will not have reliable defaults.
++	MaximumEdition *Edition `protobuf:"varint,5,opt,name=maximum_edition,json=maximumEdition,enum=google.protobuf.Edition" json:"maximum_edition,omitempty"`
++}
++
++func (x *FeatureSetDefaults) Reset() {
++	*x = FeatureSetDefaults{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSetDefaults) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSetDefaults) ProtoMessage() {}
++
++func (x *FeatureSetDefaults) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
+ }
+ 
+-func (x *UninterpretedOption) GetDoubleValue() float64 {
+-	if x != nil && x.DoubleValue != nil {
+-		return *x.DoubleValue
+-	}
+-	return 0
++// Deprecated: Use FeatureSetDefaults.ProtoReflect.Descriptor instead.
++func (*FeatureSetDefaults) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20}
+ }
+ 
+-func (x *UninterpretedOption) GetStringValue() []byte {
++func (x *FeatureSetDefaults) GetDefaults() []*FeatureSetDefaults_FeatureSetEditionDefault {
+ 	if x != nil {
+-		return x.StringValue
++		return x.Defaults
+ 	}
+ 	return nil
+ }
+ 
+-func (x *UninterpretedOption) GetAggregateValue() string {
+-	if x != nil && x.AggregateValue != nil {
+-		return *x.AggregateValue
++func (x *FeatureSetDefaults) GetMinimumEdition() Edition {
++	if x != nil && x.MinimumEdition != nil {
++		return *x.MinimumEdition
+ 	}
+-	return ""
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FeatureSetDefaults) GetMaximumEdition() Edition {
++	if x != nil && x.MaximumEdition != nil {
++		return *x.MaximumEdition
++	}
++	return Edition_EDITION_UNKNOWN
+ }
+ 
+ // Encapsulates information about the original source file from which a
+@@ -2855,7 +3553,7 @@ type SourceCodeInfo struct {
+ func (x *SourceCodeInfo) Reset() {
+ 	*x = SourceCodeInfo{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2868,7 +3566,7 @@ func (x *SourceCodeInfo) String() string {
+ func (*SourceCodeInfo) ProtoMessage() {}
+ 
+ func (x *SourceCodeInfo) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -2881,7 +3579,7 @@ func (x *SourceCodeInfo) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use SourceCodeInfo.ProtoReflect.Descriptor instead.
+ func (*SourceCodeInfo) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{21}
+ }
+ 
+ func (x *SourceCodeInfo) GetLocation() []*SourceCodeInfo_Location {
+@@ -2907,7 +3605,7 @@ type GeneratedCodeInfo struct {
+ func (x *GeneratedCodeInfo) Reset() {
+ 	*x = GeneratedCodeInfo{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2920,7 +3618,7 @@ func (x *GeneratedCodeInfo) String() string {
+ func (*GeneratedCodeInfo) ProtoMessage() {}
+ 
+ func (x *GeneratedCodeInfo) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -2933,7 +3631,7 @@ func (x *GeneratedCodeInfo) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use GeneratedCodeInfo.ProtoReflect.Descriptor instead.
+ func (*GeneratedCodeInfo) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22}
+ }
+ 
+ func (x *GeneratedCodeInfo) GetAnnotation() []*GeneratedCodeInfo_Annotation {
+@@ -2956,7 +3654,7 @@ type DescriptorProto_ExtensionRange struct {
+ func (x *DescriptorProto_ExtensionRange) Reset() {
+ 	*x = DescriptorProto_ExtensionRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2969,7 +3667,7 @@ func (x *DescriptorProto_ExtensionRange) String() string {
+ func (*DescriptorProto_ExtensionRange) ProtoMessage() {}
+ 
+ func (x *DescriptorProto_ExtensionRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3021,7 +3719,7 @@ type DescriptorProto_ReservedRange struct {
+ func (x *DescriptorProto_ReservedRange) Reset() {
+ 	*x = DescriptorProto_ReservedRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3034,7 +3732,7 @@ func (x *DescriptorProto_ReservedRange) String() string {
+ func (*DescriptorProto_ReservedRange) ProtoMessage() {}
+ 
+ func (x *DescriptorProto_ReservedRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3078,10 +3776,6 @@ type ExtensionRangeOptions_Declaration struct {
+ 	// Metadata.type, Declaration.type must have a leading dot for messages
+ 	// and enums.
+ 	Type *string `protobuf:"bytes,3,opt,name=type" json:"type,omitempty"`
+-	// Deprecated. Please use "repeated".
+-	//
+-	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-	IsRepeated *bool `protobuf:"varint,4,opt,name=is_repeated,json=isRepeated" json:"is_repeated,omitempty"`
+ 	// If true, indicates that the number is reserved in the extension range,
+ 	// and any extension field with the number will fail to compile. Set this
+ 	// when a declared extension field is deleted.
+@@ -3094,7 +3788,7 @@ type ExtensionRangeOptions_Declaration struct {
+ func (x *ExtensionRangeOptions_Declaration) Reset() {
+ 	*x = ExtensionRangeOptions_Declaration{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3107,7 +3801,7 @@ func (x *ExtensionRangeOptions_Declaration) String() string {
+ func (*ExtensionRangeOptions_Declaration) ProtoMessage() {}
+ 
+ func (x *ExtensionRangeOptions_Declaration) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3144,14 +3838,6 @@ func (x *ExtensionRangeOptions_Declaration) GetType() string {
+ 	return ""
+ }
+ 
+-// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-func (x *ExtensionRangeOptions_Declaration) GetIsRepeated() bool {
+-	if x != nil && x.IsRepeated != nil {
+-		return *x.IsRepeated
+-	}
+-	return false
+-}
+-
+ func (x *ExtensionRangeOptions_Declaration) GetReserved() bool {
+ 	if x != nil && x.Reserved != nil {
+ 		return *x.Reserved
+@@ -3184,7 +3870,7 @@ type EnumDescriptorProto_EnumReservedRange struct {
+ func (x *EnumDescriptorProto_EnumReservedRange) Reset() {
+ 	*x = EnumDescriptorProto_EnumReservedRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3197,7 +3883,7 @@ func (x *EnumDescriptorProto_EnumReservedRange) String() string {
+ func (*EnumDescriptorProto_EnumReservedRange) ProtoMessage() {}
+ 
+ func (x *EnumDescriptorProto_EnumReservedRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3227,6 +3913,61 @@ func (x *EnumDescriptorProto_EnumReservedRange) GetEnd() int32 {
+ 	return 0
+ }
+ 
++type FieldOptions_EditionDefault struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Edition *Edition `protobuf:"varint,3,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
++	Value   *string  `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"` // Textproto value.
++}
++
++func (x *FieldOptions_EditionDefault) Reset() {
++	*x = FieldOptions_EditionDefault{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FieldOptions_EditionDefault) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FieldOptions_EditionDefault) ProtoMessage() {}
++
++func (x *FieldOptions_EditionDefault) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FieldOptions_EditionDefault.ProtoReflect.Descriptor instead.
++func (*FieldOptions_EditionDefault) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{12, 0}
++}
++
++func (x *FieldOptions_EditionDefault) GetEdition() Edition {
++	if x != nil && x.Edition != nil {
++		return *x.Edition
++	}
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FieldOptions_EditionDefault) GetValue() string {
++	if x != nil && x.Value != nil {
++		return *x.Value
++	}
++	return ""
++}
++
+ // The name of the uninterpreted option.  Each string represents a segment in
+ // a dot-separated name.  is_extension is true iff a segment represents an
+ // extension (denoted with parentheses in options specs in .proto files).
+@@ -3244,7 +3985,7 @@ type UninterpretedOption_NamePart struct {
+ func (x *UninterpretedOption_NamePart) Reset() {
+ 	*x = UninterpretedOption_NamePart{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[28]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3257,7 +3998,7 @@ func (x *UninterpretedOption_NamePart) String() string {
+ func (*UninterpretedOption_NamePart) ProtoMessage() {}
+ 
+ func (x *UninterpretedOption_NamePart) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[28]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3287,6 +4028,65 @@ func (x *UninterpretedOption_NamePart) GetIsExtension() bool {
+ 	return false
+ }
+ 
++// A map from every known edition with a unique set of defaults to its
++// defaults. Not all editions may be contained here.  For a given edition,
++// the defaults at the closest matching edition ordered at or before it should
++// be used.  This field must be in strict ascending order by edition.
++type FeatureSetDefaults_FeatureSetEditionDefault struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Edition  *Edition    `protobuf:"varint,3,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
++	Features *FeatureSet `protobuf:"bytes,2,opt,name=features" json:"features,omitempty"`
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) Reset() {
++	*x = FeatureSetDefaults_FeatureSetEditionDefault{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[29]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSetDefaults_FeatureSetEditionDefault) ProtoMessage() {}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[29]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FeatureSetDefaults_FeatureSetEditionDefault.ProtoReflect.Descriptor instead.
++func (*FeatureSetDefaults_FeatureSetEditionDefault) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0}
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) GetEdition() Edition {
++	if x != nil && x.Edition != nil {
++		return *x.Edition
++	}
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ type SourceCodeInfo_Location struct {
+ 	state         protoimpl.MessageState
+ 	sizeCache     protoimpl.SizeCache
+@@ -3296,7 +4096,7 @@ type SourceCodeInfo_Location struct {
+ 	// location.
+ 	//
+ 	// Each element is a field number or an index.  They form a path from
+-	// the root FileDescriptorProto to the place where the definition occurs.
++	// the root FileDescriptorProto to the place where the definition appears.
+ 	// For example, this path:
+ 	//
+ 	//	[ 4, 3, 2, 7, 1 ]
+@@ -3388,7 +4188,7 @@ type SourceCodeInfo_Location struct {
+ func (x *SourceCodeInfo_Location) Reset() {
+ 	*x = SourceCodeInfo_Location{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[30]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3401,7 +4201,7 @@ func (x *SourceCodeInfo_Location) String() string {
+ func (*SourceCodeInfo_Location) ProtoMessage() {}
+ 
+ func (x *SourceCodeInfo_Location) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[30]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3414,7 +4214,7 @@ func (x *SourceCodeInfo_Location) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use SourceCodeInfo_Location.ProtoReflect.Descriptor instead.
+ func (*SourceCodeInfo_Location) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{21, 0}
+ }
+ 
+ func (x *SourceCodeInfo_Location) GetPath() []int32 {
+@@ -3475,7 +4275,7 @@ type GeneratedCodeInfo_Annotation struct {
+ func (x *GeneratedCodeInfo_Annotation) Reset() {
+ 	*x = GeneratedCodeInfo_Annotation{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[31]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3488,7 +4288,7 @@ func (x *GeneratedCodeInfo_Annotation) String() string {
+ func (*GeneratedCodeInfo_Annotation) ProtoMessage() {}
+ 
+ func (x *GeneratedCodeInfo_Annotation) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[31]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3501,7 +4301,7 @@ func (x *GeneratedCodeInfo_Annotation) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use GeneratedCodeInfo_Annotation.ProtoReflect.Descriptor instead.
+ func (*GeneratedCodeInfo_Annotation) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22, 0}
+ }
+ 
+ func (x *GeneratedCodeInfo_Annotation) GetPath() []int32 {
+@@ -3550,7 +4350,7 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+ 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73,
+ 	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x04, 0x66, 0x69,
+-	0x6c, 0x65, 0x22, 0xfe, 0x04, 0x0a, 0x13, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72,
++	0x6c, 0x65, 0x22, 0x98, 0x05, 0x0a, 0x13, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72,
+ 	0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61,
+ 	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x18,
+ 	0x0a, 0x07, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+@@ -3588,250 +4388,250 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
+ 	0x6f, 0x52, 0x0e, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
+ 	0x6f, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x18, 0x0c, 0x20, 0x01, 0x28,
+-	0x09, 0x52, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x12, 0x18, 0x0a, 0x07, 0x65, 0x64, 0x69,
+-	0x74, 0x69, 0x6f, 0x6e, 0x18, 0x0d, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74,
+-	0x69, 0x6f, 0x6e, 0x22, 0xb9, 0x06, 0x0a, 0x0f, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
+-	0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
+-	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3b, 0x0a, 0x05, 0x66,
+-	0x69, 0x65, 0x6c, 0x64, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f,
+-	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65,
+-	0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
+-	0x6f, 0x52, 0x05, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x12, 0x43, 0x0a, 0x09, 0x65, 0x78, 0x74, 0x65,
+-	0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69,
+-	0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
+-	0x74, 0x6f, 0x52, 0x09, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a,
+-	0x0b, 0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x03,
+-	0x28, 0x0b, 0x32, 0x20, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+-	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
+-	0x72, 0x6f, 0x74, 0x6f, 0x52, 0x0a, 0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x54, 0x79, 0x70, 0x65,
+-	0x12, 0x41, 0x0a, 0x09, 0x65, 0x6e, 0x75, 0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x04, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
+-	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54,
+-	0x79, 0x70, 0x65, 0x12, 0x58, 0x0a, 0x0f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e,
+-	0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x67,
++	0x09, 0x52, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x12, 0x32, 0x0a, 0x07, 0x65, 0x64, 0x69,
++	0x74, 0x69, 0x6f, 0x6e, 0x18, 0x0e, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69,
++	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0xb9, 0x06,
++	0x0a, 0x0f, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3b, 0x0a, 0x05, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x18, 0x02,
++	0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63,
++	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05, 0x66, 0x69, 0x65,
++	0x6c, 0x64, 0x12, 0x43, 0x0a, 0x09, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18,
++	0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73,
++	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x09, 0x65, 0x78,
++	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a, 0x0b, 0x6e, 0x65, 0x73, 0x74, 0x65,
++	0x64, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x20, 0x2e, 0x67,
+ 	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45,
+-	0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0e, 0x65,
+-	0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x44, 0x0a,
+-	0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x64, 0x65, 0x63, 0x6c, 0x18, 0x08, 0x20, 0x03, 0x28,
+-	0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+-	0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x09, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x44,
+-	0x65, 0x63, 0x6c, 0x12, 0x39, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x07,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x55,
+-	0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65,
+-	0x18, 0x09, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x0a,
++	0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x54, 0x79, 0x70, 0x65, 0x12, 0x41, 0x0a, 0x09, 0x65, 0x6e,
++	0x75, 0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72,
++	0x6f, 0x74, 0x6f, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54, 0x79, 0x70, 0x65, 0x12, 0x58, 0x0a,
++	0x0f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65,
++	0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+ 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
++	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69,
++	0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0e, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69,
++	0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x44, 0x0a, 0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66,
++	0x5f, 0x64, 0x65, 0x63, 0x6c, 0x18, 0x08, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e,
++	0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
++	0x74, 0x6f, 0x52, 0x09, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x63, 0x6c, 0x12, 0x39, 0x0a,
++	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52,
++	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x55, 0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65,
++	0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x09, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
++	0x74, 0x6f, 0x2e, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65,
++	0x52, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12,
++	0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65,
++	0x18, 0x0a, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64,
++	0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x7a, 0x0a, 0x0e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
++	0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18,
++	0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03,
++	0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x12, 0x40,
++	0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
++	0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x1a, 0x37, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67,
++	0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05,
++	0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02,
++	0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0xcc, 0x04, 0x0a, 0x15, 0x45, 0x78,
++	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
++	0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03,
++	0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x59, 0x0a,
++	0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x03,
++	0x28, 0x0b, 0x32, 0x32, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61,
++	0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x44, 0x65, 0x63, 0x6c, 0x61,
++	0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x03, 0x88, 0x01, 0x02, 0x52, 0x0b, 0x64, 0x65, 0x63,
++	0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x73, 0x18, 0x32, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x12, 0x6d, 0x0a, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f,
++	0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x38, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73,
++	0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
++	0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74,
++	0x65, 0x3a, 0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x42, 0x03, 0x88,
++	0x01, 0x02, 0x52, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x1a, 0x94, 0x01, 0x0a, 0x0b, 0x44, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05,
++	0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x1b, 0x0a, 0x09, 0x66, 0x75, 0x6c, 0x6c,
++	0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x66, 0x75, 0x6c,
++	0x6c, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20,
++	0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73,
++	0x65, 0x72, 0x76, 0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x73,
++	0x65, 0x72, 0x76, 0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65,
++	0x64, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65,
++	0x64, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x22, 0x34, 0x0a, 0x11, 0x56, 0x65, 0x72, 0x69, 0x66,
++	0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x0f, 0x0a, 0x0b,
++	0x44, 0x45, 0x43, 0x4c, 0x41, 0x52, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x10, 0x00, 0x12, 0x0e, 0x0a,
++	0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x01, 0x2a, 0x09, 0x08,
++	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0xc1, 0x06, 0x0a, 0x14, 0x46, 0x69, 0x65,
++	0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18,
++	0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x41, 0x0a,
++	0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
++	0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72,
++	0x6f, 0x74, 0x6f, 0x2e, 0x4c, 0x61, 0x62, 0x65, 0x6c, 0x52, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c,
++	0x12, 0x3e, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2a,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72,
++	0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x54, 0x79, 0x70, 0x65, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65,
++	0x12, 0x1b, 0x0a, 0x09, 0x74, 0x79, 0x70, 0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x06, 0x20,
++	0x01, 0x28, 0x09, 0x52, 0x08, 0x74, 0x79, 0x70, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1a, 0x0a,
++	0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x64, 0x65, 0x66,
++	0x61, 0x75, 0x6c, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09,
++	0x52, 0x0c, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x1f,
++	0x0a, 0x0b, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x69, 0x6e, 0x64, 0x65, 0x78, 0x18, 0x09, 0x20,
++	0x01, 0x28, 0x05, 0x52, 0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12,
++	0x1b, 0x0a, 0x09, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x08, 0x6a, 0x73, 0x6f, 0x6e, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x27, 0x0a, 0x0f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x18, 0x11, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x22, 0xb6,
++	0x02, 0x0a, 0x04, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x44, 0x4f, 0x55, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x46, 0x4c, 0x4f, 0x41, 0x54, 0x10, 0x02, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x03, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x55, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x04, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x05, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34, 0x10, 0x06, 0x12, 0x10, 0x0a, 0x0c, 0x54,
++	0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32, 0x10, 0x07, 0x12, 0x0d, 0x0a,
++	0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x4f, 0x4f, 0x4c, 0x10, 0x08, 0x12, 0x0f, 0x0a, 0x0b,
++	0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x09, 0x12, 0x0e, 0x0a,
++	0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x47, 0x52, 0x4f, 0x55, 0x50, 0x10, 0x0a, 0x12, 0x10, 0x0a,
++	0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x10, 0x0b, 0x12,
++	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x59, 0x54, 0x45, 0x53, 0x10, 0x0c, 0x12,
++	0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x0d,
++	0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x10, 0x0e, 0x12,
++	0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32,
++	0x10, 0x0f, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45,
++	0x44, 0x36, 0x34, 0x10, 0x10, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49,
++	0x4e, 0x54, 0x33, 0x32, 0x10, 0x11, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53,
++	0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x12, 0x22, 0x43, 0x0a, 0x05, 0x4c, 0x61, 0x62, 0x65, 0x6c,
++	0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x4f, 0x50, 0x54, 0x49, 0x4f, 0x4e,
++	0x41, 0x4c, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45,
++	0x50, 0x45, 0x41, 0x54, 0x45, 0x44, 0x10, 0x03, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45,
++	0x4c, 0x5f, 0x52, 0x45, 0x51, 0x55, 0x49, 0x52, 0x45, 0x44, 0x10, 0x02, 0x22, 0x63, 0x0a, 0x14,
++	0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
++	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f,
++	0x66, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x73, 0x22, 0xe3, 0x02, 0x0a, 0x13, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
++	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d,
++	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3f, 0x0a,
++	0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x29, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45,
++	0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
++	0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x36,
++	0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
++	0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x5d, 0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
++	0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x36,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+ 	0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64,
+ 	0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65,
+-	0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x7a, 0x0a, 0x0e, 0x45, 0x78,
+-	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05,
+-	0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61,
+-	0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52,
+-	0x03, 0x65, 0x6e, 0x64, 0x12, 0x40, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18,
+-	0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
+-	0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x1a, 0x37, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a,
+-	0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22,
+-	0xad, 0x04, 0x0a, 0x15, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e,
+-	0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+-	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x12, 0x59, 0x0a, 0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69,
+-	0x6f, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x32, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e,
+-	0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+-	0x2e, 0x44, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x03, 0x88, 0x01,
+-	0x02, 0x52, 0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x68,
+-	0x0a, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x0e, 0x32, 0x38, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e,
+-	0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x56, 0x65, 0x72,
+-	0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x3a, 0x0a,
+-	0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x52, 0x0c, 0x76, 0x65, 0x72, 0x69,
+-	0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xb3, 0x01, 0x0a, 0x0b, 0x44, 0x65, 0x63,
+-	0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62,
+-	0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72,
+-	0x12, 0x1b, 0x0a, 0x09, 0x66, 0x75, 0x6c, 0x6c, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20,
+-	0x01, 0x28, 0x09, 0x52, 0x08, 0x66, 0x75, 0x6c, 0x6c, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x12, 0x0a,
+-	0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70,
+-	0x65, 0x12, 0x23, 0x0a, 0x0b, 0x69, 0x73, 0x5f, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64,
+-	0x18, 0x04, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x0a, 0x69, 0x73, 0x52, 0x65,
+-	0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x18, 0x06,
+-	0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x22, 0x34,
+-	0x0a, 0x11, 0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74,
+-	0x61, 0x74, 0x65, 0x12, 0x0f, 0x0a, 0x0b, 0x44, 0x45, 0x43, 0x4c, 0x41, 0x52, 0x41, 0x54, 0x49,
+-	0x4f, 0x4e, 0x10, 0x00, 0x12, 0x0e, 0x0a, 0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49,
+-	0x45, 0x44, 0x10, 0x01, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22,
+-	0xc1, 0x06, 0x0a, 0x14, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06,
+-	0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75,
+-	0x6d, 0x62, 0x65, 0x72, 0x12, 0x41, 0x0a, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x18, 0x04, 0x20,
+-	0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72,
+-	0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x4c, 0x61, 0x62, 0x65, 0x6c,
+-	0x52, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x12, 0x3e, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18,
+-	0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73,
+-	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x54, 0x79, 0x70,
+-	0x65, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1b, 0x0a, 0x09, 0x74, 0x79, 0x70, 0x65, 0x5f,
+-	0x6e, 0x61, 0x6d, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x74, 0x79, 0x70, 0x65,
+-	0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65,
+-	0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65,
+-	0x12, 0x23, 0x0a, 0x0d, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75,
+-	0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0c, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74,
+-	0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x69,
+-	0x6e, 0x64, 0x65, 0x78, 0x18, 0x09, 0x20, 0x01, 0x28, 0x05, 0x52, 0x0a, 0x6f, 0x6e, 0x65, 0x6f,
+-	0x66, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12, 0x1b, 0x0a, 0x09, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x6a, 0x73, 0x6f, 0x6e, 0x4e,
+-	0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x08,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69,
+-	0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x27, 0x0a, 0x0f,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x18,
+-	0x11, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x22, 0xb6, 0x02, 0x0a, 0x04, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0f,
+-	0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x44, 0x4f, 0x55, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12,
+-	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x4c, 0x4f, 0x41, 0x54, 0x10, 0x02, 0x12,
+-	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x03, 0x12,
+-	0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x04,
+-	0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x05,
+-	0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34,
+-	0x10, 0x06, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44,
+-	0x33, 0x32, 0x10, 0x07, 0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x4f, 0x4f,
+-	0x4c, 0x10, 0x08, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x54, 0x52, 0x49,
+-	0x4e, 0x47, 0x10, 0x09, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x47, 0x52, 0x4f,
+-	0x55, 0x50, 0x10, 0x0a, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53,
+-	0x53, 0x41, 0x47, 0x45, 0x10, 0x0b, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42,
+-	0x59, 0x54, 0x45, 0x53, 0x10, 0x0c, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55,
+-	0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x0d, 0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f,
+-	0x45, 0x4e, 0x55, 0x4d, 0x10, 0x0e, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53,
+-	0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32, 0x10, 0x0f, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34, 0x10, 0x10, 0x12, 0x0f, 0x0a, 0x0b,
+-	0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x11, 0x12, 0x0f, 0x0a,
+-	0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x12, 0x22, 0x43,
+-	0x0a, 0x05, 0x4c, 0x61, 0x62, 0x65, 0x6c, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c,
+-	0x5f, 0x4f, 0x50, 0x54, 0x49, 0x4f, 0x4e, 0x41, 0x4c, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c,
+-	0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45, 0x51, 0x55, 0x49, 0x52, 0x45, 0x44, 0x10, 0x02, 0x12,
+-	0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45, 0x50, 0x45, 0x41, 0x54, 0x45,
+-	0x44, 0x10, 0x03, 0x22, 0x63, 0x0a, 0x14, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b,
+-	0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
+-	0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52,
+-	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0xe3, 0x02, 0x0a, 0x13, 0x45, 0x6e, 0x75,
+-	0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f,
+-	0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04,
+-	0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3f, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05,
+-	0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x36, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+-	0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x5d, 0x0a,
+-	0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18,
+-	0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x36, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x6e, 0x75, 0x6d,
+-	0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0d, 0x72,
+-	0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d,
+-	0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x05, 0x20,
+-	0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d,
+-	0x65, 0x1a, 0x3b, 0x0a, 0x11, 0x45, 0x6e, 0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18,
+-	0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03,
+-	0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0x83,
+-	0x01, 0x0a, 0x18, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52,
+-	0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x3b, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56,
+-	0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x22, 0xa7, 0x01, 0x0a, 0x16, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+-	0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12,
+-	0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x12, 0x3e, 0x0a, 0x06, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x18, 0x02, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x06, 0x6d, 0x65, 0x74,
+-	0x68, 0x6f, 0x64, 0x12, 0x39, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0x89,
+-	0x02, 0x0a, 0x15, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
++	0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x05, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65,
++	0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x3b, 0x0a, 0x11, 0x45, 0x6e,
++	0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12,
++	0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05,
++	0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01,
++	0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0x83, 0x01, 0x0a, 0x18, 0x45, 0x6e, 0x75, 0x6d,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62,
++	0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72,
++	0x12, 0x3b, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28,
++	0x0b, 0x32, 0x21, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74,
++	0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0xa7, 0x01,
++	0x0a, 0x16, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+ 	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1d, 0x0a, 0x0a,
+-	0x69, 0x6e, 0x70, 0x75, 0x74, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x09, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f,
+-	0x75, 0x74, 0x70, 0x75, 0x74, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x0a, 0x6f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x38, 0x0a, 0x07,
+-	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e,
++	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3e, 0x0a, 0x06,
++	0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d,
++	0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x52, 0x06, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x12, 0x39, 0x0a, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e,
+ 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+-	0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x30, 0x0a, 0x10, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74,
+-	0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08,
+-	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0f, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x53,
+-	0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x12, 0x30, 0x0a, 0x10, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x72, 0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x06, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0f, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x72, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x22, 0x91, 0x09, 0x0a, 0x0b, 0x46,
+-	0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x21, 0x0a, 0x0c, 0x6a, 0x61,
+-	0x76, 0x61, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x0b, 0x6a, 0x61, 0x76, 0x61, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x30, 0x0a,
+-	0x14, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6f, 0x75, 0x74, 0x65, 0x72, 0x5f, 0x63, 0x6c, 0x61, 0x73,
+-	0x73, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x6a, 0x61, 0x76,
+-	0x61, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x43, 0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x35, 0x0a, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65,
+-	0x5f, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x11, 0x6a, 0x61, 0x76, 0x61, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c,
+-	0x65, 0x46, 0x69, 0x6c, 0x65, 0x73, 0x12, 0x44, 0x0a, 0x1d, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67,
+-	0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x5f, 0x61,
+-	0x6e, 0x64, 0x5f, 0x68, 0x61, 0x73, 0x68, 0x18, 0x14, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18,
+-	0x01, 0x52, 0x19, 0x6a, 0x61, 0x76, 0x61, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x45,
+-	0x71, 0x75, 0x61, 0x6c, 0x73, 0x41, 0x6e, 0x64, 0x48, 0x61, 0x73, 0x68, 0x12, 0x3a, 0x0a, 0x16,
+-	0x6a, 0x61, 0x76, 0x61, 0x5f, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x68, 0x65, 0x63,
+-	0x6b, 0x5f, 0x75, 0x74, 0x66, 0x38, 0x18, 0x1b, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43,
+-	0x68, 0x65, 0x63, 0x6b, 0x55, 0x74, 0x66, 0x38, 0x12, 0x53, 0x0a, 0x0c, 0x6f, 0x70, 0x74, 0x69,
+-	0x6d, 0x69, 0x7a, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x29,
+-	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+-	0x2e, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74,
+-	0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64, 0x65, 0x3a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44,
+-	0x52, 0x0b, 0x6f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x46, 0x6f, 0x72, 0x12, 0x1d, 0x0a,
+-	0x0a, 0x67, 0x6f, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x0b, 0x20, 0x01, 0x28,
+-	0x09, 0x52, 0x09, 0x67, 0x6f, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x35, 0x0a, 0x13,
+-	0x63, 0x63, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69,
+-	0x63, 0x65, 0x73, 0x18, 0x10, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
+-	0x52, 0x11, 0x63, 0x63, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69,
+-	0x63, 0x65, 0x73, 0x12, 0x39, 0x0a, 0x15, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65,
+-	0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x11, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x47,
+-	0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x35,
+-	0x0a, 0x13, 0x70, 0x79, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72,
+-	0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x12, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
+-	0x73, 0x65, 0x52, 0x11, 0x70, 0x79, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72,
+-	0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x37, 0x0a, 0x14, 0x70, 0x68, 0x70, 0x5f, 0x67, 0x65, 0x6e,
+-	0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x2a, 0x20,
+-	0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x12, 0x70, 0x68, 0x70, 0x47,
++	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0x89, 0x02, 0x0a, 0x15, 0x4d, 0x65, 0x74, 0x68,
++	0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1d, 0x0a, 0x0a, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x5f, 0x74,
++	0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x69, 0x6e, 0x70, 0x75, 0x74,
++	0x54, 0x79, 0x70, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x5f, 0x74,
++	0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x6f, 0x75, 0x74, 0x70, 0x75,
++	0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x38, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12,
++	0x30, 0x0a, 0x10, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d,
++	0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x0f, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e,
++	0x67, 0x12, 0x30, 0x0a, 0x10, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x5f, 0x73, 0x74, 0x72, 0x65,
++	0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x0f, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d,
++	0x69, 0x6e, 0x67, 0x22, 0x97, 0x09, 0x0a, 0x0b, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x21, 0x0a, 0x0c, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x70, 0x61, 0x63, 0x6b,
++	0x61, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x6a, 0x61, 0x76, 0x61, 0x50,
++	0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x30, 0x0a, 0x14, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6f,
++	0x75, 0x74, 0x65, 0x72, 0x5f, 0x63, 0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x08,
++	0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x6a, 0x61, 0x76, 0x61, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x43,
++	0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x35, 0x0a, 0x13, 0x6a, 0x61, 0x76, 0x61,
++	0x5f, 0x6d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x5f, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x18,
++	0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x6a, 0x61,
++	0x76, 0x61, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x73, 0x12,
++	0x44, 0x0a, 0x1d, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
++	0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x5f, 0x61, 0x6e, 0x64, 0x5f, 0x68, 0x61, 0x73, 0x68,
++	0x18, 0x14, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x19, 0x6a, 0x61, 0x76, 0x61,
++	0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x45, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x41, 0x6e,
++	0x64, 0x48, 0x61, 0x73, 0x68, 0x12, 0x3a, 0x0a, 0x16, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x73, 0x74,
++	0x72, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x5f, 0x75, 0x74, 0x66, 0x38, 0x18,
++	0x1b, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61,
++	0x76, 0x61, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x55, 0x74, 0x66,
++	0x38, 0x12, 0x53, 0x0a, 0x0c, 0x6f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x5f, 0x66, 0x6f,
++	0x72, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f,
++	0x64, 0x65, 0x3a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44, 0x52, 0x0b, 0x6f, 0x70, 0x74, 0x69, 0x6d,
++	0x69, 0x7a, 0x65, 0x46, 0x6f, 0x72, 0x12, 0x1d, 0x0a, 0x0a, 0x67, 0x6f, 0x5f, 0x70, 0x61, 0x63,
++	0x6b, 0x61, 0x67, 0x65, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x67, 0x6f, 0x50, 0x61,
++	0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x35, 0x0a, 0x13, 0x63, 0x63, 0x5f, 0x67, 0x65, 0x6e, 0x65,
++	0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x10, 0x20, 0x01,
++	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x63, 0x63, 0x47, 0x65, 0x6e,
++	0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x39, 0x0a, 0x15,
++	0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72,
++	0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x11, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53,
++	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x35, 0x0a, 0x13, 0x70, 0x79, 0x5f, 0x67, 0x65,
++	0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x12,
++	0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x70, 0x79, 0x47,
+ 	0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x25,
+ 	0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x17, 0x20, 0x01,
+ 	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65,
+@@ -3856,259 +4656,419 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x70, 0x68, 0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x4e, 0x61, 0x6d, 0x65, 0x73,
+ 	0x70, 0x61, 0x63, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x72, 0x75, 0x62, 0x79, 0x5f, 0x70, 0x61, 0x63,
+ 	0x6b, 0x61, 0x67, 0x65, 0x18, 0x2d, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x72, 0x75, 0x62, 0x79,
+-	0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18,
+-	0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72,
+-	0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e,
+-	0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x22, 0x3a, 0x0a, 0x0c, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64,
+-	0x65, 0x12, 0x09, 0x0a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09,
+-	0x43, 0x4f, 0x44, 0x45, 0x5f, 0x53, 0x49, 0x5a, 0x45, 0x10, 0x02, 0x12, 0x10, 0x0a, 0x0c, 0x4c,
+-	0x49, 0x54, 0x45, 0x5f, 0x52, 0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x03, 0x2a, 0x09, 0x08,
+-	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x26, 0x10, 0x27, 0x22, 0xbb,
+-	0x03, 0x0a, 0x0e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x73, 0x12, 0x3c, 0x0a, 0x17, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x65, 0x74,
+-	0x5f, 0x77, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x01, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x14, 0x6d, 0x65, 0x73, 0x73, 0x61,
+-	0x67, 0x65, 0x53, 0x65, 0x74, 0x57, 0x69, 0x72, 0x65, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12,
+-	0x4c, 0x0a, 0x1f, 0x6e, 0x6f, 0x5f, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x5f, 0x64,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73,
+-	0x6f, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
+-	0x1c, 0x6e, 0x6f, 0x53, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72,
+-	0x69, 0x70, 0x74, 0x6f, 0x72, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f, 0x72, 0x12, 0x25, 0x0a,
+-	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28,
+-	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63,
+-	0x61, 0x74, 0x65, 0x64, 0x12, 0x1b, 0x0a, 0x09, 0x6d, 0x61, 0x70, 0x5f, 0x65, 0x6e, 0x74, 0x72,
+-	0x79, 0x18, 0x07, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x6d, 0x61, 0x70, 0x45, 0x6e, 0x74, 0x72,
+-	0x79, 0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f,
+-	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c,
+-	0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28,
+-	0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+-	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x04, 0x10, 0x05, 0x4a, 0x04, 0x08, 0x05, 0x10, 0x06, 0x4a, 0x04, 0x08, 0x06, 0x10, 0x07,
+-	0x4a, 0x04, 0x08, 0x08, 0x10, 0x09, 0x4a, 0x04, 0x08, 0x09, 0x10, 0x0a, 0x22, 0x85, 0x09, 0x0a,
+-	0x0c, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x41, 0x0a,
+-	0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x23, 0x2e, 0x67,
+-	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
+-	0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x43, 0x54, 0x79, 0x70,
+-	0x65, 0x3a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x52, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65,
+-	0x12, 0x16, 0x0a, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08,
+-	0x52, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x12, 0x47, 0x0a, 0x06, 0x6a, 0x73, 0x74, 0x79,
+-	0x70, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x09,
+-	0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x52, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70,
+-	0x65, 0x12, 0x19, 0x0a, 0x04, 0x6c, 0x61, 0x7a, 0x79, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a,
+-	0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04, 0x6c, 0x61, 0x7a, 0x79, 0x12, 0x2e, 0x0a, 0x0f,
+-	0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64, 0x5f, 0x6c, 0x61, 0x7a, 0x79, 0x18,
+-	0x0f, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0e, 0x75, 0x6e,
+-	0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64, 0x4c, 0x61, 0x7a, 0x79, 0x12, 0x25, 0x0a, 0x0a,
++	0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75,
++	0x72, 0x65, 0x73, 0x18, 0x32, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
++	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73,
++	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
++	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
++	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
++	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x3a, 0x0a, 0x0c, 0x4f, 0x70,
++	0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64, 0x65, 0x12, 0x09, 0x0a, 0x05, 0x53, 0x50,
++	0x45, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x43, 0x4f, 0x44, 0x45, 0x5f, 0x53, 0x49,
++	0x5a, 0x45, 0x10, 0x02, 0x12, 0x10, 0x0a, 0x0c, 0x4c, 0x49, 0x54, 0x45, 0x5f, 0x52, 0x55, 0x4e,
++	0x54, 0x49, 0x4d, 0x45, 0x10, 0x03, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80,
++	0x02, 0x4a, 0x04, 0x08, 0x2a, 0x10, 0x2b, 0x4a, 0x04, 0x08, 0x26, 0x10, 0x27, 0x22, 0xf4, 0x03,
++	0x0a, 0x0e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x12, 0x3c, 0x0a, 0x17, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x65, 0x74, 0x5f,
++	0x77, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28,
++	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x14, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67,
++	0x65, 0x53, 0x65, 0x74, 0x57, 0x69, 0x72, 0x65, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12, 0x4c,
++	0x0a, 0x1f, 0x6e, 0x6f, 0x5f, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x5f, 0x64, 0x65,
++	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f,
++	0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x1c,
++	0x6e, 0x6f, 0x53, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
++	0x70, 0x74, 0x6f, 0x72, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f, 0x72, 0x12, 0x25, 0x0a, 0x0a,
+ 	0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08,
+ 	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
+-	0x74, 0x65, 0x64, 0x12, 0x19, 0x0a, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x18, 0x0a, 0x20, 0x01, 0x28,
+-	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x12, 0x28,
+-	0x0a, 0x0c, 0x64, 0x65, 0x62, 0x75, 0x67, 0x5f, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x10,
+-	0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62,
+-	0x75, 0x67, 0x52, 0x65, 0x64, 0x61, 0x63, 0x74, 0x12, 0x4b, 0x0a, 0x09, 0x72, 0x65, 0x74, 0x65,
+-	0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x11, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2d, 0x2e, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69,
+-	0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x09, 0x72, 0x65, 0x74, 0x65,
+-	0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x4a, 0x0a, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x18,
+-	0x12, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65,
+-	0x74, 0x54, 0x79, 0x70, 0x65, 0x42, 0x02, 0x18, 0x01, 0x52, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65,
+-	0x74, 0x12, 0x48, 0x0a, 0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x18, 0x13, 0x20, 0x03,
+-	0x28, 0x0e, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+-	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79,
+-	0x70, 0x65, 0x52, 0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75,
+-	0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f,
+-	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x2f, 0x0a, 0x05, 0x43, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0a,
+-	0x0a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x43, 0x4f,
+-	0x52, 0x44, 0x10, 0x01, 0x12, 0x10, 0x0a, 0x0c, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x5f, 0x50,
+-	0x49, 0x45, 0x43, 0x45, 0x10, 0x02, 0x22, 0x35, 0x0a, 0x06, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65,
+-	0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x10, 0x00, 0x12,
+-	0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x01, 0x12, 0x0d,
+-	0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x55, 0x4d, 0x42, 0x45, 0x52, 0x10, 0x02, 0x22, 0x55, 0x0a,
+-	0x0f, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e,
+-	0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e,
+-	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e,
+-	0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x52, 0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x01, 0x12, 0x14,
+-	0x0a, 0x10, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x4f, 0x55, 0x52,
+-	0x43, 0x45, 0x10, 0x02, 0x22, 0x8c, 0x02, 0x0a, 0x10, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54,
+-	0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e,
+-	0x10, 0x00, 0x12, 0x14, 0x0a, 0x10, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x46, 0x49, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x1f, 0x0a, 0x1b, 0x54, 0x41, 0x52, 0x47,
+-	0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f,
+-	0x4e, 0x5f, 0x52, 0x41, 0x4e, 0x47, 0x45, 0x10, 0x02, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45,
+-	0x10, 0x03, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x46, 0x49, 0x45, 0x4c, 0x44, 0x10, 0x04, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4f, 0x4e, 0x45, 0x4f, 0x46, 0x10, 0x05,
+-	0x12, 0x14, 0x0a, 0x10, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
+-	0x45, 0x4e, 0x55, 0x4d, 0x10, 0x06, 0x12, 0x1a, 0x0a, 0x16, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54,
+-	0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x45, 0x4e, 0x54, 0x52, 0x59,
+-	0x10, 0x07, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x53, 0x45, 0x52, 0x56, 0x49, 0x43, 0x45, 0x10, 0x08, 0x12, 0x16, 0x0a, 0x12, 0x54,
+-	0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x54, 0x48, 0x4f,
+-	0x44, 0x10, 0x09, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x04, 0x10, 0x05, 0x22, 0x73, 0x0a, 0x0c, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
+-	0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65,
+-	0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09,
+-	0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x98, 0x02, 0x0a, 0x0b, 0x45, 0x6e,
+-	0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x6c, 0x6c,
+-	0x6f, 0x77, 0x5f, 0x61, 0x6c, 0x69, 0x61, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0a,
+-	0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x41, 0x6c, 0x69, 0x61, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65,
+-	0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05,
+-	0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f,
+-	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c,
+-	0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28,
+-	0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
++	0x74, 0x65, 0x64, 0x12, 0x1b, 0x0a, 0x09, 0x6d, 0x61, 0x70, 0x5f, 0x65, 0x6e, 0x74, 0x72, 0x79,
++	0x18, 0x07, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x6d, 0x61, 0x70, 0x45, 0x6e, 0x74, 0x72, 0x79,
++	0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x6c,
++	0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c, 0x64,
++	0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x08,
++	0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64,
++	0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43,
++	0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x73, 0x18, 0x0c, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07,
++	0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x4a, 0x04, 0x08, 0x05,
++	0x10, 0x06, 0x4a, 0x04, 0x08, 0x06, 0x10, 0x07, 0x4a, 0x04, 0x08, 0x08, 0x10, 0x09, 0x4a, 0x04,
++	0x08, 0x09, 0x10, 0x0a, 0x22, 0xad, 0x0a, 0x0a, 0x0c, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x41, 0x0a, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01,
++	0x20, 0x01, 0x28, 0x0e, 0x32, 0x23, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x2e, 0x43, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e,
++	0x47, 0x52, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x70, 0x61, 0x63, 0x6b,
++	0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64,
++	0x12, 0x47, 0x0a, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e,
++	0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
++	0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41,
++	0x4c, 0x52, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70, 0x65, 0x12, 0x19, 0x0a, 0x04, 0x6c, 0x61, 0x7a,
++	0x79, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04,
++	0x6c, 0x61, 0x7a, 0x79, 0x12, 0x2e, 0x0a, 0x0f, 0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69,
++	0x65, 0x64, 0x5f, 0x6c, 0x61, 0x7a, 0x79, 0x18, 0x0f, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66,
++	0x61, 0x6c, 0x73, 0x65, 0x52, 0x0e, 0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64,
++	0x4c, 0x61, 0x7a, 0x79, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74,
++	0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
++	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x19, 0x0a, 0x04, 0x77,
++	0x65, 0x61, 0x6b, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x12, 0x28, 0x0a, 0x0c, 0x64, 0x65, 0x62, 0x75, 0x67, 0x5f,
++	0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x10, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
++	0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62, 0x75, 0x67, 0x52, 0x65, 0x64, 0x61, 0x63, 0x74,
++	0x12, 0x4b, 0x0a, 0x09, 0x72, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x11, 0x20,
++	0x01, 0x28, 0x0e, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69,
++	0x6f, 0x6e, 0x52, 0x09, 0x72, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x48, 0x0a,
++	0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x18, 0x13, 0x20, 0x03, 0x28, 0x0e, 0x32, 0x2e,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79, 0x70, 0x65, 0x52, 0x07,
++	0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x12, 0x57, 0x0a, 0x10, 0x65, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x5f, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x18, 0x14, 0x20, 0x03, 0x28,
++	0x0b, 0x32, 0x2c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x52,
++	0x0f, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73,
++	0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x15, 0x20, 0x01,
++	0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52,
++	0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+ 	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+ 	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+ 	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+ 	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+ 	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x05, 0x10, 0x06, 0x22, 0x9e, 0x01, 0x0a, 0x10, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c,
+-	0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70,
+-	0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66,
+-	0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64,
+-	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
+-	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
+-	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
+-	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
+-	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10,
+-	0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x9c, 0x01, 0x0a, 0x0e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63,
+-	0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72,
+-	0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12,
+-	0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
+-	0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24,
+-	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+-	0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65,
+-	0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80,
+-	0x80, 0x80, 0x80, 0x02, 0x22, 0xe0, 0x02, 0x0a, 0x0d, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63,
+-	0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73,
+-	0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x71, 0x0a,
+-	0x11, 0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x5f, 0x6c, 0x65, 0x76,
+-	0x65, 0x6c, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f,
+-	0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74,
+-	0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x3a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50,
+-	0x4f, 0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x52, 0x10,
+-	0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c,
+-	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
+-	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
+-	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
+-	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
+-	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x50, 0x0a, 0x10, 0x49, 0x64,
+-	0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12, 0x17,
+-	0x0a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e,
+-	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a, 0x0f, 0x4e, 0x4f, 0x5f, 0x53, 0x49,
+-	0x44, 0x45, 0x5f, 0x45, 0x46, 0x46, 0x45, 0x43, 0x54, 0x53, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a,
+-	0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45, 0x4e, 0x54, 0x10, 0x02, 0x2a, 0x09, 0x08, 0xe8,
+-	0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x9a, 0x03, 0x0a, 0x13, 0x55, 0x6e, 0x69, 0x6e,
+-	0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12,
+-	0x41, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e,
++	0x69, 0x6f, 0x6e, 0x1a, 0x5a, 0x0a, 0x0e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65,
++	0x66, 0x61, 0x75, 0x6c, 0x74, 0x12, 0x32, 0x0a, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e,
++	0x18, 0x03, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e,
++	0x52, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c,
++	0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x22,
++	0x2f, 0x0a, 0x05, 0x43, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x54, 0x52, 0x49,
++	0x4e, 0x47, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x43, 0x4f, 0x52, 0x44, 0x10, 0x01, 0x12, 0x10,
++	0x0a, 0x0c, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x5f, 0x50, 0x49, 0x45, 0x43, 0x45, 0x10, 0x02,
++	0x22, 0x35, 0x0a, 0x06, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53,
++	0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x10, 0x00, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f,
++	0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e,
++	0x55, 0x4d, 0x42, 0x45, 0x52, 0x10, 0x02, 0x22, 0x55, 0x0a, 0x0f, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45,
++	0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10,
++	0x00, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x52,
++	0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x01, 0x12, 0x14, 0x0a, 0x10, 0x52, 0x45, 0x54, 0x45,
++	0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x4f, 0x55, 0x52, 0x43, 0x45, 0x10, 0x02, 0x22, 0x8c,
++	0x02, 0x0a, 0x10, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54,
++	0x79, 0x70, 0x65, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x14, 0x0a, 0x10,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x4c, 0x45,
++	0x10, 0x01, 0x12, 0x1f, 0x0a, 0x1b, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x45, 0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f, 0x4e, 0x5f, 0x52, 0x41, 0x4e, 0x47,
++	0x45, 0x10, 0x02, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x10, 0x03, 0x12, 0x15, 0x0a, 0x11,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x45, 0x4c,
++	0x44, 0x10, 0x04, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x4f, 0x4e, 0x45, 0x4f, 0x46, 0x10, 0x05, 0x12, 0x14, 0x0a, 0x10, 0x54, 0x41,
++	0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x10, 0x06,
++	0x12, 0x1a, 0x0a, 0x16, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x45, 0x4e, 0x54, 0x52, 0x59, 0x10, 0x07, 0x12, 0x17, 0x0a, 0x13,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x45, 0x52, 0x56,
++	0x49, 0x43, 0x45, 0x10, 0x08, 0x12, 0x16, 0x0a, 0x12, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f,
++	0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x54, 0x48, 0x4f, 0x44, 0x10, 0x09, 0x2a, 0x09, 0x08,
++	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x4a, 0x04,
++	0x08, 0x12, 0x10, 0x13, 0x22, 0xac, 0x01, 0x0a, 0x0c, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72,
++	0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58,
++	0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
+ 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+ 	0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x52, 0x04, 0x6e, 0x61,
+-	0x6d, 0x65, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72,
+-	0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x69, 0x64,
+-	0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a,
+-	0x12, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76, 0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61,
+-	0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04, 0x52, 0x10, 0x70, 0x6f, 0x73, 0x69, 0x74,
+-	0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x6e,
+-	0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75,
+-	0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52, 0x10, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76,
+-	0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x64, 0x6f, 0x75,
+-	0x62, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x52,
+-	0x0b, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c,
+-	0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01,
+-	0x28, 0x0c, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12,
+-	0x27, 0x0a, 0x0f, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x5f, 0x76, 0x61, 0x6c,
+-	0x75, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67,
+-	0x61, 0x74, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x1a, 0x4a, 0x0a, 0x08, 0x4e, 0x61, 0x6d, 0x65,
+-	0x50, 0x61, 0x72, 0x74, 0x12, 0x1b, 0x0a, 0x09, 0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x70, 0x61, 0x72,
+-	0x74, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09, 0x52, 0x08, 0x6e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72,
+-	0x74, 0x12, 0x21, 0x0a, 0x0c, 0x69, 0x73, 0x5f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
+-	0x6e, 0x18, 0x02, 0x20, 0x02, 0x28, 0x08, 0x52, 0x0b, 0x69, 0x73, 0x45, 0x78, 0x74, 0x65, 0x6e,
+-	0x73, 0x69, 0x6f, 0x6e, 0x22, 0xa7, 0x02, 0x0a, 0x0e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43,
+-	0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x44, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x28, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
+-	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72,
+-	0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x4c, 0x6f, 0x63, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x52, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xce, 0x01,
+-	0x0a, 0x08, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61,
+-	0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61,
+-	0x74, 0x68, 0x12, 0x16, 0x0a, 0x04, 0x73, 0x70, 0x61, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x05,
+-	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x73, 0x70, 0x61, 0x6e, 0x12, 0x29, 0x0a, 0x10, 0x6c, 0x65,
+-	0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d,
+-	0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x2b, 0x0a, 0x11, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e,
+-	0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x10, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e,
+-	0x74, 0x73, 0x12, 0x3a, 0x0a, 0x19, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x65,
+-	0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18,
+-	0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x17, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x44, 0x65,
+-	0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22, 0xd0,
+-	0x02, 0x0a, 0x11, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65,
+-	0x49, 0x6e, 0x66, 0x6f, 0x12, 0x4d, 0x0a, 0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69,
+-	0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72,
+-	0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e,
+-	0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x1a, 0xeb, 0x01, 0x0a, 0x0a, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69,
++	0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80,
++	0x80, 0x80, 0x02, 0x22, 0xd1, 0x02, 0x0a, 0x0b, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x5f, 0x61, 0x6c, 0x69,
++	0x61, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0a, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x41,
++	0x6c, 0x69, 0x61, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74,
++	0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
++	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x56, 0x0a, 0x26, 0x64,
++	0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79,
++	0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66,
++	0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52,
++	0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x4c, 0x65, 0x67, 0x61, 0x63,
++	0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69,
++	0x63, 0x74, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14,
++	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e,
++	0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80,
++	0x02, 0x4a, 0x04, 0x08, 0x05, 0x10, 0x06, 0x22, 0x81, 0x02, 0x0a, 0x10, 0x45, 0x6e, 0x75, 0x6d,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a,
++	0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08,
++	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
++	0x74, 0x65, 0x64, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x28, 0x0a, 0x0c,
++	0x64, 0x65, 0x62, 0x75, 0x67, 0x5f, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x03, 0x20, 0x01,
++	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62, 0x75, 0x67,
++	0x52, 0x65, 0x64, 0x61, 0x63, 0x74, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7,
++	0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69,
++	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0xd5, 0x01, 0x0a, 0x0e,
++	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x37,
++	0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0b,
++	0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66,
++	0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65,
++	0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x58,
++	0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
++	0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80,
++	0x80, 0x80, 0x02, 0x22, 0x99, 0x03, 0x0a, 0x0d, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
++	0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x71, 0x0a, 0x11,
++	0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x5f, 0x6c, 0x65, 0x76, 0x65,
++	0x6c, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65,
++	0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x3a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f,
++	0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x52, 0x10, 0x69,
++	0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12,
++	0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x23, 0x20, 0x01, 0x28,
++	0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08,
++	0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e,
++	0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75,
++	0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x22, 0x50, 0x0a, 0x10, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63,
++	0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12, 0x17, 0x0a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f,
++	0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12,
++	0x13, 0x0a, 0x0f, 0x4e, 0x4f, 0x5f, 0x53, 0x49, 0x44, 0x45, 0x5f, 0x45, 0x46, 0x46, 0x45, 0x43,
++	0x54, 0x53, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45,
++	0x4e, 0x54, 0x10, 0x02, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22,
++	0x9a, 0x03, 0x0a, 0x13, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
++	0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
++	0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65,
++	0x50, 0x61, 0x72, 0x74, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x64,
++	0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03,
++	0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76,
++	0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28,
++	0x04, 0x52, 0x10, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61,
++	0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x5f,
++	0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52,
++	0x10, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75,
++	0x65, 0x12, 0x21, 0x0a, 0x0c, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75,
++	0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x52, 0x0b, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x56,
++	0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76,
++	0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69,
++	0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x27, 0x0a, 0x0f, 0x61, 0x67, 0x67, 0x72, 0x65,
++	0x67, 0x61, 0x74, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09,
++	0x52, 0x0e, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65,
++	0x1a, 0x4a, 0x0a, 0x08, 0x4e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x12, 0x1b, 0x0a, 0x09,
++	0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x70, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09, 0x52,
++	0x08, 0x6e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x12, 0x21, 0x0a, 0x0c, 0x69, 0x73, 0x5f,
++	0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x02, 0x28, 0x08, 0x52,
++	0x0b, 0x69, 0x73, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x8c, 0x0a, 0x0a,
++	0x0a, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x12, 0x8b, 0x01, 0x0a, 0x0e,
++	0x66, 0x69, 0x65, 0x6c, 0x64, 0x5f, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x18, 0x01,
++	0x20, 0x01, 0x28, 0x0e, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x42,
++	0x39, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45,
++	0x58, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x49,
++	0x4d, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe7, 0x07, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45,
++	0x58, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe8, 0x07, 0x52, 0x0d, 0x66, 0x69, 0x65, 0x6c,
++	0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x66, 0x0a, 0x09, 0x65, 0x6e, 0x75,
++	0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x24, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
++	0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x54, 0x79,
++	0x70, 0x65, 0x42, 0x23, 0x88, 0x01, 0x01, 0x98, 0x01, 0x06, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x0b,
++	0x12, 0x06, 0x43, 0x4c, 0x4f, 0x53, 0x45, 0x44, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x09, 0x12, 0x04,
++	0x4f, 0x50, 0x45, 0x4e, 0x18, 0xe7, 0x07, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54, 0x79, 0x70,
++	0x65, 0x12, 0x92, 0x01, 0x0a, 0x17, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x66,
++	0x69, 0x65, 0x6c, 0x64, 0x5f, 0x65, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x18, 0x03, 0x20,
++	0x01, 0x28, 0x0e, 0x32, 0x31, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74,
++	0x2e, 0x52, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x45, 0x6e,
++	0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x42, 0x27, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98, 0x01,
++	0x01, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45, 0x58, 0x50, 0x41, 0x4e, 0x44, 0x45, 0x44, 0x18, 0xe6,
++	0x07, 0xa2, 0x01, 0x0b, 0x12, 0x06, 0x50, 0x41, 0x43, 0x4b, 0x45, 0x44, 0x18, 0xe7, 0x07, 0x52,
++	0x15, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x45, 0x6e,
++	0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x78, 0x0a, 0x0f, 0x75, 0x74, 0x66, 0x38, 0x5f, 0x76,
++	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0e, 0x32,
++	0x2a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x55, 0x74, 0x66,
++	0x38, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x23, 0x88, 0x01, 0x01,
++	0x98, 0x01, 0x04, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x09, 0x12, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x18,
++	0xe6, 0x07, 0xa2, 0x01, 0x0b, 0x12, 0x06, 0x56, 0x45, 0x52, 0x49, 0x46, 0x59, 0x18, 0xe7, 0x07,
++	0x52, 0x0e, 0x75, 0x74, 0x66, 0x38, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x12, 0x78, 0x0a, 0x10, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x65, 0x6e, 0x63, 0x6f,
++	0x64, 0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x45,
++	0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x42, 0x20, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98,
++	0x01, 0x01, 0xa2, 0x01, 0x14, 0x12, 0x0f, 0x4c, 0x45, 0x4e, 0x47, 0x54, 0x48, 0x5f, 0x50, 0x52,
++	0x45, 0x46, 0x49, 0x58, 0x45, 0x44, 0x18, 0xe6, 0x07, 0x52, 0x0f, 0x6d, 0x65, 0x73, 0x73, 0x61,
++	0x67, 0x65, 0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x7c, 0x0a, 0x0b, 0x6a, 0x73,
++	0x6f, 0x6e, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e, 0x32,
++	0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x4a, 0x73, 0x6f,
++	0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x42, 0x33, 0x88, 0x01, 0x01, 0x98, 0x01, 0x03, 0x98,
++	0x01, 0x06, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x17, 0x12, 0x12, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59,
++	0x5f, 0x42, 0x45, 0x53, 0x54, 0x5f, 0x45, 0x46, 0x46, 0x4f, 0x52, 0x54, 0x18, 0xe6, 0x07, 0xa2,
++	0x01, 0x0a, 0x12, 0x05, 0x41, 0x4c, 0x4c, 0x4f, 0x57, 0x18, 0xe7, 0x07, 0x52, 0x0a, 0x6a, 0x73,
++	0x6f, 0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x22, 0x5c, 0x0a, 0x0d, 0x46, 0x69, 0x65, 0x6c,
++	0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x1a, 0x0a, 0x16, 0x46, 0x49, 0x45,
++	0x4c, 0x44, 0x5f, 0x50, 0x52, 0x45, 0x53, 0x45, 0x4e, 0x43, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e,
++	0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0c, 0x0a, 0x08, 0x45, 0x58, 0x50, 0x4c, 0x49, 0x43, 0x49,
++	0x54, 0x10, 0x01, 0x12, 0x0c, 0x0a, 0x08, 0x49, 0x4d, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x10,
++	0x02, 0x12, 0x13, 0x0a, 0x0f, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59, 0x5f, 0x52, 0x45, 0x51, 0x55,
++	0x49, 0x52, 0x45, 0x44, 0x10, 0x03, 0x22, 0x37, 0x0a, 0x08, 0x45, 0x6e, 0x75, 0x6d, 0x54, 0x79,
++	0x70, 0x65, 0x12, 0x15, 0x0a, 0x11, 0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x4f, 0x50, 0x45,
++	0x4e, 0x10, 0x01, 0x12, 0x0a, 0x0a, 0x06, 0x43, 0x4c, 0x4f, 0x53, 0x45, 0x44, 0x10, 0x02, 0x22,
++	0x56, 0x0a, 0x15, 0x52, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64,
++	0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x23, 0x0a, 0x1f, 0x52, 0x45, 0x50, 0x45,
++	0x41, 0x54, 0x45, 0x44, 0x5f, 0x46, 0x49, 0x45, 0x4c, 0x44, 0x5f, 0x45, 0x4e, 0x43, 0x4f, 0x44,
++	0x49, 0x4e, 0x47, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a,
++	0x06, 0x50, 0x41, 0x43, 0x4b, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0c, 0x0a, 0x08, 0x45, 0x58, 0x50,
++	0x41, 0x4e, 0x44, 0x45, 0x44, 0x10, 0x02, 0x22, 0x43, 0x0a, 0x0e, 0x55, 0x74, 0x66, 0x38, 0x56,
++	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x1b, 0x0a, 0x17, 0x55, 0x54, 0x46,
++	0x38, 0x5f, 0x56, 0x41, 0x4c, 0x49, 0x44, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e, 0x4b,
++	0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x56, 0x45, 0x52, 0x49, 0x46, 0x59,
++	0x10, 0x02, 0x12, 0x08, 0x0a, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x03, 0x22, 0x53, 0x0a, 0x0f,
++	0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12,
++	0x1c, 0x0a, 0x18, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x5f, 0x45, 0x4e, 0x43, 0x4f, 0x44,
++	0x49, 0x4e, 0x47, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a,
++	0x0f, 0x4c, 0x45, 0x4e, 0x47, 0x54, 0x48, 0x5f, 0x50, 0x52, 0x45, 0x46, 0x49, 0x58, 0x45, 0x44,
++	0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x44, 0x45, 0x4c, 0x49, 0x4d, 0x49, 0x54, 0x45, 0x44, 0x10,
++	0x02, 0x22, 0x48, 0x0a, 0x0a, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12,
++	0x17, 0x0a, 0x13, 0x4a, 0x53, 0x4f, 0x4e, 0x5f, 0x46, 0x4f, 0x52, 0x4d, 0x41, 0x54, 0x5f, 0x55,
++	0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x4c, 0x4c, 0x4f,
++	0x57, 0x10, 0x01, 0x12, 0x16, 0x0a, 0x12, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59, 0x5f, 0x42, 0x45,
++	0x53, 0x54, 0x5f, 0x45, 0x46, 0x46, 0x4f, 0x52, 0x54, 0x10, 0x02, 0x2a, 0x06, 0x08, 0xe8, 0x07,
++	0x10, 0xe9, 0x07, 0x2a, 0x06, 0x08, 0xe9, 0x07, 0x10, 0xea, 0x07, 0x2a, 0x06, 0x08, 0xea, 0x07,
++	0x10, 0xeb, 0x07, 0x2a, 0x06, 0x08, 0x8b, 0x4e, 0x10, 0x90, 0x4e, 0x2a, 0x06, 0x08, 0x90, 0x4e,
++	0x10, 0x91, 0x4e, 0x4a, 0x06, 0x08, 0xe7, 0x07, 0x10, 0xe8, 0x07, 0x22, 0xfe, 0x02, 0x0a, 0x12,
++	0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c,
++	0x74, 0x73, 0x12, 0x58, 0x0a, 0x08, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x18, 0x01,
++	0x20, 0x03, 0x28, 0x0b, 0x32, 0x3c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72,
++	0x65, 0x53, 0x65, 0x74, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75,
++	0x6c, 0x74, 0x52, 0x08, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x12, 0x41, 0x0a, 0x0f,
++	0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x5f, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x18,
++	0x04, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x52,
++	0x0e, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12,
++	0x41, 0x0a, 0x0f, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x5f, 0x65, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
++	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x52, 0x0e, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x45, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x1a, 0x87, 0x01, 0x0a, 0x18, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x12,
++	0x32, 0x0a, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0e,
++	0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74,
++	0x69, 0x6f, 0x6e, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x22, 0xa7, 0x02, 0x0a,
++	0x0e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12,
++	0x44, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28,
++	0x0b, 0x32, 0x28, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e,
++	0x66, 0x6f, 0x2e, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x08, 0x6c, 0x6f, 0x63,
++	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xce, 0x01, 0x0a, 0x08, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69,
+ 	0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61, 0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05,
+-	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x12, 0x1f, 0x0a, 0x0b, 0x73, 0x6f,
+-	0x75, 0x72, 0x63, 0x65, 0x5f, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+-	0x0a, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x62,
+-	0x65, 0x67, 0x69, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x62, 0x65, 0x67, 0x69,
+-	0x6e, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03,
+-	0x65, 0x6e, 0x64, 0x12, 0x52, 0x0a, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18,
+-	0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x36, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
+-	0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61,
+-	0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x52, 0x08, 0x73,
+-	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x22, 0x28, 0x0a, 0x08, 0x53, 0x65, 0x6d, 0x61, 0x6e,
+-	0x74, 0x69, 0x63, 0x12, 0x08, 0x0a, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x07, 0x0a,
+-	0x03, 0x53, 0x45, 0x54, 0x10, 0x01, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x4c, 0x49, 0x41, 0x53, 0x10,
+-	0x02, 0x42, 0x7e, 0x0a, 0x13, 0x63, 0x6f, 0x6d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x42, 0x10, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
+-	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x73, 0x48, 0x01, 0x5a, 0x2d, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2f, 0x64,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x70, 0x62, 0xf8, 0x01, 0x01, 0xa2, 0x02,
+-	0x03, 0x47, 0x50, 0x42, 0xaa, 0x02, 0x1a, 0x47, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x50, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x52, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f,
+-	0x6e,
++	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x12, 0x16, 0x0a, 0x04, 0x73, 0x70,
++	0x61, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x73, 0x70,
++	0x61, 0x6e, 0x12, 0x29, 0x0a, 0x10, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f,
++	0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6c, 0x65,
++	0x61, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x2b, 0x0a,
++	0x11, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e,
++	0x74, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69,
++	0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x3a, 0x0a, 0x19, 0x6c, 0x65,
++	0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x65, 0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x5f, 0x63,
++	0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x17, 0x6c,
++	0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x44, 0x65, 0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x43, 0x6f,
++	0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22, 0xd0, 0x02, 0x0a, 0x11, 0x47, 0x65, 0x6e, 0x65, 0x72,
++	0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x4d, 0x0a, 0x0a,
++	0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65,
++	0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52,
++	0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xeb, 0x01, 0x0a, 0x0a,
++	0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61,
++	0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61,
++	0x74, 0x68, 0x12, 0x1f, 0x0a, 0x0b, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x66, 0x69, 0x6c,
++	0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x46,
++	0x69, 0x6c, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x62, 0x65, 0x67, 0x69, 0x6e, 0x18, 0x03, 0x20, 0x01,
++	0x28, 0x05, 0x52, 0x05, 0x62, 0x65, 0x67, 0x69, 0x6e, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64,
++	0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x12, 0x52, 0x0a, 0x08, 0x73,
++	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x36, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
++	0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x53, 0x65, 0x6d,
++	0x61, 0x6e, 0x74, 0x69, 0x63, 0x52, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x22,
++	0x28, 0x0a, 0x08, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x12, 0x08, 0x0a, 0x04, 0x4e,
++	0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x07, 0x0a, 0x03, 0x53, 0x45, 0x54, 0x10, 0x01, 0x12, 0x09,
++	0x0a, 0x05, 0x41, 0x4c, 0x49, 0x41, 0x53, 0x10, 0x02, 0x2a, 0x92, 0x02, 0x0a, 0x07, 0x45, 0x64,
++	0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x13, 0x0a, 0x0f, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e,
++	0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a, 0x0e, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x50, 0x52, 0x4f, 0x54, 0x4f, 0x32, 0x10, 0xe6, 0x07, 0x12,
++	0x13, 0x0a, 0x0e, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x50, 0x52, 0x4f, 0x54, 0x4f,
++	0x33, 0x10, 0xe7, 0x07, 0x12, 0x11, 0x0a, 0x0c, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f,
++	0x32, 0x30, 0x32, 0x33, 0x10, 0xe8, 0x07, 0x12, 0x11, 0x0a, 0x0c, 0x45, 0x44, 0x49, 0x54, 0x49,
++	0x4f, 0x4e, 0x5f, 0x32, 0x30, 0x32, 0x34, 0x10, 0xe9, 0x07, 0x12, 0x17, 0x0a, 0x13, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x31, 0x5f, 0x54, 0x45, 0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c,
++	0x59, 0x10, 0x01, 0x12, 0x17, 0x0a, 0x13, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x32,
++	0x5f, 0x54, 0x45, 0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x02, 0x12, 0x1d, 0x0a, 0x17,
++	0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x37, 0x5f, 0x54, 0x45,
++	0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9d, 0x8d, 0x06, 0x12, 0x1d, 0x0a, 0x17, 0x45,
++	0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x38, 0x5f, 0x54, 0x45, 0x53,
++	0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9e, 0x8d, 0x06, 0x12, 0x1d, 0x0a, 0x17, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x39, 0x5f, 0x54, 0x45, 0x53, 0x54,
++	0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9f, 0x8d, 0x06, 0x12, 0x13, 0x0a, 0x0b, 0x45, 0x44, 0x49,
++	0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x4d, 0x41, 0x58, 0x10, 0xff, 0xff, 0xff, 0xff, 0x07, 0x42, 0x7e,
++	0x0a, 0x13, 0x63, 0x6f, 0x6d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x42, 0x10, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f,
++	0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x73, 0x48, 0x01, 0x5a, 0x2d, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
++	0x65, 0x2e, 0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2f, 0x64, 0x65, 0x73, 0x63,
++	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x70, 0x62, 0xf8, 0x01, 0x01, 0xa2, 0x02, 0x03, 0x47, 0x50,
++	0x42, 0xaa, 0x02, 0x1a, 0x47, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x50, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x52, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e,
+ }
+ 
+ var (
+@@ -4123,103 +5083,136 @@ func file_google_protobuf_descriptor_proto_rawDescGZIP() []byte {
+ 	return file_google_protobuf_descriptor_proto_rawDescData
+ }
+ 
+-var file_google_protobuf_descriptor_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+-var file_google_protobuf_descriptor_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
++var file_google_protobuf_descriptor_proto_enumTypes = make([]protoimpl.EnumInfo, 17)
++var file_google_protobuf_descriptor_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+ var file_google_protobuf_descriptor_proto_goTypes = []interface{}{
+-	(ExtensionRangeOptions_VerificationState)(0),  // 0: google.protobuf.ExtensionRangeOptions.VerificationState
+-	(FieldDescriptorProto_Type)(0),                // 1: google.protobuf.FieldDescriptorProto.Type
+-	(FieldDescriptorProto_Label)(0),               // 2: google.protobuf.FieldDescriptorProto.Label
+-	(FileOptions_OptimizeMode)(0),                 // 3: google.protobuf.FileOptions.OptimizeMode
+-	(FieldOptions_CType)(0),                       // 4: google.protobuf.FieldOptions.CType
+-	(FieldOptions_JSType)(0),                      // 5: google.protobuf.FieldOptions.JSType
+-	(FieldOptions_OptionRetention)(0),             // 6: google.protobuf.FieldOptions.OptionRetention
+-	(FieldOptions_OptionTargetType)(0),            // 7: google.protobuf.FieldOptions.OptionTargetType
+-	(MethodOptions_IdempotencyLevel)(0),           // 8: google.protobuf.MethodOptions.IdempotencyLevel
+-	(GeneratedCodeInfo_Annotation_Semantic)(0),    // 9: google.protobuf.GeneratedCodeInfo.Annotation.Semantic
+-	(*FileDescriptorSet)(nil),                     // 10: google.protobuf.FileDescriptorSet
+-	(*FileDescriptorProto)(nil),                   // 11: google.protobuf.FileDescriptorProto
+-	(*DescriptorProto)(nil),                       // 12: google.protobuf.DescriptorProto
+-	(*ExtensionRangeOptions)(nil),                 // 13: google.protobuf.ExtensionRangeOptions
+-	(*FieldDescriptorProto)(nil),                  // 14: google.protobuf.FieldDescriptorProto
+-	(*OneofDescriptorProto)(nil),                  // 15: google.protobuf.OneofDescriptorProto
+-	(*EnumDescriptorProto)(nil),                   // 16: google.protobuf.EnumDescriptorProto
+-	(*EnumValueDescriptorProto)(nil),              // 17: google.protobuf.EnumValueDescriptorProto
+-	(*ServiceDescriptorProto)(nil),                // 18: google.protobuf.ServiceDescriptorProto
+-	(*MethodDescriptorProto)(nil),                 // 19: google.protobuf.MethodDescriptorProto
+-	(*FileOptions)(nil),                           // 20: google.protobuf.FileOptions
+-	(*MessageOptions)(nil),                        // 21: google.protobuf.MessageOptions
+-	(*FieldOptions)(nil),                          // 22: google.protobuf.FieldOptions
+-	(*OneofOptions)(nil),                          // 23: google.protobuf.OneofOptions
+-	(*EnumOptions)(nil),                           // 24: google.protobuf.EnumOptions
+-	(*EnumValueOptions)(nil),                      // 25: google.protobuf.EnumValueOptions
+-	(*ServiceOptions)(nil),                        // 26: google.protobuf.ServiceOptions
+-	(*MethodOptions)(nil),                         // 27: google.protobuf.MethodOptions
+-	(*UninterpretedOption)(nil),                   // 28: google.protobuf.UninterpretedOption
+-	(*SourceCodeInfo)(nil),                        // 29: google.protobuf.SourceCodeInfo
+-	(*GeneratedCodeInfo)(nil),                     // 30: google.protobuf.GeneratedCodeInfo
+-	(*DescriptorProto_ExtensionRange)(nil),        // 31: google.protobuf.DescriptorProto.ExtensionRange
+-	(*DescriptorProto_ReservedRange)(nil),         // 32: google.protobuf.DescriptorProto.ReservedRange
+-	(*ExtensionRangeOptions_Declaration)(nil),     // 33: google.protobuf.ExtensionRangeOptions.Declaration
+-	(*EnumDescriptorProto_EnumReservedRange)(nil), // 34: google.protobuf.EnumDescriptorProto.EnumReservedRange
+-	(*UninterpretedOption_NamePart)(nil),          // 35: google.protobuf.UninterpretedOption.NamePart
+-	(*SourceCodeInfo_Location)(nil),               // 36: google.protobuf.SourceCodeInfo.Location
+-	(*GeneratedCodeInfo_Annotation)(nil),          // 37: google.protobuf.GeneratedCodeInfo.Annotation
++	(Edition)(0), // 0: google.protobuf.Edition
++	(ExtensionRangeOptions_VerificationState)(0),        // 1: google.protobuf.ExtensionRangeOptions.VerificationState
++	(FieldDescriptorProto_Type)(0),                      // 2: google.protobuf.FieldDescriptorProto.Type
++	(FieldDescriptorProto_Label)(0),                     // 3: google.protobuf.FieldDescriptorProto.Label
++	(FileOptions_OptimizeMode)(0),                       // 4: google.protobuf.FileOptions.OptimizeMode
++	(FieldOptions_CType)(0),                             // 5: google.protobuf.FieldOptions.CType
++	(FieldOptions_JSType)(0),                            // 6: google.protobuf.FieldOptions.JSType
++	(FieldOptions_OptionRetention)(0),                   // 7: google.protobuf.FieldOptions.OptionRetention
++	(FieldOptions_OptionTargetType)(0),                  // 8: google.protobuf.FieldOptions.OptionTargetType
++	(MethodOptions_IdempotencyLevel)(0),                 // 9: google.protobuf.MethodOptions.IdempotencyLevel
++	(FeatureSet_FieldPresence)(0),                       // 10: google.protobuf.FeatureSet.FieldPresence
++	(FeatureSet_EnumType)(0),                            // 11: google.protobuf.FeatureSet.EnumType
++	(FeatureSet_RepeatedFieldEncoding)(0),               // 12: google.protobuf.FeatureSet.RepeatedFieldEncoding
++	(FeatureSet_Utf8Validation)(0),                      // 13: google.protobuf.FeatureSet.Utf8Validation
++	(FeatureSet_MessageEncoding)(0),                     // 14: google.protobuf.FeatureSet.MessageEncoding
++	(FeatureSet_JsonFormat)(0),                          // 15: google.protobuf.FeatureSet.JsonFormat
++	(GeneratedCodeInfo_Annotation_Semantic)(0),          // 16: google.protobuf.GeneratedCodeInfo.Annotation.Semantic
++	(*FileDescriptorSet)(nil),                           // 17: google.protobuf.FileDescriptorSet
++	(*FileDescriptorProto)(nil),                         // 18: google.protobuf.FileDescriptorProto
++	(*DescriptorProto)(nil),                             // 19: google.protobuf.DescriptorProto
++	(*ExtensionRangeOptions)(nil),                       // 20: google.protobuf.ExtensionRangeOptions
++	(*FieldDescriptorProto)(nil),                        // 21: google.protobuf.FieldDescriptorProto
++	(*OneofDescriptorProto)(nil),                        // 22: google.protobuf.OneofDescriptorProto
++	(*EnumDescriptorProto)(nil),                         // 23: google.protobuf.EnumDescriptorProto
++	(*EnumValueDescriptorProto)(nil),                    // 24: google.protobuf.EnumValueDescriptorProto
++	(*ServiceDescriptorProto)(nil),                      // 25: google.protobuf.ServiceDescriptorProto
++	(*MethodDescriptorProto)(nil),                       // 26: google.protobuf.MethodDescriptorProto
++	(*FileOptions)(nil),                                 // 27: google.protobuf.FileOptions
++	(*MessageOptions)(nil),                              // 28: google.protobuf.MessageOptions
++	(*FieldOptions)(nil),                                // 29: google.protobuf.FieldOptions
++	(*OneofOptions)(nil),                                // 30: google.protobuf.OneofOptions
++	(*EnumOptions)(nil),                                 // 31: google.protobuf.EnumOptions
++	(*EnumValueOptions)(nil),                            // 32: google.protobuf.EnumValueOptions
++	(*ServiceOptions)(nil),                              // 33: google.protobuf.ServiceOptions
++	(*MethodOptions)(nil),                               // 34: google.protobuf.MethodOptions
++	(*UninterpretedOption)(nil),                         // 35: google.protobuf.UninterpretedOption
++	(*FeatureSet)(nil),                                  // 36: google.protobuf.FeatureSet
++	(*FeatureSetDefaults)(nil),                          // 37: google.protobuf.FeatureSetDefaults
++	(*SourceCodeInfo)(nil),                              // 38: google.protobuf.SourceCodeInfo
++	(*GeneratedCodeInfo)(nil),                           // 39: google.protobuf.GeneratedCodeInfo
++	(*DescriptorProto_ExtensionRange)(nil),              // 40: google.protobuf.DescriptorProto.ExtensionRange
++	(*DescriptorProto_ReservedRange)(nil),               // 41: google.protobuf.DescriptorProto.ReservedRange
++	(*ExtensionRangeOptions_Declaration)(nil),           // 42: google.protobuf.ExtensionRangeOptions.Declaration
++	(*EnumDescriptorProto_EnumReservedRange)(nil),       // 43: google.protobuf.EnumDescriptorProto.EnumReservedRange
++	(*FieldOptions_EditionDefault)(nil),                 // 44: google.protobuf.FieldOptions.EditionDefault
++	(*UninterpretedOption_NamePart)(nil),                // 45: google.protobuf.UninterpretedOption.NamePart
++	(*FeatureSetDefaults_FeatureSetEditionDefault)(nil), // 46: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
++	(*SourceCodeInfo_Location)(nil),                     // 47: google.protobuf.SourceCodeInfo.Location
++	(*GeneratedCodeInfo_Annotation)(nil),                // 48: google.protobuf.GeneratedCodeInfo.Annotation
+ }
+ var file_google_protobuf_descriptor_proto_depIdxs = []int32{
+-	11, // 0: google.protobuf.FileDescriptorSet.file:type_name -> google.protobuf.FileDescriptorProto
+-	12, // 1: google.protobuf.FileDescriptorProto.message_type:type_name -> google.protobuf.DescriptorProto
+-	16, // 2: google.protobuf.FileDescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
+-	18, // 3: google.protobuf.FileDescriptorProto.service:type_name -> google.protobuf.ServiceDescriptorProto
+-	14, // 4: google.protobuf.FileDescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
+-	20, // 5: google.protobuf.FileDescriptorProto.options:type_name -> google.protobuf.FileOptions
+-	29, // 6: google.protobuf.FileDescriptorProto.source_code_info:type_name -> google.protobuf.SourceCodeInfo
+-	14, // 7: google.protobuf.DescriptorProto.field:type_name -> google.protobuf.FieldDescriptorProto
+-	14, // 8: google.protobuf.DescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
+-	12, // 9: google.protobuf.DescriptorProto.nested_type:type_name -> google.protobuf.DescriptorProto
+-	16, // 10: google.protobuf.DescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
+-	31, // 11: google.protobuf.DescriptorProto.extension_range:type_name -> google.protobuf.DescriptorProto.ExtensionRange
+-	15, // 12: google.protobuf.DescriptorProto.oneof_decl:type_name -> google.protobuf.OneofDescriptorProto
+-	21, // 13: google.protobuf.DescriptorProto.options:type_name -> google.protobuf.MessageOptions
+-	32, // 14: google.protobuf.DescriptorProto.reserved_range:type_name -> google.protobuf.DescriptorProto.ReservedRange
+-	28, // 15: google.protobuf.ExtensionRangeOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	33, // 16: google.protobuf.ExtensionRangeOptions.declaration:type_name -> google.protobuf.ExtensionRangeOptions.Declaration
+-	0,  // 17: google.protobuf.ExtensionRangeOptions.verification:type_name -> google.protobuf.ExtensionRangeOptions.VerificationState
+-	2,  // 18: google.protobuf.FieldDescriptorProto.label:type_name -> google.protobuf.FieldDescriptorProto.Label
+-	1,  // 19: google.protobuf.FieldDescriptorProto.type:type_name -> google.protobuf.FieldDescriptorProto.Type
+-	22, // 20: google.protobuf.FieldDescriptorProto.options:type_name -> google.protobuf.FieldOptions
+-	23, // 21: google.protobuf.OneofDescriptorProto.options:type_name -> google.protobuf.OneofOptions
+-	17, // 22: google.protobuf.EnumDescriptorProto.value:type_name -> google.protobuf.EnumValueDescriptorProto
+-	24, // 23: google.protobuf.EnumDescriptorProto.options:type_name -> google.protobuf.EnumOptions
+-	34, // 24: google.protobuf.EnumDescriptorProto.reserved_range:type_name -> google.protobuf.EnumDescriptorProto.EnumReservedRange
+-	25, // 25: google.protobuf.EnumValueDescriptorProto.options:type_name -> google.protobuf.EnumValueOptions
+-	19, // 26: google.protobuf.ServiceDescriptorProto.method:type_name -> google.protobuf.MethodDescriptorProto
+-	26, // 27: google.protobuf.ServiceDescriptorProto.options:type_name -> google.protobuf.ServiceOptions
+-	27, // 28: google.protobuf.MethodDescriptorProto.options:type_name -> google.protobuf.MethodOptions
+-	3,  // 29: google.protobuf.FileOptions.optimize_for:type_name -> google.protobuf.FileOptions.OptimizeMode
+-	28, // 30: google.protobuf.FileOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 31: google.protobuf.MessageOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	4,  // 32: google.protobuf.FieldOptions.ctype:type_name -> google.protobuf.FieldOptions.CType
+-	5,  // 33: google.protobuf.FieldOptions.jstype:type_name -> google.protobuf.FieldOptions.JSType
+-	6,  // 34: google.protobuf.FieldOptions.retention:type_name -> google.protobuf.FieldOptions.OptionRetention
+-	7,  // 35: google.protobuf.FieldOptions.target:type_name -> google.protobuf.FieldOptions.OptionTargetType
+-	7,  // 36: google.protobuf.FieldOptions.targets:type_name -> google.protobuf.FieldOptions.OptionTargetType
+-	28, // 37: google.protobuf.FieldOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 38: google.protobuf.OneofOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 39: google.protobuf.EnumOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 40: google.protobuf.EnumValueOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 41: google.protobuf.ServiceOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	8,  // 42: google.protobuf.MethodOptions.idempotency_level:type_name -> google.protobuf.MethodOptions.IdempotencyLevel
+-	28, // 43: google.protobuf.MethodOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	35, // 44: google.protobuf.UninterpretedOption.name:type_name -> google.protobuf.UninterpretedOption.NamePart
+-	36, // 45: google.protobuf.SourceCodeInfo.location:type_name -> google.protobuf.SourceCodeInfo.Location
+-	37, // 46: google.protobuf.GeneratedCodeInfo.annotation:type_name -> google.protobuf.GeneratedCodeInfo.Annotation
+-	13, // 47: google.protobuf.DescriptorProto.ExtensionRange.options:type_name -> google.protobuf.ExtensionRangeOptions
+-	9,  // 48: google.protobuf.GeneratedCodeInfo.Annotation.semantic:type_name -> google.protobuf.GeneratedCodeInfo.Annotation.Semantic
+-	49, // [49:49] is the sub-list for method output_type
+-	49, // [49:49] is the sub-list for method input_type
+-	49, // [49:49] is the sub-list for extension type_name
+-	49, // [49:49] is the sub-list for extension extendee
+-	0,  // [0:49] is the sub-list for field type_name
++	18, // 0: google.protobuf.FileDescriptorSet.file:type_name -> google.protobuf.FileDescriptorProto
++	19, // 1: google.protobuf.FileDescriptorProto.message_type:type_name -> google.protobuf.DescriptorProto
++	23, // 2: google.protobuf.FileDescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
++	25, // 3: google.protobuf.FileDescriptorProto.service:type_name -> google.protobuf.ServiceDescriptorProto
++	21, // 4: google.protobuf.FileDescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
++	27, // 5: google.protobuf.FileDescriptorProto.options:type_name -> google.protobuf.FileOptions
++	38, // 6: google.protobuf.FileDescriptorProto.source_code_info:type_name -> google.protobuf.SourceCodeInfo
++	0,  // 7: google.protobuf.FileDescriptorProto.edition:type_name -> google.protobuf.Edition
++	21, // 8: google.protobuf.DescriptorProto.field:type_name -> google.protobuf.FieldDescriptorProto
++	21, // 9: google.protobuf.DescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
++	19, // 10: google.protobuf.DescriptorProto.nested_type:type_name -> google.protobuf.DescriptorProto
++	23, // 11: google.protobuf.DescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
++	40, // 12: google.protobuf.DescriptorProto.extension_range:type_name -> google.protobuf.DescriptorProto.ExtensionRange
++	22, // 13: google.protobuf.DescriptorProto.oneof_decl:type_name -> google.protobuf.OneofDescriptorProto
++	28, // 14: google.protobuf.DescriptorProto.options:type_name -> google.protobuf.MessageOptions
++	41, // 15: google.protobuf.DescriptorProto.reserved_range:type_name -> google.protobuf.DescriptorProto.ReservedRange
++	35, // 16: google.protobuf.ExtensionRangeOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	42, // 17: google.protobuf.ExtensionRangeOptions.declaration:type_name -> google.protobuf.ExtensionRangeOptions.Declaration
++	36, // 18: google.protobuf.ExtensionRangeOptions.features:type_name -> google.protobuf.FeatureSet
++	1,  // 19: google.protobuf.ExtensionRangeOptions.verification:type_name -> google.protobuf.ExtensionRangeOptions.VerificationState
++	3,  // 20: google.protobuf.FieldDescriptorProto.label:type_name -> google.protobuf.FieldDescriptorProto.Label
++	2,  // 21: google.protobuf.FieldDescriptorProto.type:type_name -> google.protobuf.FieldDescriptorProto.Type
++	29, // 22: google.protobuf.FieldDescriptorProto.options:type_name -> google.protobuf.FieldOptions
++	30, // 23: google.protobuf.OneofDescriptorProto.options:type_name -> google.protobuf.OneofOptions
++	24, // 24: google.protobuf.EnumDescriptorProto.value:type_name -> google.protobuf.EnumValueDescriptorProto
++	31, // 25: google.protobuf.EnumDescriptorProto.options:type_name -> google.protobuf.EnumOptions
++	43, // 26: google.protobuf.EnumDescriptorProto.reserved_range:type_name -> google.protobuf.EnumDescriptorProto.EnumReservedRange
++	32, // 27: google.protobuf.EnumValueDescriptorProto.options:type_name -> google.protobuf.EnumValueOptions
++	26, // 28: google.protobuf.ServiceDescriptorProto.method:type_name -> google.protobuf.MethodDescriptorProto
++	33, // 29: google.protobuf.ServiceDescriptorProto.options:type_name -> google.protobuf.ServiceOptions
++	34, // 30: google.protobuf.MethodDescriptorProto.options:type_name -> google.protobuf.MethodOptions
++	4,  // 31: google.protobuf.FileOptions.optimize_for:type_name -> google.protobuf.FileOptions.OptimizeMode
++	36, // 32: google.protobuf.FileOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 33: google.protobuf.FileOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 34: google.protobuf.MessageOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 35: google.protobuf.MessageOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	5,  // 36: google.protobuf.FieldOptions.ctype:type_name -> google.protobuf.FieldOptions.CType
++	6,  // 37: google.protobuf.FieldOptions.jstype:type_name -> google.protobuf.FieldOptions.JSType
++	7,  // 38: google.protobuf.FieldOptions.retention:type_name -> google.protobuf.FieldOptions.OptionRetention
++	8,  // 39: google.protobuf.FieldOptions.targets:type_name -> google.protobuf.FieldOptions.OptionTargetType
++	44, // 40: google.protobuf.FieldOptions.edition_defaults:type_name -> google.protobuf.FieldOptions.EditionDefault
++	36, // 41: google.protobuf.FieldOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 42: google.protobuf.FieldOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 43: google.protobuf.OneofOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 44: google.protobuf.OneofOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 45: google.protobuf.EnumOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 46: google.protobuf.EnumOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 47: google.protobuf.EnumValueOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 48: google.protobuf.EnumValueOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 49: google.protobuf.ServiceOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 50: google.protobuf.ServiceOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	9,  // 51: google.protobuf.MethodOptions.idempotency_level:type_name -> google.protobuf.MethodOptions.IdempotencyLevel
++	36, // 52: google.protobuf.MethodOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 53: google.protobuf.MethodOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	45, // 54: google.protobuf.UninterpretedOption.name:type_name -> google.protobuf.UninterpretedOption.NamePart
++	10, // 55: google.protobuf.FeatureSet.field_presence:type_name -> google.protobuf.FeatureSet.FieldPresence
++	11, // 56: google.protobuf.FeatureSet.enum_type:type_name -> google.protobuf.FeatureSet.EnumType
++	12, // 57: google.protobuf.FeatureSet.repeated_field_encoding:type_name -> google.protobuf.FeatureSet.RepeatedFieldEncoding
++	13, // 58: google.protobuf.FeatureSet.utf8_validation:type_name -> google.protobuf.FeatureSet.Utf8Validation
++	14, // 59: google.protobuf.FeatureSet.message_encoding:type_name -> google.protobuf.FeatureSet.MessageEncoding
++	15, // 60: google.protobuf.FeatureSet.json_format:type_name -> google.protobuf.FeatureSet.JsonFormat
++	46, // 61: google.protobuf.FeatureSetDefaults.defaults:type_name -> google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
++	0,  // 62: google.protobuf.FeatureSetDefaults.minimum_edition:type_name -> google.protobuf.Edition
++	0,  // 63: google.protobuf.FeatureSetDefaults.maximum_edition:type_name -> google.protobuf.Edition
++	47, // 64: google.protobuf.SourceCodeInfo.location:type_name -> google.protobuf.SourceCodeInfo.Location
++	48, // 65: google.protobuf.GeneratedCodeInfo.annotation:type_name -> google.protobuf.GeneratedCodeInfo.Annotation
++	20, // 66: google.protobuf.DescriptorProto.ExtensionRange.options:type_name -> google.protobuf.ExtensionRangeOptions
++	0,  // 67: google.protobuf.FieldOptions.EditionDefault.edition:type_name -> google.protobuf.Edition
++	0,  // 68: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.edition:type_name -> google.protobuf.Edition
++	36, // 69: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.features:type_name -> google.protobuf.FeatureSet
++	16, // 70: google.protobuf.GeneratedCodeInfo.Annotation.semantic:type_name -> google.protobuf.GeneratedCodeInfo.Annotation.Semantic
++	71, // [71:71] is the sub-list for method output_type
++	71, // [71:71] is the sub-list for method input_type
++	71, // [71:71] is the sub-list for extension type_name
++	71, // [71:71] is the sub-list for extension extendee
++	0,  // [0:71] is the sub-list for field type_name
+ }
+ 
+ func init() { file_google_protobuf_descriptor_proto_init() }
+@@ -4475,19 +5468,21 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*SourceCodeInfo); i {
++			switch v := v.(*FeatureSet); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+ 				return &v.sizeCache
+ 			case 2:
+ 				return &v.unknownFields
++			case 3:
++				return &v.extensionFields
+ 			default:
+ 				return nil
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*GeneratedCodeInfo); i {
++			switch v := v.(*FeatureSetDefaults); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4499,7 +5494,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*DescriptorProto_ExtensionRange); i {
++			switch v := v.(*SourceCodeInfo); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4511,7 +5506,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*DescriptorProto_ReservedRange); i {
++			switch v := v.(*GeneratedCodeInfo); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4523,7 +5518,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*ExtensionRangeOptions_Declaration); i {
++			switch v := v.(*DescriptorProto_ExtensionRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4535,7 +5530,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*EnumDescriptorProto_EnumReservedRange); i {
++			switch v := v.(*DescriptorProto_ReservedRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4547,7 +5542,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*UninterpretedOption_NamePart); i {
++			switch v := v.(*ExtensionRangeOptions_Declaration); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4559,7 +5554,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*SourceCodeInfo_Location); i {
++			switch v := v.(*EnumDescriptorProto_EnumReservedRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4571,6 +5566,54 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*FieldOptions_EditionDefault); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*UninterpretedOption_NamePart); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*FeatureSetDefaults_FeatureSetEditionDefault); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*SourceCodeInfo_Location); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
+ 			switch v := v.(*GeneratedCodeInfo_Annotation); i {
+ 			case 0:
+ 				return &v.state
+@@ -4588,8 +5631,8 @@ func file_google_protobuf_descriptor_proto_init() {
+ 		File: protoimpl.DescBuilder{
+ 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
+ 			RawDescriptor: file_google_protobuf_descriptor_proto_rawDesc,
+-			NumEnums:      10,
+-			NumMessages:   28,
++			NumEnums:      17,
++			NumMessages:   32,
+ 			NumExtensions: 0,
+ 			NumServices:   0,
+ 		},
+diff --git a/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+new file mode 100644
+index 0000000..25de5ae
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+@@ -0,0 +1,177 @@
++// Protocol Buffers - Google's data interchange format
++// Copyright 2023 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++// Code generated by protoc-gen-go. DO NOT EDIT.
++// source: reflect/protodesc/proto/go_features.proto
++
++package proto
++
++import (
++	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
++	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
++	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
++	reflect "reflect"
++	sync "sync"
++)
++
++type GoFeatures struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	// Whether or not to generate the deprecated UnmarshalJSON method for enums.
++	LegacyUnmarshalJsonEnum *bool `protobuf:"varint,1,opt,name=legacy_unmarshal_json_enum,json=legacyUnmarshalJsonEnum" json:"legacy_unmarshal_json_enum,omitempty"`
++}
++
++func (x *GoFeatures) Reset() {
++	*x = GoFeatures{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_reflect_protodesc_proto_go_features_proto_msgTypes[0]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *GoFeatures) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*GoFeatures) ProtoMessage() {}
++
++func (x *GoFeatures) ProtoReflect() protoreflect.Message {
++	mi := &file_reflect_protodesc_proto_go_features_proto_msgTypes[0]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use GoFeatures.ProtoReflect.Descriptor instead.
++func (*GoFeatures) Descriptor() ([]byte, []int) {
++	return file_reflect_protodesc_proto_go_features_proto_rawDescGZIP(), []int{0}
++}
++
++func (x *GoFeatures) GetLegacyUnmarshalJsonEnum() bool {
++	if x != nil && x.LegacyUnmarshalJsonEnum != nil {
++		return *x.LegacyUnmarshalJsonEnum
++	}
++	return false
++}
++
++var file_reflect_protodesc_proto_go_features_proto_extTypes = []protoimpl.ExtensionInfo{
++	{
++		ExtendedType:  (*descriptorpb.FeatureSet)(nil),
++		ExtensionType: (*GoFeatures)(nil),
++		Field:         1002,
++		Name:          "google.protobuf.go",
++		Tag:           "bytes,1002,opt,name=go",
++		Filename:      "reflect/protodesc/proto/go_features.proto",
++	},
++}
++
++// Extension fields to descriptorpb.FeatureSet.
++var (
++	// optional google.protobuf.GoFeatures go = 1002;
++	E_Go = &file_reflect_protodesc_proto_go_features_proto_extTypes[0]
++)
++
++var File_reflect_protodesc_proto_go_features_proto protoreflect.FileDescriptor
++
++var file_reflect_protodesc_proto_go_features_proto_rawDesc = []byte{
++	0x0a, 0x29, 0x72, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x64,
++	0x65, 0x73, 0x63, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x67, 0x6f, 0x5f, 0x66, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x0f, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x1a, 0x20, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x64, 0x65,
++	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x6a,
++	0x0a, 0x0a, 0x47, 0x6f, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x5c, 0x0a, 0x1a,
++	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x75, 0x6e, 0x6d, 0x61, 0x72, 0x73, 0x68, 0x61, 0x6c,
++	0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x65, 0x6e, 0x75, 0x6d, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08,
++	0x42, 0x1f, 0x88, 0x01, 0x01, 0x98, 0x01, 0x06, 0xa2, 0x01, 0x09, 0x12, 0x04, 0x74, 0x72, 0x75,
++	0x65, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x0a, 0x12, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x18, 0xe7,
++	0x07, 0x52, 0x17, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x55, 0x6e, 0x6d, 0x61, 0x72, 0x73, 0x68,
++	0x61, 0x6c, 0x4a, 0x73, 0x6f, 0x6e, 0x45, 0x6e, 0x75, 0x6d, 0x3a, 0x49, 0x0a, 0x02, 0x67, 0x6f,
++	0x12, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x18, 0xea, 0x07,
++	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x6f, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x52, 0x02, 0x67, 0x6f, 0x42, 0x34, 0x5a, 0x32, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2f, 0x72, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x64, 0x65, 0x73, 0x63, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++}
++
++var (
++	file_reflect_protodesc_proto_go_features_proto_rawDescOnce sync.Once
++	file_reflect_protodesc_proto_go_features_proto_rawDescData = file_reflect_protodesc_proto_go_features_proto_rawDesc
++)
++
++func file_reflect_protodesc_proto_go_features_proto_rawDescGZIP() []byte {
++	file_reflect_protodesc_proto_go_features_proto_rawDescOnce.Do(func() {
++		file_reflect_protodesc_proto_go_features_proto_rawDescData = protoimpl.X.CompressGZIP(file_reflect_protodesc_proto_go_features_proto_rawDescData)
++	})
++	return file_reflect_protodesc_proto_go_features_proto_rawDescData
++}
++
++var file_reflect_protodesc_proto_go_features_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
++var file_reflect_protodesc_proto_go_features_proto_goTypes = []interface{}{
++	(*GoFeatures)(nil),              // 0: google.protobuf.GoFeatures
++	(*descriptorpb.FeatureSet)(nil), // 1: google.protobuf.FeatureSet
++}
++var file_reflect_protodesc_proto_go_features_proto_depIdxs = []int32{
++	1, // 0: google.protobuf.go:extendee -> google.protobuf.FeatureSet
++	0, // 1: google.protobuf.go:type_name -> google.protobuf.GoFeatures
++	2, // [2:2] is the sub-list for method output_type
++	2, // [2:2] is the sub-list for method input_type
++	1, // [1:2] is the sub-list for extension type_name
++	0, // [0:1] is the sub-list for extension extendee
++	0, // [0:0] is the sub-list for field type_name
++}
++
++func init() { file_reflect_protodesc_proto_go_features_proto_init() }
++func file_reflect_protodesc_proto_go_features_proto_init() {
++	if File_reflect_protodesc_proto_go_features_proto != nil {
++		return
++	}
++	if !protoimpl.UnsafeEnabled {
++		file_reflect_protodesc_proto_go_features_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*GoFeatures); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++	}
++	type x struct{}
++	out := protoimpl.TypeBuilder{
++		File: protoimpl.DescBuilder{
++			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
++			RawDescriptor: file_reflect_protodesc_proto_go_features_proto_rawDesc,
++			NumEnums:      0,
++			NumMessages:   1,
++			NumExtensions: 1,
++			NumServices:   0,
++		},
++		GoTypes:           file_reflect_protodesc_proto_go_features_proto_goTypes,
++		DependencyIndexes: file_reflect_protodesc_proto_go_features_proto_depIdxs,
++		MessageInfos:      file_reflect_protodesc_proto_go_features_proto_msgTypes,
++		ExtensionInfos:    file_reflect_protodesc_proto_go_features_proto_extTypes,
++	}.Build()
++	File_reflect_protodesc_proto_go_features_proto = out.File
++	file_reflect_protodesc_proto_go_features_proto_rawDesc = nil
++	file_reflect_protodesc_proto_go_features_proto_goTypes = nil
++	file_reflect_protodesc_proto_go_features_proto_depIdxs = nil
++}
+diff --git a/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+new file mode 100644
+index 0000000..d246571
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+@@ -0,0 +1,28 @@
++// Protocol Buffers - Google's data interchange format
++// Copyright 2023 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++syntax = "proto2";
++
++package google.protobuf;
++
++import "google/protobuf/descriptor.proto";
++
++option go_package = "google.golang.org/protobuf/types/gofeaturespb";
++
++extend google.protobuf.FeatureSet {
++  optional GoFeatures go = 1002;
++}
++
++message GoFeatures {
++  // Whether or not to generate the deprecated UnmarshalJSON method for enums.
++  optional bool legacy_unmarshal_json_enum = 1 [
++    retention = RETENTION_RUNTIME,
++    targets = TARGET_TYPE_ENUM,
++    edition_defaults = { edition: EDITION_PROTO2, value: "true" },
++    edition_defaults = { edition: EDITION_PROTO3, value: "false" }
++  ];
++}
+diff --git a/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go b/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
+index 580b232..9de51be 100644
+--- a/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
++++ b/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
+@@ -237,7 +237,8 @@ type Any struct {
+ 	//
+ 	// Note: this functionality is not currently available in the official
+ 	// protobuf release, and it is not used for type URLs beginning with
+-	// type.googleapis.com.
++	// type.googleapis.com. As of May 2023, there are no widely used type server
++	// implementations and no plans to implement one.
+ 	//
+ 	// Schemes other than `http`, `https` (or the empty scheme) might be
+ 	// used with implementation specific semantics.
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index f3db441..e57446f 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -29,8 +29,8 @@ github.com/gogo/protobuf/sortkeys
+ ## explicit; go 1.11
+ github.com/golang/mock/gomock
+ github.com/golang/mock/mockgen/model
+-# github.com/golang/protobuf v1.5.3
+-## explicit; go 1.9
++# github.com/golang/protobuf v1.5.4
++## explicit; go 1.17
+ github.com/golang/protobuf/descriptor
+ github.com/golang/protobuf/jsonpb
+ github.com/golang/protobuf/proto
+@@ -218,14 +218,15 @@ google.golang.org/grpc/serviceconfig
+ google.golang.org/grpc/stats
+ google.golang.org/grpc/status
+ google.golang.org/grpc/tap
+-# google.golang.org/protobuf v1.31.0
+-## explicit; go 1.11
++# google.golang.org/protobuf v1.33.0
++## explicit; go 1.17
+ google.golang.org/protobuf/encoding/protojson
+ google.golang.org/protobuf/encoding/prototext
+ google.golang.org/protobuf/encoding/protowire
+ google.golang.org/protobuf/internal/descfmt
+ google.golang.org/protobuf/internal/descopts
+ google.golang.org/protobuf/internal/detrand
++google.golang.org/protobuf/internal/editiondefaults
+ google.golang.org/protobuf/internal/encoding/defval
+ google.golang.org/protobuf/internal/encoding/json
+ google.golang.org/protobuf/internal/encoding/messageset
+@@ -249,6 +250,7 @@ google.golang.org/protobuf/reflect/protoregistry
+ google.golang.org/protobuf/runtime/protoiface
+ google.golang.org/protobuf/runtime/protoimpl
+ google.golang.org/protobuf/types/descriptorpb
++google.golang.org/protobuf/types/gofeaturespb
+ google.golang.org/protobuf/types/known/anypb
+ google.golang.org/protobuf/types/known/durationpb
+ google.golang.org/protobuf/types/known/timestamppb
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/livenessprobe/1-26/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-26/CHECKSUMS
@@ -1,3 +1,3 @@
-d6969295d34e8eff3c87c9d9ace64f4817b5163a175d8be4384238266757ac28  _output/1-26/bin/livenessprobe/linux-amd64/livenessprobe
-23dd70fa11a9c2e0c83eccd1b4c8eecdf5d7c7ba55f8c50b6a3a88545b2998b6  _output/1-26/bin/livenessprobe/linux-arm64/livenessprobe
-d981c39b4089a15067100c9408f44898dc9d5c332716bd904c29dc44cd019b59  _output/1-26/bin/livenessprobe/windows-amd64/livenessprobe.exe
+f22ddc72b7428124f72945a6a6ffae35f17ecf71ebe35e1cbb356048bf216b20  _output/1-26/bin/livenessprobe/linux-amd64/livenessprobe
+d855e1a5d85f62483f89761693933b4a08cc98aa465248a23b4d98bd0c677885  _output/1-26/bin/livenessprobe/linux-arm64/livenessprobe
+062bdd08c21daf93a62469e7e09a88e4c514082cc9e0baa7de260ff1ee4d09eb  _output/1-26/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-26/patches/0001-Bump-protobuf-to-resolve-CVE-2024-24786-for-Liveness.patch
+++ b/projects/kubernetes-csi/livenessprobe/1-26/patches/0001-Bump-protobuf-to-resolve-CVE-2024-24786-for-Liveness.patch
@@ -1,0 +1,8141 @@
+From 787b5e4818b71783774e36f358a57150abad5983 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Mon, 18 Mar 2024 17:37:01 +0000
+Subject: [PATCH] Bump protobuf to resolve CVE-2024-24786 for Liveness-Probe
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |    4 +-
+ go.sum                                        |   12 +-
+ .../golang/protobuf/jsonpb/decode.go          |    1 +
+ .../golang/protobuf/jsonpb/encode.go          |    1 +
+ .../protoc-gen-go/descriptor/descriptor.pb.go |  128 +-
+ .../github.com/golang/protobuf/ptypes/any.go  |    7 +-
+ .../protobuf/encoding/protojson/decode.go     |   38 +-
+ .../protobuf/encoding/protojson/doc.go        |    2 +-
+ .../protobuf/encoding/protojson/encode.go     |   39 +-
+ .../encoding/protojson/well_known_types.go    |   59 +-
+ .../protobuf/encoding/prototext/decode.go     |    8 +-
+ .../protobuf/encoding/prototext/encode.go     |    4 +-
+ .../protobuf/encoding/protowire/wire.go       |   28 +-
+ .../protobuf/internal/descfmt/stringer.go     |  183 +-
+ .../internal/editiondefaults/defaults.go      |   12 +
+ .../editiondefaults/editions_defaults.binpb   |    4 +
+ .../protobuf/internal/encoding/json/decode.go |    2 +-
+ .../protobuf/internal/filedesc/desc.go        |  102 +-
+ .../protobuf/internal/filedesc/desc_init.go   |   52 +
+ .../protobuf/internal/filedesc/desc_lazy.go   |   28 +
+ .../protobuf/internal/filedesc/editions.go    |  142 +
+ .../protobuf/internal/genid/descriptor_gen.go |  364 ++-
+ .../internal/genid/go_features_gen.go         |   31 +
+ .../protobuf/internal/genid/struct_gen.go     |    5 +
+ .../protobuf/internal/genid/type_gen.go       |   38 +
+ .../protobuf/internal/impl/codec_extension.go |   22 +-
+ .../protobuf/internal/impl/codec_gen.go       |  113 +-
+ .../protobuf/internal/impl/codec_tables.go    |    2 +-
+ .../protobuf/internal/impl/legacy_message.go  |   19 +-
+ .../protobuf/internal/impl/message.go         |   17 +-
+ .../internal/impl/message_reflect_field.go    |    2 +-
+ .../protobuf/internal/impl/pointer_reflect.go |   36 +
+ .../protobuf/internal/impl/pointer_unsafe.go  |   40 +
+ .../protobuf/internal/strs/strings.go         |    2 +-
+ ...ings_unsafe.go => strings_unsafe_go120.go} |    4 +-
+ .../internal/strs/strings_unsafe_go121.go     |   74 +
+ .../protobuf/internal/version/version.go      |    2 +-
+ .../protobuf/proto/decode.go                  |    2 +-
+ .../google.golang.org/protobuf/proto/doc.go   |   58 +-
+ .../protobuf/proto/encode.go                  |    2 +-
+ .../protobuf/proto/extension.go               |    2 +-
+ .../google.golang.org/protobuf/proto/merge.go |    2 +-
+ .../google.golang.org/protobuf/proto/proto.go |   18 +-
+ .../protobuf/reflect/protodesc/desc.go        |   29 +-
+ .../protobuf/reflect/protodesc/desc_init.go   |   56 +
+ .../reflect/protodesc/desc_resolve.go         |    4 +-
+ .../reflect/protodesc/desc_validate.go        |    6 +-
+ .../protobuf/reflect/protodesc/editions.go    |  148 +
+ .../protobuf/reflect/protodesc/proto.go       |   18 +-
+ .../protobuf/reflect/protoreflect/proto.go    |   85 +-
+ .../reflect/protoreflect/source_gen.go        |   64 +-
+ .../protobuf/reflect/protoreflect/type.go     |   44 +-
+ .../protobuf/reflect/protoreflect/value.go    |   24 +-
+ .../reflect/protoreflect/value_equal.go       |    8 +-
+ .../reflect/protoreflect/value_union.go       |   44 +-
+ ...{value_unsafe.go => value_unsafe_go120.go} |    4 +-
+ .../protoreflect/value_unsafe_go121.go        |   87 +
+ .../reflect/protoregistry/registry.go         |   24 +-
+ .../types/descriptorpb/descriptor.pb.go       | 2475 ++++++++++++-----
+ .../types/gofeaturespb/go_features.pb.go      |  177 ++
+ .../types/gofeaturespb/go_features.proto      |   28 +
+ .../protobuf/types/known/anypb/any.pb.go      |    3 +-
+ vendor/modules.txt                            |   10 +-
+ 63 files changed, 3921 insertions(+), 1128 deletions(-)
+ create mode 100644 vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+ create mode 100644 vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+ create mode 100644 vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+ create mode 100644 vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+ rename vendor/google.golang.org/protobuf/internal/strs/{strings_unsafe.go => strings_unsafe_go120.go} (96%)
+ create mode 100644 vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+ create mode 100644 vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+ rename vendor/google.golang.org/protobuf/reflect/protoreflect/{value_unsafe.go => value_unsafe_go120.go} (97%)
+ create mode 100644 vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+ create mode 100644 vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+ create mode 100644 vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+
+diff --git a/go.mod b/go.mod
+index 66f1999..1e1128d 100644
+--- a/go.mod
++++ b/go.mod
+@@ -19,7 +19,7 @@ require (
+ 	github.com/go-logr/stdr v1.2.2 // indirect
+ 	github.com/go-logr/zapr v1.2.3 // indirect
+ 	github.com/gogo/protobuf v1.3.2 // indirect
+-	github.com/golang/protobuf v1.5.3 // indirect
++	github.com/golang/protobuf v1.5.4 // indirect
+ 	github.com/google/go-cmp v0.6.0 // indirect
+ 	github.com/google/gofuzz v1.2.0 // indirect
+ 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+@@ -46,7 +46,7 @@ require (
+ 	golang.org/x/text v0.14.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
+ 	google.golang.org/grpc v1.60.1 // indirect
+-	google.golang.org/protobuf v1.31.0 // indirect
++	google.golang.org/protobuf v1.33.0 // indirect
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+ 	gopkg.in/yaml.v2 v2.4.0 // indirect
+ 	k8s.io/apimachinery v0.29.0 // indirect
+diff --git a/go.sum b/go.sum
+index 37e6f06..8d87ecd 100644
+--- a/go.sum
++++ b/go.sum
+@@ -33,10 +33,8 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
+ github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+ github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
++github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
++github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+@@ -169,10 +167,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 h1:
+ google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17/go.mod h1:oQ5rr10WTTMvP4A36n8JpR1OrO1BEiV4f78CneXZxkA=
+ google.golang.org/grpc v1.60.1 h1:26+wFr+cNqSGFcOXcabYC0lUVJVRa2Sb2ortSK7VrEU=
+ google.golang.org/grpc v1.60.1/go.mod h1:OlCHIeLYqSSsLi6i49B5QGdzaMZK9+M7LXN2FKz4eGM=
+-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
++google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
++google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+diff --git a/vendor/github.com/golang/protobuf/jsonpb/decode.go b/vendor/github.com/golang/protobuf/jsonpb/decode.go
+index 6c16c25..c6f66f1 100644
+--- a/vendor/github.com/golang/protobuf/jsonpb/decode.go
++++ b/vendor/github.com/golang/protobuf/jsonpb/decode.go
+@@ -56,6 +56,7 @@ type Unmarshaler struct {
+ // implement JSONPBMarshaler so that the custom format can be produced.
+ //
+ // The JSON unmarshaling must follow the JSON to proto specification:
++//
+ //	https://developers.google.com/protocol-buffers/docs/proto3#json
+ //
+ // Deprecated: Custom types should implement protobuf reflection instead.
+diff --git a/vendor/github.com/golang/protobuf/jsonpb/encode.go b/vendor/github.com/golang/protobuf/jsonpb/encode.go
+index 685c80a..e9438a9 100644
+--- a/vendor/github.com/golang/protobuf/jsonpb/encode.go
++++ b/vendor/github.com/golang/protobuf/jsonpb/encode.go
+@@ -55,6 +55,7 @@ type Marshaler struct {
+ // implement JSONPBUnmarshaler so that the custom format can be parsed.
+ //
+ // The JSON marshaling must follow the proto to JSON specification:
++//
+ //	https://developers.google.com/protocol-buffers/docs/proto3#json
+ //
+ // Deprecated: Custom types should implement protobuf reflection instead.
+diff --git a/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go b/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
+index 63dc057..a5a1386 100644
+--- a/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
++++ b/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
+@@ -12,6 +12,31 @@ import (
+ 
+ // Symbols defined in public import of google/protobuf/descriptor.proto.
+ 
++type Edition = descriptorpb.Edition
++
++const Edition_EDITION_UNKNOWN = descriptorpb.Edition_EDITION_UNKNOWN
++const Edition_EDITION_PROTO2 = descriptorpb.Edition_EDITION_PROTO2
++const Edition_EDITION_PROTO3 = descriptorpb.Edition_EDITION_PROTO3
++const Edition_EDITION_2023 = descriptorpb.Edition_EDITION_2023
++const Edition_EDITION_2024 = descriptorpb.Edition_EDITION_2024
++const Edition_EDITION_1_TEST_ONLY = descriptorpb.Edition_EDITION_1_TEST_ONLY
++const Edition_EDITION_2_TEST_ONLY = descriptorpb.Edition_EDITION_2_TEST_ONLY
++const Edition_EDITION_99997_TEST_ONLY = descriptorpb.Edition_EDITION_99997_TEST_ONLY
++const Edition_EDITION_99998_TEST_ONLY = descriptorpb.Edition_EDITION_99998_TEST_ONLY
++const Edition_EDITION_99999_TEST_ONLY = descriptorpb.Edition_EDITION_99999_TEST_ONLY
++const Edition_EDITION_MAX = descriptorpb.Edition_EDITION_MAX
++
++var Edition_name = descriptorpb.Edition_name
++var Edition_value = descriptorpb.Edition_value
++
++type ExtensionRangeOptions_VerificationState = descriptorpb.ExtensionRangeOptions_VerificationState
++
++const ExtensionRangeOptions_DECLARATION = descriptorpb.ExtensionRangeOptions_DECLARATION
++const ExtensionRangeOptions_UNVERIFIED = descriptorpb.ExtensionRangeOptions_UNVERIFIED
++
++var ExtensionRangeOptions_VerificationState_name = descriptorpb.ExtensionRangeOptions_VerificationState_name
++var ExtensionRangeOptions_VerificationState_value = descriptorpb.ExtensionRangeOptions_VerificationState_value
++
+ type FieldDescriptorProto_Type = descriptorpb.FieldDescriptorProto_Type
+ 
+ const FieldDescriptorProto_TYPE_DOUBLE = descriptorpb.FieldDescriptorProto_TYPE_DOUBLE
+@@ -39,8 +64,8 @@ var FieldDescriptorProto_Type_value = descriptorpb.FieldDescriptorProto_Type_val
+ type FieldDescriptorProto_Label = descriptorpb.FieldDescriptorProto_Label
+ 
+ const FieldDescriptorProto_LABEL_OPTIONAL = descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL
+-const FieldDescriptorProto_LABEL_REQUIRED = descriptorpb.FieldDescriptorProto_LABEL_REQUIRED
+ const FieldDescriptorProto_LABEL_REPEATED = descriptorpb.FieldDescriptorProto_LABEL_REPEATED
++const FieldDescriptorProto_LABEL_REQUIRED = descriptorpb.FieldDescriptorProto_LABEL_REQUIRED
+ 
+ var FieldDescriptorProto_Label_name = descriptorpb.FieldDescriptorProto_Label_name
+ var FieldDescriptorProto_Label_value = descriptorpb.FieldDescriptorProto_Label_value
+@@ -72,6 +97,31 @@ const FieldOptions_JS_NUMBER = descriptorpb.FieldOptions_JS_NUMBER
+ var FieldOptions_JSType_name = descriptorpb.FieldOptions_JSType_name
+ var FieldOptions_JSType_value = descriptorpb.FieldOptions_JSType_value
+ 
++type FieldOptions_OptionRetention = descriptorpb.FieldOptions_OptionRetention
++
++const FieldOptions_RETENTION_UNKNOWN = descriptorpb.FieldOptions_RETENTION_UNKNOWN
++const FieldOptions_RETENTION_RUNTIME = descriptorpb.FieldOptions_RETENTION_RUNTIME
++const FieldOptions_RETENTION_SOURCE = descriptorpb.FieldOptions_RETENTION_SOURCE
++
++var FieldOptions_OptionRetention_name = descriptorpb.FieldOptions_OptionRetention_name
++var FieldOptions_OptionRetention_value = descriptorpb.FieldOptions_OptionRetention_value
++
++type FieldOptions_OptionTargetType = descriptorpb.FieldOptions_OptionTargetType
++
++const FieldOptions_TARGET_TYPE_UNKNOWN = descriptorpb.FieldOptions_TARGET_TYPE_UNKNOWN
++const FieldOptions_TARGET_TYPE_FILE = descriptorpb.FieldOptions_TARGET_TYPE_FILE
++const FieldOptions_TARGET_TYPE_EXTENSION_RANGE = descriptorpb.FieldOptions_TARGET_TYPE_EXTENSION_RANGE
++const FieldOptions_TARGET_TYPE_MESSAGE = descriptorpb.FieldOptions_TARGET_TYPE_MESSAGE
++const FieldOptions_TARGET_TYPE_FIELD = descriptorpb.FieldOptions_TARGET_TYPE_FIELD
++const FieldOptions_TARGET_TYPE_ONEOF = descriptorpb.FieldOptions_TARGET_TYPE_ONEOF
++const FieldOptions_TARGET_TYPE_ENUM = descriptorpb.FieldOptions_TARGET_TYPE_ENUM
++const FieldOptions_TARGET_TYPE_ENUM_ENTRY = descriptorpb.FieldOptions_TARGET_TYPE_ENUM_ENTRY
++const FieldOptions_TARGET_TYPE_SERVICE = descriptorpb.FieldOptions_TARGET_TYPE_SERVICE
++const FieldOptions_TARGET_TYPE_METHOD = descriptorpb.FieldOptions_TARGET_TYPE_METHOD
++
++var FieldOptions_OptionTargetType_name = descriptorpb.FieldOptions_OptionTargetType_name
++var FieldOptions_OptionTargetType_value = descriptorpb.FieldOptions_OptionTargetType_value
++
+ type MethodOptions_IdempotencyLevel = descriptorpb.MethodOptions_IdempotencyLevel
+ 
+ const MethodOptions_IDEMPOTENCY_UNKNOWN = descriptorpb.MethodOptions_IDEMPOTENCY_UNKNOWN
+@@ -81,10 +131,77 @@ const MethodOptions_IDEMPOTENT = descriptorpb.MethodOptions_IDEMPOTENT
+ var MethodOptions_IdempotencyLevel_name = descriptorpb.MethodOptions_IdempotencyLevel_name
+ var MethodOptions_IdempotencyLevel_value = descriptorpb.MethodOptions_IdempotencyLevel_value
+ 
++type FeatureSet_FieldPresence = descriptorpb.FeatureSet_FieldPresence
++
++const FeatureSet_FIELD_PRESENCE_UNKNOWN = descriptorpb.FeatureSet_FIELD_PRESENCE_UNKNOWN
++const FeatureSet_EXPLICIT = descriptorpb.FeatureSet_EXPLICIT
++const FeatureSet_IMPLICIT = descriptorpb.FeatureSet_IMPLICIT
++const FeatureSet_LEGACY_REQUIRED = descriptorpb.FeatureSet_LEGACY_REQUIRED
++
++var FeatureSet_FieldPresence_name = descriptorpb.FeatureSet_FieldPresence_name
++var FeatureSet_FieldPresence_value = descriptorpb.FeatureSet_FieldPresence_value
++
++type FeatureSet_EnumType = descriptorpb.FeatureSet_EnumType
++
++const FeatureSet_ENUM_TYPE_UNKNOWN = descriptorpb.FeatureSet_ENUM_TYPE_UNKNOWN
++const FeatureSet_OPEN = descriptorpb.FeatureSet_OPEN
++const FeatureSet_CLOSED = descriptorpb.FeatureSet_CLOSED
++
++var FeatureSet_EnumType_name = descriptorpb.FeatureSet_EnumType_name
++var FeatureSet_EnumType_value = descriptorpb.FeatureSet_EnumType_value
++
++type FeatureSet_RepeatedFieldEncoding = descriptorpb.FeatureSet_RepeatedFieldEncoding
++
++const FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN = descriptorpb.FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN
++const FeatureSet_PACKED = descriptorpb.FeatureSet_PACKED
++const FeatureSet_EXPANDED = descriptorpb.FeatureSet_EXPANDED
++
++var FeatureSet_RepeatedFieldEncoding_name = descriptorpb.FeatureSet_RepeatedFieldEncoding_name
++var FeatureSet_RepeatedFieldEncoding_value = descriptorpb.FeatureSet_RepeatedFieldEncoding_value
++
++type FeatureSet_Utf8Validation = descriptorpb.FeatureSet_Utf8Validation
++
++const FeatureSet_UTF8_VALIDATION_UNKNOWN = descriptorpb.FeatureSet_UTF8_VALIDATION_UNKNOWN
++const FeatureSet_VERIFY = descriptorpb.FeatureSet_VERIFY
++const FeatureSet_NONE = descriptorpb.FeatureSet_NONE
++
++var FeatureSet_Utf8Validation_name = descriptorpb.FeatureSet_Utf8Validation_name
++var FeatureSet_Utf8Validation_value = descriptorpb.FeatureSet_Utf8Validation_value
++
++type FeatureSet_MessageEncoding = descriptorpb.FeatureSet_MessageEncoding
++
++const FeatureSet_MESSAGE_ENCODING_UNKNOWN = descriptorpb.FeatureSet_MESSAGE_ENCODING_UNKNOWN
++const FeatureSet_LENGTH_PREFIXED = descriptorpb.FeatureSet_LENGTH_PREFIXED
++const FeatureSet_DELIMITED = descriptorpb.FeatureSet_DELIMITED
++
++var FeatureSet_MessageEncoding_name = descriptorpb.FeatureSet_MessageEncoding_name
++var FeatureSet_MessageEncoding_value = descriptorpb.FeatureSet_MessageEncoding_value
++
++type FeatureSet_JsonFormat = descriptorpb.FeatureSet_JsonFormat
++
++const FeatureSet_JSON_FORMAT_UNKNOWN = descriptorpb.FeatureSet_JSON_FORMAT_UNKNOWN
++const FeatureSet_ALLOW = descriptorpb.FeatureSet_ALLOW
++const FeatureSet_LEGACY_BEST_EFFORT = descriptorpb.FeatureSet_LEGACY_BEST_EFFORT
++
++var FeatureSet_JsonFormat_name = descriptorpb.FeatureSet_JsonFormat_name
++var FeatureSet_JsonFormat_value = descriptorpb.FeatureSet_JsonFormat_value
++
++type GeneratedCodeInfo_Annotation_Semantic = descriptorpb.GeneratedCodeInfo_Annotation_Semantic
++
++const GeneratedCodeInfo_Annotation_NONE = descriptorpb.GeneratedCodeInfo_Annotation_NONE
++const GeneratedCodeInfo_Annotation_SET = descriptorpb.GeneratedCodeInfo_Annotation_SET
++const GeneratedCodeInfo_Annotation_ALIAS = descriptorpb.GeneratedCodeInfo_Annotation_ALIAS
++
++var GeneratedCodeInfo_Annotation_Semantic_name = descriptorpb.GeneratedCodeInfo_Annotation_Semantic_name
++var GeneratedCodeInfo_Annotation_Semantic_value = descriptorpb.GeneratedCodeInfo_Annotation_Semantic_value
++
+ type FileDescriptorSet = descriptorpb.FileDescriptorSet
+ type FileDescriptorProto = descriptorpb.FileDescriptorProto
+ type DescriptorProto = descriptorpb.DescriptorProto
+ type ExtensionRangeOptions = descriptorpb.ExtensionRangeOptions
++
++const Default_ExtensionRangeOptions_Verification = descriptorpb.Default_ExtensionRangeOptions_Verification
++
+ type FieldDescriptorProto = descriptorpb.FieldDescriptorProto
+ type OneofDescriptorProto = descriptorpb.OneofDescriptorProto
+ type EnumDescriptorProto = descriptorpb.EnumDescriptorProto
+@@ -103,7 +220,6 @@ const Default_FileOptions_OptimizeFor = descriptorpb.Default_FileOptions_Optimiz
+ const Default_FileOptions_CcGenericServices = descriptorpb.Default_FileOptions_CcGenericServices
+ const Default_FileOptions_JavaGenericServices = descriptorpb.Default_FileOptions_JavaGenericServices
+ const Default_FileOptions_PyGenericServices = descriptorpb.Default_FileOptions_PyGenericServices
+-const Default_FileOptions_PhpGenericServices = descriptorpb.Default_FileOptions_PhpGenericServices
+ const Default_FileOptions_Deprecated = descriptorpb.Default_FileOptions_Deprecated
+ const Default_FileOptions_CcEnableArenas = descriptorpb.Default_FileOptions_CcEnableArenas
+ 
+@@ -118,8 +234,10 @@ type FieldOptions = descriptorpb.FieldOptions
+ const Default_FieldOptions_Ctype = descriptorpb.Default_FieldOptions_Ctype
+ const Default_FieldOptions_Jstype = descriptorpb.Default_FieldOptions_Jstype
+ const Default_FieldOptions_Lazy = descriptorpb.Default_FieldOptions_Lazy
++const Default_FieldOptions_UnverifiedLazy = descriptorpb.Default_FieldOptions_UnverifiedLazy
+ const Default_FieldOptions_Deprecated = descriptorpb.Default_FieldOptions_Deprecated
+ const Default_FieldOptions_Weak = descriptorpb.Default_FieldOptions_Weak
++const Default_FieldOptions_DebugRedact = descriptorpb.Default_FieldOptions_DebugRedact
+ 
+ type OneofOptions = descriptorpb.OneofOptions
+ type EnumOptions = descriptorpb.EnumOptions
+@@ -129,6 +247,7 @@ const Default_EnumOptions_Deprecated = descriptorpb.Default_EnumOptions_Deprecat
+ type EnumValueOptions = descriptorpb.EnumValueOptions
+ 
+ const Default_EnumValueOptions_Deprecated = descriptorpb.Default_EnumValueOptions_Deprecated
++const Default_EnumValueOptions_DebugRedact = descriptorpb.Default_EnumValueOptions_DebugRedact
+ 
+ type ServiceOptions = descriptorpb.ServiceOptions
+ 
+@@ -140,12 +259,17 @@ const Default_MethodOptions_Deprecated = descriptorpb.Default_MethodOptions_Depr
+ const Default_MethodOptions_IdempotencyLevel = descriptorpb.Default_MethodOptions_IdempotencyLevel
+ 
+ type UninterpretedOption = descriptorpb.UninterpretedOption
++type FeatureSet = descriptorpb.FeatureSet
++type FeatureSetDefaults = descriptorpb.FeatureSetDefaults
+ type SourceCodeInfo = descriptorpb.SourceCodeInfo
+ type GeneratedCodeInfo = descriptorpb.GeneratedCodeInfo
+ type DescriptorProto_ExtensionRange = descriptorpb.DescriptorProto_ExtensionRange
+ type DescriptorProto_ReservedRange = descriptorpb.DescriptorProto_ReservedRange
++type ExtensionRangeOptions_Declaration = descriptorpb.ExtensionRangeOptions_Declaration
+ type EnumDescriptorProto_EnumReservedRange = descriptorpb.EnumDescriptorProto_EnumReservedRange
++type FieldOptions_EditionDefault = descriptorpb.FieldOptions_EditionDefault
+ type UninterpretedOption_NamePart = descriptorpb.UninterpretedOption_NamePart
++type FeatureSetDefaults_FeatureSetEditionDefault = descriptorpb.FeatureSetDefaults_FeatureSetEditionDefault
+ type SourceCodeInfo_Location = descriptorpb.SourceCodeInfo_Location
+ type GeneratedCodeInfo_Annotation = descriptorpb.GeneratedCodeInfo_Annotation
+ 
+diff --git a/vendor/github.com/golang/protobuf/ptypes/any.go b/vendor/github.com/golang/protobuf/ptypes/any.go
+index 85f9f57..fdff3fd 100644
+--- a/vendor/github.com/golang/protobuf/ptypes/any.go
++++ b/vendor/github.com/golang/protobuf/ptypes/any.go
+@@ -127,9 +127,10 @@ func Is(any *anypb.Any, m proto.Message) bool {
+ // The allocated message is stored in the embedded proto.Message.
+ //
+ // Example:
+-//   var x ptypes.DynamicAny
+-//   if err := ptypes.UnmarshalAny(a, &x); err != nil { ... }
+-//   fmt.Printf("unmarshaled message: %v", x.Message)
++//
++//	var x ptypes.DynamicAny
++//	if err := ptypes.UnmarshalAny(a, &x); err != nil { ... }
++//	fmt.Printf("unmarshaled message: %v", x.Message)
+ //
+ // Deprecated: Use the any.UnmarshalNew method instead to unmarshal
+ // the any message contents into a new instance of the underlying message.
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/decode.go b/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
+index 5f28148..f479023 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
+@@ -11,6 +11,7 @@ import (
+ 	"strconv"
+ 	"strings"
+ 
++	"google.golang.org/protobuf/encoding/protowire"
+ 	"google.golang.org/protobuf/internal/encoding/json"
+ 	"google.golang.org/protobuf/internal/encoding/messageset"
+ 	"google.golang.org/protobuf/internal/errors"
+@@ -23,7 +24,7 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
+-// Unmarshal reads the given []byte into the given proto.Message.
++// Unmarshal reads the given []byte into the given [proto.Message].
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func Unmarshal(b []byte, m proto.Message) error {
+ 	return UnmarshalOptions{}.Unmarshal(b, m)
+@@ -37,7 +38,7 @@ type UnmarshalOptions struct {
+ 	// required fields will not return an error.
+ 	AllowPartial bool
+ 
+-	// If DiscardUnknown is set, unknown fields are ignored.
++	// If DiscardUnknown is set, unknown fields and enum name values are ignored.
+ 	DiscardUnknown bool
+ 
+ 	// Resolver is used for looking up types when unmarshaling
+@@ -47,9 +48,13 @@ type UnmarshalOptions struct {
+ 		protoregistry.MessageTypeResolver
+ 		protoregistry.ExtensionTypeResolver
+ 	}
++
++	// RecursionLimit limits how deeply messages may be nested.
++	// If zero, a default limit is applied.
++	RecursionLimit int
+ }
+ 
+-// Unmarshal reads the given []byte and populates the given proto.Message
++// Unmarshal reads the given []byte and populates the given [proto.Message]
+ // using options in the UnmarshalOptions object.
+ // It will clear the message first before setting the fields.
+ // If it returns an error, the given message may be partially set.
+@@ -67,6 +72,9 @@ func (o UnmarshalOptions) unmarshal(b []byte, m proto.Message) error {
+ 	if o.Resolver == nil {
+ 		o.Resolver = protoregistry.GlobalTypes
+ 	}
++	if o.RecursionLimit == 0 {
++		o.RecursionLimit = protowire.DefaultRecursionLimit
++	}
+ 
+ 	dec := decoder{json.NewDecoder(b), o}
+ 	if err := dec.unmarshalMessage(m.ProtoReflect(), false); err != nil {
+@@ -114,6 +122,10 @@ func (d decoder) syntaxError(pos int, f string, x ...interface{}) error {
+ 
+ // unmarshalMessage unmarshals a message into the given protoreflect.Message.
+ func (d decoder) unmarshalMessage(m protoreflect.Message, skipTypeURL bool) error {
++	d.opts.RecursionLimit--
++	if d.opts.RecursionLimit < 0 {
++		return errors.New("exceeded max recursion depth")
++	}
+ 	if unmarshal := wellKnownTypeUnmarshaler(m.Descriptor().FullName()); unmarshal != nil {
+ 		return unmarshal(d, m)
+ 	}
+@@ -266,7 +278,9 @@ func (d decoder) unmarshalSingular(m protoreflect.Message, fd protoreflect.Field
+ 	if err != nil {
+ 		return err
+ 	}
+-	m.Set(fd, val)
++	if val.IsValid() {
++		m.Set(fd, val)
++	}
+ 	return nil
+ }
+ 
+@@ -329,7 +343,7 @@ func (d decoder) unmarshalScalar(fd protoreflect.FieldDescriptor) (protoreflect.
+ 		}
+ 
+ 	case protoreflect.EnumKind:
+-		if v, ok := unmarshalEnum(tok, fd); ok {
++		if v, ok := unmarshalEnum(tok, fd, d.opts.DiscardUnknown); ok {
+ 			return v, nil
+ 		}
+ 
+@@ -474,7 +488,7 @@ func unmarshalBytes(tok json.Token) (protoreflect.Value, bool) {
+ 	return protoreflect.ValueOfBytes(b), true
+ }
+ 
+-func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor) (protoreflect.Value, bool) {
++func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor, discardUnknown bool) (protoreflect.Value, bool) {
+ 	switch tok.Kind() {
+ 	case json.String:
+ 		// Lookup EnumNumber based on name.
+@@ -482,6 +496,9 @@ func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor) (protoreflec
+ 		if enumVal := fd.Enum().Values().ByName(protoreflect.Name(s)); enumVal != nil {
+ 			return protoreflect.ValueOfEnum(enumVal.Number()), true
+ 		}
++		if discardUnknown {
++			return protoreflect.Value{}, true
++		}
+ 
+ 	case json.Number:
+ 		if n, ok := tok.Int(32); ok {
+@@ -542,7 +559,9 @@ func (d decoder) unmarshalList(list protoreflect.List, fd protoreflect.FieldDesc
+ 			if err != nil {
+ 				return err
+ 			}
+-			list.Append(val)
++			if val.IsValid() {
++				list.Append(val)
++			}
+ 		}
+ 	}
+ 
+@@ -609,8 +628,9 @@ Loop:
+ 		if err != nil {
+ 			return err
+ 		}
+-
+-		mmap.Set(pkey, pval)
++		if pval.IsValid() {
++			mmap.Set(pkey, pval)
++		}
+ 	}
+ 
+ 	return nil
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/doc.go b/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
+index 21d5d2c..ae71007 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
+@@ -6,6 +6,6 @@
+ // format. It follows the guide at
+ // https://protobuf.dev/programming-guides/proto3#json.
+ //
+-// This package produces a different output than the standard "encoding/json"
++// This package produces a different output than the standard [encoding/json]
+ // package, which does not operate correctly on protocol buffer messages.
+ package protojson
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/encode.go b/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
+index 66b9587..3f75098 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
+@@ -31,7 +31,7 @@ func Format(m proto.Message) string {
+ 	return MarshalOptions{Multiline: true}.Format(m)
+ }
+ 
+-// Marshal writes the given proto.Message in JSON format using default options.
++// Marshal writes the given [proto.Message] in JSON format using default options.
+ // Do not depend on the output being stable. It may change over time across
+ // different versions of the program.
+ func Marshal(m proto.Message) ([]byte, error) {
+@@ -81,6 +81,25 @@ type MarshalOptions struct {
+ 	//  ╚═══════╧════════════════════════════╝
+ 	EmitUnpopulated bool
+ 
++	// EmitDefaultValues specifies whether to emit default-valued primitive fields,
++	// empty lists, and empty maps. The fields affected are as follows:
++	//  ╔═══════╤════════════════════════════════════════╗
++	//  ║ JSON  │ Protobuf field                         ║
++	//  ╠═══════╪════════════════════════════════════════╣
++	//  ║ false │ non-optional scalar boolean fields     ║
++	//  ║ 0     │ non-optional scalar numeric fields     ║
++	//  ║ ""    │ non-optional scalar string/byte fields ║
++	//  ║ []    │ empty repeated fields                  ║
++	//  ║ {}    │ empty map fields                       ║
++	//  ╚═══════╧════════════════════════════════════════╝
++	//
++	// Behaves similarly to EmitUnpopulated, but does not emit "null"-value fields,
++	// i.e. presence-sensing fields that are omitted will remain omitted to preserve
++	// presence-sensing.
++	// EmitUnpopulated takes precedence over EmitDefaultValues since the former generates
++	// a strict superset of the latter.
++	EmitDefaultValues bool
++
+ 	// Resolver is used for looking up types when expanding google.protobuf.Any
+ 	// messages. If nil, this defaults to using protoregistry.GlobalTypes.
+ 	Resolver interface {
+@@ -102,7 +121,7 @@ func (o MarshalOptions) Format(m proto.Message) string {
+ 	return string(b)
+ }
+ 
+-// Marshal marshals the given proto.Message in the JSON format using options in
++// Marshal marshals the given [proto.Message] in the JSON format using options in
+ // MarshalOptions. Do not depend on the output being stable. It may change over
+ // time across different versions of the program.
+ func (o MarshalOptions) Marshal(m proto.Message) ([]byte, error) {
+@@ -178,7 +197,11 @@ func (m typeURLFieldRanger) Range(f func(protoreflect.FieldDescriptor, protorefl
+ 
+ // unpopulatedFieldRanger wraps a protoreflect.Message and modifies its Range
+ // method to additionally iterate over unpopulated fields.
+-type unpopulatedFieldRanger struct{ protoreflect.Message }
++type unpopulatedFieldRanger struct {
++	protoreflect.Message
++
++	skipNull bool
++}
+ 
+ func (m unpopulatedFieldRanger) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+ 	fds := m.Descriptor().Fields()
+@@ -192,6 +215,9 @@ func (m unpopulatedFieldRanger) Range(f func(protoreflect.FieldDescriptor, proto
+ 		isProto2Scalar := fd.Syntax() == protoreflect.Proto2 && fd.Default().IsValid()
+ 		isSingularMessage := fd.Cardinality() != protoreflect.Repeated && fd.Message() != nil
+ 		if isProto2Scalar || isSingularMessage {
++			if m.skipNull {
++				continue
++			}
+ 			v = protoreflect.Value{} // use invalid value to emit null
+ 		}
+ 		if !f(fd, v) {
+@@ -217,8 +243,11 @@ func (e encoder) marshalMessage(m protoreflect.Message, typeURL string) error {
+ 	defer e.EndObject()
+ 
+ 	var fields order.FieldRanger = m
+-	if e.opts.EmitUnpopulated {
+-		fields = unpopulatedFieldRanger{m}
++	switch {
++	case e.opts.EmitUnpopulated:
++		fields = unpopulatedFieldRanger{Message: m, skipNull: false}
++	case e.opts.EmitDefaultValues:
++		fields = unpopulatedFieldRanger{Message: m, skipNull: true}
+ 	}
+ 	if typeURL != "" {
+ 		fields = typeURLFieldRanger{fields, typeURL}
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+index 6c37d41..4b177c8 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+@@ -176,7 +176,7 @@ func (d decoder) unmarshalAny(m protoreflect.Message) error {
+ 	// Use another decoder to parse the unread bytes for @type field. This
+ 	// avoids advancing a read from current decoder because the current JSON
+ 	// object may contain the fields of the embedded type.
+-	dec := decoder{d.Clone(), UnmarshalOptions{}}
++	dec := decoder{d.Clone(), UnmarshalOptions{RecursionLimit: d.opts.RecursionLimit}}
+ 	tok, err := findTypeURL(dec)
+ 	switch err {
+ 	case errEmptyObject:
+@@ -308,48 +308,29 @@ Loop:
+ // array) in order to advance the read to the next JSON value. It relies on
+ // the decoder returning an error if the types are not in valid sequence.
+ func (d decoder) skipJSONValue() error {
+-	tok, err := d.Read()
+-	if err != nil {
+-		return err
+-	}
+-	// Only need to continue reading for objects and arrays.
+-	switch tok.Kind() {
+-	case json.ObjectOpen:
+-		for {
+-			tok, err := d.Read()
+-			if err != nil {
+-				return err
+-			}
+-			switch tok.Kind() {
+-			case json.ObjectClose:
+-				return nil
+-			case json.Name:
+-				// Skip object field value.
+-				if err := d.skipJSONValue(); err != nil {
+-					return err
+-				}
+-			}
++	var open int
++	for {
++		tok, err := d.Read()
++		if err != nil {
++			return err
+ 		}
+-
+-	case json.ArrayOpen:
+-		for {
+-			tok, err := d.Peek()
+-			if err != nil {
+-				return err
+-			}
+-			switch tok.Kind() {
+-			case json.ArrayClose:
+-				d.Read()
+-				return nil
+-			default:
+-				// Skip array item.
+-				if err := d.skipJSONValue(); err != nil {
+-					return err
+-				}
++		switch tok.Kind() {
++		case json.ObjectClose, json.ArrayClose:
++			open--
++		case json.ObjectOpen, json.ArrayOpen:
++			open++
++			if open > d.opts.RecursionLimit {
++				return errors.New("exceeded max recursion depth")
+ 			}
++		case json.EOF:
++			// This can only happen if there's a bug in Decoder.Read.
++			// Avoid an infinite loop if this does happen.
++			return errors.New("unexpected EOF")
++		}
++		if open == 0 {
++			return nil
+ 		}
+ 	}
+-	return nil
+ }
+ 
+ // unmarshalAnyValue unmarshals the given custom-type message from the JSON
+diff --git a/vendor/google.golang.org/protobuf/encoding/prototext/decode.go b/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
+index 4921b2d..a45f112 100644
+--- a/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
++++ b/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
+@@ -21,7 +21,7 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
+-// Unmarshal reads the given []byte into the given proto.Message.
++// Unmarshal reads the given []byte into the given [proto.Message].
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func Unmarshal(b []byte, m proto.Message) error {
+ 	return UnmarshalOptions{}.Unmarshal(b, m)
+@@ -51,7 +51,7 @@ type UnmarshalOptions struct {
+ 	}
+ }
+ 
+-// Unmarshal reads the given []byte and populates the given proto.Message
++// Unmarshal reads the given []byte and populates the given [proto.Message]
+ // using options in the UnmarshalOptions object.
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func (o UnmarshalOptions) Unmarshal(b []byte, m proto.Message) error {
+@@ -739,7 +739,9 @@ func (d decoder) skipValue() error {
+ 			case text.ListClose:
+ 				return nil
+ 			case text.MessageOpen:
+-				return d.skipMessageValue()
++				if err := d.skipMessageValue(); err != nil {
++					return err
++				}
+ 			default:
+ 				// Skip items. This will not validate whether skipped values are
+ 				// of the same type or not, same behavior as C++
+diff --git a/vendor/google.golang.org/protobuf/encoding/prototext/encode.go b/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
+index 722a7b4..95967e8 100644
+--- a/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
++++ b/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
+@@ -33,7 +33,7 @@ func Format(m proto.Message) string {
+ 	return MarshalOptions{Multiline: true}.Format(m)
+ }
+ 
+-// Marshal writes the given proto.Message in textproto format using default
++// Marshal writes the given [proto.Message] in textproto format using default
+ // options. Do not depend on the output being stable. It may change over time
+ // across different versions of the program.
+ func Marshal(m proto.Message) ([]byte, error) {
+@@ -97,7 +97,7 @@ func (o MarshalOptions) Format(m proto.Message) string {
+ 	return string(b)
+ }
+ 
+-// Marshal writes the given proto.Message in textproto format using options in
++// Marshal writes the given [proto.Message] in textproto format using options in
+ // MarshalOptions object. Do not depend on the output being stable. It may
+ // change over time across different versions of the program.
+ func (o MarshalOptions) Marshal(m proto.Message) ([]byte, error) {
+diff --git a/vendor/google.golang.org/protobuf/encoding/protowire/wire.go b/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
+index f4b4686..e942bc9 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
++++ b/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
+@@ -6,7 +6,7 @@
+ // See https://protobuf.dev/programming-guides/encoding.
+ //
+ // For marshaling and unmarshaling entire protobuf messages,
+-// use the "google.golang.org/protobuf/proto" package instead.
++// use the [google.golang.org/protobuf/proto] package instead.
+ package protowire
+ 
+ import (
+@@ -87,7 +87,7 @@ func ParseError(n int) error {
+ 
+ // ConsumeField parses an entire field record (both tag and value) and returns
+ // the field number, the wire type, and the total length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ //
+ // The total length includes the tag header and the end group marker (if the
+ // field is a group).
+@@ -104,8 +104,8 @@ func ConsumeField(b []byte) (Number, Type, int) {
+ }
+ 
+ // ConsumeFieldValue parses a field value and returns its length.
+-// This assumes that the field Number and wire Type have already been parsed.
+-// This returns a negative length upon an error (see ParseError).
++// This assumes that the field [Number] and wire [Type] have already been parsed.
++// This returns a negative length upon an error (see [ParseError]).
+ //
+ // When parsing a group, the length includes the end group marker and
+ // the end group is verified to match the starting field number.
+@@ -164,7 +164,7 @@ func AppendTag(b []byte, num Number, typ Type) []byte {
+ }
+ 
+ // ConsumeTag parses b as a varint-encoded tag, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeTag(b []byte) (Number, Type, int) {
+ 	v, n := ConsumeVarint(b)
+ 	if n < 0 {
+@@ -263,7 +263,7 @@ func AppendVarint(b []byte, v uint64) []byte {
+ }
+ 
+ // ConsumeVarint parses b as a varint-encoded uint64, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeVarint(b []byte) (v uint64, n int) {
+ 	var y uint64
+ 	if len(b) <= 0 {
+@@ -384,7 +384,7 @@ func AppendFixed32(b []byte, v uint32) []byte {
+ }
+ 
+ // ConsumeFixed32 parses b as a little-endian uint32, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeFixed32(b []byte) (v uint32, n int) {
+ 	if len(b) < 4 {
+ 		return 0, errCodeTruncated
+@@ -412,7 +412,7 @@ func AppendFixed64(b []byte, v uint64) []byte {
+ }
+ 
+ // ConsumeFixed64 parses b as a little-endian uint64, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeFixed64(b []byte) (v uint64, n int) {
+ 	if len(b) < 8 {
+ 		return 0, errCodeTruncated
+@@ -432,7 +432,7 @@ func AppendBytes(b []byte, v []byte) []byte {
+ }
+ 
+ // ConsumeBytes parses b as a length-prefixed bytes value, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeBytes(b []byte) (v []byte, n int) {
+ 	m, n := ConsumeVarint(b)
+ 	if n < 0 {
+@@ -456,7 +456,7 @@ func AppendString(b []byte, v string) []byte {
+ }
+ 
+ // ConsumeString parses b as a length-prefixed bytes value, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeString(b []byte) (v string, n int) {
+ 	bb, n := ConsumeBytes(b)
+ 	return string(bb), n
+@@ -471,7 +471,7 @@ func AppendGroup(b []byte, num Number, v []byte) []byte {
+ // ConsumeGroup parses b as a group value until the trailing end group marker,
+ // and verifies that the end marker matches the provided num. The value v
+ // does not contain the end marker, while the length does contain the end marker.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeGroup(num Number, b []byte) (v []byte, n int) {
+ 	n = ConsumeFieldValue(num, StartGroupType, b)
+ 	if n < 0 {
+@@ -495,8 +495,8 @@ func SizeGroup(num Number, n int) int {
+ 	return n + SizeTag(num)
+ }
+ 
+-// DecodeTag decodes the field Number and wire Type from its unified form.
+-// The Number is -1 if the decoded field number overflows int32.
++// DecodeTag decodes the field [Number] and wire [Type] from its unified form.
++// The [Number] is -1 if the decoded field number overflows int32.
+ // Other than overflow, this does not check for field number validity.
+ func DecodeTag(x uint64) (Number, Type) {
+ 	// NOTE: MessageSet allows for larger field numbers than normal.
+@@ -506,7 +506,7 @@ func DecodeTag(x uint64) (Number, Type) {
+ 	return Number(x >> 3), Type(x & 7)
+ }
+ 
+-// EncodeTag encodes the field Number and wire Type into its unified form.
++// EncodeTag encodes the field [Number] and wire [Type] into its unified form.
+ func EncodeTag(num Number, typ Type) uint64 {
+ 	return uint64(num)<<3 | uint64(typ&7)
+ }
+diff --git a/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go b/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
+index db5248e..a45625c 100644
+--- a/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
++++ b/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
+@@ -83,7 +83,13 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
+ 	case protoreflect.FileImports:
+ 		for i := 0; i < vs.Len(); i++ {
+ 			var rs records
+-			rs.Append(reflect.ValueOf(vs.Get(i)), "Path", "Package", "IsPublic", "IsWeak")
++			rv := reflect.ValueOf(vs.Get(i))
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("IsPublic"), "IsPublic"},
++				{rv.MethodByName("IsWeak"), "IsWeak"},
++			}...)
+ 			ss = append(ss, "{"+rs.Join()+"}")
+ 		}
+ 		return start + joinStrings(ss, allowMulti) + end
+@@ -92,34 +98,26 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
+ 		for i := 0; i < vs.Len(); i++ {
+ 			m := reflect.ValueOf(vs).MethodByName("Get")
+ 			v := m.Call([]reflect.Value{reflect.ValueOf(i)})[0].Interface()
+-			ss = append(ss, formatDescOpt(v.(protoreflect.Descriptor), false, allowMulti && !isEnumValue))
++			ss = append(ss, formatDescOpt(v.(protoreflect.Descriptor), false, allowMulti && !isEnumValue, nil))
+ 		}
+ 		return start + joinStrings(ss, allowMulti && isEnumValue) + end
+ 	}
+ }
+ 
+-// descriptorAccessors is a list of accessors to print for each descriptor.
+-//
+-// Do not print all accessors since some contain redundant information,
+-// while others are pointers that we do not want to follow since the descriptor
+-// is actually a cyclic graph.
+-//
+-// Using a list allows us to print the accessors in a sensible order.
+-var descriptorAccessors = map[reflect.Type][]string{
+-	reflect.TypeOf((*protoreflect.FileDescriptor)(nil)).Elem():      {"Path", "Package", "Imports", "Messages", "Enums", "Extensions", "Services"},
+-	reflect.TypeOf((*protoreflect.MessageDescriptor)(nil)).Elem():   {"IsMapEntry", "Fields", "Oneofs", "ReservedNames", "ReservedRanges", "RequiredNumbers", "ExtensionRanges", "Messages", "Enums", "Extensions"},
+-	reflect.TypeOf((*protoreflect.FieldDescriptor)(nil)).Elem():     {"Number", "Cardinality", "Kind", "HasJSONName", "JSONName", "HasPresence", "IsExtension", "IsPacked", "IsWeak", "IsList", "IsMap", "MapKey", "MapValue", "HasDefault", "Default", "ContainingOneof", "ContainingMessage", "Message", "Enum"},
+-	reflect.TypeOf((*protoreflect.OneofDescriptor)(nil)).Elem():     {"Fields"}, // not directly used; must keep in sync with formatDescOpt
+-	reflect.TypeOf((*protoreflect.EnumDescriptor)(nil)).Elem():      {"Values", "ReservedNames", "ReservedRanges"},
+-	reflect.TypeOf((*protoreflect.EnumValueDescriptor)(nil)).Elem(): {"Number"},
+-	reflect.TypeOf((*protoreflect.ServiceDescriptor)(nil)).Elem():   {"Methods"},
+-	reflect.TypeOf((*protoreflect.MethodDescriptor)(nil)).Elem():    {"Input", "Output", "IsStreamingClient", "IsStreamingServer"},
++type methodAndName struct {
++	method reflect.Value
++	name   string
+ }
+ 
+ func FormatDesc(s fmt.State, r rune, t protoreflect.Descriptor) {
+-	io.WriteString(s, formatDescOpt(t, true, r == 'v' && (s.Flag('+') || s.Flag('#'))))
++	io.WriteString(s, formatDescOpt(t, true, r == 'v' && (s.Flag('+') || s.Flag('#')), nil))
+ }
+-func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
++
++func InternalFormatDescOptForTesting(t protoreflect.Descriptor, isRoot, allowMulti bool, record func(string)) string {
++	return formatDescOpt(t, isRoot, allowMulti, record)
++}
++
++func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool, record func(string)) string {
+ 	rv := reflect.ValueOf(t)
+ 	rt := rv.MethodByName("ProtoType").Type().In(0)
+ 
+@@ -129,26 +127,60 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 	}
+ 
+ 	_, isFile := t.(protoreflect.FileDescriptor)
+-	rs := records{allowMulti: allowMulti}
++	rs := records{
++		allowMulti: allowMulti,
++		record:     record,
++	}
+ 	if t.IsPlaceholder() {
+ 		if isFile {
+-			rs.Append(rv, "Path", "Package", "IsPlaceholder")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
++			}...)
+ 		} else {
+-			rs.Append(rv, "FullName", "IsPlaceholder")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("FullName"), "FullName"},
++				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
++			}...)
+ 		}
+ 	} else {
+ 		switch {
+ 		case isFile:
+-			rs.Append(rv, "Syntax")
++			rs.Append(rv, methodAndName{rv.MethodByName("Syntax"), "Syntax"})
+ 		case isRoot:
+-			rs.Append(rv, "Syntax", "FullName")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Syntax"), "Syntax"},
++				{rv.MethodByName("FullName"), "FullName"},
++			}...)
+ 		default:
+-			rs.Append(rv, "Name")
++			rs.Append(rv, methodAndName{rv.MethodByName("Name"), "Name"})
+ 		}
+ 		switch t := t.(type) {
+ 		case protoreflect.FieldDescriptor:
+-			for _, s := range descriptorAccessors[rt] {
+-				switch s {
++			accessors := []methodAndName{
++				{rv.MethodByName("Number"), "Number"},
++				{rv.MethodByName("Cardinality"), "Cardinality"},
++				{rv.MethodByName("Kind"), "Kind"},
++				{rv.MethodByName("HasJSONName"), "HasJSONName"},
++				{rv.MethodByName("JSONName"), "JSONName"},
++				{rv.MethodByName("HasPresence"), "HasPresence"},
++				{rv.MethodByName("IsExtension"), "IsExtension"},
++				{rv.MethodByName("IsPacked"), "IsPacked"},
++				{rv.MethodByName("IsWeak"), "IsWeak"},
++				{rv.MethodByName("IsList"), "IsList"},
++				{rv.MethodByName("IsMap"), "IsMap"},
++				{rv.MethodByName("MapKey"), "MapKey"},
++				{rv.MethodByName("MapValue"), "MapValue"},
++				{rv.MethodByName("HasDefault"), "HasDefault"},
++				{rv.MethodByName("Default"), "Default"},
++				{rv.MethodByName("ContainingOneof"), "ContainingOneof"},
++				{rv.MethodByName("ContainingMessage"), "ContainingMessage"},
++				{rv.MethodByName("Message"), "Message"},
++				{rv.MethodByName("Enum"), "Enum"},
++			}
++			for _, s := range accessors {
++				switch s.name {
+ 				case "MapKey":
+ 					if k := t.MapKey(); k != nil {
+ 						rs.recs = append(rs.recs, [2]string{"MapKey", k.Kind().String()})
+@@ -157,20 +189,20 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 					if v := t.MapValue(); v != nil {
+ 						switch v.Kind() {
+ 						case protoreflect.EnumKind:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", string(v.Enum().FullName())})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", string(v.Enum().FullName())})
+ 						case protoreflect.MessageKind, protoreflect.GroupKind:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", string(v.Message().FullName())})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", string(v.Message().FullName())})
+ 						default:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", v.Kind().String()})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", v.Kind().String()})
+ 						}
+ 					}
+ 				case "ContainingOneof":
+ 					if od := t.ContainingOneof(); od != nil {
+-						rs.recs = append(rs.recs, [2]string{"Oneof", string(od.Name())})
++						rs.AppendRecs("ContainingOneof", [2]string{"Oneof", string(od.Name())})
+ 					}
+ 				case "ContainingMessage":
+ 					if t.IsExtension() {
+-						rs.recs = append(rs.recs, [2]string{"Extendee", string(t.ContainingMessage().FullName())})
++						rs.AppendRecs("ContainingMessage", [2]string{"Extendee", string(t.ContainingMessage().FullName())})
+ 					}
+ 				case "Message":
+ 					if !t.IsMap() {
+@@ -187,13 +219,61 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 				ss = append(ss, string(fs.Get(i).Name()))
+ 			}
+ 			if len(ss) > 0 {
+-				rs.recs = append(rs.recs, [2]string{"Fields", "[" + joinStrings(ss, false) + "]"})
++				rs.AppendRecs("Fields", [2]string{"Fields", "[" + joinStrings(ss, false) + "]"})
+ 			}
+-		default:
+-			rs.Append(rv, descriptorAccessors[rt]...)
++
++		case protoreflect.FileDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("Imports"), "Imports"},
++				{rv.MethodByName("Messages"), "Messages"},
++				{rv.MethodByName("Enums"), "Enums"},
++				{rv.MethodByName("Extensions"), "Extensions"},
++				{rv.MethodByName("Services"), "Services"},
++			}...)
++
++		case protoreflect.MessageDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("IsMapEntry"), "IsMapEntry"},
++				{rv.MethodByName("Fields"), "Fields"},
++				{rv.MethodByName("Oneofs"), "Oneofs"},
++				{rv.MethodByName("ReservedNames"), "ReservedNames"},
++				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
++				{rv.MethodByName("RequiredNumbers"), "RequiredNumbers"},
++				{rv.MethodByName("ExtensionRanges"), "ExtensionRanges"},
++				{rv.MethodByName("Messages"), "Messages"},
++				{rv.MethodByName("Enums"), "Enums"},
++				{rv.MethodByName("Extensions"), "Extensions"},
++			}...)
++
++		case protoreflect.EnumDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Values"), "Values"},
++				{rv.MethodByName("ReservedNames"), "ReservedNames"},
++				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
++			}...)
++
++		case protoreflect.EnumValueDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Number"), "Number"},
++			}...)
++
++		case protoreflect.ServiceDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Methods"), "Methods"},
++			}...)
++
++		case protoreflect.MethodDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Input"), "Input"},
++				{rv.MethodByName("Output"), "Output"},
++				{rv.MethodByName("IsStreamingClient"), "IsStreamingClient"},
++				{rv.MethodByName("IsStreamingServer"), "IsStreamingServer"},
++			}...)
+ 		}
+-		if rv.MethodByName("GoType").IsValid() {
+-			rs.Append(rv, "GoType")
++		if m := rv.MethodByName("GoType"); m.IsValid() {
++			rs.Append(rv, methodAndName{m, "GoType"})
+ 		}
+ 	}
+ 	return start + rs.Join() + end
+@@ -202,19 +282,34 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ type records struct {
+ 	recs       [][2]string
+ 	allowMulti bool
++
++	// record is a function that will be called for every Append() or
++	// AppendRecs() call, to be used for testing with the
++	// InternalFormatDescOptForTesting function.
++	record func(string)
+ }
+ 
+-func (rs *records) Append(v reflect.Value, accessors ...string) {
++func (rs *records) AppendRecs(fieldName string, newRecs [2]string) {
++	if rs.record != nil {
++		rs.record(fieldName)
++	}
++	rs.recs = append(rs.recs, newRecs)
++}
++
++func (rs *records) Append(v reflect.Value, accessors ...methodAndName) {
+ 	for _, a := range accessors {
++		if rs.record != nil {
++			rs.record(a.name)
++		}
+ 		var rv reflect.Value
+-		if m := v.MethodByName(a); m.IsValid() {
+-			rv = m.Call(nil)[0]
++		if a.method.IsValid() {
++			rv = a.method.Call(nil)[0]
+ 		}
+ 		if v.Kind() == reflect.Struct && !rv.IsValid() {
+-			rv = v.FieldByName(a)
++			rv = v.FieldByName(a.name)
+ 		}
+ 		if !rv.IsValid() {
+-			panic(fmt.Sprintf("unknown accessor: %v.%s", v.Type(), a))
++			panic(fmt.Sprintf("unknown accessor: %v.%s", v.Type(), a.name))
+ 		}
+ 		if _, ok := rv.Interface().(protoreflect.Value); ok {
+ 			rv = rv.MethodByName("Interface").Call(nil)[0]
+@@ -261,7 +356,7 @@ func (rs *records) Append(v reflect.Value, accessors ...string) {
+ 		default:
+ 			s = fmt.Sprint(v)
+ 		}
+-		rs.recs = append(rs.recs, [2]string{a, s})
++		rs.recs = append(rs.recs, [2]string{a.name, s})
+ 	}
+ }
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go b/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+new file mode 100644
+index 0000000..14656b6
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+@@ -0,0 +1,12 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Package editiondefaults contains the binary representation of the editions
++// defaults.
++package editiondefaults
++
++import _ "embed"
++
++//go:embed editions_defaults.binpb
++var Defaults []byte
+diff --git a/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb b/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+new file mode 100644
+index 0000000..18f0756
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+@@ -0,0 +1,4 @@
++
++ (0�
++ (0�
++ (0� �(�
+\ No newline at end of file
+diff --git a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+index d043a6e..d2b3ac0 100644
+--- a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
++++ b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+@@ -121,7 +121,7 @@ func (d *Decoder) Read() (Token, error) {
+ 
+ 	case ObjectClose:
+ 		if len(d.openStack) == 0 ||
+-			d.lastToken.kind == comma ||
++			d.lastToken.kind&(Name|comma) != 0 ||
+ 			d.openStack[len(d.openStack)-1] != ObjectOpen {
+ 			return Token{}, d.newSyntaxError(tok.pos, unexpectedFmt, tok.RawString())
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+index 7c3689b..8826bcf 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+@@ -21,11 +21,26 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
++// Edition is an Enum for proto2.Edition
++type Edition int32
++
++// These values align with the value of Enum in descriptor.proto which allows
++// direct conversion between the proto enum and this enum.
++const (
++	EditionUnknown     Edition = 0
++	EditionProto2      Edition = 998
++	EditionProto3      Edition = 999
++	Edition2023        Edition = 1000
++	EditionUnsupported Edition = 100000
++)
++
+ // The types in this file may have a suffix:
+ //	• L0: Contains fields common to all descriptors (except File) and
+ //	must be initialized up front.
+ //	• L1: Contains fields specific to a descriptor and
+-//	must be initialized up front.
++//	must be initialized up front. If the associated proto uses Editions, the
++//  Editions features must always be resolved. If not explicitly set, the
++//  appropriate default must be resolved and set.
+ //	• L2: Contains fields that are lazily initialized when constructing
+ //	from the raw file descriptor. When constructing as a literal, the L2
+ //	fields must be initialized up front.
+@@ -44,6 +59,7 @@ type (
+ 	}
+ 	FileL1 struct {
+ 		Syntax  protoreflect.Syntax
++		Edition Edition // Only used if Syntax == Editions
+ 		Path    string
+ 		Package protoreflect.FullName
+ 
+@@ -51,12 +67,41 @@ type (
+ 		Messages   Messages
+ 		Extensions Extensions
+ 		Services   Services
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	FileL2 struct {
+ 		Options   func() protoreflect.ProtoMessage
+ 		Imports   FileImports
+ 		Locations SourceLocations
+ 	}
++
++	EditionFeatures struct {
++		// IsFieldPresence is true if field_presence is EXPLICIT
++		// https://protobuf.dev/editions/features/#field_presence
++		IsFieldPresence bool
++		// IsFieldPresence is true if field_presence is LEGACY_REQUIRED
++		// https://protobuf.dev/editions/features/#field_presence
++		IsLegacyRequired bool
++		// IsOpenEnum is true if enum_type is OPEN
++		// https://protobuf.dev/editions/features/#enum_type
++		IsOpenEnum bool
++		// IsPacked is true if repeated_field_encoding is PACKED
++		// https://protobuf.dev/editions/features/#repeated_field_encoding
++		IsPacked bool
++		// IsUTF8Validated is true if utf_validation is VERIFY
++		// https://protobuf.dev/editions/features/#utf8_validation
++		IsUTF8Validated bool
++		// IsDelimitedEncoded is true if message_encoding is DELIMITED
++		// https://protobuf.dev/editions/features/#message_encoding
++		IsDelimitedEncoded bool
++		// IsJSONCompliant is true if json_format is ALLOW
++		// https://protobuf.dev/editions/features/#json_format
++		IsJSONCompliant bool
++		// GenerateLegacyUnmarshalJSON determines if the plugin generates the
++		// UnmarshalJSON([]byte) error method for enums.
++		GenerateLegacyUnmarshalJSON bool
++	}
+ )
+ 
+ func (fd *File) ParentFile() protoreflect.FileDescriptor { return fd }
+@@ -117,6 +162,8 @@ type (
+ 	}
+ 	EnumL1 struct {
+ 		eagerValues bool // controls whether EnumL2.Values is already populated
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	EnumL2 struct {
+ 		Options        func() protoreflect.ProtoMessage
+@@ -178,6 +225,8 @@ type (
+ 		Extensions   Extensions
+ 		IsMapEntry   bool // promoted from google.protobuf.MessageOptions
+ 		IsMessageSet bool // promoted from google.protobuf.MessageOptions
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	MessageL2 struct {
+ 		Options               func() protoreflect.ProtoMessage
+@@ -210,6 +259,8 @@ type (
+ 		ContainingOneof  protoreflect.OneofDescriptor // must be consistent with Message.Oneofs.Fields
+ 		Enum             protoreflect.EnumDescriptor
+ 		Message          protoreflect.MessageDescriptor
++
++		EditionFeatures EditionFeatures
+ 	}
+ 
+ 	Oneof struct {
+@@ -219,6 +270,8 @@ type (
+ 	OneofL1 struct {
+ 		Options func() protoreflect.ProtoMessage
+ 		Fields  OneofFields // must be consistent with Message.Fields.ContainingOneof
++
++		EditionFeatures EditionFeatures
+ 	}
+ )
+ 
+@@ -268,23 +321,36 @@ func (fd *Field) Options() protoreflect.ProtoMessage {
+ }
+ func (fd *Field) Number() protoreflect.FieldNumber      { return fd.L1.Number }
+ func (fd *Field) Cardinality() protoreflect.Cardinality { return fd.L1.Cardinality }
+-func (fd *Field) Kind() protoreflect.Kind               { return fd.L1.Kind }
+-func (fd *Field) HasJSONName() bool                     { return fd.L1.StringName.hasJSON }
+-func (fd *Field) JSONName() string                      { return fd.L1.StringName.getJSON(fd) }
+-func (fd *Field) TextName() string                      { return fd.L1.StringName.getText(fd) }
++func (fd *Field) Kind() protoreflect.Kind {
++	return fd.L1.Kind
++}
++func (fd *Field) HasJSONName() bool { return fd.L1.StringName.hasJSON }
++func (fd *Field) JSONName() string  { return fd.L1.StringName.getJSON(fd) }
++func (fd *Field) TextName() string  { return fd.L1.StringName.getText(fd) }
+ func (fd *Field) HasPresence() bool {
+-	return fd.L1.Cardinality != protoreflect.Repeated && (fd.L0.ParentFile.L1.Syntax == protoreflect.Proto2 || fd.L1.Message != nil || fd.L1.ContainingOneof != nil)
++	if fd.L1.Cardinality == protoreflect.Repeated {
++		return false
++	}
++	explicitFieldPresence := fd.Syntax() == protoreflect.Editions && fd.L1.EditionFeatures.IsFieldPresence
++	return fd.Syntax() == protoreflect.Proto2 || explicitFieldPresence || fd.L1.Message != nil || fd.L1.ContainingOneof != nil
+ }
+ func (fd *Field) HasOptionalKeyword() bool {
+ 	return (fd.L0.ParentFile.L1.Syntax == protoreflect.Proto2 && fd.L1.Cardinality == protoreflect.Optional && fd.L1.ContainingOneof == nil) || fd.L1.IsProto3Optional
+ }
+ func (fd *Field) IsPacked() bool {
+-	if !fd.L1.HasPacked && fd.L0.ParentFile.L1.Syntax != protoreflect.Proto2 && fd.L1.Cardinality == protoreflect.Repeated {
+-		switch fd.L1.Kind {
+-		case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
+-		default:
+-			return true
+-		}
++	if fd.L1.Cardinality != protoreflect.Repeated {
++		return false
++	}
++	switch fd.L1.Kind {
++	case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
++		return false
++	}
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Editions {
++		return fd.L1.EditionFeatures.IsPacked
++	}
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Proto3 {
++		// proto3 repeated fields are packed by default.
++		return !fd.L1.HasPacked || fd.L1.IsPacked
+ 	}
+ 	return fd.L1.IsPacked
+ }
+@@ -333,6 +399,9 @@ func (fd *Field) ProtoType(protoreflect.FieldDescriptor) {}
+ // WARNING: This method is exempt from the compatibility promise and may be
+ // removed in the future without warning.
+ func (fd *Field) EnforceUTF8() bool {
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Editions {
++		return fd.L1.EditionFeatures.IsUTF8Validated
++	}
+ 	if fd.L1.HasEnforceUTF8 {
+ 		return fd.L1.EnforceUTF8
+ 	}
+@@ -359,10 +428,11 @@ type (
+ 		L2 *ExtensionL2 // protected by fileDesc.once
+ 	}
+ 	ExtensionL1 struct {
+-		Number      protoreflect.FieldNumber
+-		Extendee    protoreflect.MessageDescriptor
+-		Cardinality protoreflect.Cardinality
+-		Kind        protoreflect.Kind
++		Number          protoreflect.FieldNumber
++		Extendee        protoreflect.MessageDescriptor
++		Cardinality     protoreflect.Cardinality
++		Kind            protoreflect.Kind
++		EditionFeatures EditionFeatures
+ 	}
+ 	ExtensionL2 struct {
+ 		Options          func() protoreflect.ProtoMessage
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
+index 4a1584c..237e64f 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
+@@ -5,6 +5,7 @@
+ package filedesc
+ 
+ import (
++	"fmt"
+ 	"sync"
+ 
+ 	"google.golang.org/protobuf/encoding/protowire"
+@@ -98,6 +99,7 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 	var prevField protoreflect.FieldNumber
+ 	var numEnums, numMessages, numExtensions, numServices int
+ 	var posEnums, posMessages, posExtensions, posServices int
++	var options []byte
+ 	b0 := b
+ 	for len(b) > 0 {
+ 		num, typ, n := protowire.ConsumeTag(b)
+@@ -113,6 +115,8 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 					fd.L1.Syntax = protoreflect.Proto2
+ 				case "proto3":
+ 					fd.L1.Syntax = protoreflect.Proto3
++				case "editions":
++					fd.L1.Syntax = protoreflect.Editions
+ 				default:
+ 					panic("invalid syntax")
+ 				}
+@@ -120,6 +124,8 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 				fd.L1.Path = sb.MakeString(v)
+ 			case genid.FileDescriptorProto_Package_field_number:
+ 				fd.L1.Package = protoreflect.FullName(sb.MakeString(v))
++			case genid.FileDescriptorProto_Options_field_number:
++				options = v
+ 			case genid.FileDescriptorProto_EnumType_field_number:
+ 				if prevField != genid.FileDescriptorProto_EnumType_field_number {
+ 					if numEnums > 0 {
+@@ -154,6 +160,13 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 				numServices++
+ 			}
+ 			prevField = num
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FileDescriptorProto_Edition_field_number:
++				fd.L1.Edition = Edition(v)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+@@ -166,6 +179,15 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 		fd.L1.Syntax = protoreflect.Proto2
+ 	}
+ 
++	if fd.L1.Syntax == protoreflect.Editions {
++		fd.L1.EditionFeatures = getFeaturesFor(fd.L1.Edition)
++	}
++
++	// Parse editions features from options if any
++	if options != nil {
++		fd.unmarshalSeedOptions(options)
++	}
++
+ 	// Must allocate all declarations before parsing each descriptor type
+ 	// to ensure we handled all descriptors in "flattened ordering".
+ 	if numEnums > 0 {
+@@ -219,6 +241,28 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 	}
+ }
+ 
++func (fd *File) unmarshalSeedOptions(b []byte) {
++	for b := b; len(b) > 0; {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FileOptions_Features_field_number:
++				if fd.Syntax() != protoreflect.Editions {
++					panic(fmt.Sprintf("invalid descriptor: using edition features in a proto with syntax %s", fd.Syntax()))
++				}
++				fd.L1.EditionFeatures = unmarshalFeatureSet(v, fd.L1.EditionFeatures)
++			}
++		default:
++			m := protowire.ConsumeFieldValue(num, typ, b)
++			b = b[m:]
++		}
++	}
++}
++
+ func (ed *Enum) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protoreflect.Descriptor, i int) {
+ 	ed.L0.ParentFile = pf
+ 	ed.L0.Parent = pd
+@@ -275,6 +319,7 @@ func (md *Message) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protor
+ 	md.L0.ParentFile = pf
+ 	md.L0.Parent = pd
+ 	md.L0.Index = i
++	md.L1.EditionFeatures = featuresFromParentDesc(md.Parent())
+ 
+ 	var prevField protoreflect.FieldNumber
+ 	var numEnums, numMessages, numExtensions int
+@@ -380,6 +425,13 @@ func (md *Message) unmarshalSeedOptions(b []byte) {
+ 			case genid.MessageOptions_MessageSetWireFormat_field_number:
+ 				md.L1.IsMessageSet = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.MessageOptions_Features_field_number:
++				md.L1.EditionFeatures = unmarshalFeatureSet(v, md.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+index 736a19a..482a61c 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+@@ -414,6 +414,7 @@ func (fd *Field) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ 	fd.L0.ParentFile = pf
+ 	fd.L0.Parent = pd
+ 	fd.L0.Index = i
++	fd.L1.EditionFeatures = featuresFromParentDesc(fd.Parent())
+ 
+ 	var rawTypeName []byte
+ 	var rawOptions []byte
+@@ -465,6 +466,12 @@ func (fd *Field) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ 			b = b[m:]
+ 		}
+ 	}
++	if fd.Syntax() == protoreflect.Editions && fd.L1.Kind == protoreflect.MessageKind && fd.L1.EditionFeatures.IsDelimitedEncoded {
++		fd.L1.Kind = protoreflect.GroupKind
++	}
++	if fd.Syntax() == protoreflect.Editions && fd.L1.EditionFeatures.IsLegacyRequired {
++		fd.L1.Cardinality = protoreflect.Required
++	}
+ 	if rawTypeName != nil {
+ 		name := makeFullName(sb, rawTypeName)
+ 		switch fd.L1.Kind {
+@@ -497,6 +504,13 @@ func (fd *Field) unmarshalOptions(b []byte) {
+ 				fd.L1.HasEnforceUTF8 = true
+ 				fd.L1.EnforceUTF8 = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FieldOptions_Features_field_number:
++				fd.L1.EditionFeatures = unmarshalFeatureSet(v, fd.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+@@ -534,6 +548,7 @@ func (od *Oneof) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ func (xd *Extension) unmarshalFull(b []byte, sb *strs.Builder) {
+ 	var rawTypeName []byte
+ 	var rawOptions []byte
++	xd.L1.EditionFeatures = featuresFromParentDesc(xd.L1.Extendee)
+ 	xd.L2 = new(ExtensionL2)
+ 	for len(b) > 0 {
+ 		num, typ, n := protowire.ConsumeTag(b)
+@@ -565,6 +580,12 @@ func (xd *Extension) unmarshalFull(b []byte, sb *strs.Builder) {
+ 			b = b[m:]
+ 		}
+ 	}
++	if xd.Syntax() == protoreflect.Editions && xd.L1.Kind == protoreflect.MessageKind && xd.L1.EditionFeatures.IsDelimitedEncoded {
++		xd.L1.Kind = protoreflect.GroupKind
++	}
++	if xd.Syntax() == protoreflect.Editions && xd.L1.EditionFeatures.IsLegacyRequired {
++		xd.L1.Cardinality = protoreflect.Required
++	}
+ 	if rawTypeName != nil {
+ 		name := makeFullName(sb, rawTypeName)
+ 		switch xd.L1.Kind {
+@@ -589,6 +610,13 @@ func (xd *Extension) unmarshalOptions(b []byte) {
+ 			case genid.FieldOptions_Packed_field_number:
+ 				xd.L2.IsPacked = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FieldOptions_Features_field_number:
++				xd.L1.EditionFeatures = unmarshalFeatureSet(v, xd.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/editions.go b/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+new file mode 100644
+index 0000000..0375a49
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+@@ -0,0 +1,142 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package filedesc
++
++import (
++	"fmt"
++
++	"google.golang.org/protobuf/encoding/protowire"
++	"google.golang.org/protobuf/internal/editiondefaults"
++	"google.golang.org/protobuf/internal/genid"
++	"google.golang.org/protobuf/reflect/protoreflect"
++)
++
++var defaultsCache = make(map[Edition]EditionFeatures)
++
++func init() {
++	unmarshalEditionDefaults(editiondefaults.Defaults)
++}
++
++func unmarshalGoFeature(b []byte, parent EditionFeatures) EditionFeatures {
++	for len(b) > 0 {
++		num, _, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch num {
++		case genid.GoFeatures_LegacyUnmarshalJsonEnum_field_number:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			parent.GenerateLegacyUnmarshalJSON = protowire.DecodeBool(v)
++		default:
++			panic(fmt.Sprintf("unkown field number %d while unmarshalling GoFeatures", num))
++		}
++	}
++	return parent
++}
++
++func unmarshalFeatureSet(b []byte, parent EditionFeatures) EditionFeatures {
++	for len(b) > 0 {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSet_FieldPresence_field_number:
++				parent.IsFieldPresence = v == genid.FeatureSet_EXPLICIT_enum_value || v == genid.FeatureSet_LEGACY_REQUIRED_enum_value
++				parent.IsLegacyRequired = v == genid.FeatureSet_LEGACY_REQUIRED_enum_value
++			case genid.FeatureSet_EnumType_field_number:
++				parent.IsOpenEnum = v == genid.FeatureSet_OPEN_enum_value
++			case genid.FeatureSet_RepeatedFieldEncoding_field_number:
++				parent.IsPacked = v == genid.FeatureSet_PACKED_enum_value
++			case genid.FeatureSet_Utf8Validation_field_number:
++				parent.IsUTF8Validated = v == genid.FeatureSet_VERIFY_enum_value
++			case genid.FeatureSet_MessageEncoding_field_number:
++				parent.IsDelimitedEncoded = v == genid.FeatureSet_DELIMITED_enum_value
++			case genid.FeatureSet_JsonFormat_field_number:
++				parent.IsJSONCompliant = v == genid.FeatureSet_ALLOW_enum_value
++			default:
++				panic(fmt.Sprintf("unkown field number %d while unmarshalling FeatureSet", num))
++			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.GoFeatures_LegacyUnmarshalJsonEnum_field_number:
++				parent = unmarshalGoFeature(v, parent)
++			}
++		}
++	}
++
++	return parent
++}
++
++func featuresFromParentDesc(parentDesc protoreflect.Descriptor) EditionFeatures {
++	var parentFS EditionFeatures
++	switch p := parentDesc.(type) {
++	case *File:
++		parentFS = p.L1.EditionFeatures
++	case *Message:
++		parentFS = p.L1.EditionFeatures
++	default:
++		panic(fmt.Sprintf("unknown parent type %T", parentDesc))
++	}
++	return parentFS
++}
++
++func unmarshalEditionDefault(b []byte) {
++	var ed Edition
++	var fs EditionFeatures
++	for len(b) > 0 {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_number:
++				ed = Edition(v)
++			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSetDefaults_FeatureSetEditionDefault_Features_field_number:
++				fs = unmarshalFeatureSet(v, fs)
++			}
++		}
++	}
++	defaultsCache[ed] = fs
++}
++
++func unmarshalEditionDefaults(b []byte) {
++	for len(b) > 0 {
++		num, _, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch num {
++		case genid.FeatureSetDefaults_Defaults_field_number:
++			def, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			unmarshalEditionDefault(def)
++		case genid.FeatureSetDefaults_MinimumEdition_field_number,
++			genid.FeatureSetDefaults_MaximumEdition_field_number:
++			// We don't care about the minimum and maximum editions. If the
++			// edition we are looking for later on is not in the cache we know
++			// it is outside of the range between minimum and maximum edition.
++			_, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++		default:
++			panic(fmt.Sprintf("unkown field number %d while unmarshalling EditionDefault", num))
++		}
++	}
++}
++
++func getFeaturesFor(ed Edition) EditionFeatures {
++	if def, ok := defaultsCache[ed]; ok {
++		return def
++	}
++	panic(fmt.Sprintf("unsupported edition: %v", ed))
++}
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+index 136f1b2..40272c8 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+@@ -12,6 +12,27 @@ import (
+ 
+ const File_google_protobuf_descriptor_proto = "google/protobuf/descriptor.proto"
+ 
++// Full and short names for google.protobuf.Edition.
++const (
++	Edition_enum_fullname = "google.protobuf.Edition"
++	Edition_enum_name     = "Edition"
++)
++
++// Enum values for google.protobuf.Edition.
++const (
++	Edition_EDITION_UNKNOWN_enum_value         = 0
++	Edition_EDITION_PROTO2_enum_value          = 998
++	Edition_EDITION_PROTO3_enum_value          = 999
++	Edition_EDITION_2023_enum_value            = 1000
++	Edition_EDITION_2024_enum_value            = 1001
++	Edition_EDITION_1_TEST_ONLY_enum_value     = 1
++	Edition_EDITION_2_TEST_ONLY_enum_value     = 2
++	Edition_EDITION_99997_TEST_ONLY_enum_value = 99997
++	Edition_EDITION_99998_TEST_ONLY_enum_value = 99998
++	Edition_EDITION_99999_TEST_ONLY_enum_value = 99999
++	Edition_EDITION_MAX_enum_value             = 2147483647
++)
++
+ // Names for google.protobuf.FileDescriptorSet.
+ const (
+ 	FileDescriptorSet_message_name     protoreflect.Name     = "FileDescriptorSet"
+@@ -81,7 +102,7 @@ const (
+ 	FileDescriptorProto_Options_field_number          protoreflect.FieldNumber = 8
+ 	FileDescriptorProto_SourceCodeInfo_field_number   protoreflect.FieldNumber = 9
+ 	FileDescriptorProto_Syntax_field_number           protoreflect.FieldNumber = 12
+-	FileDescriptorProto_Edition_field_number          protoreflect.FieldNumber = 13
++	FileDescriptorProto_Edition_field_number          protoreflect.FieldNumber = 14
+ )
+ 
+ // Names for google.protobuf.DescriptorProto.
+@@ -184,10 +205,12 @@ const (
+ const (
+ 	ExtensionRangeOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 	ExtensionRangeOptions_Declaration_field_name         protoreflect.Name = "declaration"
++	ExtensionRangeOptions_Features_field_name            protoreflect.Name = "features"
+ 	ExtensionRangeOptions_Verification_field_name        protoreflect.Name = "verification"
+ 
+ 	ExtensionRangeOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.uninterpreted_option"
+ 	ExtensionRangeOptions_Declaration_field_fullname         protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.declaration"
++	ExtensionRangeOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.features"
+ 	ExtensionRangeOptions_Verification_field_fullname        protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.verification"
+ )
+ 
+@@ -195,6 +218,7 @@ const (
+ const (
+ 	ExtensionRangeOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ 	ExtensionRangeOptions_Declaration_field_number         protoreflect.FieldNumber = 2
++	ExtensionRangeOptions_Features_field_number            protoreflect.FieldNumber = 50
+ 	ExtensionRangeOptions_Verification_field_number        protoreflect.FieldNumber = 3
+ )
+ 
+@@ -204,6 +228,12 @@ const (
+ 	ExtensionRangeOptions_VerificationState_enum_name     = "VerificationState"
+ )
+ 
++// Enum values for google.protobuf.ExtensionRangeOptions.VerificationState.
++const (
++	ExtensionRangeOptions_DECLARATION_enum_value = 0
++	ExtensionRangeOptions_UNVERIFIED_enum_value  = 1
++)
++
+ // Names for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+ 	ExtensionRangeOptions_Declaration_message_name     protoreflect.Name     = "Declaration"
+@@ -212,29 +242,26 @@ const (
+ 
+ // Field names for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+-	ExtensionRangeOptions_Declaration_Number_field_name     protoreflect.Name = "number"
+-	ExtensionRangeOptions_Declaration_FullName_field_name   protoreflect.Name = "full_name"
+-	ExtensionRangeOptions_Declaration_Type_field_name       protoreflect.Name = "type"
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_name protoreflect.Name = "is_repeated"
+-	ExtensionRangeOptions_Declaration_Reserved_field_name   protoreflect.Name = "reserved"
+-	ExtensionRangeOptions_Declaration_Repeated_field_name   protoreflect.Name = "repeated"
++	ExtensionRangeOptions_Declaration_Number_field_name   protoreflect.Name = "number"
++	ExtensionRangeOptions_Declaration_FullName_field_name protoreflect.Name = "full_name"
++	ExtensionRangeOptions_Declaration_Type_field_name     protoreflect.Name = "type"
++	ExtensionRangeOptions_Declaration_Reserved_field_name protoreflect.Name = "reserved"
++	ExtensionRangeOptions_Declaration_Repeated_field_name protoreflect.Name = "repeated"
+ 
+-	ExtensionRangeOptions_Declaration_Number_field_fullname     protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.number"
+-	ExtensionRangeOptions_Declaration_FullName_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.full_name"
+-	ExtensionRangeOptions_Declaration_Type_field_fullname       protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.type"
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.is_repeated"
+-	ExtensionRangeOptions_Declaration_Reserved_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.reserved"
+-	ExtensionRangeOptions_Declaration_Repeated_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.repeated"
++	ExtensionRangeOptions_Declaration_Number_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.number"
++	ExtensionRangeOptions_Declaration_FullName_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.full_name"
++	ExtensionRangeOptions_Declaration_Type_field_fullname     protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.type"
++	ExtensionRangeOptions_Declaration_Reserved_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.reserved"
++	ExtensionRangeOptions_Declaration_Repeated_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.repeated"
+ )
+ 
+ // Field numbers for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+-	ExtensionRangeOptions_Declaration_Number_field_number     protoreflect.FieldNumber = 1
+-	ExtensionRangeOptions_Declaration_FullName_field_number   protoreflect.FieldNumber = 2
+-	ExtensionRangeOptions_Declaration_Type_field_number       protoreflect.FieldNumber = 3
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_number protoreflect.FieldNumber = 4
+-	ExtensionRangeOptions_Declaration_Reserved_field_number   protoreflect.FieldNumber = 5
+-	ExtensionRangeOptions_Declaration_Repeated_field_number   protoreflect.FieldNumber = 6
++	ExtensionRangeOptions_Declaration_Number_field_number   protoreflect.FieldNumber = 1
++	ExtensionRangeOptions_Declaration_FullName_field_number protoreflect.FieldNumber = 2
++	ExtensionRangeOptions_Declaration_Type_field_number     protoreflect.FieldNumber = 3
++	ExtensionRangeOptions_Declaration_Reserved_field_number protoreflect.FieldNumber = 5
++	ExtensionRangeOptions_Declaration_Repeated_field_number protoreflect.FieldNumber = 6
+ )
+ 
+ // Names for google.protobuf.FieldDescriptorProto.
+@@ -291,12 +318,41 @@ const (
+ 	FieldDescriptorProto_Type_enum_name     = "Type"
+ )
+ 
++// Enum values for google.protobuf.FieldDescriptorProto.Type.
++const (
++	FieldDescriptorProto_TYPE_DOUBLE_enum_value   = 1
++	FieldDescriptorProto_TYPE_FLOAT_enum_value    = 2
++	FieldDescriptorProto_TYPE_INT64_enum_value    = 3
++	FieldDescriptorProto_TYPE_UINT64_enum_value   = 4
++	FieldDescriptorProto_TYPE_INT32_enum_value    = 5
++	FieldDescriptorProto_TYPE_FIXED64_enum_value  = 6
++	FieldDescriptorProto_TYPE_FIXED32_enum_value  = 7
++	FieldDescriptorProto_TYPE_BOOL_enum_value     = 8
++	FieldDescriptorProto_TYPE_STRING_enum_value   = 9
++	FieldDescriptorProto_TYPE_GROUP_enum_value    = 10
++	FieldDescriptorProto_TYPE_MESSAGE_enum_value  = 11
++	FieldDescriptorProto_TYPE_BYTES_enum_value    = 12
++	FieldDescriptorProto_TYPE_UINT32_enum_value   = 13
++	FieldDescriptorProto_TYPE_ENUM_enum_value     = 14
++	FieldDescriptorProto_TYPE_SFIXED32_enum_value = 15
++	FieldDescriptorProto_TYPE_SFIXED64_enum_value = 16
++	FieldDescriptorProto_TYPE_SINT32_enum_value   = 17
++	FieldDescriptorProto_TYPE_SINT64_enum_value   = 18
++)
++
+ // Full and short names for google.protobuf.FieldDescriptorProto.Label.
+ const (
+ 	FieldDescriptorProto_Label_enum_fullname = "google.protobuf.FieldDescriptorProto.Label"
+ 	FieldDescriptorProto_Label_enum_name     = "Label"
+ )
+ 
++// Enum values for google.protobuf.FieldDescriptorProto.Label.
++const (
++	FieldDescriptorProto_LABEL_OPTIONAL_enum_value = 1
++	FieldDescriptorProto_LABEL_REPEATED_enum_value = 3
++	FieldDescriptorProto_LABEL_REQUIRED_enum_value = 2
++)
++
+ // Names for google.protobuf.OneofDescriptorProto.
+ const (
+ 	OneofDescriptorProto_message_name     protoreflect.Name     = "OneofDescriptorProto"
+@@ -468,7 +524,6 @@ const (
+ 	FileOptions_CcGenericServices_field_name         protoreflect.Name = "cc_generic_services"
+ 	FileOptions_JavaGenericServices_field_name       protoreflect.Name = "java_generic_services"
+ 	FileOptions_PyGenericServices_field_name         protoreflect.Name = "py_generic_services"
+-	FileOptions_PhpGenericServices_field_name        protoreflect.Name = "php_generic_services"
+ 	FileOptions_Deprecated_field_name                protoreflect.Name = "deprecated"
+ 	FileOptions_CcEnableArenas_field_name            protoreflect.Name = "cc_enable_arenas"
+ 	FileOptions_ObjcClassPrefix_field_name           protoreflect.Name = "objc_class_prefix"
+@@ -478,6 +533,7 @@ const (
+ 	FileOptions_PhpNamespace_field_name              protoreflect.Name = "php_namespace"
+ 	FileOptions_PhpMetadataNamespace_field_name      protoreflect.Name = "php_metadata_namespace"
+ 	FileOptions_RubyPackage_field_name               protoreflect.Name = "ruby_package"
++	FileOptions_Features_field_name                  protoreflect.Name = "features"
+ 	FileOptions_UninterpretedOption_field_name       protoreflect.Name = "uninterpreted_option"
+ 
+ 	FileOptions_JavaPackage_field_fullname               protoreflect.FullName = "google.protobuf.FileOptions.java_package"
+@@ -490,7 +546,6 @@ const (
+ 	FileOptions_CcGenericServices_field_fullname         protoreflect.FullName = "google.protobuf.FileOptions.cc_generic_services"
+ 	FileOptions_JavaGenericServices_field_fullname       protoreflect.FullName = "google.protobuf.FileOptions.java_generic_services"
+ 	FileOptions_PyGenericServices_field_fullname         protoreflect.FullName = "google.protobuf.FileOptions.py_generic_services"
+-	FileOptions_PhpGenericServices_field_fullname        protoreflect.FullName = "google.protobuf.FileOptions.php_generic_services"
+ 	FileOptions_Deprecated_field_fullname                protoreflect.FullName = "google.protobuf.FileOptions.deprecated"
+ 	FileOptions_CcEnableArenas_field_fullname            protoreflect.FullName = "google.protobuf.FileOptions.cc_enable_arenas"
+ 	FileOptions_ObjcClassPrefix_field_fullname           protoreflect.FullName = "google.protobuf.FileOptions.objc_class_prefix"
+@@ -500,6 +555,7 @@ const (
+ 	FileOptions_PhpNamespace_field_fullname              protoreflect.FullName = "google.protobuf.FileOptions.php_namespace"
+ 	FileOptions_PhpMetadataNamespace_field_fullname      protoreflect.FullName = "google.protobuf.FileOptions.php_metadata_namespace"
+ 	FileOptions_RubyPackage_field_fullname               protoreflect.FullName = "google.protobuf.FileOptions.ruby_package"
++	FileOptions_Features_field_fullname                  protoreflect.FullName = "google.protobuf.FileOptions.features"
+ 	FileOptions_UninterpretedOption_field_fullname       protoreflect.FullName = "google.protobuf.FileOptions.uninterpreted_option"
+ )
+ 
+@@ -515,7 +571,6 @@ const (
+ 	FileOptions_CcGenericServices_field_number         protoreflect.FieldNumber = 16
+ 	FileOptions_JavaGenericServices_field_number       protoreflect.FieldNumber = 17
+ 	FileOptions_PyGenericServices_field_number         protoreflect.FieldNumber = 18
+-	FileOptions_PhpGenericServices_field_number        protoreflect.FieldNumber = 42
+ 	FileOptions_Deprecated_field_number                protoreflect.FieldNumber = 23
+ 	FileOptions_CcEnableArenas_field_number            protoreflect.FieldNumber = 31
+ 	FileOptions_ObjcClassPrefix_field_number           protoreflect.FieldNumber = 36
+@@ -525,6 +580,7 @@ const (
+ 	FileOptions_PhpNamespace_field_number              protoreflect.FieldNumber = 41
+ 	FileOptions_PhpMetadataNamespace_field_number      protoreflect.FieldNumber = 44
+ 	FileOptions_RubyPackage_field_number               protoreflect.FieldNumber = 45
++	FileOptions_Features_field_number                  protoreflect.FieldNumber = 50
+ 	FileOptions_UninterpretedOption_field_number       protoreflect.FieldNumber = 999
+ )
+ 
+@@ -534,6 +590,13 @@ const (
+ 	FileOptions_OptimizeMode_enum_name     = "OptimizeMode"
+ )
+ 
++// Enum values for google.protobuf.FileOptions.OptimizeMode.
++const (
++	FileOptions_SPEED_enum_value        = 1
++	FileOptions_CODE_SIZE_enum_value    = 2
++	FileOptions_LITE_RUNTIME_enum_value = 3
++)
++
+ // Names for google.protobuf.MessageOptions.
+ const (
+ 	MessageOptions_message_name     protoreflect.Name     = "MessageOptions"
+@@ -547,6 +610,7 @@ const (
+ 	MessageOptions_Deprecated_field_name                         protoreflect.Name = "deprecated"
+ 	MessageOptions_MapEntry_field_name                           protoreflect.Name = "map_entry"
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_name protoreflect.Name = "deprecated_legacy_json_field_conflicts"
++	MessageOptions_Features_field_name                           protoreflect.Name = "features"
+ 	MessageOptions_UninterpretedOption_field_name                protoreflect.Name = "uninterpreted_option"
+ 
+ 	MessageOptions_MessageSetWireFormat_field_fullname               protoreflect.FullName = "google.protobuf.MessageOptions.message_set_wire_format"
+@@ -554,6 +618,7 @@ const (
+ 	MessageOptions_Deprecated_field_fullname                         protoreflect.FullName = "google.protobuf.MessageOptions.deprecated"
+ 	MessageOptions_MapEntry_field_fullname                           protoreflect.FullName = "google.protobuf.MessageOptions.map_entry"
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_fullname protoreflect.FullName = "google.protobuf.MessageOptions.deprecated_legacy_json_field_conflicts"
++	MessageOptions_Features_field_fullname                           protoreflect.FullName = "google.protobuf.MessageOptions.features"
+ 	MessageOptions_UninterpretedOption_field_fullname                protoreflect.FullName = "google.protobuf.MessageOptions.uninterpreted_option"
+ )
+ 
+@@ -564,6 +629,7 @@ const (
+ 	MessageOptions_Deprecated_field_number                         protoreflect.FieldNumber = 3
+ 	MessageOptions_MapEntry_field_number                           protoreflect.FieldNumber = 7
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_number protoreflect.FieldNumber = 11
++	MessageOptions_Features_field_number                           protoreflect.FieldNumber = 12
+ 	MessageOptions_UninterpretedOption_field_number                protoreflect.FieldNumber = 999
+ )
+ 
+@@ -584,8 +650,9 @@ const (
+ 	FieldOptions_Weak_field_name                protoreflect.Name = "weak"
+ 	FieldOptions_DebugRedact_field_name         protoreflect.Name = "debug_redact"
+ 	FieldOptions_Retention_field_name           protoreflect.Name = "retention"
+-	FieldOptions_Target_field_name              protoreflect.Name = "target"
+ 	FieldOptions_Targets_field_name             protoreflect.Name = "targets"
++	FieldOptions_EditionDefaults_field_name     protoreflect.Name = "edition_defaults"
++	FieldOptions_Features_field_name            protoreflect.Name = "features"
+ 	FieldOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	FieldOptions_Ctype_field_fullname               protoreflect.FullName = "google.protobuf.FieldOptions.ctype"
+@@ -597,8 +664,9 @@ const (
+ 	FieldOptions_Weak_field_fullname                protoreflect.FullName = "google.protobuf.FieldOptions.weak"
+ 	FieldOptions_DebugRedact_field_fullname         protoreflect.FullName = "google.protobuf.FieldOptions.debug_redact"
+ 	FieldOptions_Retention_field_fullname           protoreflect.FullName = "google.protobuf.FieldOptions.retention"
+-	FieldOptions_Target_field_fullname              protoreflect.FullName = "google.protobuf.FieldOptions.target"
+ 	FieldOptions_Targets_field_fullname             protoreflect.FullName = "google.protobuf.FieldOptions.targets"
++	FieldOptions_EditionDefaults_field_fullname     protoreflect.FullName = "google.protobuf.FieldOptions.edition_defaults"
++	FieldOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.FieldOptions.features"
+ 	FieldOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.FieldOptions.uninterpreted_option"
+ )
+ 
+@@ -613,8 +681,9 @@ const (
+ 	FieldOptions_Weak_field_number                protoreflect.FieldNumber = 10
+ 	FieldOptions_DebugRedact_field_number         protoreflect.FieldNumber = 16
+ 	FieldOptions_Retention_field_number           protoreflect.FieldNumber = 17
+-	FieldOptions_Target_field_number              protoreflect.FieldNumber = 18
+ 	FieldOptions_Targets_field_number             protoreflect.FieldNumber = 19
++	FieldOptions_EditionDefaults_field_number     protoreflect.FieldNumber = 20
++	FieldOptions_Features_field_number            protoreflect.FieldNumber = 21
+ 	FieldOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -624,24 +693,80 @@ const (
+ 	FieldOptions_CType_enum_name     = "CType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.CType.
++const (
++	FieldOptions_STRING_enum_value       = 0
++	FieldOptions_CORD_enum_value         = 1
++	FieldOptions_STRING_PIECE_enum_value = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.JSType.
+ const (
+ 	FieldOptions_JSType_enum_fullname = "google.protobuf.FieldOptions.JSType"
+ 	FieldOptions_JSType_enum_name     = "JSType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.JSType.
++const (
++	FieldOptions_JS_NORMAL_enum_value = 0
++	FieldOptions_JS_STRING_enum_value = 1
++	FieldOptions_JS_NUMBER_enum_value = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.OptionRetention.
+ const (
+ 	FieldOptions_OptionRetention_enum_fullname = "google.protobuf.FieldOptions.OptionRetention"
+ 	FieldOptions_OptionRetention_enum_name     = "OptionRetention"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.OptionRetention.
++const (
++	FieldOptions_RETENTION_UNKNOWN_enum_value = 0
++	FieldOptions_RETENTION_RUNTIME_enum_value = 1
++	FieldOptions_RETENTION_SOURCE_enum_value  = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.OptionTargetType.
+ const (
+ 	FieldOptions_OptionTargetType_enum_fullname = "google.protobuf.FieldOptions.OptionTargetType"
+ 	FieldOptions_OptionTargetType_enum_name     = "OptionTargetType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.OptionTargetType.
++const (
++	FieldOptions_TARGET_TYPE_UNKNOWN_enum_value         = 0
++	FieldOptions_TARGET_TYPE_FILE_enum_value            = 1
++	FieldOptions_TARGET_TYPE_EXTENSION_RANGE_enum_value = 2
++	FieldOptions_TARGET_TYPE_MESSAGE_enum_value         = 3
++	FieldOptions_TARGET_TYPE_FIELD_enum_value           = 4
++	FieldOptions_TARGET_TYPE_ONEOF_enum_value           = 5
++	FieldOptions_TARGET_TYPE_ENUM_enum_value            = 6
++	FieldOptions_TARGET_TYPE_ENUM_ENTRY_enum_value      = 7
++	FieldOptions_TARGET_TYPE_SERVICE_enum_value         = 8
++	FieldOptions_TARGET_TYPE_METHOD_enum_value          = 9
++)
++
++// Names for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_message_name     protoreflect.Name     = "EditionDefault"
++	FieldOptions_EditionDefault_message_fullname protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault"
++)
++
++// Field names for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_Edition_field_name protoreflect.Name = "edition"
++	FieldOptions_EditionDefault_Value_field_name   protoreflect.Name = "value"
++
++	FieldOptions_EditionDefault_Edition_field_fullname protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault.edition"
++	FieldOptions_EditionDefault_Value_field_fullname   protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault.value"
++)
++
++// Field numbers for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_Edition_field_number protoreflect.FieldNumber = 3
++	FieldOptions_EditionDefault_Value_field_number   protoreflect.FieldNumber = 2
++)
++
+ // Names for google.protobuf.OneofOptions.
+ const (
+ 	OneofOptions_message_name     protoreflect.Name     = "OneofOptions"
+@@ -650,13 +775,16 @@ const (
+ 
+ // Field names for google.protobuf.OneofOptions.
+ const (
++	OneofOptions_Features_field_name            protoreflect.Name = "features"
+ 	OneofOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
++	OneofOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.OneofOptions.features"
+ 	OneofOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.OneofOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.OneofOptions.
+ const (
++	OneofOptions_Features_field_number            protoreflect.FieldNumber = 1
+ 	OneofOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -671,11 +799,13 @@ const (
+ 	EnumOptions_AllowAlias_field_name                         protoreflect.Name = "allow_alias"
+ 	EnumOptions_Deprecated_field_name                         protoreflect.Name = "deprecated"
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_name protoreflect.Name = "deprecated_legacy_json_field_conflicts"
++	EnumOptions_Features_field_name                           protoreflect.Name = "features"
+ 	EnumOptions_UninterpretedOption_field_name                protoreflect.Name = "uninterpreted_option"
+ 
+ 	EnumOptions_AllowAlias_field_fullname                         protoreflect.FullName = "google.protobuf.EnumOptions.allow_alias"
+ 	EnumOptions_Deprecated_field_fullname                         protoreflect.FullName = "google.protobuf.EnumOptions.deprecated"
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_fullname protoreflect.FullName = "google.protobuf.EnumOptions.deprecated_legacy_json_field_conflicts"
++	EnumOptions_Features_field_fullname                           protoreflect.FullName = "google.protobuf.EnumOptions.features"
+ 	EnumOptions_UninterpretedOption_field_fullname                protoreflect.FullName = "google.protobuf.EnumOptions.uninterpreted_option"
+ )
+ 
+@@ -684,6 +814,7 @@ const (
+ 	EnumOptions_AllowAlias_field_number                         protoreflect.FieldNumber = 2
+ 	EnumOptions_Deprecated_field_number                         protoreflect.FieldNumber = 3
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_number protoreflect.FieldNumber = 6
++	EnumOptions_Features_field_number                           protoreflect.FieldNumber = 7
+ 	EnumOptions_UninterpretedOption_field_number                protoreflect.FieldNumber = 999
+ )
+ 
+@@ -696,15 +827,21 @@ const (
+ // Field names for google.protobuf.EnumValueOptions.
+ const (
+ 	EnumValueOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
++	EnumValueOptions_Features_field_name            protoreflect.Name = "features"
++	EnumValueOptions_DebugRedact_field_name         protoreflect.Name = "debug_redact"
+ 	EnumValueOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	EnumValueOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.EnumValueOptions.deprecated"
++	EnumValueOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.EnumValueOptions.features"
++	EnumValueOptions_DebugRedact_field_fullname         protoreflect.FullName = "google.protobuf.EnumValueOptions.debug_redact"
+ 	EnumValueOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.EnumValueOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.EnumValueOptions.
+ const (
+ 	EnumValueOptions_Deprecated_field_number          protoreflect.FieldNumber = 1
++	EnumValueOptions_Features_field_number            protoreflect.FieldNumber = 2
++	EnumValueOptions_DebugRedact_field_number         protoreflect.FieldNumber = 3
+ 	EnumValueOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -716,15 +853,18 @@ const (
+ 
+ // Field names for google.protobuf.ServiceOptions.
+ const (
++	ServiceOptions_Features_field_name            protoreflect.Name = "features"
+ 	ServiceOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
+ 	ServiceOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
++	ServiceOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.ServiceOptions.features"
+ 	ServiceOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.ServiceOptions.deprecated"
+ 	ServiceOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.ServiceOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.ServiceOptions.
+ const (
++	ServiceOptions_Features_field_number            protoreflect.FieldNumber = 34
+ 	ServiceOptions_Deprecated_field_number          protoreflect.FieldNumber = 33
+ 	ServiceOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+@@ -739,10 +879,12 @@ const (
+ const (
+ 	MethodOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
+ 	MethodOptions_IdempotencyLevel_field_name    protoreflect.Name = "idempotency_level"
++	MethodOptions_Features_field_name            protoreflect.Name = "features"
+ 	MethodOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	MethodOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.MethodOptions.deprecated"
+ 	MethodOptions_IdempotencyLevel_field_fullname    protoreflect.FullName = "google.protobuf.MethodOptions.idempotency_level"
++	MethodOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.MethodOptions.features"
+ 	MethodOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.MethodOptions.uninterpreted_option"
+ )
+ 
+@@ -750,6 +892,7 @@ const (
+ const (
+ 	MethodOptions_Deprecated_field_number          protoreflect.FieldNumber = 33
+ 	MethodOptions_IdempotencyLevel_field_number    protoreflect.FieldNumber = 34
++	MethodOptions_Features_field_number            protoreflect.FieldNumber = 35
+ 	MethodOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -759,6 +902,13 @@ const (
+ 	MethodOptions_IdempotencyLevel_enum_name     = "IdempotencyLevel"
+ )
+ 
++// Enum values for google.protobuf.MethodOptions.IdempotencyLevel.
++const (
++	MethodOptions_IDEMPOTENCY_UNKNOWN_enum_value = 0
++	MethodOptions_NO_SIDE_EFFECTS_enum_value     = 1
++	MethodOptions_IDEMPOTENT_enum_value          = 2
++)
++
+ // Names for google.protobuf.UninterpretedOption.
+ const (
+ 	UninterpretedOption_message_name     protoreflect.Name     = "UninterpretedOption"
+@@ -816,6 +966,163 @@ const (
+ 	UninterpretedOption_NamePart_IsExtension_field_number protoreflect.FieldNumber = 2
+ )
+ 
++// Names for google.protobuf.FeatureSet.
++const (
++	FeatureSet_message_name     protoreflect.Name     = "FeatureSet"
++	FeatureSet_message_fullname protoreflect.FullName = "google.protobuf.FeatureSet"
++)
++
++// Field names for google.protobuf.FeatureSet.
++const (
++	FeatureSet_FieldPresence_field_name         protoreflect.Name = "field_presence"
++	FeatureSet_EnumType_field_name              protoreflect.Name = "enum_type"
++	FeatureSet_RepeatedFieldEncoding_field_name protoreflect.Name = "repeated_field_encoding"
++	FeatureSet_Utf8Validation_field_name        protoreflect.Name = "utf8_validation"
++	FeatureSet_MessageEncoding_field_name       protoreflect.Name = "message_encoding"
++	FeatureSet_JsonFormat_field_name            protoreflect.Name = "json_format"
++
++	FeatureSet_FieldPresence_field_fullname         protoreflect.FullName = "google.protobuf.FeatureSet.field_presence"
++	FeatureSet_EnumType_field_fullname              protoreflect.FullName = "google.protobuf.FeatureSet.enum_type"
++	FeatureSet_RepeatedFieldEncoding_field_fullname protoreflect.FullName = "google.protobuf.FeatureSet.repeated_field_encoding"
++	FeatureSet_Utf8Validation_field_fullname        protoreflect.FullName = "google.protobuf.FeatureSet.utf8_validation"
++	FeatureSet_MessageEncoding_field_fullname       protoreflect.FullName = "google.protobuf.FeatureSet.message_encoding"
++	FeatureSet_JsonFormat_field_fullname            protoreflect.FullName = "google.protobuf.FeatureSet.json_format"
++)
++
++// Field numbers for google.protobuf.FeatureSet.
++const (
++	FeatureSet_FieldPresence_field_number         protoreflect.FieldNumber = 1
++	FeatureSet_EnumType_field_number              protoreflect.FieldNumber = 2
++	FeatureSet_RepeatedFieldEncoding_field_number protoreflect.FieldNumber = 3
++	FeatureSet_Utf8Validation_field_number        protoreflect.FieldNumber = 4
++	FeatureSet_MessageEncoding_field_number       protoreflect.FieldNumber = 5
++	FeatureSet_JsonFormat_field_number            protoreflect.FieldNumber = 6
++)
++
++// Full and short names for google.protobuf.FeatureSet.FieldPresence.
++const (
++	FeatureSet_FieldPresence_enum_fullname = "google.protobuf.FeatureSet.FieldPresence"
++	FeatureSet_FieldPresence_enum_name     = "FieldPresence"
++)
++
++// Enum values for google.protobuf.FeatureSet.FieldPresence.
++const (
++	FeatureSet_FIELD_PRESENCE_UNKNOWN_enum_value = 0
++	FeatureSet_EXPLICIT_enum_value               = 1
++	FeatureSet_IMPLICIT_enum_value               = 2
++	FeatureSet_LEGACY_REQUIRED_enum_value        = 3
++)
++
++// Full and short names for google.protobuf.FeatureSet.EnumType.
++const (
++	FeatureSet_EnumType_enum_fullname = "google.protobuf.FeatureSet.EnumType"
++	FeatureSet_EnumType_enum_name     = "EnumType"
++)
++
++// Enum values for google.protobuf.FeatureSet.EnumType.
++const (
++	FeatureSet_ENUM_TYPE_UNKNOWN_enum_value = 0
++	FeatureSet_OPEN_enum_value              = 1
++	FeatureSet_CLOSED_enum_value            = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.RepeatedFieldEncoding.
++const (
++	FeatureSet_RepeatedFieldEncoding_enum_fullname = "google.protobuf.FeatureSet.RepeatedFieldEncoding"
++	FeatureSet_RepeatedFieldEncoding_enum_name     = "RepeatedFieldEncoding"
++)
++
++// Enum values for google.protobuf.FeatureSet.RepeatedFieldEncoding.
++const (
++	FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN_enum_value = 0
++	FeatureSet_PACKED_enum_value                          = 1
++	FeatureSet_EXPANDED_enum_value                        = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.Utf8Validation.
++const (
++	FeatureSet_Utf8Validation_enum_fullname = "google.protobuf.FeatureSet.Utf8Validation"
++	FeatureSet_Utf8Validation_enum_name     = "Utf8Validation"
++)
++
++// Enum values for google.protobuf.FeatureSet.Utf8Validation.
++const (
++	FeatureSet_UTF8_VALIDATION_UNKNOWN_enum_value = 0
++	FeatureSet_VERIFY_enum_value                  = 2
++	FeatureSet_NONE_enum_value                    = 3
++)
++
++// Full and short names for google.protobuf.FeatureSet.MessageEncoding.
++const (
++	FeatureSet_MessageEncoding_enum_fullname = "google.protobuf.FeatureSet.MessageEncoding"
++	FeatureSet_MessageEncoding_enum_name     = "MessageEncoding"
++)
++
++// Enum values for google.protobuf.FeatureSet.MessageEncoding.
++const (
++	FeatureSet_MESSAGE_ENCODING_UNKNOWN_enum_value = 0
++	FeatureSet_LENGTH_PREFIXED_enum_value          = 1
++	FeatureSet_DELIMITED_enum_value                = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.JsonFormat.
++const (
++	FeatureSet_JsonFormat_enum_fullname = "google.protobuf.FeatureSet.JsonFormat"
++	FeatureSet_JsonFormat_enum_name     = "JsonFormat"
++)
++
++// Enum values for google.protobuf.FeatureSet.JsonFormat.
++const (
++	FeatureSet_JSON_FORMAT_UNKNOWN_enum_value = 0
++	FeatureSet_ALLOW_enum_value               = 1
++	FeatureSet_LEGACY_BEST_EFFORT_enum_value  = 2
++)
++
++// Names for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_message_name     protoreflect.Name     = "FeatureSetDefaults"
++	FeatureSetDefaults_message_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults"
++)
++
++// Field names for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_Defaults_field_name       protoreflect.Name = "defaults"
++	FeatureSetDefaults_MinimumEdition_field_name protoreflect.Name = "minimum_edition"
++	FeatureSetDefaults_MaximumEdition_field_name protoreflect.Name = "maximum_edition"
++
++	FeatureSetDefaults_Defaults_field_fullname       protoreflect.FullName = "google.protobuf.FeatureSetDefaults.defaults"
++	FeatureSetDefaults_MinimumEdition_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.minimum_edition"
++	FeatureSetDefaults_MaximumEdition_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.maximum_edition"
++)
++
++// Field numbers for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_Defaults_field_number       protoreflect.FieldNumber = 1
++	FeatureSetDefaults_MinimumEdition_field_number protoreflect.FieldNumber = 4
++	FeatureSetDefaults_MaximumEdition_field_number protoreflect.FieldNumber = 5
++)
++
++// Names for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_message_name     protoreflect.Name     = "FeatureSetEditionDefault"
++	FeatureSetDefaults_FeatureSetEditionDefault_message_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault"
++)
++
++// Field names for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_name  protoreflect.Name = "edition"
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_name protoreflect.Name = "features"
++
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_fullname  protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.edition"
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.features"
++)
++
++// Field numbers for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_number  protoreflect.FieldNumber = 3
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_number protoreflect.FieldNumber = 2
++)
++
+ // Names for google.protobuf.SourceCodeInfo.
+ const (
+ 	SourceCodeInfo_message_name     protoreflect.Name     = "SourceCodeInfo"
+@@ -917,3 +1224,10 @@ const (
+ 	GeneratedCodeInfo_Annotation_Semantic_enum_fullname = "google.protobuf.GeneratedCodeInfo.Annotation.Semantic"
+ 	GeneratedCodeInfo_Annotation_Semantic_enum_name     = "Semantic"
+ )
++
++// Enum values for google.protobuf.GeneratedCodeInfo.Annotation.Semantic.
++const (
++	GeneratedCodeInfo_Annotation_NONE_enum_value  = 0
++	GeneratedCodeInfo_Annotation_SET_enum_value   = 1
++	GeneratedCodeInfo_Annotation_ALIAS_enum_value = 2
++)
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go b/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+new file mode 100644
+index 0000000..fd9015e
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+@@ -0,0 +1,31 @@
++// Copyright 2019 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Code generated by generate-protos. DO NOT EDIT.
++
++package genid
++
++import (
++	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
++)
++
++const File_reflect_protodesc_proto_go_features_proto = "reflect/protodesc/proto/go_features.proto"
++
++// Names for google.protobuf.GoFeatures.
++const (
++	GoFeatures_message_name     protoreflect.Name     = "GoFeatures"
++	GoFeatures_message_fullname protoreflect.FullName = "google.protobuf.GoFeatures"
++)
++
++// Field names for google.protobuf.GoFeatures.
++const (
++	GoFeatures_LegacyUnmarshalJsonEnum_field_name protoreflect.Name = "legacy_unmarshal_json_enum"
++
++	GoFeatures_LegacyUnmarshalJsonEnum_field_fullname protoreflect.FullName = "google.protobuf.GoFeatures.legacy_unmarshal_json_enum"
++)
++
++// Field numbers for google.protobuf.GoFeatures.
++const (
++	GoFeatures_LegacyUnmarshalJsonEnum_field_number protoreflect.FieldNumber = 1
++)
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go b/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
+index 1a38944..ad6f80c 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
+@@ -18,6 +18,11 @@ const (
+ 	NullValue_enum_name     = "NullValue"
+ )
+ 
++// Enum values for google.protobuf.NullValue.
++const (
++	NullValue_NULL_VALUE_enum_value = 0
++)
++
+ // Names for google.protobuf.Struct.
+ const (
+ 	Struct_message_name     protoreflect.Name     = "Struct"
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/type_gen.go b/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
+index e0f75fe..49bc73e 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
+@@ -18,6 +18,13 @@ const (
+ 	Syntax_enum_name     = "Syntax"
+ )
+ 
++// Enum values for google.protobuf.Syntax.
++const (
++	Syntax_SYNTAX_PROTO2_enum_value   = 0
++	Syntax_SYNTAX_PROTO3_enum_value   = 1
++	Syntax_SYNTAX_EDITIONS_enum_value = 2
++)
++
+ // Names for google.protobuf.Type.
+ const (
+ 	Type_message_name     protoreflect.Name     = "Type"
+@@ -105,12 +112,43 @@ const (
+ 	Field_Kind_enum_name     = "Kind"
+ )
+ 
++// Enum values for google.protobuf.Field.Kind.
++const (
++	Field_TYPE_UNKNOWN_enum_value  = 0
++	Field_TYPE_DOUBLE_enum_value   = 1
++	Field_TYPE_FLOAT_enum_value    = 2
++	Field_TYPE_INT64_enum_value    = 3
++	Field_TYPE_UINT64_enum_value   = 4
++	Field_TYPE_INT32_enum_value    = 5
++	Field_TYPE_FIXED64_enum_value  = 6
++	Field_TYPE_FIXED32_enum_value  = 7
++	Field_TYPE_BOOL_enum_value     = 8
++	Field_TYPE_STRING_enum_value   = 9
++	Field_TYPE_GROUP_enum_value    = 10
++	Field_TYPE_MESSAGE_enum_value  = 11
++	Field_TYPE_BYTES_enum_value    = 12
++	Field_TYPE_UINT32_enum_value   = 13
++	Field_TYPE_ENUM_enum_value     = 14
++	Field_TYPE_SFIXED32_enum_value = 15
++	Field_TYPE_SFIXED64_enum_value = 16
++	Field_TYPE_SINT32_enum_value   = 17
++	Field_TYPE_SINT64_enum_value   = 18
++)
++
+ // Full and short names for google.protobuf.Field.Cardinality.
+ const (
+ 	Field_Cardinality_enum_fullname = "google.protobuf.Field.Cardinality"
+ 	Field_Cardinality_enum_name     = "Cardinality"
+ )
+ 
++// Enum values for google.protobuf.Field.Cardinality.
++const (
++	Field_CARDINALITY_UNKNOWN_enum_value  = 0
++	Field_CARDINALITY_OPTIONAL_enum_value = 1
++	Field_CARDINALITY_REQUIRED_enum_value = 2
++	Field_CARDINALITY_REPEATED_enum_value = 3
++)
++
+ // Names for google.protobuf.Enum.
+ const (
+ 	Enum_message_name     protoreflect.Name     = "Enum"
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go b/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
+index e74cefd..2b8f122 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
+@@ -21,26 +21,18 @@ type extensionFieldInfo struct {
+ 	validation          validationInfo
+ }
+ 
+-var legacyExtensionFieldInfoCache sync.Map // map[protoreflect.ExtensionType]*extensionFieldInfo
+-
+ func getExtensionFieldInfo(xt protoreflect.ExtensionType) *extensionFieldInfo {
+ 	if xi, ok := xt.(*ExtensionInfo); ok {
+ 		xi.lazyInit()
+ 		return xi.info
+ 	}
+-	return legacyLoadExtensionFieldInfo(xt)
+-}
+-
+-// legacyLoadExtensionFieldInfo dynamically loads a *ExtensionInfo for xt.
+-func legacyLoadExtensionFieldInfo(xt protoreflect.ExtensionType) *extensionFieldInfo {
+-	if xi, ok := legacyExtensionFieldInfoCache.Load(xt); ok {
+-		return xi.(*extensionFieldInfo)
+-	}
+-	e := makeExtensionFieldInfo(xt.TypeDescriptor())
+-	if e, ok := legacyMessageTypeCache.LoadOrStore(xt, e); ok {
+-		return e.(*extensionFieldInfo)
+-	}
+-	return e
++	// Ideally we'd cache the resulting *extensionFieldInfo so we don't have to
++	// recompute this metadata repeatedly. But without support for something like
++	// weak references, such a cache would pin temporary values (like dynamic
++	// extension types, constructed for the duration of a user request) to the
++	// heap forever, causing memory usage of the cache to grow unbounded.
++	// See discussion in https://github.com/golang/protobuf/issues/1521.
++	return makeExtensionFieldInfo(xt.TypeDescriptor())
+ }
+ 
+ func makeExtensionFieldInfo(xd protoreflect.ExtensionDescriptor) *extensionFieldInfo {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go b/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
+index 1a509b6..f55dc01 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
+@@ -162,11 +162,20 @@ func appendBoolSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptions
+ func consumeBoolSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.BoolSlice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growBoolSlice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -732,11 +741,20 @@ func appendInt32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeInt32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1138,11 +1156,20 @@ func appendSint32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeSint32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1544,11 +1571,20 @@ func appendUint32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeUint32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growUint32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1950,11 +1986,20 @@ func appendInt64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeInt64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -2356,11 +2401,20 @@ func appendSint64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeSint64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -2762,11 +2816,20 @@ func appendUint64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeUint64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growUint64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -3145,11 +3208,15 @@ func appendSfixed32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpt
+ func consumeSfixed32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -3461,11 +3528,15 @@ func appendFixed32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpti
+ func consumeFixed32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growUint32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -3777,11 +3848,15 @@ func appendFloatSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeFloatSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Float32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growFloat32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -4093,11 +4168,15 @@ func appendSfixed64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpt
+ func consumeSfixed64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+@@ -4409,11 +4488,15 @@ func appendFixed64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpti
+ func consumeFixed64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growUint64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+@@ -4725,11 +4808,15 @@ func appendDoubleSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeDoubleSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Float64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growFloat64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go b/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
+index 576dcf3..1307775 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
+@@ -197,7 +197,7 @@ func fieldCoder(fd protoreflect.FieldDescriptor, ft reflect.Type) (*MessageInfo,
+ 		return getMessageInfo(ft), makeMessageFieldCoder(fd, ft)
+ 	case fd.Kind() == protoreflect.GroupKind:
+ 		return getMessageInfo(ft), makeGroupFieldCoder(fd, ft)
+-	case fd.Syntax() == protoreflect.Proto3 && fd.ContainingOneof() == nil:
++	case !fd.HasPresence() && fd.ContainingOneof() == nil:
+ 		// Populated oneof fields always encode even if set to the zero value,
+ 		// which normally are not encoded in proto3.
+ 		switch fd.Kind() {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go b/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
+index 61c483f..2ab2c62 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
+@@ -206,13 +206,18 @@ func aberrantLoadMessageDescReentrant(t reflect.Type, name protoreflect.FullName
+ 
+ 	// Obtain a list of oneof wrapper types.
+ 	var oneofWrappers []reflect.Type
+-	for _, method := range []string{"XXX_OneofFuncs", "XXX_OneofWrappers"} {
+-		if fn, ok := t.MethodByName(method); ok {
+-			for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
+-				if vs, ok := v.Interface().([]interface{}); ok {
+-					for _, v := range vs {
+-						oneofWrappers = append(oneofWrappers, reflect.TypeOf(v))
+-					}
++	methods := make([]reflect.Method, 0, 2)
++	if m, ok := t.MethodByName("XXX_OneofFuncs"); ok {
++		methods = append(methods, m)
++	}
++	if m, ok := t.MethodByName("XXX_OneofWrappers"); ok {
++		methods = append(methods, m)
++	}
++	for _, fn := range methods {
++		for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
++			if vs, ok := v.Interface().([]interface{}); ok {
++				for _, v := range vs {
++					oneofWrappers = append(oneofWrappers, reflect.TypeOf(v))
+ 				}
+ 			}
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/message.go b/vendor/google.golang.org/protobuf/internal/impl/message.go
+index 4f5fb67..629bacd 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/message.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/message.go
+@@ -192,12 +192,17 @@ fieldLoop:
+ 
+ 	// Derive a mapping of oneof wrappers to fields.
+ 	oneofWrappers := mi.OneofWrappers
+-	for _, method := range []string{"XXX_OneofFuncs", "XXX_OneofWrappers"} {
+-		if fn, ok := reflect.PtrTo(t).MethodByName(method); ok {
+-			for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
+-				if vs, ok := v.Interface().([]interface{}); ok {
+-					oneofWrappers = vs
+-				}
++	methods := make([]reflect.Method, 0, 2)
++	if m, ok := reflect.PtrTo(t).MethodByName("XXX_OneofFuncs"); ok {
++		methods = append(methods, m)
++	}
++	if m, ok := reflect.PtrTo(t).MethodByName("XXX_OneofWrappers"); ok {
++		methods = append(methods, m)
++	}
++	for _, fn := range methods {
++		for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
++			if vs, ok := v.Interface().([]interface{}); ok {
++				oneofWrappers = vs
+ 			}
+ 		}
+ 	}
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go b/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
+index 5e736c6..986322b 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
+@@ -538,6 +538,6 @@ func isZero(v reflect.Value) bool {
+ 		}
+ 		return true
+ 	default:
+-		panic(&reflect.ValueError{"reflect.Value.IsZero", v.Kind()})
++		panic(&reflect.ValueError{Method: "reflect.Value.IsZero", Kind: v.Kind()})
+ 	}
+ }
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go b/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
+index 4c491bd..517e944 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
+@@ -159,6 +159,42 @@ func (p pointer) SetPointer(v pointer) {
+ 	p.v.Elem().Set(v.v)
+ }
+ 
++func growSlice(p pointer, addCap int) {
++	// TODO: Once we only support Go 1.20 and newer, use reflect.Grow.
++	in := p.v.Elem()
++	out := reflect.MakeSlice(in.Type(), in.Len(), in.Len()+addCap)
++	reflect.Copy(out, in)
++	p.v.Elem().Set(out)
++}
++
++func (p pointer) growBoolSlice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growInt32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growUint32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growInt64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growUint64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growFloat64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growFloat32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
+ func (Export) MessageStateOf(p Pointer) *messageState     { panic("not supported") }
+ func (ms *messageState) pointer() pointer                 { panic("not supported") }
+ func (ms *messageState) messageInfo() *MessageInfo        { panic("not supported") }
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go b/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
+index ee0e057..4b020e3 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
+@@ -138,6 +138,46 @@ func (p pointer) SetPointer(v pointer) {
+ 	*(*unsafe.Pointer)(p.p) = (unsafe.Pointer)(v.p)
+ }
+ 
++func (p pointer) growBoolSlice(addCap int) {
++	sp := p.BoolSlice()
++	s := make([]bool, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growInt32Slice(addCap int) {
++	sp := p.Int32Slice()
++	s := make([]int32, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growUint32Slice(addCap int) {
++	p.growInt32Slice(addCap)
++}
++
++func (p pointer) growFloat32Slice(addCap int) {
++	p.growInt32Slice(addCap)
++}
++
++func (p pointer) growInt64Slice(addCap int) {
++	sp := p.Int64Slice()
++	s := make([]int64, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growUint64Slice(addCap int) {
++	p.growInt64Slice(addCap)
++}
++
++func (p pointer) growFloat64Slice(addCap int) {
++	p.growInt64Slice(addCap)
++}
++
+ // Static check that MessageState does not exceed the size of a pointer.
+ const _ = uint(unsafe.Sizeof(unsafe.Pointer(nil)) - unsafe.Sizeof(MessageState{}))
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings.go b/vendor/google.golang.org/protobuf/internal/strs/strings.go
+index 0b74e76..a6e7df2 100644
+--- a/vendor/google.golang.org/protobuf/internal/strs/strings.go
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings.go
+@@ -17,7 +17,7 @@ import (
+ 
+ // EnforceUTF8 reports whether to enforce strict UTF-8 validation.
+ func EnforceUTF8(fd protoreflect.FieldDescriptor) bool {
+-	if flags.ProtoLegacy {
++	if flags.ProtoLegacy || fd.Syntax() == protoreflect.Editions {
+ 		if fd, ok := fd.(interface{ EnforceUTF8() bool }); ok {
+ 			return fd.EnforceUTF8()
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+similarity index 96%
+rename from vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
+rename to vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+index 61a84d3..a008acd 100644
+--- a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !purego && !appengine
+-// +build !purego,!appengine
++//go:build !purego && !appengine && !go1.21
++// +build !purego,!appengine,!go1.21
+ 
+ package strs
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+new file mode 100644
+index 0000000..60166f2
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+@@ -0,0 +1,74 @@
++// Copyright 2018 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !purego && !appengine && go1.21
++// +build !purego,!appengine,go1.21
++
++package strs
++
++import (
++	"unsafe"
++
++	"google.golang.org/protobuf/reflect/protoreflect"
++)
++
++// UnsafeString returns an unsafe string reference of b.
++// The caller must treat the input slice as immutable.
++//
++// WARNING: Use carefully. The returned result must not leak to the end user
++// unless the input slice is provably immutable.
++func UnsafeString(b []byte) string {
++	return unsafe.String(unsafe.SliceData(b), len(b))
++}
++
++// UnsafeBytes returns an unsafe bytes slice reference of s.
++// The caller must treat returned slice as immutable.
++//
++// WARNING: Use carefully. The returned result must not leak to the end user.
++func UnsafeBytes(s string) []byte {
++	return unsafe.Slice(unsafe.StringData(s), len(s))
++}
++
++// Builder builds a set of strings with shared lifetime.
++// This differs from strings.Builder, which is for building a single string.
++type Builder struct {
++	buf []byte
++}
++
++// AppendFullName is equivalent to protoreflect.FullName.Append,
++// but optimized for large batches where each name has a shared lifetime.
++func (sb *Builder) AppendFullName(prefix protoreflect.FullName, name protoreflect.Name) protoreflect.FullName {
++	n := len(prefix) + len(".") + len(name)
++	if len(prefix) == 0 {
++		n -= len(".")
++	}
++	sb.grow(n)
++	sb.buf = append(sb.buf, prefix...)
++	sb.buf = append(sb.buf, '.')
++	sb.buf = append(sb.buf, name...)
++	return protoreflect.FullName(sb.last(n))
++}
++
++// MakeString is equivalent to string(b), but optimized for large batches
++// with a shared lifetime.
++func (sb *Builder) MakeString(b []byte) string {
++	sb.grow(len(b))
++	sb.buf = append(sb.buf, b...)
++	return sb.last(len(b))
++}
++
++func (sb *Builder) grow(n int) {
++	if cap(sb.buf)-len(sb.buf) >= n {
++		return
++	}
++
++	// Unlike strings.Builder, we do not need to copy over the contents
++	// of the old buffer since our builder provides no API for
++	// retrieving previously created strings.
++	sb.buf = make([]byte, 0, 2*(cap(sb.buf)+n))
++}
++
++func (sb *Builder) last(n int) string {
++	return UnsafeString(sb.buf[len(sb.buf)-n:])
++}
+diff --git a/vendor/google.golang.org/protobuf/internal/version/version.go b/vendor/google.golang.org/protobuf/internal/version/version.go
+index 0999f29..a50fcfb 100644
+--- a/vendor/google.golang.org/protobuf/internal/version/version.go
++++ b/vendor/google.golang.org/protobuf/internal/version/version.go
+@@ -51,7 +51,7 @@ import (
+ //  10. Send out the CL for review and submit it.
+ const (
+ 	Major      = 1
+-	Minor      = 31
++	Minor      = 33
+ 	Patch      = 0
+ 	PreRelease = ""
+ )
+diff --git a/vendor/google.golang.org/protobuf/proto/decode.go b/vendor/google.golang.org/protobuf/proto/decode.go
+index 48d4794..e5b03b5 100644
+--- a/vendor/google.golang.org/protobuf/proto/decode.go
++++ b/vendor/google.golang.org/protobuf/proto/decode.go
+@@ -69,7 +69,7 @@ func (o UnmarshalOptions) Unmarshal(b []byte, m Message) error {
+ // UnmarshalState parses a wire-format message and places the result in m.
+ //
+ // This method permits fine-grained control over the unmarshaler.
+-// Most users should use Unmarshal instead.
++// Most users should use [Unmarshal] instead.
+ func (o UnmarshalOptions) UnmarshalState(in protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+ 	if o.RecursionLimit == 0 {
+ 		o.RecursionLimit = protowire.DefaultRecursionLimit
+diff --git a/vendor/google.golang.org/protobuf/proto/doc.go b/vendor/google.golang.org/protobuf/proto/doc.go
+index ec71e71..80ed16a 100644
+--- a/vendor/google.golang.org/protobuf/proto/doc.go
++++ b/vendor/google.golang.org/protobuf/proto/doc.go
+@@ -18,27 +18,27 @@
+ // This package contains functions to convert to and from the wire format,
+ // an efficient binary serialization of protocol buffers.
+ //
+-// • Size reports the size of a message in the wire format.
++//   - [Size] reports the size of a message in the wire format.
+ //
+-// • Marshal converts a message to the wire format.
+-// The MarshalOptions type provides more control over wire marshaling.
++//   - [Marshal] converts a message to the wire format.
++//     The [MarshalOptions] type provides more control over wire marshaling.
+ //
+-// • Unmarshal converts a message from the wire format.
+-// The UnmarshalOptions type provides more control over wire unmarshaling.
++//   - [Unmarshal] converts a message from the wire format.
++//     The [UnmarshalOptions] type provides more control over wire unmarshaling.
+ //
+ // # Basic message operations
+ //
+-// • Clone makes a deep copy of a message.
++//   - [Clone] makes a deep copy of a message.
+ //
+-// • Merge merges the content of a message into another.
++//   - [Merge] merges the content of a message into another.
+ //
+-// • Equal compares two messages. For more control over comparisons
+-// and detailed reporting of differences, see package
+-// "google.golang.org/protobuf/testing/protocmp".
++//   - [Equal] compares two messages. For more control over comparisons
++//     and detailed reporting of differences, see package
++//     [google.golang.org/protobuf/testing/protocmp].
+ //
+-// • Reset clears the content of a message.
++//   - [Reset] clears the content of a message.
+ //
+-// • CheckInitialized reports whether all required fields in a message are set.
++//   - [CheckInitialized] reports whether all required fields in a message are set.
+ //
+ // # Optional scalar constructors
+ //
+@@ -46,9 +46,9 @@
+ // as pointers to a value. For example, an optional string field has the
+ // Go type *string.
+ //
+-// • Bool, Int32, Int64, Uint32, Uint64, Float32, Float64, and String
+-// take a value and return a pointer to a new instance of it,
+-// to simplify construction of optional field values.
++//   - [Bool], [Int32], [Int64], [Uint32], [Uint64], [Float32], [Float64], and [String]
++//     take a value and return a pointer to a new instance of it,
++//     to simplify construction of optional field values.
+ //
+ // Generated enum types usually have an Enum method which performs the
+ // same operation.
+@@ -57,29 +57,29 @@
+ //
+ // # Extension accessors
+ //
+-// • HasExtension, GetExtension, SetExtension, and ClearExtension
+-// access extension field values in a protocol buffer message.
++//   - [HasExtension], [GetExtension], [SetExtension], and [ClearExtension]
++//     access extension field values in a protocol buffer message.
+ //
+ // Extension fields are only supported in proto2.
+ //
+ // # Related packages
+ //
+-// • Package "google.golang.org/protobuf/encoding/protojson" converts messages to
+-// and from JSON.
++//   - Package [google.golang.org/protobuf/encoding/protojson] converts messages to
++//     and from JSON.
+ //
+-// • Package "google.golang.org/protobuf/encoding/prototext" converts messages to
+-// and from the text format.
++//   - Package [google.golang.org/protobuf/encoding/prototext] converts messages to
++//     and from the text format.
+ //
+-// • Package "google.golang.org/protobuf/reflect/protoreflect" provides a
+-// reflection interface for protocol buffer data types.
++//   - Package [google.golang.org/protobuf/reflect/protoreflect] provides a
++//     reflection interface for protocol buffer data types.
+ //
+-// • Package "google.golang.org/protobuf/testing/protocmp" provides features
+-// to compare protocol buffer messages with the "github.com/google/go-cmp/cmp"
+-// package.
++//   - Package [google.golang.org/protobuf/testing/protocmp] provides features
++//     to compare protocol buffer messages with the [github.com/google/go-cmp/cmp]
++//     package.
+ //
+-// • Package "google.golang.org/protobuf/types/dynamicpb" provides a dynamic
+-// message type, suitable for working with messages where the protocol buffer
+-// type is only known at runtime.
++//   - Package [google.golang.org/protobuf/types/dynamicpb] provides a dynamic
++//     message type, suitable for working with messages where the protocol buffer
++//     type is only known at runtime.
+ //
+ // This module contains additional packages for more specialized use cases.
+ // Consult the individual package documentation for details.
+diff --git a/vendor/google.golang.org/protobuf/proto/encode.go b/vendor/google.golang.org/protobuf/proto/encode.go
+index bf7f816..4fed202 100644
+--- a/vendor/google.golang.org/protobuf/proto/encode.go
++++ b/vendor/google.golang.org/protobuf/proto/encode.go
+@@ -129,7 +129,7 @@ func (o MarshalOptions) MarshalAppend(b []byte, m Message) ([]byte, error) {
+ // MarshalState returns the wire-format encoding of a message.
+ //
+ // This method permits fine-grained control over the marshaler.
+-// Most users should use Marshal instead.
++// Most users should use [Marshal] instead.
+ func (o MarshalOptions) MarshalState(in protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+ 	return o.marshal(in.Buf, in.Message)
+ }
+diff --git a/vendor/google.golang.org/protobuf/proto/extension.go b/vendor/google.golang.org/protobuf/proto/extension.go
+index 5f293cd..17899a3 100644
+--- a/vendor/google.golang.org/protobuf/proto/extension.go
++++ b/vendor/google.golang.org/protobuf/proto/extension.go
+@@ -26,7 +26,7 @@ func HasExtension(m Message, xt protoreflect.ExtensionType) bool {
+ }
+ 
+ // ClearExtension clears an extension field such that subsequent
+-// HasExtension calls return false.
++// [HasExtension] calls return false.
+ // It panics if m is invalid or if xt does not extend m.
+ func ClearExtension(m Message, xt protoreflect.ExtensionType) {
+ 	m.ProtoReflect().Clear(xt.TypeDescriptor())
+diff --git a/vendor/google.golang.org/protobuf/proto/merge.go b/vendor/google.golang.org/protobuf/proto/merge.go
+index d761ab3..3c6fe57 100644
+--- a/vendor/google.golang.org/protobuf/proto/merge.go
++++ b/vendor/google.golang.org/protobuf/proto/merge.go
+@@ -21,7 +21,7 @@ import (
+ // The unknown fields of src are appended to the unknown fields of dst.
+ //
+ // It is semantically equivalent to unmarshaling the encoded form of src
+-// into dst with the UnmarshalOptions.Merge option specified.
++// into dst with the [UnmarshalOptions.Merge] option specified.
+ func Merge(dst, src Message) {
+ 	// TODO: Should nil src be treated as semantically equivalent to a
+ 	// untyped, read-only, empty message? What about a nil dst?
+diff --git a/vendor/google.golang.org/protobuf/proto/proto.go b/vendor/google.golang.org/protobuf/proto/proto.go
+index 1f0d183..7543ee6 100644
+--- a/vendor/google.golang.org/protobuf/proto/proto.go
++++ b/vendor/google.golang.org/protobuf/proto/proto.go
+@@ -15,18 +15,20 @@ import (
+ // protobuf module that accept a Message, except where otherwise specified.
+ //
+ // This is the v2 interface definition for protobuf messages.
+-// The v1 interface definition is "github.com/golang/protobuf/proto".Message.
++// The v1 interface definition is [github.com/golang/protobuf/proto.Message].
+ //
+-// To convert a v1 message to a v2 message,
+-// use "github.com/golang/protobuf/proto".MessageV2.
+-// To convert a v2 message to a v1 message,
+-// use "github.com/golang/protobuf/proto".MessageV1.
++//   - To convert a v1 message to a v2 message,
++//     use [google.golang.org/protobuf/protoadapt.MessageV2Of].
++//   - To convert a v2 message to a v1 message,
++//     use [google.golang.org/protobuf/protoadapt.MessageV1Of].
+ type Message = protoreflect.ProtoMessage
+ 
+-// Error matches all errors produced by packages in the protobuf module.
++// Error matches all errors produced by packages in the protobuf module
++// according to [errors.Is].
+ //
+-// That is, errors.Is(err, Error) reports whether an error is produced
+-// by this module.
++// Example usage:
++//
++//	if errors.Is(err, proto.Error) { ... }
+ var Error error
+ 
+ func init() {
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+index e4dfb12..baa0cc6 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+@@ -3,11 +3,11 @@
+ // license that can be found in the LICENSE file.
+ 
+ // Package protodesc provides functionality for converting
+-// FileDescriptorProto messages to/from protoreflect.FileDescriptor values.
++// FileDescriptorProto messages to/from [protoreflect.FileDescriptor] values.
+ //
+ // The google.protobuf.FileDescriptorProto is a protobuf message that describes
+ // the type information for a .proto file in a form that is easily serializable.
+-// The protoreflect.FileDescriptor is a more structured representation of
++// The [protoreflect.FileDescriptor] is a more structured representation of
+ // the FileDescriptorProto message where references and remote dependencies
+ // can be directly followed.
+ package protodesc
+@@ -24,11 +24,11 @@ import (
+ 	"google.golang.org/protobuf/types/descriptorpb"
+ )
+ 
+-// Resolver is the resolver used by NewFile to resolve dependencies.
++// Resolver is the resolver used by [NewFile] to resolve dependencies.
+ // The enums and messages provided must belong to some parent file,
+ // which is also registered.
+ //
+-// It is implemented by protoregistry.Files.
++// It is implemented by [protoregistry.Files].
+ type Resolver interface {
+ 	FindFileByPath(string) (protoreflect.FileDescriptor, error)
+ 	FindDescriptorByName(protoreflect.FullName) (protoreflect.Descriptor, error)
+@@ -61,19 +61,19 @@ type FileOptions struct {
+ 	AllowUnresolvable bool
+ }
+ 
+-// NewFile creates a new protoreflect.FileDescriptor from the provided
+-// file descriptor message. See FileOptions.New for more information.
++// NewFile creates a new [protoreflect.FileDescriptor] from the provided
++// file descriptor message. See [FileOptions.New] for more information.
+ func NewFile(fd *descriptorpb.FileDescriptorProto, r Resolver) (protoreflect.FileDescriptor, error) {
+ 	return FileOptions{}.New(fd, r)
+ }
+ 
+-// NewFiles creates a new protoregistry.Files from the provided
+-// FileDescriptorSet message. See FileOptions.NewFiles for more information.
++// NewFiles creates a new [protoregistry.Files] from the provided
++// FileDescriptorSet message. See [FileOptions.NewFiles] for more information.
+ func NewFiles(fd *descriptorpb.FileDescriptorSet) (*protoregistry.Files, error) {
+ 	return FileOptions{}.NewFiles(fd)
+ }
+ 
+-// New creates a new protoreflect.FileDescriptor from the provided
++// New creates a new [protoreflect.FileDescriptor] from the provided
+ // file descriptor message. The file must represent a valid proto file according
+ // to protobuf semantics. The returned descriptor is a deep copy of the input.
+ //
+@@ -93,9 +93,15 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
+ 		f.L1.Syntax = protoreflect.Proto2
+ 	case "proto3":
+ 		f.L1.Syntax = protoreflect.Proto3
++	case "editions":
++		f.L1.Syntax = protoreflect.Editions
++		f.L1.Edition = fromEditionProto(fd.GetEdition())
+ 	default:
+ 		return nil, errors.New("invalid syntax: %q", fd.GetSyntax())
+ 	}
++	if f.L1.Syntax == protoreflect.Editions && (fd.GetEdition() < SupportedEditionsMinimum || fd.GetEdition() > SupportedEditionsMaximum) {
++		return nil, errors.New("use of edition %v not yet supported by the Go Protobuf runtime", fd.GetEdition())
++	}
+ 	f.L1.Path = fd.GetName()
+ 	if f.L1.Path == "" {
+ 		return nil, errors.New("file path must be populated")
+@@ -108,6 +114,9 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
+ 		opts = proto.Clone(opts).(*descriptorpb.FileOptions)
+ 		f.L2.Options = func() protoreflect.ProtoMessage { return opts }
+ 	}
++	if f.L1.Syntax == protoreflect.Editions {
++		initFileDescFromFeatureSet(f, fd.GetOptions().GetFeatures())
++	}
+ 
+ 	f.L2.Imports = make(filedesc.FileImports, len(fd.GetDependency()))
+ 	for _, i := range fd.GetPublicDependency() {
+@@ -231,7 +240,7 @@ func (is importSet) importPublic(imps protoreflect.FileImports) {
+ 	}
+ }
+ 
+-// NewFiles creates a new protoregistry.Files from the provided
++// NewFiles creates a new [protoregistry.Files] from the provided
+ // FileDescriptorSet message. The descriptor set must include only
+ // valid files according to protobuf semantics. The returned descriptors
+ // are a deep copy of the input.
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
+index 37efda1..b327816 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
+@@ -28,6 +28,7 @@ func (r descsByName) initEnumDeclarations(eds []*descriptorpb.EnumDescriptorProt
+ 			opts = proto.Clone(opts).(*descriptorpb.EnumOptions)
+ 			e.L2.Options = func() protoreflect.ProtoMessage { return opts }
+ 		}
++		e.L1.EditionFeatures = mergeEditionFeatures(parent, ed.GetOptions().GetFeatures())
+ 		for _, s := range ed.GetReservedName() {
+ 			e.L2.ReservedNames.List = append(e.L2.ReservedNames.List, protoreflect.Name(s))
+ 		}
+@@ -68,6 +69,9 @@ func (r descsByName) initMessagesDeclarations(mds []*descriptorpb.DescriptorProt
+ 		if m.L0, err = r.makeBase(m, parent, md.GetName(), i, sb); err != nil {
+ 			return nil, err
+ 		}
++		if m.Base.L0.ParentFile.Syntax() == protoreflect.Editions {
++			m.L1.EditionFeatures = mergeEditionFeatures(parent, md.GetOptions().GetFeatures())
++		}
+ 		if opts := md.GetOptions(); opts != nil {
+ 			opts = proto.Clone(opts).(*descriptorpb.MessageOptions)
+ 			m.L2.Options = func() protoreflect.ProtoMessage { return opts }
+@@ -114,6 +118,27 @@ func (r descsByName) initMessagesDeclarations(mds []*descriptorpb.DescriptorProt
+ 	return ms, nil
+ }
+ 
++// canBePacked returns whether the field can use packed encoding:
++// https://protobuf.dev/programming-guides/encoding/#packed
++func canBePacked(fd *descriptorpb.FieldDescriptorProto) bool {
++	if fd.GetLabel() != descriptorpb.FieldDescriptorProto_LABEL_REPEATED {
++		return false // not a repeated field
++	}
++
++	switch protoreflect.Kind(fd.GetType()) {
++	case protoreflect.MessageKind, protoreflect.GroupKind:
++		return false // not a scalar type field
++
++	case protoreflect.StringKind, protoreflect.BytesKind:
++		// string and bytes can explicitly not be declared as packed,
++		// see https://protobuf.dev/programming-guides/encoding/#packed
++		return false
++
++	default:
++		return true
++	}
++}
++
+ func (r descsByName) initFieldsFromDescriptorProto(fds []*descriptorpb.FieldDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (fs []filedesc.Field, err error) {
+ 	fs = make([]filedesc.Field, len(fds)) // allocate up-front to ensure stable pointers
+ 	for i, fd := range fds {
+@@ -137,6 +162,34 @@ func (r descsByName) initFieldsFromDescriptorProto(fds []*descriptorpb.FieldDesc
+ 		if fd.JsonName != nil {
+ 			f.L1.StringName.InitJSON(fd.GetJsonName())
+ 		}
++
++		if f.Base.L0.ParentFile.Syntax() == protoreflect.Editions {
++			f.L1.EditionFeatures = mergeEditionFeatures(parent, fd.GetOptions().GetFeatures())
++
++			if f.L1.EditionFeatures.IsLegacyRequired {
++				f.L1.Cardinality = protoreflect.Required
++			}
++			// We reuse the existing field because the old option `[packed =
++			// true]` is mutually exclusive with the editions feature.
++			if canBePacked(fd) {
++				f.L1.HasPacked = true
++				f.L1.IsPacked = f.L1.EditionFeatures.IsPacked
++			}
++
++			// We pretend this option is always explicitly set because the only
++			// use of HasEnforceUTF8 is to determine whether to use EnforceUTF8
++			// or to return the appropriate default.
++			// When using editions we either parse the option or resolve the
++			// appropriate default here (instead of later when this option is
++			// requested from the descriptor).
++			// In proto2/proto3 syntax HasEnforceUTF8 might be false.
++			f.L1.HasEnforceUTF8 = true
++			f.L1.EnforceUTF8 = f.L1.EditionFeatures.IsUTF8Validated
++
++			if f.L1.Kind == protoreflect.MessageKind && f.L1.EditionFeatures.IsDelimitedEncoded {
++				f.L1.Kind = protoreflect.GroupKind
++			}
++		}
+ 	}
+ 	return fs, nil
+ }
+@@ -151,6 +204,9 @@ func (r descsByName) initOneofsFromDescriptorProto(ods []*descriptorpb.OneofDesc
+ 		if opts := od.GetOptions(); opts != nil {
+ 			opts = proto.Clone(opts).(*descriptorpb.OneofOptions)
+ 			o.L1.Options = func() protoreflect.ProtoMessage { return opts }
++			if parent.Syntax() == protoreflect.Editions {
++				o.L1.EditionFeatures = mergeEditionFeatures(parent, opts.GetFeatures())
++			}
+ 		}
+ 	}
+ 	return os, nil
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
+index 27d7e35..254ca58 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
+@@ -276,8 +276,8 @@ func unmarshalDefault(s string, fd protoreflect.FieldDescriptor, allowUnresolvab
+ 	} else if err != nil {
+ 		return v, ev, err
+ 	}
+-	if fd.Syntax() == protoreflect.Proto3 {
+-		return v, ev, errors.New("cannot be specified under proto3 semantics")
++	if !fd.HasPresence() {
++		return v, ev, errors.New("cannot be specified with implicit field presence")
+ 	}
+ 	if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind || fd.Cardinality() == protoreflect.Repeated {
+ 		return v, ev, errors.New("cannot be specified on composite types")
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
+index 9af1d56..e4dcaf8 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
+@@ -107,7 +107,7 @@ func validateMessageDeclarations(ms []filedesc.Message, mds []*descriptorpb.Desc
+ 		if isMessageSet && !flags.ProtoLegacy {
+ 			return errors.New("message %q is a MessageSet, which is a legacy proto1 feature that is no longer supported", m.FullName())
+ 		}
+-		if isMessageSet && (m.Syntax() != protoreflect.Proto2 || m.Fields().Len() > 0 || m.ExtensionRanges().Len() == 0) {
++		if isMessageSet && (m.Syntax() == protoreflect.Proto3 || m.Fields().Len() > 0 || m.ExtensionRanges().Len() == 0) {
+ 			return errors.New("message %q is an invalid proto1 MessageSet", m.FullName())
+ 		}
+ 		if m.Syntax() == protoreflect.Proto3 {
+@@ -314,8 +314,8 @@ func checkValidGroup(fd protoreflect.FieldDescriptor) error {
+ 	switch {
+ 	case fd.Kind() != protoreflect.GroupKind:
+ 		return nil
+-	case fd.Syntax() != protoreflect.Proto2:
+-		return errors.New("invalid under proto2 semantics")
++	case fd.Syntax() == protoreflect.Proto3:
++		return errors.New("invalid under proto3 semantics")
+ 	case md == nil || md.IsPlaceholder():
+ 		return errors.New("message must be resolvable")
+ 	case fd.FullName().Parent() != md.FullName().Parent():
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go b/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+new file mode 100644
+index 0000000..2a6b29d
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+@@ -0,0 +1,148 @@
++// Copyright 2019 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package protodesc
++
++import (
++	"fmt"
++	"os"
++	"sync"
++
++	"google.golang.org/protobuf/internal/editiondefaults"
++	"google.golang.org/protobuf/internal/filedesc"
++	"google.golang.org/protobuf/proto"
++	"google.golang.org/protobuf/reflect/protoreflect"
++	"google.golang.org/protobuf/types/descriptorpb"
++	gofeaturespb "google.golang.org/protobuf/types/gofeaturespb"
++)
++
++const (
++	SupportedEditionsMinimum = descriptorpb.Edition_EDITION_PROTO2
++	SupportedEditionsMaximum = descriptorpb.Edition_EDITION_2023
++)
++
++var defaults = &descriptorpb.FeatureSetDefaults{}
++var defaultsCacheMu sync.Mutex
++var defaultsCache = make(map[filedesc.Edition]*descriptorpb.FeatureSet)
++
++func init() {
++	err := proto.Unmarshal(editiondefaults.Defaults, defaults)
++	if err != nil {
++		fmt.Fprintf(os.Stderr, "unmarshal editions defaults: %v\n", err)
++		os.Exit(1)
++	}
++}
++
++func fromEditionProto(epb descriptorpb.Edition) filedesc.Edition {
++	return filedesc.Edition(epb)
++}
++
++func toEditionProto(ed filedesc.Edition) descriptorpb.Edition {
++	switch ed {
++	case filedesc.EditionUnknown:
++		return descriptorpb.Edition_EDITION_UNKNOWN
++	case filedesc.EditionProto2:
++		return descriptorpb.Edition_EDITION_PROTO2
++	case filedesc.EditionProto3:
++		return descriptorpb.Edition_EDITION_PROTO3
++	case filedesc.Edition2023:
++		return descriptorpb.Edition_EDITION_2023
++	default:
++		panic(fmt.Sprintf("unknown value for edition: %v", ed))
++	}
++}
++
++func getFeatureSetFor(ed filedesc.Edition) *descriptorpb.FeatureSet {
++	defaultsCacheMu.Lock()
++	defer defaultsCacheMu.Unlock()
++	if def, ok := defaultsCache[ed]; ok {
++		return def
++	}
++	edpb := toEditionProto(ed)
++	if defaults.GetMinimumEdition() > edpb || defaults.GetMaximumEdition() < edpb {
++		// This should never happen protodesc.(FileOptions).New would fail when
++		// initializing the file descriptor.
++		// This most likely means the embedded defaults were not updated.
++		fmt.Fprintf(os.Stderr, "internal error: unsupported edition %v (did you forget to update the embedded defaults (i.e. the bootstrap descriptor proto)?)\n", edpb)
++		os.Exit(1)
++	}
++	fs := defaults.GetDefaults()[0].GetFeatures()
++	// Using a linear search for now.
++	// Editions are guaranteed to be sorted and thus we could use a binary search.
++	// Given that there are only a handful of editions (with one more per year)
++	// there is not much reason to use a binary search.
++	for _, def := range defaults.GetDefaults() {
++		if def.GetEdition() <= edpb {
++			fs = def.GetFeatures()
++		} else {
++			break
++		}
++	}
++	defaultsCache[ed] = fs
++	return fs
++}
++
++// mergeEditionFeatures merges the parent and child feature sets. This function
++// should be used when initializing Go descriptors from descriptor protos which
++// is why the parent is a filedesc.EditionsFeatures (Go representation) while
++// the child is a descriptorproto.FeatureSet (protoc representation).
++// Any feature set by the child overwrites what is set by the parent.
++func mergeEditionFeatures(parentDesc protoreflect.Descriptor, child *descriptorpb.FeatureSet) filedesc.EditionFeatures {
++	var parentFS filedesc.EditionFeatures
++	switch p := parentDesc.(type) {
++	case *filedesc.File:
++		parentFS = p.L1.EditionFeatures
++	case *filedesc.Message:
++		parentFS = p.L1.EditionFeatures
++	default:
++		panic(fmt.Sprintf("unknown parent type %T", parentDesc))
++	}
++	if child == nil {
++		return parentFS
++	}
++	if fp := child.FieldPresence; fp != nil {
++		parentFS.IsFieldPresence = *fp == descriptorpb.FeatureSet_LEGACY_REQUIRED ||
++			*fp == descriptorpb.FeatureSet_EXPLICIT
++		parentFS.IsLegacyRequired = *fp == descriptorpb.FeatureSet_LEGACY_REQUIRED
++	}
++	if et := child.EnumType; et != nil {
++		parentFS.IsOpenEnum = *et == descriptorpb.FeatureSet_OPEN
++	}
++
++	if rfe := child.RepeatedFieldEncoding; rfe != nil {
++		parentFS.IsPacked = *rfe == descriptorpb.FeatureSet_PACKED
++	}
++
++	if utf8val := child.Utf8Validation; utf8val != nil {
++		parentFS.IsUTF8Validated = *utf8val == descriptorpb.FeatureSet_VERIFY
++	}
++
++	if me := child.MessageEncoding; me != nil {
++		parentFS.IsDelimitedEncoded = *me == descriptorpb.FeatureSet_DELIMITED
++	}
++
++	if jf := child.JsonFormat; jf != nil {
++		parentFS.IsJSONCompliant = *jf == descriptorpb.FeatureSet_ALLOW
++	}
++
++	if goFeatures, ok := proto.GetExtension(child, gofeaturespb.E_Go).(*gofeaturespb.GoFeatures); ok && goFeatures != nil {
++		if luje := goFeatures.LegacyUnmarshalJsonEnum; luje != nil {
++			parentFS.GenerateLegacyUnmarshalJSON = *luje
++		}
++	}
++
++	return parentFS
++}
++
++// initFileDescFromFeatureSet initializes editions related fields in fd based
++// on fs. If fs is nil it is assumed to be an empty featureset and all fields
++// will be initialized with the appropriate default. fd.L1.Edition must be set
++// before calling this function.
++func initFileDescFromFeatureSet(fd *filedesc.File, fs *descriptorpb.FeatureSet) {
++	dfs := getFeatureSetFor(fd.L1.Edition)
++	// initialize the featureset with the defaults
++	fd.L1.EditionFeatures = mergeEditionFeatures(fd, dfs)
++	// overwrite any options explicitly specified
++	fd.L1.EditionFeatures = mergeEditionFeatures(fd, fs)
++}
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go b/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
+index a7c5cef..9d6e054 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
+@@ -16,7 +16,7 @@ import (
+ 	"google.golang.org/protobuf/types/descriptorpb"
+ )
+ 
+-// ToFileDescriptorProto copies a protoreflect.FileDescriptor into a
++// ToFileDescriptorProto copies a [protoreflect.FileDescriptor] into a
+ // google.protobuf.FileDescriptorProto message.
+ func ToFileDescriptorProto(file protoreflect.FileDescriptor) *descriptorpb.FileDescriptorProto {
+ 	p := &descriptorpb.FileDescriptorProto{
+@@ -70,13 +70,13 @@ func ToFileDescriptorProto(file protoreflect.FileDescriptor) *descriptorpb.FileD
+ 	for i, exts := 0, file.Extensions(); i < exts.Len(); i++ {
+ 		p.Extension = append(p.Extension, ToFieldDescriptorProto(exts.Get(i)))
+ 	}
+-	if syntax := file.Syntax(); syntax != protoreflect.Proto2 {
++	if syntax := file.Syntax(); syntax != protoreflect.Proto2 && syntax.IsValid() {
+ 		p.Syntax = proto.String(file.Syntax().String())
+ 	}
+ 	return p
+ }
+ 
+-// ToDescriptorProto copies a protoreflect.MessageDescriptor into a
++// ToDescriptorProto copies a [protoreflect.MessageDescriptor] into a
+ // google.protobuf.DescriptorProto message.
+ func ToDescriptorProto(message protoreflect.MessageDescriptor) *descriptorpb.DescriptorProto {
+ 	p := &descriptorpb.DescriptorProto{
+@@ -119,7 +119,7 @@ func ToDescriptorProto(message protoreflect.MessageDescriptor) *descriptorpb.Des
+ 	return p
+ }
+ 
+-// ToFieldDescriptorProto copies a protoreflect.FieldDescriptor into a
++// ToFieldDescriptorProto copies a [protoreflect.FieldDescriptor] into a
+ // google.protobuf.FieldDescriptorProto message.
+ func ToFieldDescriptorProto(field protoreflect.FieldDescriptor) *descriptorpb.FieldDescriptorProto {
+ 	p := &descriptorpb.FieldDescriptorProto{
+@@ -168,7 +168,7 @@ func ToFieldDescriptorProto(field protoreflect.FieldDescriptor) *descriptorpb.Fi
+ 	return p
+ }
+ 
+-// ToOneofDescriptorProto copies a protoreflect.OneofDescriptor into a
++// ToOneofDescriptorProto copies a [protoreflect.OneofDescriptor] into a
+ // google.protobuf.OneofDescriptorProto message.
+ func ToOneofDescriptorProto(oneof protoreflect.OneofDescriptor) *descriptorpb.OneofDescriptorProto {
+ 	return &descriptorpb.OneofDescriptorProto{
+@@ -177,7 +177,7 @@ func ToOneofDescriptorProto(oneof protoreflect.OneofDescriptor) *descriptorpb.On
+ 	}
+ }
+ 
+-// ToEnumDescriptorProto copies a protoreflect.EnumDescriptor into a
++// ToEnumDescriptorProto copies a [protoreflect.EnumDescriptor] into a
+ // google.protobuf.EnumDescriptorProto message.
+ func ToEnumDescriptorProto(enum protoreflect.EnumDescriptor) *descriptorpb.EnumDescriptorProto {
+ 	p := &descriptorpb.EnumDescriptorProto{
+@@ -200,7 +200,7 @@ func ToEnumDescriptorProto(enum protoreflect.EnumDescriptor) *descriptorpb.EnumD
+ 	return p
+ }
+ 
+-// ToEnumValueDescriptorProto copies a protoreflect.EnumValueDescriptor into a
++// ToEnumValueDescriptorProto copies a [protoreflect.EnumValueDescriptor] into a
+ // google.protobuf.EnumValueDescriptorProto message.
+ func ToEnumValueDescriptorProto(value protoreflect.EnumValueDescriptor) *descriptorpb.EnumValueDescriptorProto {
+ 	return &descriptorpb.EnumValueDescriptorProto{
+@@ -210,7 +210,7 @@ func ToEnumValueDescriptorProto(value protoreflect.EnumValueDescriptor) *descrip
+ 	}
+ }
+ 
+-// ToServiceDescriptorProto copies a protoreflect.ServiceDescriptor into a
++// ToServiceDescriptorProto copies a [protoreflect.ServiceDescriptor] into a
+ // google.protobuf.ServiceDescriptorProto message.
+ func ToServiceDescriptorProto(service protoreflect.ServiceDescriptor) *descriptorpb.ServiceDescriptorProto {
+ 	p := &descriptorpb.ServiceDescriptorProto{
+@@ -223,7 +223,7 @@ func ToServiceDescriptorProto(service protoreflect.ServiceDescriptor) *descripto
+ 	return p
+ }
+ 
+-// ToMethodDescriptorProto copies a protoreflect.MethodDescriptor into a
++// ToMethodDescriptorProto copies a [protoreflect.MethodDescriptor] into a
+ // google.protobuf.MethodDescriptorProto message.
+ func ToMethodDescriptorProto(method protoreflect.MethodDescriptor) *descriptorpb.MethodDescriptorProto {
+ 	p := &descriptorpb.MethodDescriptorProto{
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
+index 55aa149..00b01fb 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
+@@ -10,46 +10,46 @@
+ //
+ // # Protocol Buffer Descriptors
+ //
+-// Protobuf descriptors (e.g., EnumDescriptor or MessageDescriptor)
++// Protobuf descriptors (e.g., [EnumDescriptor] or [MessageDescriptor])
+ // are immutable objects that represent protobuf type information.
+ // They are wrappers around the messages declared in descriptor.proto.
+ // Protobuf descriptors alone lack any information regarding Go types.
+ //
+-// Enums and messages generated by this module implement Enum and ProtoMessage,
++// Enums and messages generated by this module implement [Enum] and [ProtoMessage],
+ // where the Descriptor and ProtoReflect.Descriptor accessors respectively
+ // return the protobuf descriptor for the values.
+ //
+ // The protobuf descriptor interfaces are not meant to be implemented by
+ // user code since they might need to be extended in the future to support
+ // additions to the protobuf language.
+-// The "google.golang.org/protobuf/reflect/protodesc" package converts between
++// The [google.golang.org/protobuf/reflect/protodesc] package converts between
+ // google.protobuf.DescriptorProto messages and protobuf descriptors.
+ //
+ // # Go Type Descriptors
+ //
+-// A type descriptor (e.g., EnumType or MessageType) is a constructor for
++// A type descriptor (e.g., [EnumType] or [MessageType]) is a constructor for
+ // a concrete Go type that represents the associated protobuf descriptor.
+ // There is commonly a one-to-one relationship between protobuf descriptors and
+ // Go type descriptors, but it can potentially be a one-to-many relationship.
+ //
+-// Enums and messages generated by this module implement Enum and ProtoMessage,
++// Enums and messages generated by this module implement [Enum] and [ProtoMessage],
+ // where the Type and ProtoReflect.Type accessors respectively
+ // return the protobuf descriptor for the values.
+ //
+-// The "google.golang.org/protobuf/types/dynamicpb" package can be used to
++// The [google.golang.org/protobuf/types/dynamicpb] package can be used to
+ // create Go type descriptors from protobuf descriptors.
+ //
+ // # Value Interfaces
+ //
+-// The Enum and Message interfaces provide a reflective view over an
++// The [Enum] and [Message] interfaces provide a reflective view over an
+ // enum or message instance. For enums, it provides the ability to retrieve
+ // the enum value number for any concrete enum type. For messages, it provides
+ // the ability to access or manipulate fields of the message.
+ //
+-// To convert a proto.Message to a protoreflect.Message, use the
++// To convert a [google.golang.org/protobuf/proto.Message] to a [protoreflect.Message], use the
+ // former's ProtoReflect method. Since the ProtoReflect method is new to the
+ // v2 message interface, it may not be present on older message implementations.
+-// The "github.com/golang/protobuf/proto".MessageReflect function can be used
++// The [github.com/golang/protobuf/proto.MessageReflect] function can be used
+ // to obtain a reflective view on older messages.
+ //
+ // # Relationships
+@@ -71,12 +71,12 @@
+ //	      │                                 │
+ //	      └────────────────── Type() ───────┘
+ //
+-// • An EnumType describes a concrete Go enum type.
++// • An [EnumType] describes a concrete Go enum type.
+ // It has an EnumDescriptor and can construct an Enum instance.
+ //
+-// • An EnumDescriptor describes an abstract protobuf enum type.
++// • An [EnumDescriptor] describes an abstract protobuf enum type.
+ //
+-// • An Enum is a concrete enum instance. Generated enums implement Enum.
++// • An [Enum] is a concrete enum instance. Generated enums implement Enum.
+ //
+ //	  ┌──────────────── New() ─────────────────┐
+ //	  │                                        │
+@@ -90,24 +90,26 @@
+ //	       │                                    │
+ //	       └─────────────────── Type() ─────────┘
+ //
+-// • A MessageType describes a concrete Go message type.
+-// It has a MessageDescriptor and can construct a Message instance.
+-// Just as how Go's reflect.Type is a reflective description of a Go type,
+-// a MessageType is a reflective description of a Go type for a protobuf message.
++// • A [MessageType] describes a concrete Go message type.
++// It has a [MessageDescriptor] and can construct a [Message] instance.
++// Just as how Go's [reflect.Type] is a reflective description of a Go type,
++// a [MessageType] is a reflective description of a Go type for a protobuf message.
+ //
+-// • A MessageDescriptor describes an abstract protobuf message type.
+-// It has no understanding of Go types. In order to construct a MessageType
+-// from just a MessageDescriptor, you can consider looking up the message type
+-// in the global registry using protoregistry.GlobalTypes.FindMessageByName
+-// or constructing a dynamic MessageType using dynamicpb.NewMessageType.
++// • A [MessageDescriptor] describes an abstract protobuf message type.
++// It has no understanding of Go types. In order to construct a [MessageType]
++// from just a [MessageDescriptor], you can consider looking up the message type
++// in the global registry using the FindMessageByName method on
++// [google.golang.org/protobuf/reflect/protoregistry.GlobalTypes]
++// or constructing a dynamic [MessageType] using
++// [google.golang.org/protobuf/types/dynamicpb.NewMessageType].
+ //
+-// • A Message is a reflective view over a concrete message instance.
+-// Generated messages implement ProtoMessage, which can convert to a Message.
+-// Just as how Go's reflect.Value is a reflective view over a Go value,
+-// a Message is a reflective view over a concrete protobuf message instance.
+-// Using Go reflection as an analogy, the ProtoReflect method is similar to
+-// calling reflect.ValueOf, and the Message.Interface method is similar to
+-// calling reflect.Value.Interface.
++// • A [Message] is a reflective view over a concrete message instance.
++// Generated messages implement [ProtoMessage], which can convert to a [Message].
++// Just as how Go's [reflect.Value] is a reflective view over a Go value,
++// a [Message] is a reflective view over a concrete protobuf message instance.
++// Using Go reflection as an analogy, the [ProtoMessage.ProtoReflect] method is similar to
++// calling [reflect.ValueOf], and the [Message.Interface] method is similar to
++// calling [reflect.Value.Interface].
+ //
+ //	      ┌── TypeDescriptor() ──┐    ┌───── Descriptor() ─────┐
+ //	      │                      V    │                        V
+@@ -119,15 +121,15 @@
+ //	                                 │                          │
+ //	                                 └────── implements ────────┘
+ //
+-// • An ExtensionType describes a concrete Go implementation of an extension.
+-// It has an ExtensionTypeDescriptor and can convert to/from
+-// abstract Values and Go values.
++// • An [ExtensionType] describes a concrete Go implementation of an extension.
++// It has an [ExtensionTypeDescriptor] and can convert to/from
++// an abstract [Value] and a Go value.
+ //
+-// • An ExtensionTypeDescriptor is an ExtensionDescriptor
+-// which also has an ExtensionType.
++// • An [ExtensionTypeDescriptor] is an [ExtensionDescriptor]
++// which also has an [ExtensionType].
+ //
+-// • An ExtensionDescriptor describes an abstract protobuf extension field and
+-// may not always be an ExtensionTypeDescriptor.
++// • An [ExtensionDescriptor] describes an abstract protobuf extension field and
++// may not always be an [ExtensionTypeDescriptor].
+ package protoreflect
+ 
+ import (
+@@ -142,7 +144,7 @@ type doNotImplement pragma.DoNotImplement
+ 
+ // ProtoMessage is the top-level interface that all proto messages implement.
+ // This is declared in the protoreflect package to avoid a cyclic dependency;
+-// use the proto.Message type instead, which aliases this type.
++// use the [google.golang.org/protobuf/proto.Message] type instead, which aliases this type.
+ type ProtoMessage interface{ ProtoReflect() Message }
+ 
+ // Syntax is the language version of the proto file.
+@@ -151,8 +153,9 @@ type Syntax syntax
+ type syntax int8 // keep exact type opaque as the int type may change
+ 
+ const (
+-	Proto2 Syntax = 2
+-	Proto3 Syntax = 3
++	Proto2   Syntax = 2
++	Proto3   Syntax = 3
++	Editions Syntax = 4
+ )
+ 
+ // IsValid reports whether the syntax is valid.
+@@ -172,6 +175,8 @@ func (s Syntax) String() string {
+ 		return "proto2"
+ 	case Proto3:
+ 		return "proto3"
++	case Editions:
++		return "editions"
+ 	default:
+ 		return fmt.Sprintf("<unknown:%d>", s)
+ 	}
+@@ -436,7 +441,7 @@ type Names interface {
+ // FullName is a qualified name that uniquely identifies a proto declaration.
+ // A qualified name is the concatenation of the proto package along with the
+ // fully-declared name (i.e., name of parent preceding the name of the child),
+-// with a '.' delimiter placed between each Name.
++// with a '.' delimiter placed between each [Name].
+ //
+ // This should not have any leading or trailing dots.
+ type FullName string // e.g., "google.protobuf.Field.Kind"
+@@ -480,7 +485,7 @@ func isLetterDigit(c byte) bool {
+ }
+ 
+ // Name returns the short name, which is the last identifier segment.
+-// A single segment FullName is the Name itself.
++// A single segment FullName is the [Name] itself.
+ func (n FullName) Name() Name {
+ 	if i := strings.LastIndexByte(string(n), '.'); i >= 0 {
+ 		return Name(n[i+1:])
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
+index 717b106..7dcc2ff 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
+@@ -35,7 +35,7 @@ func (p *SourcePath) appendFileDescriptorProto(b []byte) []byte {
+ 		b = p.appendSingularField(b, "source_code_info", (*SourcePath).appendSourceCodeInfo)
+ 	case 12:
+ 		b = p.appendSingularField(b, "syntax", nil)
+-	case 13:
++	case 14:
+ 		b = p.appendSingularField(b, "edition", nil)
+ 	}
+ 	return b
+@@ -160,8 +160,6 @@ func (p *SourcePath) appendFileOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "java_generic_services", nil)
+ 	case 18:
+ 		b = p.appendSingularField(b, "py_generic_services", nil)
+-	case 42:
+-		b = p.appendSingularField(b, "php_generic_services", nil)
+ 	case 23:
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 31:
+@@ -180,6 +178,8 @@ func (p *SourcePath) appendFileOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "php_metadata_namespace", nil)
+ 	case 45:
+ 		b = p.appendSingularField(b, "ruby_package", nil)
++	case 50:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -240,6 +240,8 @@ func (p *SourcePath) appendMessageOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "map_entry", nil)
+ 	case 11:
+ 		b = p.appendSingularField(b, "deprecated_legacy_json_field_conflicts", nil)
++	case 12:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -285,6 +287,8 @@ func (p *SourcePath) appendEnumOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 6:
+ 		b = p.appendSingularField(b, "deprecated_legacy_json_field_conflicts", nil)
++	case 7:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -330,6 +334,8 @@ func (p *SourcePath) appendServiceOptions(b []byte) []byte {
+ 		return b
+ 	}
+ 	switch (*p)[0] {
++	case 34:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 33:
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 999:
+@@ -361,16 +367,39 @@ func (p *SourcePath) appendFieldOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "debug_redact", nil)
+ 	case 17:
+ 		b = p.appendSingularField(b, "retention", nil)
+-	case 18:
+-		b = p.appendSingularField(b, "target", nil)
+ 	case 19:
+ 		b = p.appendRepeatedField(b, "targets", nil)
++	case 20:
++		b = p.appendRepeatedField(b, "edition_defaults", (*SourcePath).appendFieldOptions_EditionDefault)
++	case 21:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+ 	return b
+ }
+ 
++func (p *SourcePath) appendFeatureSet(b []byte) []byte {
++	if len(*p) == 0 {
++		return b
++	}
++	switch (*p)[0] {
++	case 1:
++		b = p.appendSingularField(b, "field_presence", nil)
++	case 2:
++		b = p.appendSingularField(b, "enum_type", nil)
++	case 3:
++		b = p.appendSingularField(b, "repeated_field_encoding", nil)
++	case 4:
++		b = p.appendSingularField(b, "utf8_validation", nil)
++	case 5:
++		b = p.appendSingularField(b, "message_encoding", nil)
++	case 6:
++		b = p.appendSingularField(b, "json_format", nil)
++	}
++	return b
++}
++
+ func (p *SourcePath) appendUninterpretedOption(b []byte) []byte {
+ 	if len(*p) == 0 {
+ 		return b
+@@ -422,6 +451,8 @@ func (p *SourcePath) appendExtensionRangeOptions(b []byte) []byte {
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	case 2:
+ 		b = p.appendRepeatedField(b, "declaration", (*SourcePath).appendExtensionRangeOptions_Declaration)
++	case 50:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 3:
+ 		b = p.appendSingularField(b, "verification", nil)
+ 	}
+@@ -433,6 +464,8 @@ func (p *SourcePath) appendOneofOptions(b []byte) []byte {
+ 		return b
+ 	}
+ 	switch (*p)[0] {
++	case 1:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -446,6 +479,10 @@ func (p *SourcePath) appendEnumValueOptions(b []byte) []byte {
+ 	switch (*p)[0] {
+ 	case 1:
+ 		b = p.appendSingularField(b, "deprecated", nil)
++	case 2:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
++	case 3:
++		b = p.appendSingularField(b, "debug_redact", nil)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -461,12 +498,27 @@ func (p *SourcePath) appendMethodOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 34:
+ 		b = p.appendSingularField(b, "idempotency_level", nil)
++	case 35:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+ 	return b
+ }
+ 
++func (p *SourcePath) appendFieldOptions_EditionDefault(b []byte) []byte {
++	if len(*p) == 0 {
++		return b
++	}
++	switch (*p)[0] {
++	case 3:
++		b = p.appendSingularField(b, "edition", nil)
++	case 2:
++		b = p.appendSingularField(b, "value", nil)
++	}
++	return b
++}
++
+ func (p *SourcePath) appendUninterpretedOption_NamePart(b []byte) []byte {
+ 	if len(*p) == 0 {
+ 		return b
+@@ -491,8 +543,6 @@ func (p *SourcePath) appendExtensionRangeOptions_Declaration(b []byte) []byte {
+ 		b = p.appendSingularField(b, "full_name", nil)
+ 	case 3:
+ 		b = p.appendSingularField(b, "type", nil)
+-	case 4:
+-		b = p.appendSingularField(b, "is_repeated", nil)
+ 	case 5:
+ 		b = p.appendSingularField(b, "reserved", nil)
+ 	case 6:
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
+index 3867470..60ff62b 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
+@@ -12,7 +12,7 @@ package protoreflect
+ // exactly identical. However, it is possible for the same semantically
+ // identical proto type to be represented by multiple type descriptors.
+ //
+-// For example, suppose we have t1 and t2 which are both MessageDescriptors.
++// For example, suppose we have t1 and t2 which are both an [MessageDescriptor].
+ // If t1 == t2, then the types are definitely equal and all accessors return
+ // the same information. However, if t1 != t2, then it is still possible that
+ // they still represent the same proto type (e.g., t1.FullName == t2.FullName).
+@@ -115,7 +115,7 @@ type Descriptor interface {
+ // corresponds with the google.protobuf.FileDescriptorProto message.
+ //
+ // Top-level declarations:
+-// EnumDescriptor, MessageDescriptor, FieldDescriptor, and/or ServiceDescriptor.
++// [EnumDescriptor], [MessageDescriptor], [FieldDescriptor], and/or [ServiceDescriptor].
+ type FileDescriptor interface {
+ 	Descriptor // Descriptor.FullName is identical to Package
+ 
+@@ -180,8 +180,8 @@ type FileImport struct {
+ // corresponds with the google.protobuf.DescriptorProto message.
+ //
+ // Nested declarations:
+-// FieldDescriptor, OneofDescriptor, FieldDescriptor, EnumDescriptor,
+-// and/or MessageDescriptor.
++// [FieldDescriptor], [OneofDescriptor], [FieldDescriptor], [EnumDescriptor],
++// and/or [MessageDescriptor].
+ type MessageDescriptor interface {
+ 	Descriptor
+ 
+@@ -214,7 +214,7 @@ type MessageDescriptor interface {
+ 	ExtensionRanges() FieldRanges
+ 	// ExtensionRangeOptions returns the ith extension range options.
+ 	//
+-	// To avoid a dependency cycle, this method returns a proto.Message value,
++	// To avoid a dependency cycle, this method returns a proto.Message] value,
+ 	// which always contains a google.protobuf.ExtensionRangeOptions message.
+ 	// This method returns a typed nil-pointer if no options are present.
+ 	// The caller must import the descriptorpb package to use this.
+@@ -231,9 +231,9 @@ type MessageDescriptor interface {
+ }
+ type isMessageDescriptor interface{ ProtoType(MessageDescriptor) }
+ 
+-// MessageType encapsulates a MessageDescriptor with a concrete Go implementation.
++// MessageType encapsulates a [MessageDescriptor] with a concrete Go implementation.
+ // It is recommended that implementations of this interface also implement the
+-// MessageFieldTypes interface.
++// [MessageFieldTypes] interface.
+ type MessageType interface {
+ 	// New returns a newly allocated empty message.
+ 	// It may return nil for synthetic messages representing a map entry.
+@@ -249,19 +249,19 @@ type MessageType interface {
+ 	Descriptor() MessageDescriptor
+ }
+ 
+-// MessageFieldTypes extends a MessageType by providing type information
++// MessageFieldTypes extends a [MessageType] by providing type information
+ // regarding enums and messages referenced by the message fields.
+ type MessageFieldTypes interface {
+ 	MessageType
+ 
+-	// Enum returns the EnumType for the ith field in Descriptor.Fields.
++	// Enum returns the EnumType for the ith field in MessageDescriptor.Fields.
+ 	// It returns nil if the ith field is not an enum kind.
+ 	// It panics if out of bounds.
+ 	//
+ 	// Invariant: mt.Enum(i).Descriptor() == mt.Descriptor().Fields(i).Enum()
+ 	Enum(i int) EnumType
+ 
+-	// Message returns the MessageType for the ith field in Descriptor.Fields.
++	// Message returns the MessageType for the ith field in MessageDescriptor.Fields.
+ 	// It returns nil if the ith field is not a message or group kind.
+ 	// It panics if out of bounds.
+ 	//
+@@ -286,8 +286,8 @@ type MessageDescriptors interface {
+ // corresponds with the google.protobuf.FieldDescriptorProto message.
+ //
+ // It is used for both normal fields defined within the parent message
+-// (e.g., MessageDescriptor.Fields) and fields that extend some remote message
+-// (e.g., FileDescriptor.Extensions or MessageDescriptor.Extensions).
++// (e.g., [MessageDescriptor.Fields]) and fields that extend some remote message
++// (e.g., [FileDescriptor.Extensions] or [MessageDescriptor.Extensions]).
+ type FieldDescriptor interface {
+ 	Descriptor
+ 
+@@ -344,7 +344,7 @@ type FieldDescriptor interface {
+ 	// IsMap reports whether this field represents a map,
+ 	// where the value type for the associated field is a Map.
+ 	// It is equivalent to checking whether Cardinality is Repeated,
+-	// that the Kind is MessageKind, and that Message.IsMapEntry reports true.
++	// that the Kind is MessageKind, and that MessageDescriptor.IsMapEntry reports true.
+ 	IsMap() bool
+ 
+ 	// MapKey returns the field descriptor for the key in the map entry.
+@@ -419,7 +419,7 @@ type OneofDescriptor interface {
+ 
+ 	// IsSynthetic reports whether this is a synthetic oneof created to support
+ 	// proto3 optional semantics. If true, Fields contains exactly one field
+-	// with HasOptionalKeyword specified.
++	// with FieldDescriptor.HasOptionalKeyword specified.
+ 	IsSynthetic() bool
+ 
+ 	// Fields is a list of fields belonging to this oneof.
+@@ -442,10 +442,10 @@ type OneofDescriptors interface {
+ 	doNotImplement
+ }
+ 
+-// ExtensionDescriptor is an alias of FieldDescriptor for documentation.
++// ExtensionDescriptor is an alias of [FieldDescriptor] for documentation.
+ type ExtensionDescriptor = FieldDescriptor
+ 
+-// ExtensionTypeDescriptor is an ExtensionDescriptor with an associated ExtensionType.
++// ExtensionTypeDescriptor is an [ExtensionDescriptor] with an associated [ExtensionType].
+ type ExtensionTypeDescriptor interface {
+ 	ExtensionDescriptor
+ 
+@@ -470,12 +470,12 @@ type ExtensionDescriptors interface {
+ 	doNotImplement
+ }
+ 
+-// ExtensionType encapsulates an ExtensionDescriptor with a concrete
++// ExtensionType encapsulates an [ExtensionDescriptor] with a concrete
+ // Go implementation. The nested field descriptor must be for a extension field.
+ //
+ // While a normal field is a member of the parent message that it is declared
+-// within (see Descriptor.Parent), an extension field is a member of some other
+-// target message (see ExtensionDescriptor.Extendee) and may have no
++// within (see [Descriptor.Parent]), an extension field is a member of some other
++// target message (see [FieldDescriptor.ContainingMessage]) and may have no
+ // relationship with the parent. However, the full name of an extension field is
+ // relative to the parent that it is declared within.
+ //
+@@ -532,7 +532,7 @@ type ExtensionType interface {
+ // corresponds with the google.protobuf.EnumDescriptorProto message.
+ //
+ // Nested declarations:
+-// EnumValueDescriptor.
++// [EnumValueDescriptor].
+ type EnumDescriptor interface {
+ 	Descriptor
+ 
+@@ -548,7 +548,7 @@ type EnumDescriptor interface {
+ }
+ type isEnumDescriptor interface{ ProtoType(EnumDescriptor) }
+ 
+-// EnumType encapsulates an EnumDescriptor with a concrete Go implementation.
++// EnumType encapsulates an [EnumDescriptor] with a concrete Go implementation.
+ type EnumType interface {
+ 	// New returns an instance of this enum type with its value set to n.
+ 	New(n EnumNumber) Enum
+@@ -610,7 +610,7 @@ type EnumValueDescriptors interface {
+ // ServiceDescriptor describes a service and
+ // corresponds with the google.protobuf.ServiceDescriptorProto message.
+ //
+-// Nested declarations: MethodDescriptor.
++// Nested declarations: [MethodDescriptor].
+ type ServiceDescriptor interface {
+ 	Descriptor
+ 
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
+index 37601b7..a7b0d06 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
+@@ -27,16 +27,16 @@ type Enum interface {
+ // Message is a reflective interface for a concrete message value,
+ // encapsulating both type and value information for the message.
+ //
+-// Accessor/mutators for individual fields are keyed by FieldDescriptor.
++// Accessor/mutators for individual fields are keyed by [FieldDescriptor].
+ // For non-extension fields, the descriptor must exactly match the
+ // field known by the parent message.
+-// For extension fields, the descriptor must implement ExtensionTypeDescriptor,
+-// extend the parent message (i.e., have the same message FullName), and
++// For extension fields, the descriptor must implement [ExtensionTypeDescriptor],
++// extend the parent message (i.e., have the same message [FullName]), and
+ // be within the parent's extension range.
+ //
+-// Each field Value can be a scalar or a composite type (Message, List, or Map).
+-// See Value for the Go types associated with a FieldDescriptor.
+-// Providing a Value that is invalid or of an incorrect type panics.
++// Each field [Value] can be a scalar or a composite type ([Message], [List], or [Map]).
++// See [Value] for the Go types associated with a [FieldDescriptor].
++// Providing a [Value] that is invalid or of an incorrect type panics.
+ type Message interface {
+ 	// Descriptor returns message descriptor, which contains only the protobuf
+ 	// type information for the message.
+@@ -152,7 +152,7 @@ type Message interface {
+ 	// This method may return nil.
+ 	//
+ 	// The returned methods type is identical to
+-	// "google.golang.org/protobuf/runtime/protoiface".Methods.
++	// google.golang.org/protobuf/runtime/protoiface.Methods.
+ 	// Consult the protoiface package documentation for details.
+ 	ProtoMethods() *methods
+ }
+@@ -175,8 +175,8 @@ func (b RawFields) IsValid() bool {
+ }
+ 
+ // List is a zero-indexed, ordered list.
+-// The element Value type is determined by FieldDescriptor.Kind.
+-// Providing a Value that is invalid or of an incorrect type panics.
++// The element [Value] type is determined by [FieldDescriptor.Kind].
++// Providing a [Value] that is invalid or of an incorrect type panics.
+ type List interface {
+ 	// Len reports the number of entries in the List.
+ 	// Get, Set, and Truncate panic with out of bound indexes.
+@@ -226,9 +226,9 @@ type List interface {
+ }
+ 
+ // Map is an unordered, associative map.
+-// The entry MapKey type is determined by FieldDescriptor.MapKey.Kind.
+-// The entry Value type is determined by FieldDescriptor.MapValue.Kind.
+-// Providing a MapKey or Value that is invalid or of an incorrect type panics.
++// The entry [MapKey] type is determined by [FieldDescriptor.MapKey].Kind.
++// The entry [Value] type is determined by [FieldDescriptor.MapValue].Kind.
++// Providing a [MapKey] or [Value] that is invalid or of an incorrect type panics.
+ type Map interface {
+ 	// Len reports the number of elements in the map.
+ 	Len() int
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
+index 5916525..654599d 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
+@@ -24,19 +24,19 @@ import (
+ //     Unlike the == operator, a NaN is equal to another NaN.
+ //
+ //   - Enums are equal if they contain the same number.
+-//     Since Value does not contain an enum descriptor,
++//     Since [Value] does not contain an enum descriptor,
+ //     enum values do not consider the type of the enum.
+ //
+ //   - Other scalar values are equal if they contain the same value.
+ //
+-//   - Message values are equal if they belong to the same message descriptor,
++//   - [Message] values are equal if they belong to the same message descriptor,
+ //     have the same set of populated known and extension field values,
+ //     and the same set of unknown fields values.
+ //
+-//   - Lists are equal if they are the same length and
++//   - [List] values are equal if they are the same length and
+ //     each corresponding element is equal.
+ //
+-//   - Maps are equal if they have the same set of keys and
++//   - [Map] values are equal if they have the same set of keys and
+ //     the corresponding value for each key is equal.
+ func (v1 Value) Equal(v2 Value) bool {
+ 	return equalValue(v1, v2)
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
+index 08e5ef7..1603097 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
+@@ -11,7 +11,7 @@ import (
+ 
+ // Value is a union where only one Go type may be set at a time.
+ // The Value is used to represent all possible values a field may take.
+-// The following shows which Go type is used to represent each proto Kind:
++// The following shows which Go type is used to represent each proto [Kind]:
+ //
+ //	╔════════════╤═════════════════════════════════════╗
+ //	║ Go type    │ Protobuf kind                       ║
+@@ -31,22 +31,22 @@ import (
+ //
+ // Multiple protobuf Kinds may be represented by a single Go type if the type
+ // can losslessly represent the information for the proto kind. For example,
+-// Int64Kind, Sint64Kind, and Sfixed64Kind are all represented by int64,
++// [Int64Kind], [Sint64Kind], and [Sfixed64Kind] are all represented by int64,
+ // but use different integer encoding methods.
+ //
+-// The List or Map types are used if the field cardinality is repeated.
+-// A field is a List if FieldDescriptor.IsList reports true.
+-// A field is a Map if FieldDescriptor.IsMap reports true.
++// The [List] or [Map] types are used if the field cardinality is repeated.
++// A field is a [List] if [FieldDescriptor.IsList] reports true.
++// A field is a [Map] if [FieldDescriptor.IsMap] reports true.
+ //
+ // Converting to/from a Value and a concrete Go value panics on type mismatch.
+-// For example, ValueOf("hello").Int() panics because this attempts to
++// For example, [ValueOf]("hello").Int() panics because this attempts to
+ // retrieve an int64 from a string.
+ //
+-// List, Map, and Message Values are called "composite" values.
++// [List], [Map], and [Message] Values are called "composite" values.
+ //
+ // A composite Value may alias (reference) memory at some location,
+ // such that changes to the Value updates the that location.
+-// A composite value acquired with a Mutable method, such as Message.Mutable,
++// A composite value acquired with a Mutable method, such as [Message.Mutable],
+ // always references the source object.
+ //
+ // For example:
+@@ -65,7 +65,7 @@ import (
+ //	// appending to the List here may or may not modify the message.
+ //	list.Append(protoreflect.ValueOfInt32(0))
+ //
+-// Some operations, such as Message.Get, may return an "empty, read-only"
++// Some operations, such as [Message.Get], may return an "empty, read-only"
+ // composite Value. Modifying an empty, read-only value panics.
+ type Value value
+ 
+@@ -306,7 +306,7 @@ func (v Value) Float() float64 {
+ 	}
+ }
+ 
+-// String returns v as a string. Since this method implements fmt.Stringer,
++// String returns v as a string. Since this method implements [fmt.Stringer],
+ // this returns the formatted string value for any non-string type.
+ func (v Value) String() string {
+ 	switch v.typ {
+@@ -327,7 +327,7 @@ func (v Value) Bytes() []byte {
+ 	}
+ }
+ 
+-// Enum returns v as a EnumNumber and panics if the type is not a EnumNumber.
++// Enum returns v as a [EnumNumber] and panics if the type is not a [EnumNumber].
+ func (v Value) Enum() EnumNumber {
+ 	switch v.typ {
+ 	case enumType:
+@@ -337,7 +337,7 @@ func (v Value) Enum() EnumNumber {
+ 	}
+ }
+ 
+-// Message returns v as a Message and panics if the type is not a Message.
++// Message returns v as a [Message] and panics if the type is not a [Message].
+ func (v Value) Message() Message {
+ 	switch vi := v.getIface().(type) {
+ 	case Message:
+@@ -347,7 +347,7 @@ func (v Value) Message() Message {
+ 	}
+ }
+ 
+-// List returns v as a List and panics if the type is not a List.
++// List returns v as a [List] and panics if the type is not a [List].
+ func (v Value) List() List {
+ 	switch vi := v.getIface().(type) {
+ 	case List:
+@@ -357,7 +357,7 @@ func (v Value) List() List {
+ 	}
+ }
+ 
+-// Map returns v as a Map and panics if the type is not a Map.
++// Map returns v as a [Map] and panics if the type is not a [Map].
+ func (v Value) Map() Map {
+ 	switch vi := v.getIface().(type) {
+ 	case Map:
+@@ -367,7 +367,7 @@ func (v Value) Map() Map {
+ 	}
+ }
+ 
+-// MapKey returns v as a MapKey and panics for invalid MapKey types.
++// MapKey returns v as a [MapKey] and panics for invalid [MapKey] types.
+ func (v Value) MapKey() MapKey {
+ 	switch v.typ {
+ 	case boolType, int32Type, int64Type, uint32Type, uint64Type, stringType:
+@@ -378,8 +378,8 @@ func (v Value) MapKey() MapKey {
+ }
+ 
+ // MapKey is used to index maps, where the Go type of the MapKey must match
+-// the specified key Kind (see MessageDescriptor.IsMapEntry).
+-// The following shows what Go type is used to represent each proto Kind:
++// the specified key [Kind] (see [MessageDescriptor.IsMapEntry]).
++// The following shows what Go type is used to represent each proto [Kind]:
+ //
+ //	╔═════════╤═════════════════════════════════════╗
+ //	║ Go type │ Protobuf kind                       ║
+@@ -392,13 +392,13 @@ func (v Value) MapKey() MapKey {
+ //	║ string  │ StringKind                          ║
+ //	╚═════════╧═════════════════════════════════════╝
+ //
+-// A MapKey is constructed and accessed through a Value:
++// A MapKey is constructed and accessed through a [Value]:
+ //
+ //	k := ValueOf("hash").MapKey() // convert string to MapKey
+ //	s := k.String()               // convert MapKey to string
+ //
+-// The MapKey is a strict subset of valid types used in Value;
+-// converting a Value to a MapKey with an invalid type panics.
++// The MapKey is a strict subset of valid types used in [Value];
++// converting a [Value] to a MapKey with an invalid type panics.
+ type MapKey value
+ 
+ // IsValid reports whether k is populated with a value.
+@@ -426,13 +426,13 @@ func (k MapKey) Uint() uint64 {
+ 	return Value(k).Uint()
+ }
+ 
+-// String returns k as a string. Since this method implements fmt.Stringer,
++// String returns k as a string. Since this method implements [fmt.Stringer],
+ // this returns the formatted string value for any non-string type.
+ func (k MapKey) String() string {
+ 	return Value(k).String()
+ }
+ 
+-// Value returns k as a Value.
++// Value returns k as a [Value].
+ func (k MapKey) Value() Value {
+ 	return Value(k)
+ }
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+similarity index 97%
+rename from vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
+rename to vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+index 702ddf2..b1fdbe3 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !purego && !appengine
+-// +build !purego,!appengine
++//go:build !purego && !appengine && !go1.21
++// +build !purego,!appengine,!go1.21
+ 
+ package protoreflect
+ 
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+new file mode 100644
+index 0000000..4354701
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+@@ -0,0 +1,87 @@
++// Copyright 2018 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !purego && !appengine && go1.21
++// +build !purego,!appengine,go1.21
++
++package protoreflect
++
++import (
++	"unsafe"
++
++	"google.golang.org/protobuf/internal/pragma"
++)
++
++type (
++	ifaceHeader struct {
++		_    [0]interface{} // if interfaces have greater alignment than unsafe.Pointer, this will enforce it.
++		Type unsafe.Pointer
++		Data unsafe.Pointer
++	}
++)
++
++var (
++	nilType     = typeOf(nil)
++	boolType    = typeOf(*new(bool))
++	int32Type   = typeOf(*new(int32))
++	int64Type   = typeOf(*new(int64))
++	uint32Type  = typeOf(*new(uint32))
++	uint64Type  = typeOf(*new(uint64))
++	float32Type = typeOf(*new(float32))
++	float64Type = typeOf(*new(float64))
++	stringType  = typeOf(*new(string))
++	bytesType   = typeOf(*new([]byte))
++	enumType    = typeOf(*new(EnumNumber))
++)
++
++// typeOf returns a pointer to the Go type information.
++// The pointer is comparable and equal if and only if the types are identical.
++func typeOf(t interface{}) unsafe.Pointer {
++	return (*ifaceHeader)(unsafe.Pointer(&t)).Type
++}
++
++// value is a union where only one type can be represented at a time.
++// The struct is 24B large on 64-bit systems and requires the minimum storage
++// necessary to represent each possible type.
++//
++// The Go GC needs to be able to scan variables containing pointers.
++// As such, pointers and non-pointers cannot be intermixed.
++type value struct {
++	pragma.DoNotCompare // 0B
++
++	// typ stores the type of the value as a pointer to the Go type.
++	typ unsafe.Pointer // 8B
++
++	// ptr stores the data pointer for a String, Bytes, or interface value.
++	ptr unsafe.Pointer // 8B
++
++	// num stores a Bool, Int32, Int64, Uint32, Uint64, Float32, Float64, or
++	// Enum value as a raw uint64.
++	//
++	// It is also used to store the length of a String or Bytes value;
++	// the capacity is ignored.
++	num uint64 // 8B
++}
++
++func valueOfString(v string) Value {
++	return Value{typ: stringType, ptr: unsafe.Pointer(unsafe.StringData(v)), num: uint64(len(v))}
++}
++func valueOfBytes(v []byte) Value {
++	return Value{typ: bytesType, ptr: unsafe.Pointer(unsafe.SliceData(v)), num: uint64(len(v))}
++}
++func valueOfIface(v interface{}) Value {
++	p := (*ifaceHeader)(unsafe.Pointer(&v))
++	return Value{typ: p.Type, ptr: p.Data}
++}
++
++func (v Value) getString() string {
++	return unsafe.String((*byte)(v.ptr), v.num)
++}
++func (v Value) getBytes() []byte {
++	return unsafe.Slice((*byte)(v.ptr), v.num)
++}
++func (v Value) getIface() (x interface{}) {
++	*(*ifaceHeader)(unsafe.Pointer(&x)) = ifaceHeader{Type: v.typ, Data: v.ptr}
++	return x
++}
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go b/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
+index aeb5597..6267dc5 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
+@@ -5,12 +5,12 @@
+ // Package protoregistry provides data structures to register and lookup
+ // protobuf descriptor types.
+ //
+-// The Files registry contains file descriptors and provides the ability
++// The [Files] registry contains file descriptors and provides the ability
+ // to iterate over the files or lookup a specific descriptor within the files.
+-// Files only contains protobuf descriptors and has no understanding of Go
++// [Files] only contains protobuf descriptors and has no understanding of Go
+ // type information that may be associated with each descriptor.
+ //
+-// The Types registry contains descriptor types for which there is a known
++// The [Types] registry contains descriptor types for which there is a known
+ // Go type associated with that descriptor. It provides the ability to iterate
+ // over the registered types or lookup a type by name.
+ package protoregistry
+@@ -218,7 +218,7 @@ func (r *Files) checkGenProtoConflict(path string) {
+ 
+ // FindDescriptorByName looks up a descriptor by the full name.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Files) FindDescriptorByName(name protoreflect.FullName) (protoreflect.Descriptor, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -310,7 +310,7 @@ func (s *nameSuffix) Pop() (name protoreflect.Name) {
+ 
+ // FindFileByPath looks up a file by the path.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ // This returns an error if multiple files have the same path.
+ func (r *Files) FindFileByPath(path string) (protoreflect.FileDescriptor, error) {
+ 	if r == nil {
+@@ -431,7 +431,7 @@ func rangeTopLevelDescriptors(fd protoreflect.FileDescriptor, f func(protoreflec
+ // A compliant implementation must deterministically return the same type
+ // if no error is encountered.
+ //
+-// The Types type implements this interface.
++// The [Types] type implements this interface.
+ type MessageTypeResolver interface {
+ 	// FindMessageByName looks up a message by its full name.
+ 	// E.g., "google.protobuf.Any"
+@@ -451,7 +451,7 @@ type MessageTypeResolver interface {
+ // A compliant implementation must deterministically return the same type
+ // if no error is encountered.
+ //
+-// The Types type implements this interface.
++// The [Types] type implements this interface.
+ type ExtensionTypeResolver interface {
+ 	// FindExtensionByName looks up a extension field by the field's full name.
+ 	// Note that this is the full name of the field as determined by
+@@ -590,7 +590,7 @@ func (r *Types) register(kind string, desc protoreflect.Descriptor, typ interfac
+ // FindEnumByName looks up an enum by its full name.
+ // E.g., "google.protobuf.Field.Kind".
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -611,7 +611,7 @@ func (r *Types) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumTyp
+ // FindMessageByName looks up a message by its full name,
+ // e.g. "google.protobuf.Any".
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -632,7 +632,7 @@ func (r *Types) FindMessageByName(message protoreflect.FullName) (protoreflect.M
+ // FindMessageByURL looks up a message by a URL identifier.
+ // See documentation on google.protobuf.Any.type_url for the URL format.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+ 	// This function is similar to FindMessageByName but
+ 	// truncates anything before and including '/' in the URL.
+@@ -662,7 +662,7 @@ func (r *Types) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+ // where the extension is declared and is unrelated to the full name of the
+ // message being extended.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -703,7 +703,7 @@ func (r *Types) FindExtensionByName(field protoreflect.FullName) (protoreflect.E
+ // FindExtensionByNumber looks up a extension field by the field number
+ // within some parent message, identified by full name.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+diff --git a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+index 04c00f7..78624cf 100644
+--- a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
++++ b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+@@ -48,6 +48,103 @@ import (
+ 	sync "sync"
+ )
+ 
++// The full set of known editions.
++type Edition int32
++
++const (
++	// A placeholder for an unknown edition value.
++	Edition_EDITION_UNKNOWN Edition = 0
++	// Legacy syntax "editions".  These pre-date editions, but behave much like
++	// distinct editions.  These can't be used to specify the edition of proto
++	// files, but feature definitions must supply proto2/proto3 defaults for
++	// backwards compatibility.
++	Edition_EDITION_PROTO2 Edition = 998
++	Edition_EDITION_PROTO3 Edition = 999
++	// Editions that have been released.  The specific values are arbitrary and
++	// should not be depended on, but they will always be time-ordered for easy
++	// comparison.
++	Edition_EDITION_2023 Edition = 1000
++	Edition_EDITION_2024 Edition = 1001
++	// Placeholder editions for testing feature resolution.  These should not be
++	// used or relyed on outside of tests.
++	Edition_EDITION_1_TEST_ONLY     Edition = 1
++	Edition_EDITION_2_TEST_ONLY     Edition = 2
++	Edition_EDITION_99997_TEST_ONLY Edition = 99997
++	Edition_EDITION_99998_TEST_ONLY Edition = 99998
++	Edition_EDITION_99999_TEST_ONLY Edition = 99999
++	// Placeholder for specifying unbounded edition support.  This should only
++	// ever be used by plugins that can expect to never require any changes to
++	// support a new edition.
++	Edition_EDITION_MAX Edition = 2147483647
++)
++
++// Enum value maps for Edition.
++var (
++	Edition_name = map[int32]string{
++		0:          "EDITION_UNKNOWN",
++		998:        "EDITION_PROTO2",
++		999:        "EDITION_PROTO3",
++		1000:       "EDITION_2023",
++		1001:       "EDITION_2024",
++		1:          "EDITION_1_TEST_ONLY",
++		2:          "EDITION_2_TEST_ONLY",
++		99997:      "EDITION_99997_TEST_ONLY",
++		99998:      "EDITION_99998_TEST_ONLY",
++		99999:      "EDITION_99999_TEST_ONLY",
++		2147483647: "EDITION_MAX",
++	}
++	Edition_value = map[string]int32{
++		"EDITION_UNKNOWN":         0,
++		"EDITION_PROTO2":          998,
++		"EDITION_PROTO3":          999,
++		"EDITION_2023":            1000,
++		"EDITION_2024":            1001,
++		"EDITION_1_TEST_ONLY":     1,
++		"EDITION_2_TEST_ONLY":     2,
++		"EDITION_99997_TEST_ONLY": 99997,
++		"EDITION_99998_TEST_ONLY": 99998,
++		"EDITION_99999_TEST_ONLY": 99999,
++		"EDITION_MAX":             2147483647,
++	}
++)
++
++func (x Edition) Enum() *Edition {
++	p := new(Edition)
++	*p = x
++	return p
++}
++
++func (x Edition) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (Edition) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[0].Descriptor()
++}
++
++func (Edition) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[0]
++}
++
++func (x Edition) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *Edition) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = Edition(num)
++	return nil
++}
++
++// Deprecated: Use Edition.Descriptor instead.
++func (Edition) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{0}
++}
++
+ // The verification state of the extension range.
+ type ExtensionRangeOptions_VerificationState int32
+ 
+@@ -80,11 +177,11 @@ func (x ExtensionRangeOptions_VerificationState) String() string {
+ }
+ 
+ func (ExtensionRangeOptions_VerificationState) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[0].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[1].Descriptor()
+ }
+ 
+ func (ExtensionRangeOptions_VerificationState) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[0]
++	return &file_google_protobuf_descriptor_proto_enumTypes[1]
+ }
+ 
+ func (x ExtensionRangeOptions_VerificationState) Number() protoreflect.EnumNumber {
+@@ -125,9 +222,10 @@ const (
+ 	FieldDescriptorProto_TYPE_BOOL    FieldDescriptorProto_Type = 8
+ 	FieldDescriptorProto_TYPE_STRING  FieldDescriptorProto_Type = 9
+ 	// Tag-delimited aggregate.
+-	// Group type is deprecated and not supported in proto3. However, Proto3
++	// Group type is deprecated and not supported after google.protobuf. However, Proto3
+ 	// implementations should still be able to parse the group wire format and
+-	// treat group fields as unknown fields.
++	// treat group fields as unknown fields.  In Editions, the group wire format
++	// can be enabled via the `message_encoding` feature.
+ 	FieldDescriptorProto_TYPE_GROUP   FieldDescriptorProto_Type = 10
+ 	FieldDescriptorProto_TYPE_MESSAGE FieldDescriptorProto_Type = 11 // Length-delimited aggregate.
+ 	// New in version 2.
+@@ -195,11 +293,11 @@ func (x FieldDescriptorProto_Type) String() string {
+ }
+ 
+ func (FieldDescriptorProto_Type) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[1].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[2].Descriptor()
+ }
+ 
+ func (FieldDescriptorProto_Type) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[1]
++	return &file_google_protobuf_descriptor_proto_enumTypes[2]
+ }
+ 
+ func (x FieldDescriptorProto_Type) Number() protoreflect.EnumNumber {
+@@ -226,21 +324,24 @@ type FieldDescriptorProto_Label int32
+ const (
+ 	// 0 is reserved for errors
+ 	FieldDescriptorProto_LABEL_OPTIONAL FieldDescriptorProto_Label = 1
+-	FieldDescriptorProto_LABEL_REQUIRED FieldDescriptorProto_Label = 2
+ 	FieldDescriptorProto_LABEL_REPEATED FieldDescriptorProto_Label = 3
++	// The required label is only allowed in google.protobuf.  In proto3 and Editions
++	// it's explicitly prohibited.  In Editions, the `field_presence` feature
++	// can be used to get this behavior.
++	FieldDescriptorProto_LABEL_REQUIRED FieldDescriptorProto_Label = 2
+ )
+ 
+ // Enum value maps for FieldDescriptorProto_Label.
+ var (
+ 	FieldDescriptorProto_Label_name = map[int32]string{
+ 		1: "LABEL_OPTIONAL",
+-		2: "LABEL_REQUIRED",
+ 		3: "LABEL_REPEATED",
++		2: "LABEL_REQUIRED",
+ 	}
+ 	FieldDescriptorProto_Label_value = map[string]int32{
+ 		"LABEL_OPTIONAL": 1,
+-		"LABEL_REQUIRED": 2,
+ 		"LABEL_REPEATED": 3,
++		"LABEL_REQUIRED": 2,
+ 	}
+ )
+ 
+@@ -255,11 +356,11 @@ func (x FieldDescriptorProto_Label) String() string {
+ }
+ 
+ func (FieldDescriptorProto_Label) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[2].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[3].Descriptor()
+ }
+ 
+ func (FieldDescriptorProto_Label) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[2]
++	return &file_google_protobuf_descriptor_proto_enumTypes[3]
+ }
+ 
+ func (x FieldDescriptorProto_Label) Number() protoreflect.EnumNumber {
+@@ -316,11 +417,11 @@ func (x FileOptions_OptimizeMode) String() string {
+ }
+ 
+ func (FileOptions_OptimizeMode) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[3].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[4].Descriptor()
+ }
+ 
+ func (FileOptions_OptimizeMode) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[3]
++	return &file_google_protobuf_descriptor_proto_enumTypes[4]
+ }
+ 
+ func (x FileOptions_OptimizeMode) Number() protoreflect.EnumNumber {
+@@ -382,11 +483,11 @@ func (x FieldOptions_CType) String() string {
+ }
+ 
+ func (FieldOptions_CType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[4].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[5].Descriptor()
+ }
+ 
+ func (FieldOptions_CType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[4]
++	return &file_google_protobuf_descriptor_proto_enumTypes[5]
+ }
+ 
+ func (x FieldOptions_CType) Number() protoreflect.EnumNumber {
+@@ -444,11 +545,11 @@ func (x FieldOptions_JSType) String() string {
+ }
+ 
+ func (FieldOptions_JSType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[5].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[6].Descriptor()
+ }
+ 
+ func (FieldOptions_JSType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[5]
++	return &file_google_protobuf_descriptor_proto_enumTypes[6]
+ }
+ 
+ func (x FieldOptions_JSType) Number() protoreflect.EnumNumber {
+@@ -506,11 +607,11 @@ func (x FieldOptions_OptionRetention) String() string {
+ }
+ 
+ func (FieldOptions_OptionRetention) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[6].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[7].Descriptor()
+ }
+ 
+ func (FieldOptions_OptionRetention) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[6]
++	return &file_google_protobuf_descriptor_proto_enumTypes[7]
+ }
+ 
+ func (x FieldOptions_OptionRetention) Number() protoreflect.EnumNumber {
+@@ -590,11 +691,11 @@ func (x FieldOptions_OptionTargetType) String() string {
+ }
+ 
+ func (FieldOptions_OptionTargetType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[7].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[8].Descriptor()
+ }
+ 
+ func (FieldOptions_OptionTargetType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[7]
++	return &file_google_protobuf_descriptor_proto_enumTypes[8]
+ }
+ 
+ func (x FieldOptions_OptionTargetType) Number() protoreflect.EnumNumber {
+@@ -652,11 +753,11 @@ func (x MethodOptions_IdempotencyLevel) String() string {
+ }
+ 
+ func (MethodOptions_IdempotencyLevel) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[8].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[9].Descriptor()
+ }
+ 
+ func (MethodOptions_IdempotencyLevel) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[8]
++	return &file_google_protobuf_descriptor_proto_enumTypes[9]
+ }
+ 
+ func (x MethodOptions_IdempotencyLevel) Number() protoreflect.EnumNumber {
+@@ -678,6 +779,363 @@ func (MethodOptions_IdempotencyLevel) EnumDescriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{17, 0}
+ }
+ 
++type FeatureSet_FieldPresence int32
++
++const (
++	FeatureSet_FIELD_PRESENCE_UNKNOWN FeatureSet_FieldPresence = 0
++	FeatureSet_EXPLICIT               FeatureSet_FieldPresence = 1
++	FeatureSet_IMPLICIT               FeatureSet_FieldPresence = 2
++	FeatureSet_LEGACY_REQUIRED        FeatureSet_FieldPresence = 3
++)
++
++// Enum value maps for FeatureSet_FieldPresence.
++var (
++	FeatureSet_FieldPresence_name = map[int32]string{
++		0: "FIELD_PRESENCE_UNKNOWN",
++		1: "EXPLICIT",
++		2: "IMPLICIT",
++		3: "LEGACY_REQUIRED",
++	}
++	FeatureSet_FieldPresence_value = map[string]int32{
++		"FIELD_PRESENCE_UNKNOWN": 0,
++		"EXPLICIT":               1,
++		"IMPLICIT":               2,
++		"LEGACY_REQUIRED":        3,
++	}
++)
++
++func (x FeatureSet_FieldPresence) Enum() *FeatureSet_FieldPresence {
++	p := new(FeatureSet_FieldPresence)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_FieldPresence) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_FieldPresence) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[10].Descriptor()
++}
++
++func (FeatureSet_FieldPresence) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[10]
++}
++
++func (x FeatureSet_FieldPresence) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_FieldPresence) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_FieldPresence(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_FieldPresence.Descriptor instead.
++func (FeatureSet_FieldPresence) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 0}
++}
++
++type FeatureSet_EnumType int32
++
++const (
++	FeatureSet_ENUM_TYPE_UNKNOWN FeatureSet_EnumType = 0
++	FeatureSet_OPEN              FeatureSet_EnumType = 1
++	FeatureSet_CLOSED            FeatureSet_EnumType = 2
++)
++
++// Enum value maps for FeatureSet_EnumType.
++var (
++	FeatureSet_EnumType_name = map[int32]string{
++		0: "ENUM_TYPE_UNKNOWN",
++		1: "OPEN",
++		2: "CLOSED",
++	}
++	FeatureSet_EnumType_value = map[string]int32{
++		"ENUM_TYPE_UNKNOWN": 0,
++		"OPEN":              1,
++		"CLOSED":            2,
++	}
++)
++
++func (x FeatureSet_EnumType) Enum() *FeatureSet_EnumType {
++	p := new(FeatureSet_EnumType)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_EnumType) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_EnumType) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[11].Descriptor()
++}
++
++func (FeatureSet_EnumType) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[11]
++}
++
++func (x FeatureSet_EnumType) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_EnumType) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_EnumType(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_EnumType.Descriptor instead.
++func (FeatureSet_EnumType) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 1}
++}
++
++type FeatureSet_RepeatedFieldEncoding int32
++
++const (
++	FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN FeatureSet_RepeatedFieldEncoding = 0
++	FeatureSet_PACKED                          FeatureSet_RepeatedFieldEncoding = 1
++	FeatureSet_EXPANDED                        FeatureSet_RepeatedFieldEncoding = 2
++)
++
++// Enum value maps for FeatureSet_RepeatedFieldEncoding.
++var (
++	FeatureSet_RepeatedFieldEncoding_name = map[int32]string{
++		0: "REPEATED_FIELD_ENCODING_UNKNOWN",
++		1: "PACKED",
++		2: "EXPANDED",
++	}
++	FeatureSet_RepeatedFieldEncoding_value = map[string]int32{
++		"REPEATED_FIELD_ENCODING_UNKNOWN": 0,
++		"PACKED":                          1,
++		"EXPANDED":                        2,
++	}
++)
++
++func (x FeatureSet_RepeatedFieldEncoding) Enum() *FeatureSet_RepeatedFieldEncoding {
++	p := new(FeatureSet_RepeatedFieldEncoding)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_RepeatedFieldEncoding) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_RepeatedFieldEncoding) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[12].Descriptor()
++}
++
++func (FeatureSet_RepeatedFieldEncoding) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[12]
++}
++
++func (x FeatureSet_RepeatedFieldEncoding) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_RepeatedFieldEncoding) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_RepeatedFieldEncoding(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_RepeatedFieldEncoding.Descriptor instead.
++func (FeatureSet_RepeatedFieldEncoding) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 2}
++}
++
++type FeatureSet_Utf8Validation int32
++
++const (
++	FeatureSet_UTF8_VALIDATION_UNKNOWN FeatureSet_Utf8Validation = 0
++	FeatureSet_VERIFY                  FeatureSet_Utf8Validation = 2
++	FeatureSet_NONE                    FeatureSet_Utf8Validation = 3
++)
++
++// Enum value maps for FeatureSet_Utf8Validation.
++var (
++	FeatureSet_Utf8Validation_name = map[int32]string{
++		0: "UTF8_VALIDATION_UNKNOWN",
++		2: "VERIFY",
++		3: "NONE",
++	}
++	FeatureSet_Utf8Validation_value = map[string]int32{
++		"UTF8_VALIDATION_UNKNOWN": 0,
++		"VERIFY":                  2,
++		"NONE":                    3,
++	}
++)
++
++func (x FeatureSet_Utf8Validation) Enum() *FeatureSet_Utf8Validation {
++	p := new(FeatureSet_Utf8Validation)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_Utf8Validation) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_Utf8Validation) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[13].Descriptor()
++}
++
++func (FeatureSet_Utf8Validation) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[13]
++}
++
++func (x FeatureSet_Utf8Validation) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_Utf8Validation) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_Utf8Validation(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_Utf8Validation.Descriptor instead.
++func (FeatureSet_Utf8Validation) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 3}
++}
++
++type FeatureSet_MessageEncoding int32
++
++const (
++	FeatureSet_MESSAGE_ENCODING_UNKNOWN FeatureSet_MessageEncoding = 0
++	FeatureSet_LENGTH_PREFIXED          FeatureSet_MessageEncoding = 1
++	FeatureSet_DELIMITED                FeatureSet_MessageEncoding = 2
++)
++
++// Enum value maps for FeatureSet_MessageEncoding.
++var (
++	FeatureSet_MessageEncoding_name = map[int32]string{
++		0: "MESSAGE_ENCODING_UNKNOWN",
++		1: "LENGTH_PREFIXED",
++		2: "DELIMITED",
++	}
++	FeatureSet_MessageEncoding_value = map[string]int32{
++		"MESSAGE_ENCODING_UNKNOWN": 0,
++		"LENGTH_PREFIXED":          1,
++		"DELIMITED":                2,
++	}
++)
++
++func (x FeatureSet_MessageEncoding) Enum() *FeatureSet_MessageEncoding {
++	p := new(FeatureSet_MessageEncoding)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_MessageEncoding) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_MessageEncoding) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[14].Descriptor()
++}
++
++func (FeatureSet_MessageEncoding) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[14]
++}
++
++func (x FeatureSet_MessageEncoding) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_MessageEncoding) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_MessageEncoding(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_MessageEncoding.Descriptor instead.
++func (FeatureSet_MessageEncoding) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 4}
++}
++
++type FeatureSet_JsonFormat int32
++
++const (
++	FeatureSet_JSON_FORMAT_UNKNOWN FeatureSet_JsonFormat = 0
++	FeatureSet_ALLOW               FeatureSet_JsonFormat = 1
++	FeatureSet_LEGACY_BEST_EFFORT  FeatureSet_JsonFormat = 2
++)
++
++// Enum value maps for FeatureSet_JsonFormat.
++var (
++	FeatureSet_JsonFormat_name = map[int32]string{
++		0: "JSON_FORMAT_UNKNOWN",
++		1: "ALLOW",
++		2: "LEGACY_BEST_EFFORT",
++	}
++	FeatureSet_JsonFormat_value = map[string]int32{
++		"JSON_FORMAT_UNKNOWN": 0,
++		"ALLOW":               1,
++		"LEGACY_BEST_EFFORT":  2,
++	}
++)
++
++func (x FeatureSet_JsonFormat) Enum() *FeatureSet_JsonFormat {
++	p := new(FeatureSet_JsonFormat)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_JsonFormat) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_JsonFormat) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[15].Descriptor()
++}
++
++func (FeatureSet_JsonFormat) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[15]
++}
++
++func (x FeatureSet_JsonFormat) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_JsonFormat) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_JsonFormat(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_JsonFormat.Descriptor instead.
++func (FeatureSet_JsonFormat) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 5}
++}
++
+ // Represents the identified object's effect on the element in the original
+ // .proto file.
+ type GeneratedCodeInfo_Annotation_Semantic int32
+@@ -716,11 +1174,11 @@ func (x GeneratedCodeInfo_Annotation_Semantic) String() string {
+ }
+ 
+ func (GeneratedCodeInfo_Annotation_Semantic) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[9].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[16].Descriptor()
+ }
+ 
+ func (GeneratedCodeInfo_Annotation_Semantic) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[9]
++	return &file_google_protobuf_descriptor_proto_enumTypes[16]
+ }
+ 
+ func (x GeneratedCodeInfo_Annotation_Semantic) Number() protoreflect.EnumNumber {
+@@ -739,7 +1197,7 @@ func (x *GeneratedCodeInfo_Annotation_Semantic) UnmarshalJSON(b []byte) error {
+ 
+ // Deprecated: Use GeneratedCodeInfo_Annotation_Semantic.Descriptor instead.
+ func (GeneratedCodeInfo_Annotation_Semantic) EnumDescriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22, 0, 0}
+ }
+ 
+ // The protocol compiler can output a FileDescriptorSet containing the .proto
+@@ -822,8 +1280,8 @@ type FileDescriptorProto struct {
+ 	//
+ 	// If `edition` is present, this value must be "editions".
+ 	Syntax *string `protobuf:"bytes,12,opt,name=syntax" json:"syntax,omitempty"`
+-	// The edition of the proto file, which is an opaque string.
+-	Edition *string `protobuf:"bytes,13,opt,name=edition" json:"edition,omitempty"`
++	// The edition of the proto file.
++	Edition *Edition `protobuf:"varint,14,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
+ }
+ 
+ func (x *FileDescriptorProto) Reset() {
+@@ -942,11 +1400,11 @@ func (x *FileDescriptorProto) GetSyntax() string {
+ 	return ""
+ }
+ 
+-func (x *FileDescriptorProto) GetEdition() string {
++func (x *FileDescriptorProto) GetEdition() Edition {
+ 	if x != nil && x.Edition != nil {
+ 		return *x.Edition
+ 	}
+-	return ""
++	return Edition_EDITION_UNKNOWN
+ }
+ 
+ // Describes a message type.
+@@ -1079,13 +1537,14 @@ type ExtensionRangeOptions struct {
+ 
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+-	// go/protobuf-stripping-extension-declarations
+-	// Like Metadata, but we use a repeated field to hold all extension
+-	// declarations. This should avoid the size increases of transforming a large
+-	// extension range into small ranges in generated binaries.
++	// For external users: DO NOT USE. We are in the process of open sourcing
++	// extension declaration and executing internal cleanups before it can be
++	// used externally.
+ 	Declaration []*ExtensionRangeOptions_Declaration `protobuf:"bytes,2,rep,name=declaration" json:"declaration,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,50,opt,name=features" json:"features,omitempty"`
+ 	// The verification state of the range.
+-	// TODO(b/278783756): flip the default to DECLARATION once all empty ranges
++	// TODO: flip the default to DECLARATION once all empty ranges
+ 	// are marked as UNVERIFIED.
+ 	Verification *ExtensionRangeOptions_VerificationState `protobuf:"varint,3,opt,name=verification,enum=google.protobuf.ExtensionRangeOptions_VerificationState,def=1" json:"verification,omitempty"`
+ }
+@@ -1141,6 +1600,13 @@ func (x *ExtensionRangeOptions) GetDeclaration() []*ExtensionRangeOptions_Declar
+ 	return nil
+ }
+ 
++func (x *ExtensionRangeOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *ExtensionRangeOptions) GetVerification() ExtensionRangeOptions_VerificationState {
+ 	if x != nil && x.Verification != nil {
+ 		return *x.Verification
+@@ -1186,12 +1652,12 @@ type FieldDescriptorProto struct {
+ 	// If true, this is a proto3 "optional". When a proto3 field is optional, it
+ 	// tracks presence regardless of field type.
+ 	//
+-	// When proto3_optional is true, this field must be belong to a oneof to
+-	// signal to old proto3 clients that presence is tracked for this field. This
+-	// oneof is known as a "synthetic" oneof, and this field must be its sole
+-	// member (each proto3 optional field gets its own synthetic oneof). Synthetic
+-	// oneofs exist in the descriptor only, and do not generate any API. Synthetic
+-	// oneofs must be ordered after all "real" oneofs.
++	// When proto3_optional is true, this field must belong to a oneof to signal
++	// to old proto3 clients that presence is tracked for this field. This oneof
++	// is known as a "synthetic" oneof, and this field must be its sole member
++	// (each proto3 optional field gets its own synthetic oneof). Synthetic oneofs
++	// exist in the descriptor only, and do not generate any API. Synthetic oneofs
++	// must be ordered after all "real" oneofs.
+ 	//
+ 	// For message fields, proto3_optional doesn't create any semantic change,
+ 	// since non-repeated message fields always track presence. However it still
+@@ -1738,7 +2204,6 @@ type FileOptions struct {
+ 	CcGenericServices   *bool `protobuf:"varint,16,opt,name=cc_generic_services,json=ccGenericServices,def=0" json:"cc_generic_services,omitempty"`
+ 	JavaGenericServices *bool `protobuf:"varint,17,opt,name=java_generic_services,json=javaGenericServices,def=0" json:"java_generic_services,omitempty"`
+ 	PyGenericServices   *bool `protobuf:"varint,18,opt,name=py_generic_services,json=pyGenericServices,def=0" json:"py_generic_services,omitempty"`
+-	PhpGenericServices  *bool `protobuf:"varint,42,opt,name=php_generic_services,json=phpGenericServices,def=0" json:"php_generic_services,omitempty"`
+ 	// Is this file deprecated?
+ 	// Depending on the target platform, this can emit Deprecated annotations
+ 	// for everything in the file, or it will be completely ignored; in the very
+@@ -1772,6 +2237,8 @@ type FileOptions struct {
+ 	// is empty. When this option is not set, the package name will be used for
+ 	// determining the ruby package.
+ 	RubyPackage *string `protobuf:"bytes,45,opt,name=ruby_package,json=rubyPackage" json:"ruby_package,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,50,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here.
+ 	// See the documentation for the "Options" section above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+@@ -1785,7 +2252,6 @@ const (
+ 	Default_FileOptions_CcGenericServices   = bool(false)
+ 	Default_FileOptions_JavaGenericServices = bool(false)
+ 	Default_FileOptions_PyGenericServices   = bool(false)
+-	Default_FileOptions_PhpGenericServices  = bool(false)
+ 	Default_FileOptions_Deprecated          = bool(false)
+ 	Default_FileOptions_CcEnableArenas      = bool(true)
+ )
+@@ -1893,13 +2359,6 @@ func (x *FileOptions) GetPyGenericServices() bool {
+ 	return Default_FileOptions_PyGenericServices
+ }
+ 
+-func (x *FileOptions) GetPhpGenericServices() bool {
+-	if x != nil && x.PhpGenericServices != nil {
+-		return *x.PhpGenericServices
+-	}
+-	return Default_FileOptions_PhpGenericServices
+-}
+-
+ func (x *FileOptions) GetDeprecated() bool {
+ 	if x != nil && x.Deprecated != nil {
+ 		return *x.Deprecated
+@@ -1963,6 +2422,13 @@ func (x *FileOptions) GetRubyPackage() string {
+ 	return ""
+ }
+ 
++func (x *FileOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *FileOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2006,10 +2472,6 @@ type MessageOptions struct {
+ 	// for the message, or it will be completely ignored; in the very least,
+ 	// this is a formalization for deprecating messages.
+ 	Deprecated *bool `protobuf:"varint,3,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
+-	// NOTE: Do not set the option in .proto files. Always use the maps syntax
+-	// instead. The option should only be implicitly set by the proto compiler
+-	// parser.
+-	//
+ 	// Whether the message is an automatically generated map entry type for the
+ 	// maps field.
+ 	//
+@@ -2030,6 +2492,10 @@ type MessageOptions struct {
+ 	// use a native map in the target language to hold the keys and values.
+ 	// The reflection APIs in such implementations still need to work as
+ 	// if the field is a repeated message field.
++	//
++	// NOTE: Do not set the option in .proto files. Always use the maps syntax
++	// instead. The option should only be implicitly set by the proto compiler
++	// parser.
+ 	MapEntry *bool `protobuf:"varint,7,opt,name=map_entry,json=mapEntry" json:"map_entry,omitempty"`
+ 	// Enable the legacy handling of JSON field name conflicts.  This lowercases
+ 	// and strips underscored from the fields before comparison in proto3 only.
+@@ -2039,11 +2505,13 @@ type MessageOptions struct {
+ 	// This should only be used as a temporary measure against broken builds due
+ 	// to the change in behavior for JSON field name conflicts.
+ 	//
+-	// TODO(b/261750190) This is legacy behavior we plan to remove once downstream
++	// TODO This is legacy behavior we plan to remove once downstream
+ 	// teams have had time to migrate.
+ 	//
+ 	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+ 	DeprecatedLegacyJsonFieldConflicts *bool `protobuf:"varint,11,opt,name=deprecated_legacy_json_field_conflicts,json=deprecatedLegacyJsonFieldConflicts" json:"deprecated_legacy_json_field_conflicts,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,12,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2123,6 +2591,13 @@ func (x *MessageOptions) GetDeprecatedLegacyJsonFieldConflicts() bool {
+ 	return false
+ }
+ 
++func (x *MessageOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *MessageOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2147,7 +2622,9 @@ type FieldOptions struct {
+ 	// a more efficient representation on the wire. Rather than repeatedly
+ 	// writing the tag and type for each element, the entire array is encoded as
+ 	// a single length-delimited blob. In proto3, only explicit setting it to
+-	// false will avoid using packed encoding.
++	// false will avoid using packed encoding.  This option is prohibited in
++	// Editions, but the `repeated_field_encoding` feature can be used to control
++	// the behavior.
+ 	Packed *bool `protobuf:"varint,2,opt,name=packed" json:"packed,omitempty"`
+ 	// The jstype option determines the JavaScript type used for values of the
+ 	// field.  The option is permitted only for 64 bit integral and fixed types
+@@ -2178,19 +2655,11 @@ type FieldOptions struct {
+ 	// call from multiple threads concurrently, while non-const methods continue
+ 	// to require exclusive access.
+ 	//
+-	// Note that implementations may choose not to check required fields within
+-	// a lazy sub-message.  That is, calling IsInitialized() on the outer message
+-	// may return true even if the inner message has missing required fields.
+-	// This is necessary because otherwise the inner message would have to be
+-	// parsed in order to perform the check, defeating the purpose of lazy
+-	// parsing.  An implementation which chooses not to check required fields
+-	// must be consistent about it.  That is, for any particular sub-message, the
+-	// implementation must either *always* check its required fields, or *never*
+-	// check its required fields, regardless of whether or not the message has
+-	// been parsed.
+-	//
+-	// As of May 2022, lazy verifies the contents of the byte stream during
+-	// parsing.  An invalid byte stream will cause the overall parsing to fail.
++	// Note that lazy message fields are still eagerly verified to check
++	// ill-formed wireformat or missing required fields. Calling IsInitialized()
++	// on the outer message would fail if the inner message has missing required
++	// fields. Failed verification would result in parsing failure (except when
++	// uninitialized messages are acceptable).
+ 	Lazy *bool `protobuf:"varint,5,opt,name=lazy,def=0" json:"lazy,omitempty"`
+ 	// unverified_lazy does no correctness checks on the byte stream. This should
+ 	// only be used where lazy with verification is prohibitive for performance
+@@ -2205,11 +2674,12 @@ type FieldOptions struct {
+ 	Weak *bool `protobuf:"varint,10,opt,name=weak,def=0" json:"weak,omitempty"`
+ 	// Indicate that the field value should not be printed out when using debug
+ 	// formats, e.g. when the field contains sensitive credentials.
+-	DebugRedact *bool                         `protobuf:"varint,16,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
+-	Retention   *FieldOptions_OptionRetention `protobuf:"varint,17,opt,name=retention,enum=google.protobuf.FieldOptions_OptionRetention" json:"retention,omitempty"`
+-	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-	Target  *FieldOptions_OptionTargetType  `protobuf:"varint,18,opt,name=target,enum=google.protobuf.FieldOptions_OptionTargetType" json:"target,omitempty"`
+-	Targets []FieldOptions_OptionTargetType `protobuf:"varint,19,rep,name=targets,enum=google.protobuf.FieldOptions_OptionTargetType" json:"targets,omitempty"`
++	DebugRedact     *bool                           `protobuf:"varint,16,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
++	Retention       *FieldOptions_OptionRetention   `protobuf:"varint,17,opt,name=retention,enum=google.protobuf.FieldOptions_OptionRetention" json:"retention,omitempty"`
++	Targets         []FieldOptions_OptionTargetType `protobuf:"varint,19,rep,name=targets,enum=google.protobuf.FieldOptions_OptionTargetType" json:"targets,omitempty"`
++	EditionDefaults []*FieldOptions_EditionDefault  `protobuf:"bytes,20,rep,name=edition_defaults,json=editionDefaults" json:"edition_defaults,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,21,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2320,17 +2790,23 @@ func (x *FieldOptions) GetRetention() FieldOptions_OptionRetention {
+ 	return FieldOptions_RETENTION_UNKNOWN
+ }
+ 
+-// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-func (x *FieldOptions) GetTarget() FieldOptions_OptionTargetType {
+-	if x != nil && x.Target != nil {
+-		return *x.Target
++func (x *FieldOptions) GetTargets() []FieldOptions_OptionTargetType {
++	if x != nil {
++		return x.Targets
+ 	}
+-	return FieldOptions_TARGET_TYPE_UNKNOWN
++	return nil
+ }
+ 
+-func (x *FieldOptions) GetTargets() []FieldOptions_OptionTargetType {
++func (x *FieldOptions) GetEditionDefaults() []*FieldOptions_EditionDefault {
+ 	if x != nil {
+-		return x.Targets
++		return x.EditionDefaults
++	}
++	return nil
++}
++
++func (x *FieldOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
+ 	}
+ 	return nil
+ }
+@@ -2348,6 +2824,8 @@ type OneofOptions struct {
+ 	unknownFields   protoimpl.UnknownFields
+ 	extensionFields protoimpl.ExtensionFields
+ 
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,1,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2384,6 +2862,13 @@ func (*OneofOptions) Descriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{13}
+ }
+ 
++func (x *OneofOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *OneofOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2409,11 +2894,13 @@ type EnumOptions struct {
+ 	// and strips underscored from the fields before comparison in proto3 only.
+ 	// The new behavior takes `json_name` into account and applies to proto2 as
+ 	// well.
+-	// TODO(b/261750190) Remove this legacy behavior once downstream teams have
++	// TODO Remove this legacy behavior once downstream teams have
+ 	// had time to migrate.
+ 	//
+ 	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+ 	DeprecatedLegacyJsonFieldConflicts *bool `protobuf:"varint,6,opt,name=deprecated_legacy_json_field_conflicts,json=deprecatedLegacyJsonFieldConflicts" json:"deprecated_legacy_json_field_conflicts,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,7,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2477,6 +2964,13 @@ func (x *EnumOptions) GetDeprecatedLegacyJsonFieldConflicts() bool {
+ 	return false
+ }
+ 
++func (x *EnumOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *EnumOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2495,13 +2989,20 @@ type EnumValueOptions struct {
+ 	// for the enum value, or it will be completely ignored; in the very least,
+ 	// this is a formalization for deprecating enum values.
+ 	Deprecated *bool `protobuf:"varint,1,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,2,opt,name=features" json:"features,omitempty"`
++	// Indicate that fields annotated with this enum value should not be printed
++	// out when using debug formats, e.g. when the field contains sensitive
++	// credentials.
++	DebugRedact *bool `protobuf:"varint,3,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+ 
+ // Default values for EnumValueOptions fields.
+ const (
+-	Default_EnumValueOptions_Deprecated = bool(false)
++	Default_EnumValueOptions_Deprecated  = bool(false)
++	Default_EnumValueOptions_DebugRedact = bool(false)
+ )
+ 
+ func (x *EnumValueOptions) Reset() {
+@@ -2543,6 +3044,20 @@ func (x *EnumValueOptions) GetDeprecated() bool {
+ 	return Default_EnumValueOptions_Deprecated
+ }
+ 
++func (x *EnumValueOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
++func (x *EnumValueOptions) GetDebugRedact() bool {
++	if x != nil && x.DebugRedact != nil {
++		return *x.DebugRedact
++	}
++	return Default_EnumValueOptions_DebugRedact
++}
++
+ func (x *EnumValueOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2556,6 +3071,8 @@ type ServiceOptions struct {
+ 	unknownFields   protoimpl.UnknownFields
+ 	extensionFields protoimpl.ExtensionFields
+ 
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,34,opt,name=features" json:"features,omitempty"`
+ 	// Is this service deprecated?
+ 	// Depending on the target platform, this can emit Deprecated annotations
+ 	// for the service, or it will be completely ignored; in the very least,
+@@ -2602,6 +3119,13 @@ func (*ServiceOptions) Descriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{16}
+ }
+ 
++func (x *ServiceOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *ServiceOptions) GetDeprecated() bool {
+ 	if x != nil && x.Deprecated != nil {
+ 		return *x.Deprecated
+@@ -2628,6 +3152,8 @@ type MethodOptions struct {
+ 	// this is a formalization for deprecating methods.
+ 	Deprecated       *bool                           `protobuf:"varint,33,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
+ 	IdempotencyLevel *MethodOptions_IdempotencyLevel `protobuf:"varint,34,opt,name=idempotency_level,json=idempotencyLevel,enum=google.protobuf.MethodOptions_IdempotencyLevel,def=0" json:"idempotency_level,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,35,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2684,6 +3210,13 @@ func (x *MethodOptions) GetIdempotencyLevel() MethodOptions_IdempotencyLevel {
+ 	return Default_MethodOptions_IdempotencyLevel
+ }
+ 
++func (x *MethodOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *MethodOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2770,28 +3303,193 @@ func (x *UninterpretedOption) GetNegativeIntValue() int64 {
+ 	if x != nil && x.NegativeIntValue != nil {
+ 		return *x.NegativeIntValue
+ 	}
+-	return 0
++	return 0
++}
++
++func (x *UninterpretedOption) GetDoubleValue() float64 {
++	if x != nil && x.DoubleValue != nil {
++		return *x.DoubleValue
++	}
++	return 0
++}
++
++func (x *UninterpretedOption) GetStringValue() []byte {
++	if x != nil {
++		return x.StringValue
++	}
++	return nil
++}
++
++func (x *UninterpretedOption) GetAggregateValue() string {
++	if x != nil && x.AggregateValue != nil {
++		return *x.AggregateValue
++	}
++	return ""
++}
++
++// TODO Enums in C++ gencode (and potentially other languages) are
++// not well scoped.  This means that each of the feature enums below can clash
++// with each other.  The short names we've chosen maximize call-site
++// readability, but leave us very open to this scenario.  A future feature will
++// be designed and implemented to handle this, hopefully before we ever hit a
++// conflict here.
++type FeatureSet struct {
++	state           protoimpl.MessageState
++	sizeCache       protoimpl.SizeCache
++	unknownFields   protoimpl.UnknownFields
++	extensionFields protoimpl.ExtensionFields
++
++	FieldPresence         *FeatureSet_FieldPresence         `protobuf:"varint,1,opt,name=field_presence,json=fieldPresence,enum=google.protobuf.FeatureSet_FieldPresence" json:"field_presence,omitempty"`
++	EnumType              *FeatureSet_EnumType              `protobuf:"varint,2,opt,name=enum_type,json=enumType,enum=google.protobuf.FeatureSet_EnumType" json:"enum_type,omitempty"`
++	RepeatedFieldEncoding *FeatureSet_RepeatedFieldEncoding `protobuf:"varint,3,opt,name=repeated_field_encoding,json=repeatedFieldEncoding,enum=google.protobuf.FeatureSet_RepeatedFieldEncoding" json:"repeated_field_encoding,omitempty"`
++	Utf8Validation        *FeatureSet_Utf8Validation        `protobuf:"varint,4,opt,name=utf8_validation,json=utf8Validation,enum=google.protobuf.FeatureSet_Utf8Validation" json:"utf8_validation,omitempty"`
++	MessageEncoding       *FeatureSet_MessageEncoding       `protobuf:"varint,5,opt,name=message_encoding,json=messageEncoding,enum=google.protobuf.FeatureSet_MessageEncoding" json:"message_encoding,omitempty"`
++	JsonFormat            *FeatureSet_JsonFormat            `protobuf:"varint,6,opt,name=json_format,json=jsonFormat,enum=google.protobuf.FeatureSet_JsonFormat" json:"json_format,omitempty"`
++}
++
++func (x *FeatureSet) Reset() {
++	*x = FeatureSet{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSet) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSet) ProtoMessage() {}
++
++func (x *FeatureSet) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FeatureSet.ProtoReflect.Descriptor instead.
++func (*FeatureSet) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19}
++}
++
++func (x *FeatureSet) GetFieldPresence() FeatureSet_FieldPresence {
++	if x != nil && x.FieldPresence != nil {
++		return *x.FieldPresence
++	}
++	return FeatureSet_FIELD_PRESENCE_UNKNOWN
++}
++
++func (x *FeatureSet) GetEnumType() FeatureSet_EnumType {
++	if x != nil && x.EnumType != nil {
++		return *x.EnumType
++	}
++	return FeatureSet_ENUM_TYPE_UNKNOWN
++}
++
++func (x *FeatureSet) GetRepeatedFieldEncoding() FeatureSet_RepeatedFieldEncoding {
++	if x != nil && x.RepeatedFieldEncoding != nil {
++		return *x.RepeatedFieldEncoding
++	}
++	return FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN
++}
++
++func (x *FeatureSet) GetUtf8Validation() FeatureSet_Utf8Validation {
++	if x != nil && x.Utf8Validation != nil {
++		return *x.Utf8Validation
++	}
++	return FeatureSet_UTF8_VALIDATION_UNKNOWN
++}
++
++func (x *FeatureSet) GetMessageEncoding() FeatureSet_MessageEncoding {
++	if x != nil && x.MessageEncoding != nil {
++		return *x.MessageEncoding
++	}
++	return FeatureSet_MESSAGE_ENCODING_UNKNOWN
++}
++
++func (x *FeatureSet) GetJsonFormat() FeatureSet_JsonFormat {
++	if x != nil && x.JsonFormat != nil {
++		return *x.JsonFormat
++	}
++	return FeatureSet_JSON_FORMAT_UNKNOWN
++}
++
++// A compiled specification for the defaults of a set of features.  These
++// messages are generated from FeatureSet extensions and can be used to seed
++// feature resolution. The resolution with this object becomes a simple search
++// for the closest matching edition, followed by proto merges.
++type FeatureSetDefaults struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Defaults []*FeatureSetDefaults_FeatureSetEditionDefault `protobuf:"bytes,1,rep,name=defaults" json:"defaults,omitempty"`
++	// The minimum supported edition (inclusive) when this was constructed.
++	// Editions before this will not have defaults.
++	MinimumEdition *Edition `protobuf:"varint,4,opt,name=minimum_edition,json=minimumEdition,enum=google.protobuf.Edition" json:"minimum_edition,omitempty"`
++	// The maximum known edition (inclusive) when this was constructed. Editions
++	// after this will not have reliable defaults.
++	MaximumEdition *Edition `protobuf:"varint,5,opt,name=maximum_edition,json=maximumEdition,enum=google.protobuf.Edition" json:"maximum_edition,omitempty"`
++}
++
++func (x *FeatureSetDefaults) Reset() {
++	*x = FeatureSetDefaults{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSetDefaults) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSetDefaults) ProtoMessage() {}
++
++func (x *FeatureSetDefaults) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
+ }
+ 
+-func (x *UninterpretedOption) GetDoubleValue() float64 {
+-	if x != nil && x.DoubleValue != nil {
+-		return *x.DoubleValue
+-	}
+-	return 0
++// Deprecated: Use FeatureSetDefaults.ProtoReflect.Descriptor instead.
++func (*FeatureSetDefaults) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20}
+ }
+ 
+-func (x *UninterpretedOption) GetStringValue() []byte {
++func (x *FeatureSetDefaults) GetDefaults() []*FeatureSetDefaults_FeatureSetEditionDefault {
+ 	if x != nil {
+-		return x.StringValue
++		return x.Defaults
+ 	}
+ 	return nil
+ }
+ 
+-func (x *UninterpretedOption) GetAggregateValue() string {
+-	if x != nil && x.AggregateValue != nil {
+-		return *x.AggregateValue
++func (x *FeatureSetDefaults) GetMinimumEdition() Edition {
++	if x != nil && x.MinimumEdition != nil {
++		return *x.MinimumEdition
+ 	}
+-	return ""
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FeatureSetDefaults) GetMaximumEdition() Edition {
++	if x != nil && x.MaximumEdition != nil {
++		return *x.MaximumEdition
++	}
++	return Edition_EDITION_UNKNOWN
+ }
+ 
+ // Encapsulates information about the original source file from which a
+@@ -2855,7 +3553,7 @@ type SourceCodeInfo struct {
+ func (x *SourceCodeInfo) Reset() {
+ 	*x = SourceCodeInfo{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2868,7 +3566,7 @@ func (x *SourceCodeInfo) String() string {
+ func (*SourceCodeInfo) ProtoMessage() {}
+ 
+ func (x *SourceCodeInfo) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -2881,7 +3579,7 @@ func (x *SourceCodeInfo) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use SourceCodeInfo.ProtoReflect.Descriptor instead.
+ func (*SourceCodeInfo) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{21}
+ }
+ 
+ func (x *SourceCodeInfo) GetLocation() []*SourceCodeInfo_Location {
+@@ -2907,7 +3605,7 @@ type GeneratedCodeInfo struct {
+ func (x *GeneratedCodeInfo) Reset() {
+ 	*x = GeneratedCodeInfo{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2920,7 +3618,7 @@ func (x *GeneratedCodeInfo) String() string {
+ func (*GeneratedCodeInfo) ProtoMessage() {}
+ 
+ func (x *GeneratedCodeInfo) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -2933,7 +3631,7 @@ func (x *GeneratedCodeInfo) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use GeneratedCodeInfo.ProtoReflect.Descriptor instead.
+ func (*GeneratedCodeInfo) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22}
+ }
+ 
+ func (x *GeneratedCodeInfo) GetAnnotation() []*GeneratedCodeInfo_Annotation {
+@@ -2956,7 +3654,7 @@ type DescriptorProto_ExtensionRange struct {
+ func (x *DescriptorProto_ExtensionRange) Reset() {
+ 	*x = DescriptorProto_ExtensionRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2969,7 +3667,7 @@ func (x *DescriptorProto_ExtensionRange) String() string {
+ func (*DescriptorProto_ExtensionRange) ProtoMessage() {}
+ 
+ func (x *DescriptorProto_ExtensionRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3021,7 +3719,7 @@ type DescriptorProto_ReservedRange struct {
+ func (x *DescriptorProto_ReservedRange) Reset() {
+ 	*x = DescriptorProto_ReservedRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3034,7 +3732,7 @@ func (x *DescriptorProto_ReservedRange) String() string {
+ func (*DescriptorProto_ReservedRange) ProtoMessage() {}
+ 
+ func (x *DescriptorProto_ReservedRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3078,10 +3776,6 @@ type ExtensionRangeOptions_Declaration struct {
+ 	// Metadata.type, Declaration.type must have a leading dot for messages
+ 	// and enums.
+ 	Type *string `protobuf:"bytes,3,opt,name=type" json:"type,omitempty"`
+-	// Deprecated. Please use "repeated".
+-	//
+-	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-	IsRepeated *bool `protobuf:"varint,4,opt,name=is_repeated,json=isRepeated" json:"is_repeated,omitempty"`
+ 	// If true, indicates that the number is reserved in the extension range,
+ 	// and any extension field with the number will fail to compile. Set this
+ 	// when a declared extension field is deleted.
+@@ -3094,7 +3788,7 @@ type ExtensionRangeOptions_Declaration struct {
+ func (x *ExtensionRangeOptions_Declaration) Reset() {
+ 	*x = ExtensionRangeOptions_Declaration{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3107,7 +3801,7 @@ func (x *ExtensionRangeOptions_Declaration) String() string {
+ func (*ExtensionRangeOptions_Declaration) ProtoMessage() {}
+ 
+ func (x *ExtensionRangeOptions_Declaration) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3144,14 +3838,6 @@ func (x *ExtensionRangeOptions_Declaration) GetType() string {
+ 	return ""
+ }
+ 
+-// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-func (x *ExtensionRangeOptions_Declaration) GetIsRepeated() bool {
+-	if x != nil && x.IsRepeated != nil {
+-		return *x.IsRepeated
+-	}
+-	return false
+-}
+-
+ func (x *ExtensionRangeOptions_Declaration) GetReserved() bool {
+ 	if x != nil && x.Reserved != nil {
+ 		return *x.Reserved
+@@ -3184,7 +3870,7 @@ type EnumDescriptorProto_EnumReservedRange struct {
+ func (x *EnumDescriptorProto_EnumReservedRange) Reset() {
+ 	*x = EnumDescriptorProto_EnumReservedRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3197,7 +3883,7 @@ func (x *EnumDescriptorProto_EnumReservedRange) String() string {
+ func (*EnumDescriptorProto_EnumReservedRange) ProtoMessage() {}
+ 
+ func (x *EnumDescriptorProto_EnumReservedRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3227,6 +3913,61 @@ func (x *EnumDescriptorProto_EnumReservedRange) GetEnd() int32 {
+ 	return 0
+ }
+ 
++type FieldOptions_EditionDefault struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Edition *Edition `protobuf:"varint,3,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
++	Value   *string  `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"` // Textproto value.
++}
++
++func (x *FieldOptions_EditionDefault) Reset() {
++	*x = FieldOptions_EditionDefault{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FieldOptions_EditionDefault) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FieldOptions_EditionDefault) ProtoMessage() {}
++
++func (x *FieldOptions_EditionDefault) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FieldOptions_EditionDefault.ProtoReflect.Descriptor instead.
++func (*FieldOptions_EditionDefault) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{12, 0}
++}
++
++func (x *FieldOptions_EditionDefault) GetEdition() Edition {
++	if x != nil && x.Edition != nil {
++		return *x.Edition
++	}
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FieldOptions_EditionDefault) GetValue() string {
++	if x != nil && x.Value != nil {
++		return *x.Value
++	}
++	return ""
++}
++
+ // The name of the uninterpreted option.  Each string represents a segment in
+ // a dot-separated name.  is_extension is true iff a segment represents an
+ // extension (denoted with parentheses in options specs in .proto files).
+@@ -3244,7 +3985,7 @@ type UninterpretedOption_NamePart struct {
+ func (x *UninterpretedOption_NamePart) Reset() {
+ 	*x = UninterpretedOption_NamePart{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[28]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3257,7 +3998,7 @@ func (x *UninterpretedOption_NamePart) String() string {
+ func (*UninterpretedOption_NamePart) ProtoMessage() {}
+ 
+ func (x *UninterpretedOption_NamePart) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[28]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3287,6 +4028,65 @@ func (x *UninterpretedOption_NamePart) GetIsExtension() bool {
+ 	return false
+ }
+ 
++// A map from every known edition with a unique set of defaults to its
++// defaults. Not all editions may be contained here.  For a given edition,
++// the defaults at the closest matching edition ordered at or before it should
++// be used.  This field must be in strict ascending order by edition.
++type FeatureSetDefaults_FeatureSetEditionDefault struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Edition  *Edition    `protobuf:"varint,3,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
++	Features *FeatureSet `protobuf:"bytes,2,opt,name=features" json:"features,omitempty"`
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) Reset() {
++	*x = FeatureSetDefaults_FeatureSetEditionDefault{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[29]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSetDefaults_FeatureSetEditionDefault) ProtoMessage() {}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[29]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FeatureSetDefaults_FeatureSetEditionDefault.ProtoReflect.Descriptor instead.
++func (*FeatureSetDefaults_FeatureSetEditionDefault) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0}
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) GetEdition() Edition {
++	if x != nil && x.Edition != nil {
++		return *x.Edition
++	}
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ type SourceCodeInfo_Location struct {
+ 	state         protoimpl.MessageState
+ 	sizeCache     protoimpl.SizeCache
+@@ -3296,7 +4096,7 @@ type SourceCodeInfo_Location struct {
+ 	// location.
+ 	//
+ 	// Each element is a field number or an index.  They form a path from
+-	// the root FileDescriptorProto to the place where the definition occurs.
++	// the root FileDescriptorProto to the place where the definition appears.
+ 	// For example, this path:
+ 	//
+ 	//	[ 4, 3, 2, 7, 1 ]
+@@ -3388,7 +4188,7 @@ type SourceCodeInfo_Location struct {
+ func (x *SourceCodeInfo_Location) Reset() {
+ 	*x = SourceCodeInfo_Location{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[30]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3401,7 +4201,7 @@ func (x *SourceCodeInfo_Location) String() string {
+ func (*SourceCodeInfo_Location) ProtoMessage() {}
+ 
+ func (x *SourceCodeInfo_Location) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[30]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3414,7 +4214,7 @@ func (x *SourceCodeInfo_Location) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use SourceCodeInfo_Location.ProtoReflect.Descriptor instead.
+ func (*SourceCodeInfo_Location) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{21, 0}
+ }
+ 
+ func (x *SourceCodeInfo_Location) GetPath() []int32 {
+@@ -3475,7 +4275,7 @@ type GeneratedCodeInfo_Annotation struct {
+ func (x *GeneratedCodeInfo_Annotation) Reset() {
+ 	*x = GeneratedCodeInfo_Annotation{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[31]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3488,7 +4288,7 @@ func (x *GeneratedCodeInfo_Annotation) String() string {
+ func (*GeneratedCodeInfo_Annotation) ProtoMessage() {}
+ 
+ func (x *GeneratedCodeInfo_Annotation) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[31]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3501,7 +4301,7 @@ func (x *GeneratedCodeInfo_Annotation) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use GeneratedCodeInfo_Annotation.ProtoReflect.Descriptor instead.
+ func (*GeneratedCodeInfo_Annotation) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22, 0}
+ }
+ 
+ func (x *GeneratedCodeInfo_Annotation) GetPath() []int32 {
+@@ -3550,7 +4350,7 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+ 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73,
+ 	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x04, 0x66, 0x69,
+-	0x6c, 0x65, 0x22, 0xfe, 0x04, 0x0a, 0x13, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72,
++	0x6c, 0x65, 0x22, 0x98, 0x05, 0x0a, 0x13, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72,
+ 	0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61,
+ 	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x18,
+ 	0x0a, 0x07, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+@@ -3588,250 +4388,250 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
+ 	0x6f, 0x52, 0x0e, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
+ 	0x6f, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x18, 0x0c, 0x20, 0x01, 0x28,
+-	0x09, 0x52, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x12, 0x18, 0x0a, 0x07, 0x65, 0x64, 0x69,
+-	0x74, 0x69, 0x6f, 0x6e, 0x18, 0x0d, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74,
+-	0x69, 0x6f, 0x6e, 0x22, 0xb9, 0x06, 0x0a, 0x0f, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
+-	0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
+-	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3b, 0x0a, 0x05, 0x66,
+-	0x69, 0x65, 0x6c, 0x64, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f,
+-	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65,
+-	0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
+-	0x6f, 0x52, 0x05, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x12, 0x43, 0x0a, 0x09, 0x65, 0x78, 0x74, 0x65,
+-	0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69,
+-	0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
+-	0x74, 0x6f, 0x52, 0x09, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a,
+-	0x0b, 0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x03,
+-	0x28, 0x0b, 0x32, 0x20, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+-	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
+-	0x72, 0x6f, 0x74, 0x6f, 0x52, 0x0a, 0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x54, 0x79, 0x70, 0x65,
+-	0x12, 0x41, 0x0a, 0x09, 0x65, 0x6e, 0x75, 0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x04, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
+-	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54,
+-	0x79, 0x70, 0x65, 0x12, 0x58, 0x0a, 0x0f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e,
+-	0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x67,
++	0x09, 0x52, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x12, 0x32, 0x0a, 0x07, 0x65, 0x64, 0x69,
++	0x74, 0x69, 0x6f, 0x6e, 0x18, 0x0e, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69,
++	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0xb9, 0x06,
++	0x0a, 0x0f, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3b, 0x0a, 0x05, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x18, 0x02,
++	0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63,
++	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05, 0x66, 0x69, 0x65,
++	0x6c, 0x64, 0x12, 0x43, 0x0a, 0x09, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18,
++	0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73,
++	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x09, 0x65, 0x78,
++	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a, 0x0b, 0x6e, 0x65, 0x73, 0x74, 0x65,
++	0x64, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x20, 0x2e, 0x67,
+ 	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45,
+-	0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0e, 0x65,
+-	0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x44, 0x0a,
+-	0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x64, 0x65, 0x63, 0x6c, 0x18, 0x08, 0x20, 0x03, 0x28,
+-	0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+-	0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x09, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x44,
+-	0x65, 0x63, 0x6c, 0x12, 0x39, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x07,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x55,
+-	0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65,
+-	0x18, 0x09, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x0a,
++	0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x54, 0x79, 0x70, 0x65, 0x12, 0x41, 0x0a, 0x09, 0x65, 0x6e,
++	0x75, 0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72,
++	0x6f, 0x74, 0x6f, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54, 0x79, 0x70, 0x65, 0x12, 0x58, 0x0a,
++	0x0f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65,
++	0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+ 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
++	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69,
++	0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0e, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69,
++	0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x44, 0x0a, 0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66,
++	0x5f, 0x64, 0x65, 0x63, 0x6c, 0x18, 0x08, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e,
++	0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
++	0x74, 0x6f, 0x52, 0x09, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x63, 0x6c, 0x12, 0x39, 0x0a,
++	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52,
++	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x55, 0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65,
++	0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x09, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
++	0x74, 0x6f, 0x2e, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65,
++	0x52, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12,
++	0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65,
++	0x18, 0x0a, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64,
++	0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x7a, 0x0a, 0x0e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
++	0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18,
++	0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03,
++	0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x12, 0x40,
++	0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
++	0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x1a, 0x37, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67,
++	0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05,
++	0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02,
++	0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0xcc, 0x04, 0x0a, 0x15, 0x45, 0x78,
++	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
++	0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03,
++	0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x59, 0x0a,
++	0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x03,
++	0x28, 0x0b, 0x32, 0x32, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61,
++	0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x44, 0x65, 0x63, 0x6c, 0x61,
++	0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x03, 0x88, 0x01, 0x02, 0x52, 0x0b, 0x64, 0x65, 0x63,
++	0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x73, 0x18, 0x32, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x12, 0x6d, 0x0a, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f,
++	0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x38, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73,
++	0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
++	0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74,
++	0x65, 0x3a, 0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x42, 0x03, 0x88,
++	0x01, 0x02, 0x52, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x1a, 0x94, 0x01, 0x0a, 0x0b, 0x44, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05,
++	0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x1b, 0x0a, 0x09, 0x66, 0x75, 0x6c, 0x6c,
++	0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x66, 0x75, 0x6c,
++	0x6c, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20,
++	0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73,
++	0x65, 0x72, 0x76, 0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x73,
++	0x65, 0x72, 0x76, 0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65,
++	0x64, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65,
++	0x64, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x22, 0x34, 0x0a, 0x11, 0x56, 0x65, 0x72, 0x69, 0x66,
++	0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x0f, 0x0a, 0x0b,
++	0x44, 0x45, 0x43, 0x4c, 0x41, 0x52, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x10, 0x00, 0x12, 0x0e, 0x0a,
++	0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x01, 0x2a, 0x09, 0x08,
++	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0xc1, 0x06, 0x0a, 0x14, 0x46, 0x69, 0x65,
++	0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18,
++	0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x41, 0x0a,
++	0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
++	0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72,
++	0x6f, 0x74, 0x6f, 0x2e, 0x4c, 0x61, 0x62, 0x65, 0x6c, 0x52, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c,
++	0x12, 0x3e, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2a,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72,
++	0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x54, 0x79, 0x70, 0x65, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65,
++	0x12, 0x1b, 0x0a, 0x09, 0x74, 0x79, 0x70, 0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x06, 0x20,
++	0x01, 0x28, 0x09, 0x52, 0x08, 0x74, 0x79, 0x70, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1a, 0x0a,
++	0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x64, 0x65, 0x66,
++	0x61, 0x75, 0x6c, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09,
++	0x52, 0x0c, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x1f,
++	0x0a, 0x0b, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x69, 0x6e, 0x64, 0x65, 0x78, 0x18, 0x09, 0x20,
++	0x01, 0x28, 0x05, 0x52, 0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12,
++	0x1b, 0x0a, 0x09, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x08, 0x6a, 0x73, 0x6f, 0x6e, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x27, 0x0a, 0x0f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x18, 0x11, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x22, 0xb6,
++	0x02, 0x0a, 0x04, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x44, 0x4f, 0x55, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x46, 0x4c, 0x4f, 0x41, 0x54, 0x10, 0x02, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x03, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x55, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x04, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x05, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34, 0x10, 0x06, 0x12, 0x10, 0x0a, 0x0c, 0x54,
++	0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32, 0x10, 0x07, 0x12, 0x0d, 0x0a,
++	0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x4f, 0x4f, 0x4c, 0x10, 0x08, 0x12, 0x0f, 0x0a, 0x0b,
++	0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x09, 0x12, 0x0e, 0x0a,
++	0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x47, 0x52, 0x4f, 0x55, 0x50, 0x10, 0x0a, 0x12, 0x10, 0x0a,
++	0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x10, 0x0b, 0x12,
++	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x59, 0x54, 0x45, 0x53, 0x10, 0x0c, 0x12,
++	0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x0d,
++	0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x10, 0x0e, 0x12,
++	0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32,
++	0x10, 0x0f, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45,
++	0x44, 0x36, 0x34, 0x10, 0x10, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49,
++	0x4e, 0x54, 0x33, 0x32, 0x10, 0x11, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53,
++	0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x12, 0x22, 0x43, 0x0a, 0x05, 0x4c, 0x61, 0x62, 0x65, 0x6c,
++	0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x4f, 0x50, 0x54, 0x49, 0x4f, 0x4e,
++	0x41, 0x4c, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45,
++	0x50, 0x45, 0x41, 0x54, 0x45, 0x44, 0x10, 0x03, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45,
++	0x4c, 0x5f, 0x52, 0x45, 0x51, 0x55, 0x49, 0x52, 0x45, 0x44, 0x10, 0x02, 0x22, 0x63, 0x0a, 0x14,
++	0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
++	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f,
++	0x66, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x73, 0x22, 0xe3, 0x02, 0x0a, 0x13, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
++	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d,
++	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3f, 0x0a,
++	0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x29, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45,
++	0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
++	0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x36,
++	0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
++	0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x5d, 0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
++	0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x36,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+ 	0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64,
+ 	0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65,
+-	0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x7a, 0x0a, 0x0e, 0x45, 0x78,
+-	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05,
+-	0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61,
+-	0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52,
+-	0x03, 0x65, 0x6e, 0x64, 0x12, 0x40, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18,
+-	0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
+-	0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x1a, 0x37, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a,
+-	0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22,
+-	0xad, 0x04, 0x0a, 0x15, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e,
+-	0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+-	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x12, 0x59, 0x0a, 0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69,
+-	0x6f, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x32, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e,
+-	0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+-	0x2e, 0x44, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x03, 0x88, 0x01,
+-	0x02, 0x52, 0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x68,
+-	0x0a, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x0e, 0x32, 0x38, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e,
+-	0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x56, 0x65, 0x72,
+-	0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x3a, 0x0a,
+-	0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x52, 0x0c, 0x76, 0x65, 0x72, 0x69,
+-	0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xb3, 0x01, 0x0a, 0x0b, 0x44, 0x65, 0x63,
+-	0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62,
+-	0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72,
+-	0x12, 0x1b, 0x0a, 0x09, 0x66, 0x75, 0x6c, 0x6c, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20,
+-	0x01, 0x28, 0x09, 0x52, 0x08, 0x66, 0x75, 0x6c, 0x6c, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x12, 0x0a,
+-	0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70,
+-	0x65, 0x12, 0x23, 0x0a, 0x0b, 0x69, 0x73, 0x5f, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64,
+-	0x18, 0x04, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x0a, 0x69, 0x73, 0x52, 0x65,
+-	0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x18, 0x06,
+-	0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x22, 0x34,
+-	0x0a, 0x11, 0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74,
+-	0x61, 0x74, 0x65, 0x12, 0x0f, 0x0a, 0x0b, 0x44, 0x45, 0x43, 0x4c, 0x41, 0x52, 0x41, 0x54, 0x49,
+-	0x4f, 0x4e, 0x10, 0x00, 0x12, 0x0e, 0x0a, 0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49,
+-	0x45, 0x44, 0x10, 0x01, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22,
+-	0xc1, 0x06, 0x0a, 0x14, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06,
+-	0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75,
+-	0x6d, 0x62, 0x65, 0x72, 0x12, 0x41, 0x0a, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x18, 0x04, 0x20,
+-	0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72,
+-	0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x4c, 0x61, 0x62, 0x65, 0x6c,
+-	0x52, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x12, 0x3e, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18,
+-	0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73,
+-	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x54, 0x79, 0x70,
+-	0x65, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1b, 0x0a, 0x09, 0x74, 0x79, 0x70, 0x65, 0x5f,
+-	0x6e, 0x61, 0x6d, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x74, 0x79, 0x70, 0x65,
+-	0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65,
+-	0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65,
+-	0x12, 0x23, 0x0a, 0x0d, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75,
+-	0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0c, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74,
+-	0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x69,
+-	0x6e, 0x64, 0x65, 0x78, 0x18, 0x09, 0x20, 0x01, 0x28, 0x05, 0x52, 0x0a, 0x6f, 0x6e, 0x65, 0x6f,
+-	0x66, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12, 0x1b, 0x0a, 0x09, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x6a, 0x73, 0x6f, 0x6e, 0x4e,
+-	0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x08,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69,
+-	0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x27, 0x0a, 0x0f,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x18,
+-	0x11, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x22, 0xb6, 0x02, 0x0a, 0x04, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0f,
+-	0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x44, 0x4f, 0x55, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12,
+-	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x4c, 0x4f, 0x41, 0x54, 0x10, 0x02, 0x12,
+-	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x03, 0x12,
+-	0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x04,
+-	0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x05,
+-	0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34,
+-	0x10, 0x06, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44,
+-	0x33, 0x32, 0x10, 0x07, 0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x4f, 0x4f,
+-	0x4c, 0x10, 0x08, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x54, 0x52, 0x49,
+-	0x4e, 0x47, 0x10, 0x09, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x47, 0x52, 0x4f,
+-	0x55, 0x50, 0x10, 0x0a, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53,
+-	0x53, 0x41, 0x47, 0x45, 0x10, 0x0b, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42,
+-	0x59, 0x54, 0x45, 0x53, 0x10, 0x0c, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55,
+-	0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x0d, 0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f,
+-	0x45, 0x4e, 0x55, 0x4d, 0x10, 0x0e, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53,
+-	0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32, 0x10, 0x0f, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34, 0x10, 0x10, 0x12, 0x0f, 0x0a, 0x0b,
+-	0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x11, 0x12, 0x0f, 0x0a,
+-	0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x12, 0x22, 0x43,
+-	0x0a, 0x05, 0x4c, 0x61, 0x62, 0x65, 0x6c, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c,
+-	0x5f, 0x4f, 0x50, 0x54, 0x49, 0x4f, 0x4e, 0x41, 0x4c, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c,
+-	0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45, 0x51, 0x55, 0x49, 0x52, 0x45, 0x44, 0x10, 0x02, 0x12,
+-	0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45, 0x50, 0x45, 0x41, 0x54, 0x45,
+-	0x44, 0x10, 0x03, 0x22, 0x63, 0x0a, 0x14, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b,
+-	0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
+-	0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52,
+-	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0xe3, 0x02, 0x0a, 0x13, 0x45, 0x6e, 0x75,
+-	0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f,
+-	0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04,
+-	0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3f, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05,
+-	0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x36, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+-	0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x5d, 0x0a,
+-	0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18,
+-	0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x36, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x6e, 0x75, 0x6d,
+-	0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0d, 0x72,
+-	0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d,
+-	0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x05, 0x20,
+-	0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d,
+-	0x65, 0x1a, 0x3b, 0x0a, 0x11, 0x45, 0x6e, 0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18,
+-	0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03,
+-	0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0x83,
+-	0x01, 0x0a, 0x18, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52,
+-	0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x3b, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56,
+-	0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x22, 0xa7, 0x01, 0x0a, 0x16, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+-	0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12,
+-	0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x12, 0x3e, 0x0a, 0x06, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x18, 0x02, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x06, 0x6d, 0x65, 0x74,
+-	0x68, 0x6f, 0x64, 0x12, 0x39, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0x89,
+-	0x02, 0x0a, 0x15, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
++	0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x05, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65,
++	0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x3b, 0x0a, 0x11, 0x45, 0x6e,
++	0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12,
++	0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05,
++	0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01,
++	0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0x83, 0x01, 0x0a, 0x18, 0x45, 0x6e, 0x75, 0x6d,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62,
++	0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72,
++	0x12, 0x3b, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28,
++	0x0b, 0x32, 0x21, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74,
++	0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0xa7, 0x01,
++	0x0a, 0x16, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+ 	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1d, 0x0a, 0x0a,
+-	0x69, 0x6e, 0x70, 0x75, 0x74, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x09, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f,
+-	0x75, 0x74, 0x70, 0x75, 0x74, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x0a, 0x6f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x38, 0x0a, 0x07,
+-	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e,
++	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3e, 0x0a, 0x06,
++	0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d,
++	0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x52, 0x06, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x12, 0x39, 0x0a, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e,
+ 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+-	0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x30, 0x0a, 0x10, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74,
+-	0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08,
+-	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0f, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x53,
+-	0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x12, 0x30, 0x0a, 0x10, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x72, 0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x06, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0f, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x72, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x22, 0x91, 0x09, 0x0a, 0x0b, 0x46,
+-	0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x21, 0x0a, 0x0c, 0x6a, 0x61,
+-	0x76, 0x61, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x0b, 0x6a, 0x61, 0x76, 0x61, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x30, 0x0a,
+-	0x14, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6f, 0x75, 0x74, 0x65, 0x72, 0x5f, 0x63, 0x6c, 0x61, 0x73,
+-	0x73, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x6a, 0x61, 0x76,
+-	0x61, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x43, 0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x35, 0x0a, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65,
+-	0x5f, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x11, 0x6a, 0x61, 0x76, 0x61, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c,
+-	0x65, 0x46, 0x69, 0x6c, 0x65, 0x73, 0x12, 0x44, 0x0a, 0x1d, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67,
+-	0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x5f, 0x61,
+-	0x6e, 0x64, 0x5f, 0x68, 0x61, 0x73, 0x68, 0x18, 0x14, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18,
+-	0x01, 0x52, 0x19, 0x6a, 0x61, 0x76, 0x61, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x45,
+-	0x71, 0x75, 0x61, 0x6c, 0x73, 0x41, 0x6e, 0x64, 0x48, 0x61, 0x73, 0x68, 0x12, 0x3a, 0x0a, 0x16,
+-	0x6a, 0x61, 0x76, 0x61, 0x5f, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x68, 0x65, 0x63,
+-	0x6b, 0x5f, 0x75, 0x74, 0x66, 0x38, 0x18, 0x1b, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43,
+-	0x68, 0x65, 0x63, 0x6b, 0x55, 0x74, 0x66, 0x38, 0x12, 0x53, 0x0a, 0x0c, 0x6f, 0x70, 0x74, 0x69,
+-	0x6d, 0x69, 0x7a, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x29,
+-	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+-	0x2e, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74,
+-	0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64, 0x65, 0x3a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44,
+-	0x52, 0x0b, 0x6f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x46, 0x6f, 0x72, 0x12, 0x1d, 0x0a,
+-	0x0a, 0x67, 0x6f, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x0b, 0x20, 0x01, 0x28,
+-	0x09, 0x52, 0x09, 0x67, 0x6f, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x35, 0x0a, 0x13,
+-	0x63, 0x63, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69,
+-	0x63, 0x65, 0x73, 0x18, 0x10, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
+-	0x52, 0x11, 0x63, 0x63, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69,
+-	0x63, 0x65, 0x73, 0x12, 0x39, 0x0a, 0x15, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65,
+-	0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x11, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x47,
+-	0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x35,
+-	0x0a, 0x13, 0x70, 0x79, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72,
+-	0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x12, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
+-	0x73, 0x65, 0x52, 0x11, 0x70, 0x79, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72,
+-	0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x37, 0x0a, 0x14, 0x70, 0x68, 0x70, 0x5f, 0x67, 0x65, 0x6e,
+-	0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x2a, 0x20,
+-	0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x12, 0x70, 0x68, 0x70, 0x47,
++	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0x89, 0x02, 0x0a, 0x15, 0x4d, 0x65, 0x74, 0x68,
++	0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1d, 0x0a, 0x0a, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x5f, 0x74,
++	0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x69, 0x6e, 0x70, 0x75, 0x74,
++	0x54, 0x79, 0x70, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x5f, 0x74,
++	0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x6f, 0x75, 0x74, 0x70, 0x75,
++	0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x38, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12,
++	0x30, 0x0a, 0x10, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d,
++	0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x0f, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e,
++	0x67, 0x12, 0x30, 0x0a, 0x10, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x5f, 0x73, 0x74, 0x72, 0x65,
++	0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x0f, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d,
++	0x69, 0x6e, 0x67, 0x22, 0x97, 0x09, 0x0a, 0x0b, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x21, 0x0a, 0x0c, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x70, 0x61, 0x63, 0x6b,
++	0x61, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x6a, 0x61, 0x76, 0x61, 0x50,
++	0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x30, 0x0a, 0x14, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6f,
++	0x75, 0x74, 0x65, 0x72, 0x5f, 0x63, 0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x08,
++	0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x6a, 0x61, 0x76, 0x61, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x43,
++	0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x35, 0x0a, 0x13, 0x6a, 0x61, 0x76, 0x61,
++	0x5f, 0x6d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x5f, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x18,
++	0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x6a, 0x61,
++	0x76, 0x61, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x73, 0x12,
++	0x44, 0x0a, 0x1d, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
++	0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x5f, 0x61, 0x6e, 0x64, 0x5f, 0x68, 0x61, 0x73, 0x68,
++	0x18, 0x14, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x19, 0x6a, 0x61, 0x76, 0x61,
++	0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x45, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x41, 0x6e,
++	0x64, 0x48, 0x61, 0x73, 0x68, 0x12, 0x3a, 0x0a, 0x16, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x73, 0x74,
++	0x72, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x5f, 0x75, 0x74, 0x66, 0x38, 0x18,
++	0x1b, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61,
++	0x76, 0x61, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x55, 0x74, 0x66,
++	0x38, 0x12, 0x53, 0x0a, 0x0c, 0x6f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x5f, 0x66, 0x6f,
++	0x72, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f,
++	0x64, 0x65, 0x3a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44, 0x52, 0x0b, 0x6f, 0x70, 0x74, 0x69, 0x6d,
++	0x69, 0x7a, 0x65, 0x46, 0x6f, 0x72, 0x12, 0x1d, 0x0a, 0x0a, 0x67, 0x6f, 0x5f, 0x70, 0x61, 0x63,
++	0x6b, 0x61, 0x67, 0x65, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x67, 0x6f, 0x50, 0x61,
++	0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x35, 0x0a, 0x13, 0x63, 0x63, 0x5f, 0x67, 0x65, 0x6e, 0x65,
++	0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x10, 0x20, 0x01,
++	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x63, 0x63, 0x47, 0x65, 0x6e,
++	0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x39, 0x0a, 0x15,
++	0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72,
++	0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x11, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53,
++	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x35, 0x0a, 0x13, 0x70, 0x79, 0x5f, 0x67, 0x65,
++	0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x12,
++	0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x70, 0x79, 0x47,
+ 	0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x25,
+ 	0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x17, 0x20, 0x01,
+ 	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65,
+@@ -3856,259 +4656,419 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x70, 0x68, 0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x4e, 0x61, 0x6d, 0x65, 0x73,
+ 	0x70, 0x61, 0x63, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x72, 0x75, 0x62, 0x79, 0x5f, 0x70, 0x61, 0x63,
+ 	0x6b, 0x61, 0x67, 0x65, 0x18, 0x2d, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x72, 0x75, 0x62, 0x79,
+-	0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18,
+-	0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72,
+-	0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e,
+-	0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x22, 0x3a, 0x0a, 0x0c, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64,
+-	0x65, 0x12, 0x09, 0x0a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09,
+-	0x43, 0x4f, 0x44, 0x45, 0x5f, 0x53, 0x49, 0x5a, 0x45, 0x10, 0x02, 0x12, 0x10, 0x0a, 0x0c, 0x4c,
+-	0x49, 0x54, 0x45, 0x5f, 0x52, 0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x03, 0x2a, 0x09, 0x08,
+-	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x26, 0x10, 0x27, 0x22, 0xbb,
+-	0x03, 0x0a, 0x0e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x73, 0x12, 0x3c, 0x0a, 0x17, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x65, 0x74,
+-	0x5f, 0x77, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x01, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x14, 0x6d, 0x65, 0x73, 0x73, 0x61,
+-	0x67, 0x65, 0x53, 0x65, 0x74, 0x57, 0x69, 0x72, 0x65, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12,
+-	0x4c, 0x0a, 0x1f, 0x6e, 0x6f, 0x5f, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x5f, 0x64,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73,
+-	0x6f, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
+-	0x1c, 0x6e, 0x6f, 0x53, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72,
+-	0x69, 0x70, 0x74, 0x6f, 0x72, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f, 0x72, 0x12, 0x25, 0x0a,
+-	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28,
+-	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63,
+-	0x61, 0x74, 0x65, 0x64, 0x12, 0x1b, 0x0a, 0x09, 0x6d, 0x61, 0x70, 0x5f, 0x65, 0x6e, 0x74, 0x72,
+-	0x79, 0x18, 0x07, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x6d, 0x61, 0x70, 0x45, 0x6e, 0x74, 0x72,
+-	0x79, 0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f,
+-	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c,
+-	0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28,
+-	0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+-	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x04, 0x10, 0x05, 0x4a, 0x04, 0x08, 0x05, 0x10, 0x06, 0x4a, 0x04, 0x08, 0x06, 0x10, 0x07,
+-	0x4a, 0x04, 0x08, 0x08, 0x10, 0x09, 0x4a, 0x04, 0x08, 0x09, 0x10, 0x0a, 0x22, 0x85, 0x09, 0x0a,
+-	0x0c, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x41, 0x0a,
+-	0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x23, 0x2e, 0x67,
+-	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
+-	0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x43, 0x54, 0x79, 0x70,
+-	0x65, 0x3a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x52, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65,
+-	0x12, 0x16, 0x0a, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08,
+-	0x52, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x12, 0x47, 0x0a, 0x06, 0x6a, 0x73, 0x74, 0x79,
+-	0x70, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x09,
+-	0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x52, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70,
+-	0x65, 0x12, 0x19, 0x0a, 0x04, 0x6c, 0x61, 0x7a, 0x79, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a,
+-	0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04, 0x6c, 0x61, 0x7a, 0x79, 0x12, 0x2e, 0x0a, 0x0f,
+-	0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64, 0x5f, 0x6c, 0x61, 0x7a, 0x79, 0x18,
+-	0x0f, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0e, 0x75, 0x6e,
+-	0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64, 0x4c, 0x61, 0x7a, 0x79, 0x12, 0x25, 0x0a, 0x0a,
++	0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75,
++	0x72, 0x65, 0x73, 0x18, 0x32, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
++	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73,
++	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
++	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
++	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
++	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x3a, 0x0a, 0x0c, 0x4f, 0x70,
++	0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64, 0x65, 0x12, 0x09, 0x0a, 0x05, 0x53, 0x50,
++	0x45, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x43, 0x4f, 0x44, 0x45, 0x5f, 0x53, 0x49,
++	0x5a, 0x45, 0x10, 0x02, 0x12, 0x10, 0x0a, 0x0c, 0x4c, 0x49, 0x54, 0x45, 0x5f, 0x52, 0x55, 0x4e,
++	0x54, 0x49, 0x4d, 0x45, 0x10, 0x03, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80,
++	0x02, 0x4a, 0x04, 0x08, 0x2a, 0x10, 0x2b, 0x4a, 0x04, 0x08, 0x26, 0x10, 0x27, 0x22, 0xf4, 0x03,
++	0x0a, 0x0e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x12, 0x3c, 0x0a, 0x17, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x65, 0x74, 0x5f,
++	0x77, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28,
++	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x14, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67,
++	0x65, 0x53, 0x65, 0x74, 0x57, 0x69, 0x72, 0x65, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12, 0x4c,
++	0x0a, 0x1f, 0x6e, 0x6f, 0x5f, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x5f, 0x64, 0x65,
++	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f,
++	0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x1c,
++	0x6e, 0x6f, 0x53, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
++	0x70, 0x74, 0x6f, 0x72, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f, 0x72, 0x12, 0x25, 0x0a, 0x0a,
+ 	0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08,
+ 	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
+-	0x74, 0x65, 0x64, 0x12, 0x19, 0x0a, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x18, 0x0a, 0x20, 0x01, 0x28,
+-	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x12, 0x28,
+-	0x0a, 0x0c, 0x64, 0x65, 0x62, 0x75, 0x67, 0x5f, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x10,
+-	0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62,
+-	0x75, 0x67, 0x52, 0x65, 0x64, 0x61, 0x63, 0x74, 0x12, 0x4b, 0x0a, 0x09, 0x72, 0x65, 0x74, 0x65,
+-	0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x11, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2d, 0x2e, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69,
+-	0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x09, 0x72, 0x65, 0x74, 0x65,
+-	0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x4a, 0x0a, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x18,
+-	0x12, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65,
+-	0x74, 0x54, 0x79, 0x70, 0x65, 0x42, 0x02, 0x18, 0x01, 0x52, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65,
+-	0x74, 0x12, 0x48, 0x0a, 0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x18, 0x13, 0x20, 0x03,
+-	0x28, 0x0e, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+-	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79,
+-	0x70, 0x65, 0x52, 0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75,
+-	0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f,
+-	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x2f, 0x0a, 0x05, 0x43, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0a,
+-	0x0a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x43, 0x4f,
+-	0x52, 0x44, 0x10, 0x01, 0x12, 0x10, 0x0a, 0x0c, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x5f, 0x50,
+-	0x49, 0x45, 0x43, 0x45, 0x10, 0x02, 0x22, 0x35, 0x0a, 0x06, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65,
+-	0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x10, 0x00, 0x12,
+-	0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x01, 0x12, 0x0d,
+-	0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x55, 0x4d, 0x42, 0x45, 0x52, 0x10, 0x02, 0x22, 0x55, 0x0a,
+-	0x0f, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e,
+-	0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e,
+-	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e,
+-	0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x52, 0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x01, 0x12, 0x14,
+-	0x0a, 0x10, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x4f, 0x55, 0x52,
+-	0x43, 0x45, 0x10, 0x02, 0x22, 0x8c, 0x02, 0x0a, 0x10, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54,
+-	0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e,
+-	0x10, 0x00, 0x12, 0x14, 0x0a, 0x10, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x46, 0x49, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x1f, 0x0a, 0x1b, 0x54, 0x41, 0x52, 0x47,
+-	0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f,
+-	0x4e, 0x5f, 0x52, 0x41, 0x4e, 0x47, 0x45, 0x10, 0x02, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45,
+-	0x10, 0x03, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x46, 0x49, 0x45, 0x4c, 0x44, 0x10, 0x04, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4f, 0x4e, 0x45, 0x4f, 0x46, 0x10, 0x05,
+-	0x12, 0x14, 0x0a, 0x10, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
+-	0x45, 0x4e, 0x55, 0x4d, 0x10, 0x06, 0x12, 0x1a, 0x0a, 0x16, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54,
+-	0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x45, 0x4e, 0x54, 0x52, 0x59,
+-	0x10, 0x07, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x53, 0x45, 0x52, 0x56, 0x49, 0x43, 0x45, 0x10, 0x08, 0x12, 0x16, 0x0a, 0x12, 0x54,
+-	0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x54, 0x48, 0x4f,
+-	0x44, 0x10, 0x09, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x04, 0x10, 0x05, 0x22, 0x73, 0x0a, 0x0c, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
+-	0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65,
+-	0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09,
+-	0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x98, 0x02, 0x0a, 0x0b, 0x45, 0x6e,
+-	0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x6c, 0x6c,
+-	0x6f, 0x77, 0x5f, 0x61, 0x6c, 0x69, 0x61, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0a,
+-	0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x41, 0x6c, 0x69, 0x61, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65,
+-	0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05,
+-	0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f,
+-	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c,
+-	0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28,
+-	0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
++	0x74, 0x65, 0x64, 0x12, 0x1b, 0x0a, 0x09, 0x6d, 0x61, 0x70, 0x5f, 0x65, 0x6e, 0x74, 0x72, 0x79,
++	0x18, 0x07, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x6d, 0x61, 0x70, 0x45, 0x6e, 0x74, 0x72, 0x79,
++	0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x6c,
++	0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c, 0x64,
++	0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x08,
++	0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64,
++	0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43,
++	0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x73, 0x18, 0x0c, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07,
++	0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x4a, 0x04, 0x08, 0x05,
++	0x10, 0x06, 0x4a, 0x04, 0x08, 0x06, 0x10, 0x07, 0x4a, 0x04, 0x08, 0x08, 0x10, 0x09, 0x4a, 0x04,
++	0x08, 0x09, 0x10, 0x0a, 0x22, 0xad, 0x0a, 0x0a, 0x0c, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x41, 0x0a, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01,
++	0x20, 0x01, 0x28, 0x0e, 0x32, 0x23, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x2e, 0x43, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e,
++	0x47, 0x52, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x70, 0x61, 0x63, 0x6b,
++	0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64,
++	0x12, 0x47, 0x0a, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e,
++	0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
++	0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41,
++	0x4c, 0x52, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70, 0x65, 0x12, 0x19, 0x0a, 0x04, 0x6c, 0x61, 0x7a,
++	0x79, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04,
++	0x6c, 0x61, 0x7a, 0x79, 0x12, 0x2e, 0x0a, 0x0f, 0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69,
++	0x65, 0x64, 0x5f, 0x6c, 0x61, 0x7a, 0x79, 0x18, 0x0f, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66,
++	0x61, 0x6c, 0x73, 0x65, 0x52, 0x0e, 0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64,
++	0x4c, 0x61, 0x7a, 0x79, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74,
++	0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
++	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x19, 0x0a, 0x04, 0x77,
++	0x65, 0x61, 0x6b, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x12, 0x28, 0x0a, 0x0c, 0x64, 0x65, 0x62, 0x75, 0x67, 0x5f,
++	0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x10, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
++	0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62, 0x75, 0x67, 0x52, 0x65, 0x64, 0x61, 0x63, 0x74,
++	0x12, 0x4b, 0x0a, 0x09, 0x72, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x11, 0x20,
++	0x01, 0x28, 0x0e, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69,
++	0x6f, 0x6e, 0x52, 0x09, 0x72, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x48, 0x0a,
++	0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x18, 0x13, 0x20, 0x03, 0x28, 0x0e, 0x32, 0x2e,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79, 0x70, 0x65, 0x52, 0x07,
++	0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x12, 0x57, 0x0a, 0x10, 0x65, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x5f, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x18, 0x14, 0x20, 0x03, 0x28,
++	0x0b, 0x32, 0x2c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x52,
++	0x0f, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73,
++	0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x15, 0x20, 0x01,
++	0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52,
++	0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+ 	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+ 	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+ 	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+ 	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+ 	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x05, 0x10, 0x06, 0x22, 0x9e, 0x01, 0x0a, 0x10, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c,
+-	0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70,
+-	0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66,
+-	0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64,
+-	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
+-	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
+-	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
+-	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
+-	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10,
+-	0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x9c, 0x01, 0x0a, 0x0e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63,
+-	0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72,
+-	0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12,
+-	0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
+-	0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24,
+-	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+-	0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65,
+-	0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80,
+-	0x80, 0x80, 0x80, 0x02, 0x22, 0xe0, 0x02, 0x0a, 0x0d, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63,
+-	0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73,
+-	0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x71, 0x0a,
+-	0x11, 0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x5f, 0x6c, 0x65, 0x76,
+-	0x65, 0x6c, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f,
+-	0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74,
+-	0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x3a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50,
+-	0x4f, 0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x52, 0x10,
+-	0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c,
+-	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
+-	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
+-	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
+-	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
+-	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x50, 0x0a, 0x10, 0x49, 0x64,
+-	0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12, 0x17,
+-	0x0a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e,
+-	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a, 0x0f, 0x4e, 0x4f, 0x5f, 0x53, 0x49,
+-	0x44, 0x45, 0x5f, 0x45, 0x46, 0x46, 0x45, 0x43, 0x54, 0x53, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a,
+-	0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45, 0x4e, 0x54, 0x10, 0x02, 0x2a, 0x09, 0x08, 0xe8,
+-	0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x9a, 0x03, 0x0a, 0x13, 0x55, 0x6e, 0x69, 0x6e,
+-	0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12,
+-	0x41, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e,
++	0x69, 0x6f, 0x6e, 0x1a, 0x5a, 0x0a, 0x0e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65,
++	0x66, 0x61, 0x75, 0x6c, 0x74, 0x12, 0x32, 0x0a, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e,
++	0x18, 0x03, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e,
++	0x52, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c,
++	0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x22,
++	0x2f, 0x0a, 0x05, 0x43, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x54, 0x52, 0x49,
++	0x4e, 0x47, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x43, 0x4f, 0x52, 0x44, 0x10, 0x01, 0x12, 0x10,
++	0x0a, 0x0c, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x5f, 0x50, 0x49, 0x45, 0x43, 0x45, 0x10, 0x02,
++	0x22, 0x35, 0x0a, 0x06, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53,
++	0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x10, 0x00, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f,
++	0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e,
++	0x55, 0x4d, 0x42, 0x45, 0x52, 0x10, 0x02, 0x22, 0x55, 0x0a, 0x0f, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45,
++	0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10,
++	0x00, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x52,
++	0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x01, 0x12, 0x14, 0x0a, 0x10, 0x52, 0x45, 0x54, 0x45,
++	0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x4f, 0x55, 0x52, 0x43, 0x45, 0x10, 0x02, 0x22, 0x8c,
++	0x02, 0x0a, 0x10, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54,
++	0x79, 0x70, 0x65, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x14, 0x0a, 0x10,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x4c, 0x45,
++	0x10, 0x01, 0x12, 0x1f, 0x0a, 0x1b, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x45, 0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f, 0x4e, 0x5f, 0x52, 0x41, 0x4e, 0x47,
++	0x45, 0x10, 0x02, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x10, 0x03, 0x12, 0x15, 0x0a, 0x11,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x45, 0x4c,
++	0x44, 0x10, 0x04, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x4f, 0x4e, 0x45, 0x4f, 0x46, 0x10, 0x05, 0x12, 0x14, 0x0a, 0x10, 0x54, 0x41,
++	0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x10, 0x06,
++	0x12, 0x1a, 0x0a, 0x16, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x45, 0x4e, 0x54, 0x52, 0x59, 0x10, 0x07, 0x12, 0x17, 0x0a, 0x13,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x45, 0x52, 0x56,
++	0x49, 0x43, 0x45, 0x10, 0x08, 0x12, 0x16, 0x0a, 0x12, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f,
++	0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x54, 0x48, 0x4f, 0x44, 0x10, 0x09, 0x2a, 0x09, 0x08,
++	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x4a, 0x04,
++	0x08, 0x12, 0x10, 0x13, 0x22, 0xac, 0x01, 0x0a, 0x0c, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72,
++	0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58,
++	0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
+ 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+ 	0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x52, 0x04, 0x6e, 0x61,
+-	0x6d, 0x65, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72,
+-	0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x69, 0x64,
+-	0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a,
+-	0x12, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76, 0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61,
+-	0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04, 0x52, 0x10, 0x70, 0x6f, 0x73, 0x69, 0x74,
+-	0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x6e,
+-	0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75,
+-	0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52, 0x10, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76,
+-	0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x64, 0x6f, 0x75,
+-	0x62, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x52,
+-	0x0b, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c,
+-	0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01,
+-	0x28, 0x0c, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12,
+-	0x27, 0x0a, 0x0f, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x5f, 0x76, 0x61, 0x6c,
+-	0x75, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67,
+-	0x61, 0x74, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x1a, 0x4a, 0x0a, 0x08, 0x4e, 0x61, 0x6d, 0x65,
+-	0x50, 0x61, 0x72, 0x74, 0x12, 0x1b, 0x0a, 0x09, 0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x70, 0x61, 0x72,
+-	0x74, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09, 0x52, 0x08, 0x6e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72,
+-	0x74, 0x12, 0x21, 0x0a, 0x0c, 0x69, 0x73, 0x5f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
+-	0x6e, 0x18, 0x02, 0x20, 0x02, 0x28, 0x08, 0x52, 0x0b, 0x69, 0x73, 0x45, 0x78, 0x74, 0x65, 0x6e,
+-	0x73, 0x69, 0x6f, 0x6e, 0x22, 0xa7, 0x02, 0x0a, 0x0e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43,
+-	0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x44, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x28, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
+-	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72,
+-	0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x4c, 0x6f, 0x63, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x52, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xce, 0x01,
+-	0x0a, 0x08, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61,
+-	0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61,
+-	0x74, 0x68, 0x12, 0x16, 0x0a, 0x04, 0x73, 0x70, 0x61, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x05,
+-	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x73, 0x70, 0x61, 0x6e, 0x12, 0x29, 0x0a, 0x10, 0x6c, 0x65,
+-	0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d,
+-	0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x2b, 0x0a, 0x11, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e,
+-	0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x10, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e,
+-	0x74, 0x73, 0x12, 0x3a, 0x0a, 0x19, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x65,
+-	0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18,
+-	0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x17, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x44, 0x65,
+-	0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22, 0xd0,
+-	0x02, 0x0a, 0x11, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65,
+-	0x49, 0x6e, 0x66, 0x6f, 0x12, 0x4d, 0x0a, 0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69,
+-	0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72,
+-	0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e,
+-	0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x1a, 0xeb, 0x01, 0x0a, 0x0a, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69,
++	0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80,
++	0x80, 0x80, 0x02, 0x22, 0xd1, 0x02, 0x0a, 0x0b, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x5f, 0x61, 0x6c, 0x69,
++	0x61, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0a, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x41,
++	0x6c, 0x69, 0x61, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74,
++	0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
++	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x56, 0x0a, 0x26, 0x64,
++	0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79,
++	0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66,
++	0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52,
++	0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x4c, 0x65, 0x67, 0x61, 0x63,
++	0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69,
++	0x63, 0x74, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14,
++	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e,
++	0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80,
++	0x02, 0x4a, 0x04, 0x08, 0x05, 0x10, 0x06, 0x22, 0x81, 0x02, 0x0a, 0x10, 0x45, 0x6e, 0x75, 0x6d,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a,
++	0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08,
++	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
++	0x74, 0x65, 0x64, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x28, 0x0a, 0x0c,
++	0x64, 0x65, 0x62, 0x75, 0x67, 0x5f, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x03, 0x20, 0x01,
++	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62, 0x75, 0x67,
++	0x52, 0x65, 0x64, 0x61, 0x63, 0x74, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7,
++	0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69,
++	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0xd5, 0x01, 0x0a, 0x0e,
++	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x37,
++	0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0b,
++	0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66,
++	0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65,
++	0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x58,
++	0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
++	0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80,
++	0x80, 0x80, 0x02, 0x22, 0x99, 0x03, 0x0a, 0x0d, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
++	0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x71, 0x0a, 0x11,
++	0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x5f, 0x6c, 0x65, 0x76, 0x65,
++	0x6c, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65,
++	0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x3a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f,
++	0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x52, 0x10, 0x69,
++	0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12,
++	0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x23, 0x20, 0x01, 0x28,
++	0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08,
++	0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e,
++	0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75,
++	0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x22, 0x50, 0x0a, 0x10, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63,
++	0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12, 0x17, 0x0a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f,
++	0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12,
++	0x13, 0x0a, 0x0f, 0x4e, 0x4f, 0x5f, 0x53, 0x49, 0x44, 0x45, 0x5f, 0x45, 0x46, 0x46, 0x45, 0x43,
++	0x54, 0x53, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45,
++	0x4e, 0x54, 0x10, 0x02, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22,
++	0x9a, 0x03, 0x0a, 0x13, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
++	0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
++	0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65,
++	0x50, 0x61, 0x72, 0x74, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x64,
++	0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03,
++	0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76,
++	0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28,
++	0x04, 0x52, 0x10, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61,
++	0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x5f,
++	0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52,
++	0x10, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75,
++	0x65, 0x12, 0x21, 0x0a, 0x0c, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75,
++	0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x52, 0x0b, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x56,
++	0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76,
++	0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69,
++	0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x27, 0x0a, 0x0f, 0x61, 0x67, 0x67, 0x72, 0x65,
++	0x67, 0x61, 0x74, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09,
++	0x52, 0x0e, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65,
++	0x1a, 0x4a, 0x0a, 0x08, 0x4e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x12, 0x1b, 0x0a, 0x09,
++	0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x70, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09, 0x52,
++	0x08, 0x6e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x12, 0x21, 0x0a, 0x0c, 0x69, 0x73, 0x5f,
++	0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x02, 0x28, 0x08, 0x52,
++	0x0b, 0x69, 0x73, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x8c, 0x0a, 0x0a,
++	0x0a, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x12, 0x8b, 0x01, 0x0a, 0x0e,
++	0x66, 0x69, 0x65, 0x6c, 0x64, 0x5f, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x18, 0x01,
++	0x20, 0x01, 0x28, 0x0e, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x42,
++	0x39, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45,
++	0x58, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x49,
++	0x4d, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe7, 0x07, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45,
++	0x58, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe8, 0x07, 0x52, 0x0d, 0x66, 0x69, 0x65, 0x6c,
++	0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x66, 0x0a, 0x09, 0x65, 0x6e, 0x75,
++	0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x24, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
++	0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x54, 0x79,
++	0x70, 0x65, 0x42, 0x23, 0x88, 0x01, 0x01, 0x98, 0x01, 0x06, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x0b,
++	0x12, 0x06, 0x43, 0x4c, 0x4f, 0x53, 0x45, 0x44, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x09, 0x12, 0x04,
++	0x4f, 0x50, 0x45, 0x4e, 0x18, 0xe7, 0x07, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54, 0x79, 0x70,
++	0x65, 0x12, 0x92, 0x01, 0x0a, 0x17, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x66,
++	0x69, 0x65, 0x6c, 0x64, 0x5f, 0x65, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x18, 0x03, 0x20,
++	0x01, 0x28, 0x0e, 0x32, 0x31, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74,
++	0x2e, 0x52, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x45, 0x6e,
++	0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x42, 0x27, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98, 0x01,
++	0x01, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45, 0x58, 0x50, 0x41, 0x4e, 0x44, 0x45, 0x44, 0x18, 0xe6,
++	0x07, 0xa2, 0x01, 0x0b, 0x12, 0x06, 0x50, 0x41, 0x43, 0x4b, 0x45, 0x44, 0x18, 0xe7, 0x07, 0x52,
++	0x15, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x45, 0x6e,
++	0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x78, 0x0a, 0x0f, 0x75, 0x74, 0x66, 0x38, 0x5f, 0x76,
++	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0e, 0x32,
++	0x2a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x55, 0x74, 0x66,
++	0x38, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x23, 0x88, 0x01, 0x01,
++	0x98, 0x01, 0x04, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x09, 0x12, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x18,
++	0xe6, 0x07, 0xa2, 0x01, 0x0b, 0x12, 0x06, 0x56, 0x45, 0x52, 0x49, 0x46, 0x59, 0x18, 0xe7, 0x07,
++	0x52, 0x0e, 0x75, 0x74, 0x66, 0x38, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x12, 0x78, 0x0a, 0x10, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x65, 0x6e, 0x63, 0x6f,
++	0x64, 0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x45,
++	0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x42, 0x20, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98,
++	0x01, 0x01, 0xa2, 0x01, 0x14, 0x12, 0x0f, 0x4c, 0x45, 0x4e, 0x47, 0x54, 0x48, 0x5f, 0x50, 0x52,
++	0x45, 0x46, 0x49, 0x58, 0x45, 0x44, 0x18, 0xe6, 0x07, 0x52, 0x0f, 0x6d, 0x65, 0x73, 0x73, 0x61,
++	0x67, 0x65, 0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x7c, 0x0a, 0x0b, 0x6a, 0x73,
++	0x6f, 0x6e, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e, 0x32,
++	0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x4a, 0x73, 0x6f,
++	0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x42, 0x33, 0x88, 0x01, 0x01, 0x98, 0x01, 0x03, 0x98,
++	0x01, 0x06, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x17, 0x12, 0x12, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59,
++	0x5f, 0x42, 0x45, 0x53, 0x54, 0x5f, 0x45, 0x46, 0x46, 0x4f, 0x52, 0x54, 0x18, 0xe6, 0x07, 0xa2,
++	0x01, 0x0a, 0x12, 0x05, 0x41, 0x4c, 0x4c, 0x4f, 0x57, 0x18, 0xe7, 0x07, 0x52, 0x0a, 0x6a, 0x73,
++	0x6f, 0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x22, 0x5c, 0x0a, 0x0d, 0x46, 0x69, 0x65, 0x6c,
++	0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x1a, 0x0a, 0x16, 0x46, 0x49, 0x45,
++	0x4c, 0x44, 0x5f, 0x50, 0x52, 0x45, 0x53, 0x45, 0x4e, 0x43, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e,
++	0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0c, 0x0a, 0x08, 0x45, 0x58, 0x50, 0x4c, 0x49, 0x43, 0x49,
++	0x54, 0x10, 0x01, 0x12, 0x0c, 0x0a, 0x08, 0x49, 0x4d, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x10,
++	0x02, 0x12, 0x13, 0x0a, 0x0f, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59, 0x5f, 0x52, 0x45, 0x51, 0x55,
++	0x49, 0x52, 0x45, 0x44, 0x10, 0x03, 0x22, 0x37, 0x0a, 0x08, 0x45, 0x6e, 0x75, 0x6d, 0x54, 0x79,
++	0x70, 0x65, 0x12, 0x15, 0x0a, 0x11, 0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x4f, 0x50, 0x45,
++	0x4e, 0x10, 0x01, 0x12, 0x0a, 0x0a, 0x06, 0x43, 0x4c, 0x4f, 0x53, 0x45, 0x44, 0x10, 0x02, 0x22,
++	0x56, 0x0a, 0x15, 0x52, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64,
++	0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x23, 0x0a, 0x1f, 0x52, 0x45, 0x50, 0x45,
++	0x41, 0x54, 0x45, 0x44, 0x5f, 0x46, 0x49, 0x45, 0x4c, 0x44, 0x5f, 0x45, 0x4e, 0x43, 0x4f, 0x44,
++	0x49, 0x4e, 0x47, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a,
++	0x06, 0x50, 0x41, 0x43, 0x4b, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0c, 0x0a, 0x08, 0x45, 0x58, 0x50,
++	0x41, 0x4e, 0x44, 0x45, 0x44, 0x10, 0x02, 0x22, 0x43, 0x0a, 0x0e, 0x55, 0x74, 0x66, 0x38, 0x56,
++	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x1b, 0x0a, 0x17, 0x55, 0x54, 0x46,
++	0x38, 0x5f, 0x56, 0x41, 0x4c, 0x49, 0x44, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e, 0x4b,
++	0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x56, 0x45, 0x52, 0x49, 0x46, 0x59,
++	0x10, 0x02, 0x12, 0x08, 0x0a, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x03, 0x22, 0x53, 0x0a, 0x0f,
++	0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12,
++	0x1c, 0x0a, 0x18, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x5f, 0x45, 0x4e, 0x43, 0x4f, 0x44,
++	0x49, 0x4e, 0x47, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a,
++	0x0f, 0x4c, 0x45, 0x4e, 0x47, 0x54, 0x48, 0x5f, 0x50, 0x52, 0x45, 0x46, 0x49, 0x58, 0x45, 0x44,
++	0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x44, 0x45, 0x4c, 0x49, 0x4d, 0x49, 0x54, 0x45, 0x44, 0x10,
++	0x02, 0x22, 0x48, 0x0a, 0x0a, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12,
++	0x17, 0x0a, 0x13, 0x4a, 0x53, 0x4f, 0x4e, 0x5f, 0x46, 0x4f, 0x52, 0x4d, 0x41, 0x54, 0x5f, 0x55,
++	0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x4c, 0x4c, 0x4f,
++	0x57, 0x10, 0x01, 0x12, 0x16, 0x0a, 0x12, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59, 0x5f, 0x42, 0x45,
++	0x53, 0x54, 0x5f, 0x45, 0x46, 0x46, 0x4f, 0x52, 0x54, 0x10, 0x02, 0x2a, 0x06, 0x08, 0xe8, 0x07,
++	0x10, 0xe9, 0x07, 0x2a, 0x06, 0x08, 0xe9, 0x07, 0x10, 0xea, 0x07, 0x2a, 0x06, 0x08, 0xea, 0x07,
++	0x10, 0xeb, 0x07, 0x2a, 0x06, 0x08, 0x8b, 0x4e, 0x10, 0x90, 0x4e, 0x2a, 0x06, 0x08, 0x90, 0x4e,
++	0x10, 0x91, 0x4e, 0x4a, 0x06, 0x08, 0xe7, 0x07, 0x10, 0xe8, 0x07, 0x22, 0xfe, 0x02, 0x0a, 0x12,
++	0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c,
++	0x74, 0x73, 0x12, 0x58, 0x0a, 0x08, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x18, 0x01,
++	0x20, 0x03, 0x28, 0x0b, 0x32, 0x3c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72,
++	0x65, 0x53, 0x65, 0x74, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75,
++	0x6c, 0x74, 0x52, 0x08, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x12, 0x41, 0x0a, 0x0f,
++	0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x5f, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x18,
++	0x04, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x52,
++	0x0e, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12,
++	0x41, 0x0a, 0x0f, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x5f, 0x65, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
++	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x52, 0x0e, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x45, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x1a, 0x87, 0x01, 0x0a, 0x18, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x12,
++	0x32, 0x0a, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0e,
++	0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74,
++	0x69, 0x6f, 0x6e, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x22, 0xa7, 0x02, 0x0a,
++	0x0e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12,
++	0x44, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28,
++	0x0b, 0x32, 0x28, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e,
++	0x66, 0x6f, 0x2e, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x08, 0x6c, 0x6f, 0x63,
++	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xce, 0x01, 0x0a, 0x08, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69,
+ 	0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61, 0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05,
+-	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x12, 0x1f, 0x0a, 0x0b, 0x73, 0x6f,
+-	0x75, 0x72, 0x63, 0x65, 0x5f, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+-	0x0a, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x62,
+-	0x65, 0x67, 0x69, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x62, 0x65, 0x67, 0x69,
+-	0x6e, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03,
+-	0x65, 0x6e, 0x64, 0x12, 0x52, 0x0a, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18,
+-	0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x36, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
+-	0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61,
+-	0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x52, 0x08, 0x73,
+-	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x22, 0x28, 0x0a, 0x08, 0x53, 0x65, 0x6d, 0x61, 0x6e,
+-	0x74, 0x69, 0x63, 0x12, 0x08, 0x0a, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x07, 0x0a,
+-	0x03, 0x53, 0x45, 0x54, 0x10, 0x01, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x4c, 0x49, 0x41, 0x53, 0x10,
+-	0x02, 0x42, 0x7e, 0x0a, 0x13, 0x63, 0x6f, 0x6d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x42, 0x10, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
+-	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x73, 0x48, 0x01, 0x5a, 0x2d, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2f, 0x64,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x70, 0x62, 0xf8, 0x01, 0x01, 0xa2, 0x02,
+-	0x03, 0x47, 0x50, 0x42, 0xaa, 0x02, 0x1a, 0x47, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x50, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x52, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f,
+-	0x6e,
++	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x12, 0x16, 0x0a, 0x04, 0x73, 0x70,
++	0x61, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x73, 0x70,
++	0x61, 0x6e, 0x12, 0x29, 0x0a, 0x10, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f,
++	0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6c, 0x65,
++	0x61, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x2b, 0x0a,
++	0x11, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e,
++	0x74, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69,
++	0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x3a, 0x0a, 0x19, 0x6c, 0x65,
++	0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x65, 0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x5f, 0x63,
++	0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x17, 0x6c,
++	0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x44, 0x65, 0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x43, 0x6f,
++	0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22, 0xd0, 0x02, 0x0a, 0x11, 0x47, 0x65, 0x6e, 0x65, 0x72,
++	0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x4d, 0x0a, 0x0a,
++	0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65,
++	0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52,
++	0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xeb, 0x01, 0x0a, 0x0a,
++	0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61,
++	0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61,
++	0x74, 0x68, 0x12, 0x1f, 0x0a, 0x0b, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x66, 0x69, 0x6c,
++	0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x46,
++	0x69, 0x6c, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x62, 0x65, 0x67, 0x69, 0x6e, 0x18, 0x03, 0x20, 0x01,
++	0x28, 0x05, 0x52, 0x05, 0x62, 0x65, 0x67, 0x69, 0x6e, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64,
++	0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x12, 0x52, 0x0a, 0x08, 0x73,
++	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x36, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
++	0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x53, 0x65, 0x6d,
++	0x61, 0x6e, 0x74, 0x69, 0x63, 0x52, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x22,
++	0x28, 0x0a, 0x08, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x12, 0x08, 0x0a, 0x04, 0x4e,
++	0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x07, 0x0a, 0x03, 0x53, 0x45, 0x54, 0x10, 0x01, 0x12, 0x09,
++	0x0a, 0x05, 0x41, 0x4c, 0x49, 0x41, 0x53, 0x10, 0x02, 0x2a, 0x92, 0x02, 0x0a, 0x07, 0x45, 0x64,
++	0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x13, 0x0a, 0x0f, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e,
++	0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a, 0x0e, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x50, 0x52, 0x4f, 0x54, 0x4f, 0x32, 0x10, 0xe6, 0x07, 0x12,
++	0x13, 0x0a, 0x0e, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x50, 0x52, 0x4f, 0x54, 0x4f,
++	0x33, 0x10, 0xe7, 0x07, 0x12, 0x11, 0x0a, 0x0c, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f,
++	0x32, 0x30, 0x32, 0x33, 0x10, 0xe8, 0x07, 0x12, 0x11, 0x0a, 0x0c, 0x45, 0x44, 0x49, 0x54, 0x49,
++	0x4f, 0x4e, 0x5f, 0x32, 0x30, 0x32, 0x34, 0x10, 0xe9, 0x07, 0x12, 0x17, 0x0a, 0x13, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x31, 0x5f, 0x54, 0x45, 0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c,
++	0x59, 0x10, 0x01, 0x12, 0x17, 0x0a, 0x13, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x32,
++	0x5f, 0x54, 0x45, 0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x02, 0x12, 0x1d, 0x0a, 0x17,
++	0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x37, 0x5f, 0x54, 0x45,
++	0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9d, 0x8d, 0x06, 0x12, 0x1d, 0x0a, 0x17, 0x45,
++	0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x38, 0x5f, 0x54, 0x45, 0x53,
++	0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9e, 0x8d, 0x06, 0x12, 0x1d, 0x0a, 0x17, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x39, 0x5f, 0x54, 0x45, 0x53, 0x54,
++	0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9f, 0x8d, 0x06, 0x12, 0x13, 0x0a, 0x0b, 0x45, 0x44, 0x49,
++	0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x4d, 0x41, 0x58, 0x10, 0xff, 0xff, 0xff, 0xff, 0x07, 0x42, 0x7e,
++	0x0a, 0x13, 0x63, 0x6f, 0x6d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x42, 0x10, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f,
++	0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x73, 0x48, 0x01, 0x5a, 0x2d, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
++	0x65, 0x2e, 0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2f, 0x64, 0x65, 0x73, 0x63,
++	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x70, 0x62, 0xf8, 0x01, 0x01, 0xa2, 0x02, 0x03, 0x47, 0x50,
++	0x42, 0xaa, 0x02, 0x1a, 0x47, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x50, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x52, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e,
+ }
+ 
+ var (
+@@ -4123,103 +5083,136 @@ func file_google_protobuf_descriptor_proto_rawDescGZIP() []byte {
+ 	return file_google_protobuf_descriptor_proto_rawDescData
+ }
+ 
+-var file_google_protobuf_descriptor_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+-var file_google_protobuf_descriptor_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
++var file_google_protobuf_descriptor_proto_enumTypes = make([]protoimpl.EnumInfo, 17)
++var file_google_protobuf_descriptor_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+ var file_google_protobuf_descriptor_proto_goTypes = []interface{}{
+-	(ExtensionRangeOptions_VerificationState)(0),  // 0: google.protobuf.ExtensionRangeOptions.VerificationState
+-	(FieldDescriptorProto_Type)(0),                // 1: google.protobuf.FieldDescriptorProto.Type
+-	(FieldDescriptorProto_Label)(0),               // 2: google.protobuf.FieldDescriptorProto.Label
+-	(FileOptions_OptimizeMode)(0),                 // 3: google.protobuf.FileOptions.OptimizeMode
+-	(FieldOptions_CType)(0),                       // 4: google.protobuf.FieldOptions.CType
+-	(FieldOptions_JSType)(0),                      // 5: google.protobuf.FieldOptions.JSType
+-	(FieldOptions_OptionRetention)(0),             // 6: google.protobuf.FieldOptions.OptionRetention
+-	(FieldOptions_OptionTargetType)(0),            // 7: google.protobuf.FieldOptions.OptionTargetType
+-	(MethodOptions_IdempotencyLevel)(0),           // 8: google.protobuf.MethodOptions.IdempotencyLevel
+-	(GeneratedCodeInfo_Annotation_Semantic)(0),    // 9: google.protobuf.GeneratedCodeInfo.Annotation.Semantic
+-	(*FileDescriptorSet)(nil),                     // 10: google.protobuf.FileDescriptorSet
+-	(*FileDescriptorProto)(nil),                   // 11: google.protobuf.FileDescriptorProto
+-	(*DescriptorProto)(nil),                       // 12: google.protobuf.DescriptorProto
+-	(*ExtensionRangeOptions)(nil),                 // 13: google.protobuf.ExtensionRangeOptions
+-	(*FieldDescriptorProto)(nil),                  // 14: google.protobuf.FieldDescriptorProto
+-	(*OneofDescriptorProto)(nil),                  // 15: google.protobuf.OneofDescriptorProto
+-	(*EnumDescriptorProto)(nil),                   // 16: google.protobuf.EnumDescriptorProto
+-	(*EnumValueDescriptorProto)(nil),              // 17: google.protobuf.EnumValueDescriptorProto
+-	(*ServiceDescriptorProto)(nil),                // 18: google.protobuf.ServiceDescriptorProto
+-	(*MethodDescriptorProto)(nil),                 // 19: google.protobuf.MethodDescriptorProto
+-	(*FileOptions)(nil),                           // 20: google.protobuf.FileOptions
+-	(*MessageOptions)(nil),                        // 21: google.protobuf.MessageOptions
+-	(*FieldOptions)(nil),                          // 22: google.protobuf.FieldOptions
+-	(*OneofOptions)(nil),                          // 23: google.protobuf.OneofOptions
+-	(*EnumOptions)(nil),                           // 24: google.protobuf.EnumOptions
+-	(*EnumValueOptions)(nil),                      // 25: google.protobuf.EnumValueOptions
+-	(*ServiceOptions)(nil),                        // 26: google.protobuf.ServiceOptions
+-	(*MethodOptions)(nil),                         // 27: google.protobuf.MethodOptions
+-	(*UninterpretedOption)(nil),                   // 28: google.protobuf.UninterpretedOption
+-	(*SourceCodeInfo)(nil),                        // 29: google.protobuf.SourceCodeInfo
+-	(*GeneratedCodeInfo)(nil),                     // 30: google.protobuf.GeneratedCodeInfo
+-	(*DescriptorProto_ExtensionRange)(nil),        // 31: google.protobuf.DescriptorProto.ExtensionRange
+-	(*DescriptorProto_ReservedRange)(nil),         // 32: google.protobuf.DescriptorProto.ReservedRange
+-	(*ExtensionRangeOptions_Declaration)(nil),     // 33: google.protobuf.ExtensionRangeOptions.Declaration
+-	(*EnumDescriptorProto_EnumReservedRange)(nil), // 34: google.protobuf.EnumDescriptorProto.EnumReservedRange
+-	(*UninterpretedOption_NamePart)(nil),          // 35: google.protobuf.UninterpretedOption.NamePart
+-	(*SourceCodeInfo_Location)(nil),               // 36: google.protobuf.SourceCodeInfo.Location
+-	(*GeneratedCodeInfo_Annotation)(nil),          // 37: google.protobuf.GeneratedCodeInfo.Annotation
++	(Edition)(0), // 0: google.protobuf.Edition
++	(ExtensionRangeOptions_VerificationState)(0),        // 1: google.protobuf.ExtensionRangeOptions.VerificationState
++	(FieldDescriptorProto_Type)(0),                      // 2: google.protobuf.FieldDescriptorProto.Type
++	(FieldDescriptorProto_Label)(0),                     // 3: google.protobuf.FieldDescriptorProto.Label
++	(FileOptions_OptimizeMode)(0),                       // 4: google.protobuf.FileOptions.OptimizeMode
++	(FieldOptions_CType)(0),                             // 5: google.protobuf.FieldOptions.CType
++	(FieldOptions_JSType)(0),                            // 6: google.protobuf.FieldOptions.JSType
++	(FieldOptions_OptionRetention)(0),                   // 7: google.protobuf.FieldOptions.OptionRetention
++	(FieldOptions_OptionTargetType)(0),                  // 8: google.protobuf.FieldOptions.OptionTargetType
++	(MethodOptions_IdempotencyLevel)(0),                 // 9: google.protobuf.MethodOptions.IdempotencyLevel
++	(FeatureSet_FieldPresence)(0),                       // 10: google.protobuf.FeatureSet.FieldPresence
++	(FeatureSet_EnumType)(0),                            // 11: google.protobuf.FeatureSet.EnumType
++	(FeatureSet_RepeatedFieldEncoding)(0),               // 12: google.protobuf.FeatureSet.RepeatedFieldEncoding
++	(FeatureSet_Utf8Validation)(0),                      // 13: google.protobuf.FeatureSet.Utf8Validation
++	(FeatureSet_MessageEncoding)(0),                     // 14: google.protobuf.FeatureSet.MessageEncoding
++	(FeatureSet_JsonFormat)(0),                          // 15: google.protobuf.FeatureSet.JsonFormat
++	(GeneratedCodeInfo_Annotation_Semantic)(0),          // 16: google.protobuf.GeneratedCodeInfo.Annotation.Semantic
++	(*FileDescriptorSet)(nil),                           // 17: google.protobuf.FileDescriptorSet
++	(*FileDescriptorProto)(nil),                         // 18: google.protobuf.FileDescriptorProto
++	(*DescriptorProto)(nil),                             // 19: google.protobuf.DescriptorProto
++	(*ExtensionRangeOptions)(nil),                       // 20: google.protobuf.ExtensionRangeOptions
++	(*FieldDescriptorProto)(nil),                        // 21: google.protobuf.FieldDescriptorProto
++	(*OneofDescriptorProto)(nil),                        // 22: google.protobuf.OneofDescriptorProto
++	(*EnumDescriptorProto)(nil),                         // 23: google.protobuf.EnumDescriptorProto
++	(*EnumValueDescriptorProto)(nil),                    // 24: google.protobuf.EnumValueDescriptorProto
++	(*ServiceDescriptorProto)(nil),                      // 25: google.protobuf.ServiceDescriptorProto
++	(*MethodDescriptorProto)(nil),                       // 26: google.protobuf.MethodDescriptorProto
++	(*FileOptions)(nil),                                 // 27: google.protobuf.FileOptions
++	(*MessageOptions)(nil),                              // 28: google.protobuf.MessageOptions
++	(*FieldOptions)(nil),                                // 29: google.protobuf.FieldOptions
++	(*OneofOptions)(nil),                                // 30: google.protobuf.OneofOptions
++	(*EnumOptions)(nil),                                 // 31: google.protobuf.EnumOptions
++	(*EnumValueOptions)(nil),                            // 32: google.protobuf.EnumValueOptions
++	(*ServiceOptions)(nil),                              // 33: google.protobuf.ServiceOptions
++	(*MethodOptions)(nil),                               // 34: google.protobuf.MethodOptions
++	(*UninterpretedOption)(nil),                         // 35: google.protobuf.UninterpretedOption
++	(*FeatureSet)(nil),                                  // 36: google.protobuf.FeatureSet
++	(*FeatureSetDefaults)(nil),                          // 37: google.protobuf.FeatureSetDefaults
++	(*SourceCodeInfo)(nil),                              // 38: google.protobuf.SourceCodeInfo
++	(*GeneratedCodeInfo)(nil),                           // 39: google.protobuf.GeneratedCodeInfo
++	(*DescriptorProto_ExtensionRange)(nil),              // 40: google.protobuf.DescriptorProto.ExtensionRange
++	(*DescriptorProto_ReservedRange)(nil),               // 41: google.protobuf.DescriptorProto.ReservedRange
++	(*ExtensionRangeOptions_Declaration)(nil),           // 42: google.protobuf.ExtensionRangeOptions.Declaration
++	(*EnumDescriptorProto_EnumReservedRange)(nil),       // 43: google.protobuf.EnumDescriptorProto.EnumReservedRange
++	(*FieldOptions_EditionDefault)(nil),                 // 44: google.protobuf.FieldOptions.EditionDefault
++	(*UninterpretedOption_NamePart)(nil),                // 45: google.protobuf.UninterpretedOption.NamePart
++	(*FeatureSetDefaults_FeatureSetEditionDefault)(nil), // 46: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
++	(*SourceCodeInfo_Location)(nil),                     // 47: google.protobuf.SourceCodeInfo.Location
++	(*GeneratedCodeInfo_Annotation)(nil),                // 48: google.protobuf.GeneratedCodeInfo.Annotation
+ }
+ var file_google_protobuf_descriptor_proto_depIdxs = []int32{
+-	11, // 0: google.protobuf.FileDescriptorSet.file:type_name -> google.protobuf.FileDescriptorProto
+-	12, // 1: google.protobuf.FileDescriptorProto.message_type:type_name -> google.protobuf.DescriptorProto
+-	16, // 2: google.protobuf.FileDescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
+-	18, // 3: google.protobuf.FileDescriptorProto.service:type_name -> google.protobuf.ServiceDescriptorProto
+-	14, // 4: google.protobuf.FileDescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
+-	20, // 5: google.protobuf.FileDescriptorProto.options:type_name -> google.protobuf.FileOptions
+-	29, // 6: google.protobuf.FileDescriptorProto.source_code_info:type_name -> google.protobuf.SourceCodeInfo
+-	14, // 7: google.protobuf.DescriptorProto.field:type_name -> google.protobuf.FieldDescriptorProto
+-	14, // 8: google.protobuf.DescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
+-	12, // 9: google.protobuf.DescriptorProto.nested_type:type_name -> google.protobuf.DescriptorProto
+-	16, // 10: google.protobuf.DescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
+-	31, // 11: google.protobuf.DescriptorProto.extension_range:type_name -> google.protobuf.DescriptorProto.ExtensionRange
+-	15, // 12: google.protobuf.DescriptorProto.oneof_decl:type_name -> google.protobuf.OneofDescriptorProto
+-	21, // 13: google.protobuf.DescriptorProto.options:type_name -> google.protobuf.MessageOptions
+-	32, // 14: google.protobuf.DescriptorProto.reserved_range:type_name -> google.protobuf.DescriptorProto.ReservedRange
+-	28, // 15: google.protobuf.ExtensionRangeOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	33, // 16: google.protobuf.ExtensionRangeOptions.declaration:type_name -> google.protobuf.ExtensionRangeOptions.Declaration
+-	0,  // 17: google.protobuf.ExtensionRangeOptions.verification:type_name -> google.protobuf.ExtensionRangeOptions.VerificationState
+-	2,  // 18: google.protobuf.FieldDescriptorProto.label:type_name -> google.protobuf.FieldDescriptorProto.Label
+-	1,  // 19: google.protobuf.FieldDescriptorProto.type:type_name -> google.protobuf.FieldDescriptorProto.Type
+-	22, // 20: google.protobuf.FieldDescriptorProto.options:type_name -> google.protobuf.FieldOptions
+-	23, // 21: google.protobuf.OneofDescriptorProto.options:type_name -> google.protobuf.OneofOptions
+-	17, // 22: google.protobuf.EnumDescriptorProto.value:type_name -> google.protobuf.EnumValueDescriptorProto
+-	24, // 23: google.protobuf.EnumDescriptorProto.options:type_name -> google.protobuf.EnumOptions
+-	34, // 24: google.protobuf.EnumDescriptorProto.reserved_range:type_name -> google.protobuf.EnumDescriptorProto.EnumReservedRange
+-	25, // 25: google.protobuf.EnumValueDescriptorProto.options:type_name -> google.protobuf.EnumValueOptions
+-	19, // 26: google.protobuf.ServiceDescriptorProto.method:type_name -> google.protobuf.MethodDescriptorProto
+-	26, // 27: google.protobuf.ServiceDescriptorProto.options:type_name -> google.protobuf.ServiceOptions
+-	27, // 28: google.protobuf.MethodDescriptorProto.options:type_name -> google.protobuf.MethodOptions
+-	3,  // 29: google.protobuf.FileOptions.optimize_for:type_name -> google.protobuf.FileOptions.OptimizeMode
+-	28, // 30: google.protobuf.FileOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 31: google.protobuf.MessageOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	4,  // 32: google.protobuf.FieldOptions.ctype:type_name -> google.protobuf.FieldOptions.CType
+-	5,  // 33: google.protobuf.FieldOptions.jstype:type_name -> google.protobuf.FieldOptions.JSType
+-	6,  // 34: google.protobuf.FieldOptions.retention:type_name -> google.protobuf.FieldOptions.OptionRetention
+-	7,  // 35: google.protobuf.FieldOptions.target:type_name -> google.protobuf.FieldOptions.OptionTargetType
+-	7,  // 36: google.protobuf.FieldOptions.targets:type_name -> google.protobuf.FieldOptions.OptionTargetType
+-	28, // 37: google.protobuf.FieldOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 38: google.protobuf.OneofOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 39: google.protobuf.EnumOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 40: google.protobuf.EnumValueOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 41: google.protobuf.ServiceOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	8,  // 42: google.protobuf.MethodOptions.idempotency_level:type_name -> google.protobuf.MethodOptions.IdempotencyLevel
+-	28, // 43: google.protobuf.MethodOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	35, // 44: google.protobuf.UninterpretedOption.name:type_name -> google.protobuf.UninterpretedOption.NamePart
+-	36, // 45: google.protobuf.SourceCodeInfo.location:type_name -> google.protobuf.SourceCodeInfo.Location
+-	37, // 46: google.protobuf.GeneratedCodeInfo.annotation:type_name -> google.protobuf.GeneratedCodeInfo.Annotation
+-	13, // 47: google.protobuf.DescriptorProto.ExtensionRange.options:type_name -> google.protobuf.ExtensionRangeOptions
+-	9,  // 48: google.protobuf.GeneratedCodeInfo.Annotation.semantic:type_name -> google.protobuf.GeneratedCodeInfo.Annotation.Semantic
+-	49, // [49:49] is the sub-list for method output_type
+-	49, // [49:49] is the sub-list for method input_type
+-	49, // [49:49] is the sub-list for extension type_name
+-	49, // [49:49] is the sub-list for extension extendee
+-	0,  // [0:49] is the sub-list for field type_name
++	18, // 0: google.protobuf.FileDescriptorSet.file:type_name -> google.protobuf.FileDescriptorProto
++	19, // 1: google.protobuf.FileDescriptorProto.message_type:type_name -> google.protobuf.DescriptorProto
++	23, // 2: google.protobuf.FileDescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
++	25, // 3: google.protobuf.FileDescriptorProto.service:type_name -> google.protobuf.ServiceDescriptorProto
++	21, // 4: google.protobuf.FileDescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
++	27, // 5: google.protobuf.FileDescriptorProto.options:type_name -> google.protobuf.FileOptions
++	38, // 6: google.protobuf.FileDescriptorProto.source_code_info:type_name -> google.protobuf.SourceCodeInfo
++	0,  // 7: google.protobuf.FileDescriptorProto.edition:type_name -> google.protobuf.Edition
++	21, // 8: google.protobuf.DescriptorProto.field:type_name -> google.protobuf.FieldDescriptorProto
++	21, // 9: google.protobuf.DescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
++	19, // 10: google.protobuf.DescriptorProto.nested_type:type_name -> google.protobuf.DescriptorProto
++	23, // 11: google.protobuf.DescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
++	40, // 12: google.protobuf.DescriptorProto.extension_range:type_name -> google.protobuf.DescriptorProto.ExtensionRange
++	22, // 13: google.protobuf.DescriptorProto.oneof_decl:type_name -> google.protobuf.OneofDescriptorProto
++	28, // 14: google.protobuf.DescriptorProto.options:type_name -> google.protobuf.MessageOptions
++	41, // 15: google.protobuf.DescriptorProto.reserved_range:type_name -> google.protobuf.DescriptorProto.ReservedRange
++	35, // 16: google.protobuf.ExtensionRangeOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	42, // 17: google.protobuf.ExtensionRangeOptions.declaration:type_name -> google.protobuf.ExtensionRangeOptions.Declaration
++	36, // 18: google.protobuf.ExtensionRangeOptions.features:type_name -> google.protobuf.FeatureSet
++	1,  // 19: google.protobuf.ExtensionRangeOptions.verification:type_name -> google.protobuf.ExtensionRangeOptions.VerificationState
++	3,  // 20: google.protobuf.FieldDescriptorProto.label:type_name -> google.protobuf.FieldDescriptorProto.Label
++	2,  // 21: google.protobuf.FieldDescriptorProto.type:type_name -> google.protobuf.FieldDescriptorProto.Type
++	29, // 22: google.protobuf.FieldDescriptorProto.options:type_name -> google.protobuf.FieldOptions
++	30, // 23: google.protobuf.OneofDescriptorProto.options:type_name -> google.protobuf.OneofOptions
++	24, // 24: google.protobuf.EnumDescriptorProto.value:type_name -> google.protobuf.EnumValueDescriptorProto
++	31, // 25: google.protobuf.EnumDescriptorProto.options:type_name -> google.protobuf.EnumOptions
++	43, // 26: google.protobuf.EnumDescriptorProto.reserved_range:type_name -> google.protobuf.EnumDescriptorProto.EnumReservedRange
++	32, // 27: google.protobuf.EnumValueDescriptorProto.options:type_name -> google.protobuf.EnumValueOptions
++	26, // 28: google.protobuf.ServiceDescriptorProto.method:type_name -> google.protobuf.MethodDescriptorProto
++	33, // 29: google.protobuf.ServiceDescriptorProto.options:type_name -> google.protobuf.ServiceOptions
++	34, // 30: google.protobuf.MethodDescriptorProto.options:type_name -> google.protobuf.MethodOptions
++	4,  // 31: google.protobuf.FileOptions.optimize_for:type_name -> google.protobuf.FileOptions.OptimizeMode
++	36, // 32: google.protobuf.FileOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 33: google.protobuf.FileOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 34: google.protobuf.MessageOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 35: google.protobuf.MessageOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	5,  // 36: google.protobuf.FieldOptions.ctype:type_name -> google.protobuf.FieldOptions.CType
++	6,  // 37: google.protobuf.FieldOptions.jstype:type_name -> google.protobuf.FieldOptions.JSType
++	7,  // 38: google.protobuf.FieldOptions.retention:type_name -> google.protobuf.FieldOptions.OptionRetention
++	8,  // 39: google.protobuf.FieldOptions.targets:type_name -> google.protobuf.FieldOptions.OptionTargetType
++	44, // 40: google.protobuf.FieldOptions.edition_defaults:type_name -> google.protobuf.FieldOptions.EditionDefault
++	36, // 41: google.protobuf.FieldOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 42: google.protobuf.FieldOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 43: google.protobuf.OneofOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 44: google.protobuf.OneofOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 45: google.protobuf.EnumOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 46: google.protobuf.EnumOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 47: google.protobuf.EnumValueOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 48: google.protobuf.EnumValueOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 49: google.protobuf.ServiceOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 50: google.protobuf.ServiceOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	9,  // 51: google.protobuf.MethodOptions.idempotency_level:type_name -> google.protobuf.MethodOptions.IdempotencyLevel
++	36, // 52: google.protobuf.MethodOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 53: google.protobuf.MethodOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	45, // 54: google.protobuf.UninterpretedOption.name:type_name -> google.protobuf.UninterpretedOption.NamePart
++	10, // 55: google.protobuf.FeatureSet.field_presence:type_name -> google.protobuf.FeatureSet.FieldPresence
++	11, // 56: google.protobuf.FeatureSet.enum_type:type_name -> google.protobuf.FeatureSet.EnumType
++	12, // 57: google.protobuf.FeatureSet.repeated_field_encoding:type_name -> google.protobuf.FeatureSet.RepeatedFieldEncoding
++	13, // 58: google.protobuf.FeatureSet.utf8_validation:type_name -> google.protobuf.FeatureSet.Utf8Validation
++	14, // 59: google.protobuf.FeatureSet.message_encoding:type_name -> google.protobuf.FeatureSet.MessageEncoding
++	15, // 60: google.protobuf.FeatureSet.json_format:type_name -> google.protobuf.FeatureSet.JsonFormat
++	46, // 61: google.protobuf.FeatureSetDefaults.defaults:type_name -> google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
++	0,  // 62: google.protobuf.FeatureSetDefaults.minimum_edition:type_name -> google.protobuf.Edition
++	0,  // 63: google.protobuf.FeatureSetDefaults.maximum_edition:type_name -> google.protobuf.Edition
++	47, // 64: google.protobuf.SourceCodeInfo.location:type_name -> google.protobuf.SourceCodeInfo.Location
++	48, // 65: google.protobuf.GeneratedCodeInfo.annotation:type_name -> google.protobuf.GeneratedCodeInfo.Annotation
++	20, // 66: google.protobuf.DescriptorProto.ExtensionRange.options:type_name -> google.protobuf.ExtensionRangeOptions
++	0,  // 67: google.protobuf.FieldOptions.EditionDefault.edition:type_name -> google.protobuf.Edition
++	0,  // 68: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.edition:type_name -> google.protobuf.Edition
++	36, // 69: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.features:type_name -> google.protobuf.FeatureSet
++	16, // 70: google.protobuf.GeneratedCodeInfo.Annotation.semantic:type_name -> google.protobuf.GeneratedCodeInfo.Annotation.Semantic
++	71, // [71:71] is the sub-list for method output_type
++	71, // [71:71] is the sub-list for method input_type
++	71, // [71:71] is the sub-list for extension type_name
++	71, // [71:71] is the sub-list for extension extendee
++	0,  // [0:71] is the sub-list for field type_name
+ }
+ 
+ func init() { file_google_protobuf_descriptor_proto_init() }
+@@ -4475,19 +5468,21 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*SourceCodeInfo); i {
++			switch v := v.(*FeatureSet); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+ 				return &v.sizeCache
+ 			case 2:
+ 				return &v.unknownFields
++			case 3:
++				return &v.extensionFields
+ 			default:
+ 				return nil
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*GeneratedCodeInfo); i {
++			switch v := v.(*FeatureSetDefaults); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4499,7 +5494,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*DescriptorProto_ExtensionRange); i {
++			switch v := v.(*SourceCodeInfo); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4511,7 +5506,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*DescriptorProto_ReservedRange); i {
++			switch v := v.(*GeneratedCodeInfo); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4523,7 +5518,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*ExtensionRangeOptions_Declaration); i {
++			switch v := v.(*DescriptorProto_ExtensionRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4535,7 +5530,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*EnumDescriptorProto_EnumReservedRange); i {
++			switch v := v.(*DescriptorProto_ReservedRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4547,7 +5542,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*UninterpretedOption_NamePart); i {
++			switch v := v.(*ExtensionRangeOptions_Declaration); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4559,7 +5554,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*SourceCodeInfo_Location); i {
++			switch v := v.(*EnumDescriptorProto_EnumReservedRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4571,6 +5566,54 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*FieldOptions_EditionDefault); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*UninterpretedOption_NamePart); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*FeatureSetDefaults_FeatureSetEditionDefault); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*SourceCodeInfo_Location); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
+ 			switch v := v.(*GeneratedCodeInfo_Annotation); i {
+ 			case 0:
+ 				return &v.state
+@@ -4588,8 +5631,8 @@ func file_google_protobuf_descriptor_proto_init() {
+ 		File: protoimpl.DescBuilder{
+ 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
+ 			RawDescriptor: file_google_protobuf_descriptor_proto_rawDesc,
+-			NumEnums:      10,
+-			NumMessages:   28,
++			NumEnums:      17,
++			NumMessages:   32,
+ 			NumExtensions: 0,
+ 			NumServices:   0,
+ 		},
+diff --git a/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+new file mode 100644
+index 0000000..25de5ae
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+@@ -0,0 +1,177 @@
++// Protocol Buffers - Google's data interchange format
++// Copyright 2023 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++// Code generated by protoc-gen-go. DO NOT EDIT.
++// source: reflect/protodesc/proto/go_features.proto
++
++package proto
++
++import (
++	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
++	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
++	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
++	reflect "reflect"
++	sync "sync"
++)
++
++type GoFeatures struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	// Whether or not to generate the deprecated UnmarshalJSON method for enums.
++	LegacyUnmarshalJsonEnum *bool `protobuf:"varint,1,opt,name=legacy_unmarshal_json_enum,json=legacyUnmarshalJsonEnum" json:"legacy_unmarshal_json_enum,omitempty"`
++}
++
++func (x *GoFeatures) Reset() {
++	*x = GoFeatures{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_reflect_protodesc_proto_go_features_proto_msgTypes[0]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *GoFeatures) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*GoFeatures) ProtoMessage() {}
++
++func (x *GoFeatures) ProtoReflect() protoreflect.Message {
++	mi := &file_reflect_protodesc_proto_go_features_proto_msgTypes[0]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use GoFeatures.ProtoReflect.Descriptor instead.
++func (*GoFeatures) Descriptor() ([]byte, []int) {
++	return file_reflect_protodesc_proto_go_features_proto_rawDescGZIP(), []int{0}
++}
++
++func (x *GoFeatures) GetLegacyUnmarshalJsonEnum() bool {
++	if x != nil && x.LegacyUnmarshalJsonEnum != nil {
++		return *x.LegacyUnmarshalJsonEnum
++	}
++	return false
++}
++
++var file_reflect_protodesc_proto_go_features_proto_extTypes = []protoimpl.ExtensionInfo{
++	{
++		ExtendedType:  (*descriptorpb.FeatureSet)(nil),
++		ExtensionType: (*GoFeatures)(nil),
++		Field:         1002,
++		Name:          "google.protobuf.go",
++		Tag:           "bytes,1002,opt,name=go",
++		Filename:      "reflect/protodesc/proto/go_features.proto",
++	},
++}
++
++// Extension fields to descriptorpb.FeatureSet.
++var (
++	// optional google.protobuf.GoFeatures go = 1002;
++	E_Go = &file_reflect_protodesc_proto_go_features_proto_extTypes[0]
++)
++
++var File_reflect_protodesc_proto_go_features_proto protoreflect.FileDescriptor
++
++var file_reflect_protodesc_proto_go_features_proto_rawDesc = []byte{
++	0x0a, 0x29, 0x72, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x64,
++	0x65, 0x73, 0x63, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x67, 0x6f, 0x5f, 0x66, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x0f, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x1a, 0x20, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x64, 0x65,
++	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x6a,
++	0x0a, 0x0a, 0x47, 0x6f, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x5c, 0x0a, 0x1a,
++	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x75, 0x6e, 0x6d, 0x61, 0x72, 0x73, 0x68, 0x61, 0x6c,
++	0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x65, 0x6e, 0x75, 0x6d, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08,
++	0x42, 0x1f, 0x88, 0x01, 0x01, 0x98, 0x01, 0x06, 0xa2, 0x01, 0x09, 0x12, 0x04, 0x74, 0x72, 0x75,
++	0x65, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x0a, 0x12, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x18, 0xe7,
++	0x07, 0x52, 0x17, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x55, 0x6e, 0x6d, 0x61, 0x72, 0x73, 0x68,
++	0x61, 0x6c, 0x4a, 0x73, 0x6f, 0x6e, 0x45, 0x6e, 0x75, 0x6d, 0x3a, 0x49, 0x0a, 0x02, 0x67, 0x6f,
++	0x12, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x18, 0xea, 0x07,
++	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x6f, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x52, 0x02, 0x67, 0x6f, 0x42, 0x34, 0x5a, 0x32, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2f, 0x72, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x64, 0x65, 0x73, 0x63, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++}
++
++var (
++	file_reflect_protodesc_proto_go_features_proto_rawDescOnce sync.Once
++	file_reflect_protodesc_proto_go_features_proto_rawDescData = file_reflect_protodesc_proto_go_features_proto_rawDesc
++)
++
++func file_reflect_protodesc_proto_go_features_proto_rawDescGZIP() []byte {
++	file_reflect_protodesc_proto_go_features_proto_rawDescOnce.Do(func() {
++		file_reflect_protodesc_proto_go_features_proto_rawDescData = protoimpl.X.CompressGZIP(file_reflect_protodesc_proto_go_features_proto_rawDescData)
++	})
++	return file_reflect_protodesc_proto_go_features_proto_rawDescData
++}
++
++var file_reflect_protodesc_proto_go_features_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
++var file_reflect_protodesc_proto_go_features_proto_goTypes = []interface{}{
++	(*GoFeatures)(nil),              // 0: google.protobuf.GoFeatures
++	(*descriptorpb.FeatureSet)(nil), // 1: google.protobuf.FeatureSet
++}
++var file_reflect_protodesc_proto_go_features_proto_depIdxs = []int32{
++	1, // 0: google.protobuf.go:extendee -> google.protobuf.FeatureSet
++	0, // 1: google.protobuf.go:type_name -> google.protobuf.GoFeatures
++	2, // [2:2] is the sub-list for method output_type
++	2, // [2:2] is the sub-list for method input_type
++	1, // [1:2] is the sub-list for extension type_name
++	0, // [0:1] is the sub-list for extension extendee
++	0, // [0:0] is the sub-list for field type_name
++}
++
++func init() { file_reflect_protodesc_proto_go_features_proto_init() }
++func file_reflect_protodesc_proto_go_features_proto_init() {
++	if File_reflect_protodesc_proto_go_features_proto != nil {
++		return
++	}
++	if !protoimpl.UnsafeEnabled {
++		file_reflect_protodesc_proto_go_features_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*GoFeatures); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++	}
++	type x struct{}
++	out := protoimpl.TypeBuilder{
++		File: protoimpl.DescBuilder{
++			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
++			RawDescriptor: file_reflect_protodesc_proto_go_features_proto_rawDesc,
++			NumEnums:      0,
++			NumMessages:   1,
++			NumExtensions: 1,
++			NumServices:   0,
++		},
++		GoTypes:           file_reflect_protodesc_proto_go_features_proto_goTypes,
++		DependencyIndexes: file_reflect_protodesc_proto_go_features_proto_depIdxs,
++		MessageInfos:      file_reflect_protodesc_proto_go_features_proto_msgTypes,
++		ExtensionInfos:    file_reflect_protodesc_proto_go_features_proto_extTypes,
++	}.Build()
++	File_reflect_protodesc_proto_go_features_proto = out.File
++	file_reflect_protodesc_proto_go_features_proto_rawDesc = nil
++	file_reflect_protodesc_proto_go_features_proto_goTypes = nil
++	file_reflect_protodesc_proto_go_features_proto_depIdxs = nil
++}
+diff --git a/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+new file mode 100644
+index 0000000..d246571
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+@@ -0,0 +1,28 @@
++// Protocol Buffers - Google's data interchange format
++// Copyright 2023 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++syntax = "proto2";
++
++package google.protobuf;
++
++import "google/protobuf/descriptor.proto";
++
++option go_package = "google.golang.org/protobuf/types/gofeaturespb";
++
++extend google.protobuf.FeatureSet {
++  optional GoFeatures go = 1002;
++}
++
++message GoFeatures {
++  // Whether or not to generate the deprecated UnmarshalJSON method for enums.
++  optional bool legacy_unmarshal_json_enum = 1 [
++    retention = RETENTION_RUNTIME,
++    targets = TARGET_TYPE_ENUM,
++    edition_defaults = { edition: EDITION_PROTO2, value: "true" },
++    edition_defaults = { edition: EDITION_PROTO3, value: "false" }
++  ];
++}
+diff --git a/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go b/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
+index 580b232..9de51be 100644
+--- a/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
++++ b/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
+@@ -237,7 +237,8 @@ type Any struct {
+ 	//
+ 	// Note: this functionality is not currently available in the official
+ 	// protobuf release, and it is not used for type URLs beginning with
+-	// type.googleapis.com.
++	// type.googleapis.com. As of May 2023, there are no widely used type server
++	// implementations and no plans to implement one.
+ 	//
+ 	// Schemes other than `http`, `https` (or the empty scheme) might be
+ 	// used with implementation specific semantics.
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index f3db441..e57446f 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -29,8 +29,8 @@ github.com/gogo/protobuf/sortkeys
+ ## explicit; go 1.11
+ github.com/golang/mock/gomock
+ github.com/golang/mock/mockgen/model
+-# github.com/golang/protobuf v1.5.3
+-## explicit; go 1.9
++# github.com/golang/protobuf v1.5.4
++## explicit; go 1.17
+ github.com/golang/protobuf/descriptor
+ github.com/golang/protobuf/jsonpb
+ github.com/golang/protobuf/proto
+@@ -218,14 +218,15 @@ google.golang.org/grpc/serviceconfig
+ google.golang.org/grpc/stats
+ google.golang.org/grpc/status
+ google.golang.org/grpc/tap
+-# google.golang.org/protobuf v1.31.0
+-## explicit; go 1.11
++# google.golang.org/protobuf v1.33.0
++## explicit; go 1.17
+ google.golang.org/protobuf/encoding/protojson
+ google.golang.org/protobuf/encoding/prototext
+ google.golang.org/protobuf/encoding/protowire
+ google.golang.org/protobuf/internal/descfmt
+ google.golang.org/protobuf/internal/descopts
+ google.golang.org/protobuf/internal/detrand
++google.golang.org/protobuf/internal/editiondefaults
+ google.golang.org/protobuf/internal/encoding/defval
+ google.golang.org/protobuf/internal/encoding/json
+ google.golang.org/protobuf/internal/encoding/messageset
+@@ -249,6 +250,7 @@ google.golang.org/protobuf/reflect/protoregistry
+ google.golang.org/protobuf/runtime/protoiface
+ google.golang.org/protobuf/runtime/protoimpl
+ google.golang.org/protobuf/types/descriptorpb
++google.golang.org/protobuf/types/gofeaturespb
+ google.golang.org/protobuf/types/known/anypb
+ google.golang.org/protobuf/types/known/durationpb
+ google.golang.org/protobuf/types/known/timestamppb
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/livenessprobe/1-27/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-27/CHECKSUMS
@@ -1,3 +1,3 @@
-d6969295d34e8eff3c87c9d9ace64f4817b5163a175d8be4384238266757ac28  _output/1-27/bin/livenessprobe/linux-amd64/livenessprobe
-23dd70fa11a9c2e0c83eccd1b4c8eecdf5d7c7ba55f8c50b6a3a88545b2998b6  _output/1-27/bin/livenessprobe/linux-arm64/livenessprobe
-d981c39b4089a15067100c9408f44898dc9d5c332716bd904c29dc44cd019b59  _output/1-27/bin/livenessprobe/windows-amd64/livenessprobe.exe
+f22ddc72b7428124f72945a6a6ffae35f17ecf71ebe35e1cbb356048bf216b20  _output/1-27/bin/livenessprobe/linux-amd64/livenessprobe
+d855e1a5d85f62483f89761693933b4a08cc98aa465248a23b4d98bd0c677885  _output/1-27/bin/livenessprobe/linux-arm64/livenessprobe
+062bdd08c21daf93a62469e7e09a88e4c514082cc9e0baa7de260ff1ee4d09eb  _output/1-27/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-27/patches/0001-Bump-protobuf-to-resolve-CVE-2024-24786-for-Liveness.patch
+++ b/projects/kubernetes-csi/livenessprobe/1-27/patches/0001-Bump-protobuf-to-resolve-CVE-2024-24786-for-Liveness.patch
@@ -1,0 +1,8141 @@
+From 787b5e4818b71783774e36f358a57150abad5983 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Mon, 18 Mar 2024 17:37:01 +0000
+Subject: [PATCH] Bump protobuf to resolve CVE-2024-24786 for Liveness-Probe
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |    4 +-
+ go.sum                                        |   12 +-
+ .../golang/protobuf/jsonpb/decode.go          |    1 +
+ .../golang/protobuf/jsonpb/encode.go          |    1 +
+ .../protoc-gen-go/descriptor/descriptor.pb.go |  128 +-
+ .../github.com/golang/protobuf/ptypes/any.go  |    7 +-
+ .../protobuf/encoding/protojson/decode.go     |   38 +-
+ .../protobuf/encoding/protojson/doc.go        |    2 +-
+ .../protobuf/encoding/protojson/encode.go     |   39 +-
+ .../encoding/protojson/well_known_types.go    |   59 +-
+ .../protobuf/encoding/prototext/decode.go     |    8 +-
+ .../protobuf/encoding/prototext/encode.go     |    4 +-
+ .../protobuf/encoding/protowire/wire.go       |   28 +-
+ .../protobuf/internal/descfmt/stringer.go     |  183 +-
+ .../internal/editiondefaults/defaults.go      |   12 +
+ .../editiondefaults/editions_defaults.binpb   |    4 +
+ .../protobuf/internal/encoding/json/decode.go |    2 +-
+ .../protobuf/internal/filedesc/desc.go        |  102 +-
+ .../protobuf/internal/filedesc/desc_init.go   |   52 +
+ .../protobuf/internal/filedesc/desc_lazy.go   |   28 +
+ .../protobuf/internal/filedesc/editions.go    |  142 +
+ .../protobuf/internal/genid/descriptor_gen.go |  364 ++-
+ .../internal/genid/go_features_gen.go         |   31 +
+ .../protobuf/internal/genid/struct_gen.go     |    5 +
+ .../protobuf/internal/genid/type_gen.go       |   38 +
+ .../protobuf/internal/impl/codec_extension.go |   22 +-
+ .../protobuf/internal/impl/codec_gen.go       |  113 +-
+ .../protobuf/internal/impl/codec_tables.go    |    2 +-
+ .../protobuf/internal/impl/legacy_message.go  |   19 +-
+ .../protobuf/internal/impl/message.go         |   17 +-
+ .../internal/impl/message_reflect_field.go    |    2 +-
+ .../protobuf/internal/impl/pointer_reflect.go |   36 +
+ .../protobuf/internal/impl/pointer_unsafe.go  |   40 +
+ .../protobuf/internal/strs/strings.go         |    2 +-
+ ...ings_unsafe.go => strings_unsafe_go120.go} |    4 +-
+ .../internal/strs/strings_unsafe_go121.go     |   74 +
+ .../protobuf/internal/version/version.go      |    2 +-
+ .../protobuf/proto/decode.go                  |    2 +-
+ .../google.golang.org/protobuf/proto/doc.go   |   58 +-
+ .../protobuf/proto/encode.go                  |    2 +-
+ .../protobuf/proto/extension.go               |    2 +-
+ .../google.golang.org/protobuf/proto/merge.go |    2 +-
+ .../google.golang.org/protobuf/proto/proto.go |   18 +-
+ .../protobuf/reflect/protodesc/desc.go        |   29 +-
+ .../protobuf/reflect/protodesc/desc_init.go   |   56 +
+ .../reflect/protodesc/desc_resolve.go         |    4 +-
+ .../reflect/protodesc/desc_validate.go        |    6 +-
+ .../protobuf/reflect/protodesc/editions.go    |  148 +
+ .../protobuf/reflect/protodesc/proto.go       |   18 +-
+ .../protobuf/reflect/protoreflect/proto.go    |   85 +-
+ .../reflect/protoreflect/source_gen.go        |   64 +-
+ .../protobuf/reflect/protoreflect/type.go     |   44 +-
+ .../protobuf/reflect/protoreflect/value.go    |   24 +-
+ .../reflect/protoreflect/value_equal.go       |    8 +-
+ .../reflect/protoreflect/value_union.go       |   44 +-
+ ...{value_unsafe.go => value_unsafe_go120.go} |    4 +-
+ .../protoreflect/value_unsafe_go121.go        |   87 +
+ .../reflect/protoregistry/registry.go         |   24 +-
+ .../types/descriptorpb/descriptor.pb.go       | 2475 ++++++++++++-----
+ .../types/gofeaturespb/go_features.pb.go      |  177 ++
+ .../types/gofeaturespb/go_features.proto      |   28 +
+ .../protobuf/types/known/anypb/any.pb.go      |    3 +-
+ vendor/modules.txt                            |   10 +-
+ 63 files changed, 3921 insertions(+), 1128 deletions(-)
+ create mode 100644 vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+ create mode 100644 vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+ create mode 100644 vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+ create mode 100644 vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+ rename vendor/google.golang.org/protobuf/internal/strs/{strings_unsafe.go => strings_unsafe_go120.go} (96%)
+ create mode 100644 vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+ create mode 100644 vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+ rename vendor/google.golang.org/protobuf/reflect/protoreflect/{value_unsafe.go => value_unsafe_go120.go} (97%)
+ create mode 100644 vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+ create mode 100644 vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+ create mode 100644 vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+
+diff --git a/go.mod b/go.mod
+index 66f1999..1e1128d 100644
+--- a/go.mod
++++ b/go.mod
+@@ -19,7 +19,7 @@ require (
+ 	github.com/go-logr/stdr v1.2.2 // indirect
+ 	github.com/go-logr/zapr v1.2.3 // indirect
+ 	github.com/gogo/protobuf v1.3.2 // indirect
+-	github.com/golang/protobuf v1.5.3 // indirect
++	github.com/golang/protobuf v1.5.4 // indirect
+ 	github.com/google/go-cmp v0.6.0 // indirect
+ 	github.com/google/gofuzz v1.2.0 // indirect
+ 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+@@ -46,7 +46,7 @@ require (
+ 	golang.org/x/text v0.14.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
+ 	google.golang.org/grpc v1.60.1 // indirect
+-	google.golang.org/protobuf v1.31.0 // indirect
++	google.golang.org/protobuf v1.33.0 // indirect
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+ 	gopkg.in/yaml.v2 v2.4.0 // indirect
+ 	k8s.io/apimachinery v0.29.0 // indirect
+diff --git a/go.sum b/go.sum
+index 37e6f06..8d87ecd 100644
+--- a/go.sum
++++ b/go.sum
+@@ -33,10 +33,8 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
+ github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+ github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
++github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
++github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+@@ -169,10 +167,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 h1:
+ google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17/go.mod h1:oQ5rr10WTTMvP4A36n8JpR1OrO1BEiV4f78CneXZxkA=
+ google.golang.org/grpc v1.60.1 h1:26+wFr+cNqSGFcOXcabYC0lUVJVRa2Sb2ortSK7VrEU=
+ google.golang.org/grpc v1.60.1/go.mod h1:OlCHIeLYqSSsLi6i49B5QGdzaMZK9+M7LXN2FKz4eGM=
+-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
++google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
++google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+diff --git a/vendor/github.com/golang/protobuf/jsonpb/decode.go b/vendor/github.com/golang/protobuf/jsonpb/decode.go
+index 6c16c25..c6f66f1 100644
+--- a/vendor/github.com/golang/protobuf/jsonpb/decode.go
++++ b/vendor/github.com/golang/protobuf/jsonpb/decode.go
+@@ -56,6 +56,7 @@ type Unmarshaler struct {
+ // implement JSONPBMarshaler so that the custom format can be produced.
+ //
+ // The JSON unmarshaling must follow the JSON to proto specification:
++//
+ //	https://developers.google.com/protocol-buffers/docs/proto3#json
+ //
+ // Deprecated: Custom types should implement protobuf reflection instead.
+diff --git a/vendor/github.com/golang/protobuf/jsonpb/encode.go b/vendor/github.com/golang/protobuf/jsonpb/encode.go
+index 685c80a..e9438a9 100644
+--- a/vendor/github.com/golang/protobuf/jsonpb/encode.go
++++ b/vendor/github.com/golang/protobuf/jsonpb/encode.go
+@@ -55,6 +55,7 @@ type Marshaler struct {
+ // implement JSONPBUnmarshaler so that the custom format can be parsed.
+ //
+ // The JSON marshaling must follow the proto to JSON specification:
++//
+ //	https://developers.google.com/protocol-buffers/docs/proto3#json
+ //
+ // Deprecated: Custom types should implement protobuf reflection instead.
+diff --git a/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go b/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
+index 63dc057..a5a1386 100644
+--- a/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
++++ b/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
+@@ -12,6 +12,31 @@ import (
+ 
+ // Symbols defined in public import of google/protobuf/descriptor.proto.
+ 
++type Edition = descriptorpb.Edition
++
++const Edition_EDITION_UNKNOWN = descriptorpb.Edition_EDITION_UNKNOWN
++const Edition_EDITION_PROTO2 = descriptorpb.Edition_EDITION_PROTO2
++const Edition_EDITION_PROTO3 = descriptorpb.Edition_EDITION_PROTO3
++const Edition_EDITION_2023 = descriptorpb.Edition_EDITION_2023
++const Edition_EDITION_2024 = descriptorpb.Edition_EDITION_2024
++const Edition_EDITION_1_TEST_ONLY = descriptorpb.Edition_EDITION_1_TEST_ONLY
++const Edition_EDITION_2_TEST_ONLY = descriptorpb.Edition_EDITION_2_TEST_ONLY
++const Edition_EDITION_99997_TEST_ONLY = descriptorpb.Edition_EDITION_99997_TEST_ONLY
++const Edition_EDITION_99998_TEST_ONLY = descriptorpb.Edition_EDITION_99998_TEST_ONLY
++const Edition_EDITION_99999_TEST_ONLY = descriptorpb.Edition_EDITION_99999_TEST_ONLY
++const Edition_EDITION_MAX = descriptorpb.Edition_EDITION_MAX
++
++var Edition_name = descriptorpb.Edition_name
++var Edition_value = descriptorpb.Edition_value
++
++type ExtensionRangeOptions_VerificationState = descriptorpb.ExtensionRangeOptions_VerificationState
++
++const ExtensionRangeOptions_DECLARATION = descriptorpb.ExtensionRangeOptions_DECLARATION
++const ExtensionRangeOptions_UNVERIFIED = descriptorpb.ExtensionRangeOptions_UNVERIFIED
++
++var ExtensionRangeOptions_VerificationState_name = descriptorpb.ExtensionRangeOptions_VerificationState_name
++var ExtensionRangeOptions_VerificationState_value = descriptorpb.ExtensionRangeOptions_VerificationState_value
++
+ type FieldDescriptorProto_Type = descriptorpb.FieldDescriptorProto_Type
+ 
+ const FieldDescriptorProto_TYPE_DOUBLE = descriptorpb.FieldDescriptorProto_TYPE_DOUBLE
+@@ -39,8 +64,8 @@ var FieldDescriptorProto_Type_value = descriptorpb.FieldDescriptorProto_Type_val
+ type FieldDescriptorProto_Label = descriptorpb.FieldDescriptorProto_Label
+ 
+ const FieldDescriptorProto_LABEL_OPTIONAL = descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL
+-const FieldDescriptorProto_LABEL_REQUIRED = descriptorpb.FieldDescriptorProto_LABEL_REQUIRED
+ const FieldDescriptorProto_LABEL_REPEATED = descriptorpb.FieldDescriptorProto_LABEL_REPEATED
++const FieldDescriptorProto_LABEL_REQUIRED = descriptorpb.FieldDescriptorProto_LABEL_REQUIRED
+ 
+ var FieldDescriptorProto_Label_name = descriptorpb.FieldDescriptorProto_Label_name
+ var FieldDescriptorProto_Label_value = descriptorpb.FieldDescriptorProto_Label_value
+@@ -72,6 +97,31 @@ const FieldOptions_JS_NUMBER = descriptorpb.FieldOptions_JS_NUMBER
+ var FieldOptions_JSType_name = descriptorpb.FieldOptions_JSType_name
+ var FieldOptions_JSType_value = descriptorpb.FieldOptions_JSType_value
+ 
++type FieldOptions_OptionRetention = descriptorpb.FieldOptions_OptionRetention
++
++const FieldOptions_RETENTION_UNKNOWN = descriptorpb.FieldOptions_RETENTION_UNKNOWN
++const FieldOptions_RETENTION_RUNTIME = descriptorpb.FieldOptions_RETENTION_RUNTIME
++const FieldOptions_RETENTION_SOURCE = descriptorpb.FieldOptions_RETENTION_SOURCE
++
++var FieldOptions_OptionRetention_name = descriptorpb.FieldOptions_OptionRetention_name
++var FieldOptions_OptionRetention_value = descriptorpb.FieldOptions_OptionRetention_value
++
++type FieldOptions_OptionTargetType = descriptorpb.FieldOptions_OptionTargetType
++
++const FieldOptions_TARGET_TYPE_UNKNOWN = descriptorpb.FieldOptions_TARGET_TYPE_UNKNOWN
++const FieldOptions_TARGET_TYPE_FILE = descriptorpb.FieldOptions_TARGET_TYPE_FILE
++const FieldOptions_TARGET_TYPE_EXTENSION_RANGE = descriptorpb.FieldOptions_TARGET_TYPE_EXTENSION_RANGE
++const FieldOptions_TARGET_TYPE_MESSAGE = descriptorpb.FieldOptions_TARGET_TYPE_MESSAGE
++const FieldOptions_TARGET_TYPE_FIELD = descriptorpb.FieldOptions_TARGET_TYPE_FIELD
++const FieldOptions_TARGET_TYPE_ONEOF = descriptorpb.FieldOptions_TARGET_TYPE_ONEOF
++const FieldOptions_TARGET_TYPE_ENUM = descriptorpb.FieldOptions_TARGET_TYPE_ENUM
++const FieldOptions_TARGET_TYPE_ENUM_ENTRY = descriptorpb.FieldOptions_TARGET_TYPE_ENUM_ENTRY
++const FieldOptions_TARGET_TYPE_SERVICE = descriptorpb.FieldOptions_TARGET_TYPE_SERVICE
++const FieldOptions_TARGET_TYPE_METHOD = descriptorpb.FieldOptions_TARGET_TYPE_METHOD
++
++var FieldOptions_OptionTargetType_name = descriptorpb.FieldOptions_OptionTargetType_name
++var FieldOptions_OptionTargetType_value = descriptorpb.FieldOptions_OptionTargetType_value
++
+ type MethodOptions_IdempotencyLevel = descriptorpb.MethodOptions_IdempotencyLevel
+ 
+ const MethodOptions_IDEMPOTENCY_UNKNOWN = descriptorpb.MethodOptions_IDEMPOTENCY_UNKNOWN
+@@ -81,10 +131,77 @@ const MethodOptions_IDEMPOTENT = descriptorpb.MethodOptions_IDEMPOTENT
+ var MethodOptions_IdempotencyLevel_name = descriptorpb.MethodOptions_IdempotencyLevel_name
+ var MethodOptions_IdempotencyLevel_value = descriptorpb.MethodOptions_IdempotencyLevel_value
+ 
++type FeatureSet_FieldPresence = descriptorpb.FeatureSet_FieldPresence
++
++const FeatureSet_FIELD_PRESENCE_UNKNOWN = descriptorpb.FeatureSet_FIELD_PRESENCE_UNKNOWN
++const FeatureSet_EXPLICIT = descriptorpb.FeatureSet_EXPLICIT
++const FeatureSet_IMPLICIT = descriptorpb.FeatureSet_IMPLICIT
++const FeatureSet_LEGACY_REQUIRED = descriptorpb.FeatureSet_LEGACY_REQUIRED
++
++var FeatureSet_FieldPresence_name = descriptorpb.FeatureSet_FieldPresence_name
++var FeatureSet_FieldPresence_value = descriptorpb.FeatureSet_FieldPresence_value
++
++type FeatureSet_EnumType = descriptorpb.FeatureSet_EnumType
++
++const FeatureSet_ENUM_TYPE_UNKNOWN = descriptorpb.FeatureSet_ENUM_TYPE_UNKNOWN
++const FeatureSet_OPEN = descriptorpb.FeatureSet_OPEN
++const FeatureSet_CLOSED = descriptorpb.FeatureSet_CLOSED
++
++var FeatureSet_EnumType_name = descriptorpb.FeatureSet_EnumType_name
++var FeatureSet_EnumType_value = descriptorpb.FeatureSet_EnumType_value
++
++type FeatureSet_RepeatedFieldEncoding = descriptorpb.FeatureSet_RepeatedFieldEncoding
++
++const FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN = descriptorpb.FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN
++const FeatureSet_PACKED = descriptorpb.FeatureSet_PACKED
++const FeatureSet_EXPANDED = descriptorpb.FeatureSet_EXPANDED
++
++var FeatureSet_RepeatedFieldEncoding_name = descriptorpb.FeatureSet_RepeatedFieldEncoding_name
++var FeatureSet_RepeatedFieldEncoding_value = descriptorpb.FeatureSet_RepeatedFieldEncoding_value
++
++type FeatureSet_Utf8Validation = descriptorpb.FeatureSet_Utf8Validation
++
++const FeatureSet_UTF8_VALIDATION_UNKNOWN = descriptorpb.FeatureSet_UTF8_VALIDATION_UNKNOWN
++const FeatureSet_VERIFY = descriptorpb.FeatureSet_VERIFY
++const FeatureSet_NONE = descriptorpb.FeatureSet_NONE
++
++var FeatureSet_Utf8Validation_name = descriptorpb.FeatureSet_Utf8Validation_name
++var FeatureSet_Utf8Validation_value = descriptorpb.FeatureSet_Utf8Validation_value
++
++type FeatureSet_MessageEncoding = descriptorpb.FeatureSet_MessageEncoding
++
++const FeatureSet_MESSAGE_ENCODING_UNKNOWN = descriptorpb.FeatureSet_MESSAGE_ENCODING_UNKNOWN
++const FeatureSet_LENGTH_PREFIXED = descriptorpb.FeatureSet_LENGTH_PREFIXED
++const FeatureSet_DELIMITED = descriptorpb.FeatureSet_DELIMITED
++
++var FeatureSet_MessageEncoding_name = descriptorpb.FeatureSet_MessageEncoding_name
++var FeatureSet_MessageEncoding_value = descriptorpb.FeatureSet_MessageEncoding_value
++
++type FeatureSet_JsonFormat = descriptorpb.FeatureSet_JsonFormat
++
++const FeatureSet_JSON_FORMAT_UNKNOWN = descriptorpb.FeatureSet_JSON_FORMAT_UNKNOWN
++const FeatureSet_ALLOW = descriptorpb.FeatureSet_ALLOW
++const FeatureSet_LEGACY_BEST_EFFORT = descriptorpb.FeatureSet_LEGACY_BEST_EFFORT
++
++var FeatureSet_JsonFormat_name = descriptorpb.FeatureSet_JsonFormat_name
++var FeatureSet_JsonFormat_value = descriptorpb.FeatureSet_JsonFormat_value
++
++type GeneratedCodeInfo_Annotation_Semantic = descriptorpb.GeneratedCodeInfo_Annotation_Semantic
++
++const GeneratedCodeInfo_Annotation_NONE = descriptorpb.GeneratedCodeInfo_Annotation_NONE
++const GeneratedCodeInfo_Annotation_SET = descriptorpb.GeneratedCodeInfo_Annotation_SET
++const GeneratedCodeInfo_Annotation_ALIAS = descriptorpb.GeneratedCodeInfo_Annotation_ALIAS
++
++var GeneratedCodeInfo_Annotation_Semantic_name = descriptorpb.GeneratedCodeInfo_Annotation_Semantic_name
++var GeneratedCodeInfo_Annotation_Semantic_value = descriptorpb.GeneratedCodeInfo_Annotation_Semantic_value
++
+ type FileDescriptorSet = descriptorpb.FileDescriptorSet
+ type FileDescriptorProto = descriptorpb.FileDescriptorProto
+ type DescriptorProto = descriptorpb.DescriptorProto
+ type ExtensionRangeOptions = descriptorpb.ExtensionRangeOptions
++
++const Default_ExtensionRangeOptions_Verification = descriptorpb.Default_ExtensionRangeOptions_Verification
++
+ type FieldDescriptorProto = descriptorpb.FieldDescriptorProto
+ type OneofDescriptorProto = descriptorpb.OneofDescriptorProto
+ type EnumDescriptorProto = descriptorpb.EnumDescriptorProto
+@@ -103,7 +220,6 @@ const Default_FileOptions_OptimizeFor = descriptorpb.Default_FileOptions_Optimiz
+ const Default_FileOptions_CcGenericServices = descriptorpb.Default_FileOptions_CcGenericServices
+ const Default_FileOptions_JavaGenericServices = descriptorpb.Default_FileOptions_JavaGenericServices
+ const Default_FileOptions_PyGenericServices = descriptorpb.Default_FileOptions_PyGenericServices
+-const Default_FileOptions_PhpGenericServices = descriptorpb.Default_FileOptions_PhpGenericServices
+ const Default_FileOptions_Deprecated = descriptorpb.Default_FileOptions_Deprecated
+ const Default_FileOptions_CcEnableArenas = descriptorpb.Default_FileOptions_CcEnableArenas
+ 
+@@ -118,8 +234,10 @@ type FieldOptions = descriptorpb.FieldOptions
+ const Default_FieldOptions_Ctype = descriptorpb.Default_FieldOptions_Ctype
+ const Default_FieldOptions_Jstype = descriptorpb.Default_FieldOptions_Jstype
+ const Default_FieldOptions_Lazy = descriptorpb.Default_FieldOptions_Lazy
++const Default_FieldOptions_UnverifiedLazy = descriptorpb.Default_FieldOptions_UnverifiedLazy
+ const Default_FieldOptions_Deprecated = descriptorpb.Default_FieldOptions_Deprecated
+ const Default_FieldOptions_Weak = descriptorpb.Default_FieldOptions_Weak
++const Default_FieldOptions_DebugRedact = descriptorpb.Default_FieldOptions_DebugRedact
+ 
+ type OneofOptions = descriptorpb.OneofOptions
+ type EnumOptions = descriptorpb.EnumOptions
+@@ -129,6 +247,7 @@ const Default_EnumOptions_Deprecated = descriptorpb.Default_EnumOptions_Deprecat
+ type EnumValueOptions = descriptorpb.EnumValueOptions
+ 
+ const Default_EnumValueOptions_Deprecated = descriptorpb.Default_EnumValueOptions_Deprecated
++const Default_EnumValueOptions_DebugRedact = descriptorpb.Default_EnumValueOptions_DebugRedact
+ 
+ type ServiceOptions = descriptorpb.ServiceOptions
+ 
+@@ -140,12 +259,17 @@ const Default_MethodOptions_Deprecated = descriptorpb.Default_MethodOptions_Depr
+ const Default_MethodOptions_IdempotencyLevel = descriptorpb.Default_MethodOptions_IdempotencyLevel
+ 
+ type UninterpretedOption = descriptorpb.UninterpretedOption
++type FeatureSet = descriptorpb.FeatureSet
++type FeatureSetDefaults = descriptorpb.FeatureSetDefaults
+ type SourceCodeInfo = descriptorpb.SourceCodeInfo
+ type GeneratedCodeInfo = descriptorpb.GeneratedCodeInfo
+ type DescriptorProto_ExtensionRange = descriptorpb.DescriptorProto_ExtensionRange
+ type DescriptorProto_ReservedRange = descriptorpb.DescriptorProto_ReservedRange
++type ExtensionRangeOptions_Declaration = descriptorpb.ExtensionRangeOptions_Declaration
+ type EnumDescriptorProto_EnumReservedRange = descriptorpb.EnumDescriptorProto_EnumReservedRange
++type FieldOptions_EditionDefault = descriptorpb.FieldOptions_EditionDefault
+ type UninterpretedOption_NamePart = descriptorpb.UninterpretedOption_NamePart
++type FeatureSetDefaults_FeatureSetEditionDefault = descriptorpb.FeatureSetDefaults_FeatureSetEditionDefault
+ type SourceCodeInfo_Location = descriptorpb.SourceCodeInfo_Location
+ type GeneratedCodeInfo_Annotation = descriptorpb.GeneratedCodeInfo_Annotation
+ 
+diff --git a/vendor/github.com/golang/protobuf/ptypes/any.go b/vendor/github.com/golang/protobuf/ptypes/any.go
+index 85f9f57..fdff3fd 100644
+--- a/vendor/github.com/golang/protobuf/ptypes/any.go
++++ b/vendor/github.com/golang/protobuf/ptypes/any.go
+@@ -127,9 +127,10 @@ func Is(any *anypb.Any, m proto.Message) bool {
+ // The allocated message is stored in the embedded proto.Message.
+ //
+ // Example:
+-//   var x ptypes.DynamicAny
+-//   if err := ptypes.UnmarshalAny(a, &x); err != nil { ... }
+-//   fmt.Printf("unmarshaled message: %v", x.Message)
++//
++//	var x ptypes.DynamicAny
++//	if err := ptypes.UnmarshalAny(a, &x); err != nil { ... }
++//	fmt.Printf("unmarshaled message: %v", x.Message)
+ //
+ // Deprecated: Use the any.UnmarshalNew method instead to unmarshal
+ // the any message contents into a new instance of the underlying message.
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/decode.go b/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
+index 5f28148..f479023 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
+@@ -11,6 +11,7 @@ import (
+ 	"strconv"
+ 	"strings"
+ 
++	"google.golang.org/protobuf/encoding/protowire"
+ 	"google.golang.org/protobuf/internal/encoding/json"
+ 	"google.golang.org/protobuf/internal/encoding/messageset"
+ 	"google.golang.org/protobuf/internal/errors"
+@@ -23,7 +24,7 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
+-// Unmarshal reads the given []byte into the given proto.Message.
++// Unmarshal reads the given []byte into the given [proto.Message].
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func Unmarshal(b []byte, m proto.Message) error {
+ 	return UnmarshalOptions{}.Unmarshal(b, m)
+@@ -37,7 +38,7 @@ type UnmarshalOptions struct {
+ 	// required fields will not return an error.
+ 	AllowPartial bool
+ 
+-	// If DiscardUnknown is set, unknown fields are ignored.
++	// If DiscardUnknown is set, unknown fields and enum name values are ignored.
+ 	DiscardUnknown bool
+ 
+ 	// Resolver is used for looking up types when unmarshaling
+@@ -47,9 +48,13 @@ type UnmarshalOptions struct {
+ 		protoregistry.MessageTypeResolver
+ 		protoregistry.ExtensionTypeResolver
+ 	}
++
++	// RecursionLimit limits how deeply messages may be nested.
++	// If zero, a default limit is applied.
++	RecursionLimit int
+ }
+ 
+-// Unmarshal reads the given []byte and populates the given proto.Message
++// Unmarshal reads the given []byte and populates the given [proto.Message]
+ // using options in the UnmarshalOptions object.
+ // It will clear the message first before setting the fields.
+ // If it returns an error, the given message may be partially set.
+@@ -67,6 +72,9 @@ func (o UnmarshalOptions) unmarshal(b []byte, m proto.Message) error {
+ 	if o.Resolver == nil {
+ 		o.Resolver = protoregistry.GlobalTypes
+ 	}
++	if o.RecursionLimit == 0 {
++		o.RecursionLimit = protowire.DefaultRecursionLimit
++	}
+ 
+ 	dec := decoder{json.NewDecoder(b), o}
+ 	if err := dec.unmarshalMessage(m.ProtoReflect(), false); err != nil {
+@@ -114,6 +122,10 @@ func (d decoder) syntaxError(pos int, f string, x ...interface{}) error {
+ 
+ // unmarshalMessage unmarshals a message into the given protoreflect.Message.
+ func (d decoder) unmarshalMessage(m protoreflect.Message, skipTypeURL bool) error {
++	d.opts.RecursionLimit--
++	if d.opts.RecursionLimit < 0 {
++		return errors.New("exceeded max recursion depth")
++	}
+ 	if unmarshal := wellKnownTypeUnmarshaler(m.Descriptor().FullName()); unmarshal != nil {
+ 		return unmarshal(d, m)
+ 	}
+@@ -266,7 +278,9 @@ func (d decoder) unmarshalSingular(m protoreflect.Message, fd protoreflect.Field
+ 	if err != nil {
+ 		return err
+ 	}
+-	m.Set(fd, val)
++	if val.IsValid() {
++		m.Set(fd, val)
++	}
+ 	return nil
+ }
+ 
+@@ -329,7 +343,7 @@ func (d decoder) unmarshalScalar(fd protoreflect.FieldDescriptor) (protoreflect.
+ 		}
+ 
+ 	case protoreflect.EnumKind:
+-		if v, ok := unmarshalEnum(tok, fd); ok {
++		if v, ok := unmarshalEnum(tok, fd, d.opts.DiscardUnknown); ok {
+ 			return v, nil
+ 		}
+ 
+@@ -474,7 +488,7 @@ func unmarshalBytes(tok json.Token) (protoreflect.Value, bool) {
+ 	return protoreflect.ValueOfBytes(b), true
+ }
+ 
+-func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor) (protoreflect.Value, bool) {
++func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor, discardUnknown bool) (protoreflect.Value, bool) {
+ 	switch tok.Kind() {
+ 	case json.String:
+ 		// Lookup EnumNumber based on name.
+@@ -482,6 +496,9 @@ func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor) (protoreflec
+ 		if enumVal := fd.Enum().Values().ByName(protoreflect.Name(s)); enumVal != nil {
+ 			return protoreflect.ValueOfEnum(enumVal.Number()), true
+ 		}
++		if discardUnknown {
++			return protoreflect.Value{}, true
++		}
+ 
+ 	case json.Number:
+ 		if n, ok := tok.Int(32); ok {
+@@ -542,7 +559,9 @@ func (d decoder) unmarshalList(list protoreflect.List, fd protoreflect.FieldDesc
+ 			if err != nil {
+ 				return err
+ 			}
+-			list.Append(val)
++			if val.IsValid() {
++				list.Append(val)
++			}
+ 		}
+ 	}
+ 
+@@ -609,8 +628,9 @@ Loop:
+ 		if err != nil {
+ 			return err
+ 		}
+-
+-		mmap.Set(pkey, pval)
++		if pval.IsValid() {
++			mmap.Set(pkey, pval)
++		}
+ 	}
+ 
+ 	return nil
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/doc.go b/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
+index 21d5d2c..ae71007 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
+@@ -6,6 +6,6 @@
+ // format. It follows the guide at
+ // https://protobuf.dev/programming-guides/proto3#json.
+ //
+-// This package produces a different output than the standard "encoding/json"
++// This package produces a different output than the standard [encoding/json]
+ // package, which does not operate correctly on protocol buffer messages.
+ package protojson
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/encode.go b/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
+index 66b9587..3f75098 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
+@@ -31,7 +31,7 @@ func Format(m proto.Message) string {
+ 	return MarshalOptions{Multiline: true}.Format(m)
+ }
+ 
+-// Marshal writes the given proto.Message in JSON format using default options.
++// Marshal writes the given [proto.Message] in JSON format using default options.
+ // Do not depend on the output being stable. It may change over time across
+ // different versions of the program.
+ func Marshal(m proto.Message) ([]byte, error) {
+@@ -81,6 +81,25 @@ type MarshalOptions struct {
+ 	//  ╚═══════╧════════════════════════════╝
+ 	EmitUnpopulated bool
+ 
++	// EmitDefaultValues specifies whether to emit default-valued primitive fields,
++	// empty lists, and empty maps. The fields affected are as follows:
++	//  ╔═══════╤════════════════════════════════════════╗
++	//  ║ JSON  │ Protobuf field                         ║
++	//  ╠═══════╪════════════════════════════════════════╣
++	//  ║ false │ non-optional scalar boolean fields     ║
++	//  ║ 0     │ non-optional scalar numeric fields     ║
++	//  ║ ""    │ non-optional scalar string/byte fields ║
++	//  ║ []    │ empty repeated fields                  ║
++	//  ║ {}    │ empty map fields                       ║
++	//  ╚═══════╧════════════════════════════════════════╝
++	//
++	// Behaves similarly to EmitUnpopulated, but does not emit "null"-value fields,
++	// i.e. presence-sensing fields that are omitted will remain omitted to preserve
++	// presence-sensing.
++	// EmitUnpopulated takes precedence over EmitDefaultValues since the former generates
++	// a strict superset of the latter.
++	EmitDefaultValues bool
++
+ 	// Resolver is used for looking up types when expanding google.protobuf.Any
+ 	// messages. If nil, this defaults to using protoregistry.GlobalTypes.
+ 	Resolver interface {
+@@ -102,7 +121,7 @@ func (o MarshalOptions) Format(m proto.Message) string {
+ 	return string(b)
+ }
+ 
+-// Marshal marshals the given proto.Message in the JSON format using options in
++// Marshal marshals the given [proto.Message] in the JSON format using options in
+ // MarshalOptions. Do not depend on the output being stable. It may change over
+ // time across different versions of the program.
+ func (o MarshalOptions) Marshal(m proto.Message) ([]byte, error) {
+@@ -178,7 +197,11 @@ func (m typeURLFieldRanger) Range(f func(protoreflect.FieldDescriptor, protorefl
+ 
+ // unpopulatedFieldRanger wraps a protoreflect.Message and modifies its Range
+ // method to additionally iterate over unpopulated fields.
+-type unpopulatedFieldRanger struct{ protoreflect.Message }
++type unpopulatedFieldRanger struct {
++	protoreflect.Message
++
++	skipNull bool
++}
+ 
+ func (m unpopulatedFieldRanger) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+ 	fds := m.Descriptor().Fields()
+@@ -192,6 +215,9 @@ func (m unpopulatedFieldRanger) Range(f func(protoreflect.FieldDescriptor, proto
+ 		isProto2Scalar := fd.Syntax() == protoreflect.Proto2 && fd.Default().IsValid()
+ 		isSingularMessage := fd.Cardinality() != protoreflect.Repeated && fd.Message() != nil
+ 		if isProto2Scalar || isSingularMessage {
++			if m.skipNull {
++				continue
++			}
+ 			v = protoreflect.Value{} // use invalid value to emit null
+ 		}
+ 		if !f(fd, v) {
+@@ -217,8 +243,11 @@ func (e encoder) marshalMessage(m protoreflect.Message, typeURL string) error {
+ 	defer e.EndObject()
+ 
+ 	var fields order.FieldRanger = m
+-	if e.opts.EmitUnpopulated {
+-		fields = unpopulatedFieldRanger{m}
++	switch {
++	case e.opts.EmitUnpopulated:
++		fields = unpopulatedFieldRanger{Message: m, skipNull: false}
++	case e.opts.EmitDefaultValues:
++		fields = unpopulatedFieldRanger{Message: m, skipNull: true}
+ 	}
+ 	if typeURL != "" {
+ 		fields = typeURLFieldRanger{fields, typeURL}
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+index 6c37d41..4b177c8 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+@@ -176,7 +176,7 @@ func (d decoder) unmarshalAny(m protoreflect.Message) error {
+ 	// Use another decoder to parse the unread bytes for @type field. This
+ 	// avoids advancing a read from current decoder because the current JSON
+ 	// object may contain the fields of the embedded type.
+-	dec := decoder{d.Clone(), UnmarshalOptions{}}
++	dec := decoder{d.Clone(), UnmarshalOptions{RecursionLimit: d.opts.RecursionLimit}}
+ 	tok, err := findTypeURL(dec)
+ 	switch err {
+ 	case errEmptyObject:
+@@ -308,48 +308,29 @@ Loop:
+ // array) in order to advance the read to the next JSON value. It relies on
+ // the decoder returning an error if the types are not in valid sequence.
+ func (d decoder) skipJSONValue() error {
+-	tok, err := d.Read()
+-	if err != nil {
+-		return err
+-	}
+-	// Only need to continue reading for objects and arrays.
+-	switch tok.Kind() {
+-	case json.ObjectOpen:
+-		for {
+-			tok, err := d.Read()
+-			if err != nil {
+-				return err
+-			}
+-			switch tok.Kind() {
+-			case json.ObjectClose:
+-				return nil
+-			case json.Name:
+-				// Skip object field value.
+-				if err := d.skipJSONValue(); err != nil {
+-					return err
+-				}
+-			}
++	var open int
++	for {
++		tok, err := d.Read()
++		if err != nil {
++			return err
+ 		}
+-
+-	case json.ArrayOpen:
+-		for {
+-			tok, err := d.Peek()
+-			if err != nil {
+-				return err
+-			}
+-			switch tok.Kind() {
+-			case json.ArrayClose:
+-				d.Read()
+-				return nil
+-			default:
+-				// Skip array item.
+-				if err := d.skipJSONValue(); err != nil {
+-					return err
+-				}
++		switch tok.Kind() {
++		case json.ObjectClose, json.ArrayClose:
++			open--
++		case json.ObjectOpen, json.ArrayOpen:
++			open++
++			if open > d.opts.RecursionLimit {
++				return errors.New("exceeded max recursion depth")
+ 			}
++		case json.EOF:
++			// This can only happen if there's a bug in Decoder.Read.
++			// Avoid an infinite loop if this does happen.
++			return errors.New("unexpected EOF")
++		}
++		if open == 0 {
++			return nil
+ 		}
+ 	}
+-	return nil
+ }
+ 
+ // unmarshalAnyValue unmarshals the given custom-type message from the JSON
+diff --git a/vendor/google.golang.org/protobuf/encoding/prototext/decode.go b/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
+index 4921b2d..a45f112 100644
+--- a/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
++++ b/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
+@@ -21,7 +21,7 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
+-// Unmarshal reads the given []byte into the given proto.Message.
++// Unmarshal reads the given []byte into the given [proto.Message].
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func Unmarshal(b []byte, m proto.Message) error {
+ 	return UnmarshalOptions{}.Unmarshal(b, m)
+@@ -51,7 +51,7 @@ type UnmarshalOptions struct {
+ 	}
+ }
+ 
+-// Unmarshal reads the given []byte and populates the given proto.Message
++// Unmarshal reads the given []byte and populates the given [proto.Message]
+ // using options in the UnmarshalOptions object.
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func (o UnmarshalOptions) Unmarshal(b []byte, m proto.Message) error {
+@@ -739,7 +739,9 @@ func (d decoder) skipValue() error {
+ 			case text.ListClose:
+ 				return nil
+ 			case text.MessageOpen:
+-				return d.skipMessageValue()
++				if err := d.skipMessageValue(); err != nil {
++					return err
++				}
+ 			default:
+ 				// Skip items. This will not validate whether skipped values are
+ 				// of the same type or not, same behavior as C++
+diff --git a/vendor/google.golang.org/protobuf/encoding/prototext/encode.go b/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
+index 722a7b4..95967e8 100644
+--- a/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
++++ b/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
+@@ -33,7 +33,7 @@ func Format(m proto.Message) string {
+ 	return MarshalOptions{Multiline: true}.Format(m)
+ }
+ 
+-// Marshal writes the given proto.Message in textproto format using default
++// Marshal writes the given [proto.Message] in textproto format using default
+ // options. Do not depend on the output being stable. It may change over time
+ // across different versions of the program.
+ func Marshal(m proto.Message) ([]byte, error) {
+@@ -97,7 +97,7 @@ func (o MarshalOptions) Format(m proto.Message) string {
+ 	return string(b)
+ }
+ 
+-// Marshal writes the given proto.Message in textproto format using options in
++// Marshal writes the given [proto.Message] in textproto format using options in
+ // MarshalOptions object. Do not depend on the output being stable. It may
+ // change over time across different versions of the program.
+ func (o MarshalOptions) Marshal(m proto.Message) ([]byte, error) {
+diff --git a/vendor/google.golang.org/protobuf/encoding/protowire/wire.go b/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
+index f4b4686..e942bc9 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
++++ b/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
+@@ -6,7 +6,7 @@
+ // See https://protobuf.dev/programming-guides/encoding.
+ //
+ // For marshaling and unmarshaling entire protobuf messages,
+-// use the "google.golang.org/protobuf/proto" package instead.
++// use the [google.golang.org/protobuf/proto] package instead.
+ package protowire
+ 
+ import (
+@@ -87,7 +87,7 @@ func ParseError(n int) error {
+ 
+ // ConsumeField parses an entire field record (both tag and value) and returns
+ // the field number, the wire type, and the total length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ //
+ // The total length includes the tag header and the end group marker (if the
+ // field is a group).
+@@ -104,8 +104,8 @@ func ConsumeField(b []byte) (Number, Type, int) {
+ }
+ 
+ // ConsumeFieldValue parses a field value and returns its length.
+-// This assumes that the field Number and wire Type have already been parsed.
+-// This returns a negative length upon an error (see ParseError).
++// This assumes that the field [Number] and wire [Type] have already been parsed.
++// This returns a negative length upon an error (see [ParseError]).
+ //
+ // When parsing a group, the length includes the end group marker and
+ // the end group is verified to match the starting field number.
+@@ -164,7 +164,7 @@ func AppendTag(b []byte, num Number, typ Type) []byte {
+ }
+ 
+ // ConsumeTag parses b as a varint-encoded tag, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeTag(b []byte) (Number, Type, int) {
+ 	v, n := ConsumeVarint(b)
+ 	if n < 0 {
+@@ -263,7 +263,7 @@ func AppendVarint(b []byte, v uint64) []byte {
+ }
+ 
+ // ConsumeVarint parses b as a varint-encoded uint64, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeVarint(b []byte) (v uint64, n int) {
+ 	var y uint64
+ 	if len(b) <= 0 {
+@@ -384,7 +384,7 @@ func AppendFixed32(b []byte, v uint32) []byte {
+ }
+ 
+ // ConsumeFixed32 parses b as a little-endian uint32, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeFixed32(b []byte) (v uint32, n int) {
+ 	if len(b) < 4 {
+ 		return 0, errCodeTruncated
+@@ -412,7 +412,7 @@ func AppendFixed64(b []byte, v uint64) []byte {
+ }
+ 
+ // ConsumeFixed64 parses b as a little-endian uint64, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeFixed64(b []byte) (v uint64, n int) {
+ 	if len(b) < 8 {
+ 		return 0, errCodeTruncated
+@@ -432,7 +432,7 @@ func AppendBytes(b []byte, v []byte) []byte {
+ }
+ 
+ // ConsumeBytes parses b as a length-prefixed bytes value, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeBytes(b []byte) (v []byte, n int) {
+ 	m, n := ConsumeVarint(b)
+ 	if n < 0 {
+@@ -456,7 +456,7 @@ func AppendString(b []byte, v string) []byte {
+ }
+ 
+ // ConsumeString parses b as a length-prefixed bytes value, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeString(b []byte) (v string, n int) {
+ 	bb, n := ConsumeBytes(b)
+ 	return string(bb), n
+@@ -471,7 +471,7 @@ func AppendGroup(b []byte, num Number, v []byte) []byte {
+ // ConsumeGroup parses b as a group value until the trailing end group marker,
+ // and verifies that the end marker matches the provided num. The value v
+ // does not contain the end marker, while the length does contain the end marker.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeGroup(num Number, b []byte) (v []byte, n int) {
+ 	n = ConsumeFieldValue(num, StartGroupType, b)
+ 	if n < 0 {
+@@ -495,8 +495,8 @@ func SizeGroup(num Number, n int) int {
+ 	return n + SizeTag(num)
+ }
+ 
+-// DecodeTag decodes the field Number and wire Type from its unified form.
+-// The Number is -1 if the decoded field number overflows int32.
++// DecodeTag decodes the field [Number] and wire [Type] from its unified form.
++// The [Number] is -1 if the decoded field number overflows int32.
+ // Other than overflow, this does not check for field number validity.
+ func DecodeTag(x uint64) (Number, Type) {
+ 	// NOTE: MessageSet allows for larger field numbers than normal.
+@@ -506,7 +506,7 @@ func DecodeTag(x uint64) (Number, Type) {
+ 	return Number(x >> 3), Type(x & 7)
+ }
+ 
+-// EncodeTag encodes the field Number and wire Type into its unified form.
++// EncodeTag encodes the field [Number] and wire [Type] into its unified form.
+ func EncodeTag(num Number, typ Type) uint64 {
+ 	return uint64(num)<<3 | uint64(typ&7)
+ }
+diff --git a/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go b/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
+index db5248e..a45625c 100644
+--- a/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
++++ b/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
+@@ -83,7 +83,13 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
+ 	case protoreflect.FileImports:
+ 		for i := 0; i < vs.Len(); i++ {
+ 			var rs records
+-			rs.Append(reflect.ValueOf(vs.Get(i)), "Path", "Package", "IsPublic", "IsWeak")
++			rv := reflect.ValueOf(vs.Get(i))
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("IsPublic"), "IsPublic"},
++				{rv.MethodByName("IsWeak"), "IsWeak"},
++			}...)
+ 			ss = append(ss, "{"+rs.Join()+"}")
+ 		}
+ 		return start + joinStrings(ss, allowMulti) + end
+@@ -92,34 +98,26 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
+ 		for i := 0; i < vs.Len(); i++ {
+ 			m := reflect.ValueOf(vs).MethodByName("Get")
+ 			v := m.Call([]reflect.Value{reflect.ValueOf(i)})[0].Interface()
+-			ss = append(ss, formatDescOpt(v.(protoreflect.Descriptor), false, allowMulti && !isEnumValue))
++			ss = append(ss, formatDescOpt(v.(protoreflect.Descriptor), false, allowMulti && !isEnumValue, nil))
+ 		}
+ 		return start + joinStrings(ss, allowMulti && isEnumValue) + end
+ 	}
+ }
+ 
+-// descriptorAccessors is a list of accessors to print for each descriptor.
+-//
+-// Do not print all accessors since some contain redundant information,
+-// while others are pointers that we do not want to follow since the descriptor
+-// is actually a cyclic graph.
+-//
+-// Using a list allows us to print the accessors in a sensible order.
+-var descriptorAccessors = map[reflect.Type][]string{
+-	reflect.TypeOf((*protoreflect.FileDescriptor)(nil)).Elem():      {"Path", "Package", "Imports", "Messages", "Enums", "Extensions", "Services"},
+-	reflect.TypeOf((*protoreflect.MessageDescriptor)(nil)).Elem():   {"IsMapEntry", "Fields", "Oneofs", "ReservedNames", "ReservedRanges", "RequiredNumbers", "ExtensionRanges", "Messages", "Enums", "Extensions"},
+-	reflect.TypeOf((*protoreflect.FieldDescriptor)(nil)).Elem():     {"Number", "Cardinality", "Kind", "HasJSONName", "JSONName", "HasPresence", "IsExtension", "IsPacked", "IsWeak", "IsList", "IsMap", "MapKey", "MapValue", "HasDefault", "Default", "ContainingOneof", "ContainingMessage", "Message", "Enum"},
+-	reflect.TypeOf((*protoreflect.OneofDescriptor)(nil)).Elem():     {"Fields"}, // not directly used; must keep in sync with formatDescOpt
+-	reflect.TypeOf((*protoreflect.EnumDescriptor)(nil)).Elem():      {"Values", "ReservedNames", "ReservedRanges"},
+-	reflect.TypeOf((*protoreflect.EnumValueDescriptor)(nil)).Elem(): {"Number"},
+-	reflect.TypeOf((*protoreflect.ServiceDescriptor)(nil)).Elem():   {"Methods"},
+-	reflect.TypeOf((*protoreflect.MethodDescriptor)(nil)).Elem():    {"Input", "Output", "IsStreamingClient", "IsStreamingServer"},
++type methodAndName struct {
++	method reflect.Value
++	name   string
+ }
+ 
+ func FormatDesc(s fmt.State, r rune, t protoreflect.Descriptor) {
+-	io.WriteString(s, formatDescOpt(t, true, r == 'v' && (s.Flag('+') || s.Flag('#'))))
++	io.WriteString(s, formatDescOpt(t, true, r == 'v' && (s.Flag('+') || s.Flag('#')), nil))
+ }
+-func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
++
++func InternalFormatDescOptForTesting(t protoreflect.Descriptor, isRoot, allowMulti bool, record func(string)) string {
++	return formatDescOpt(t, isRoot, allowMulti, record)
++}
++
++func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool, record func(string)) string {
+ 	rv := reflect.ValueOf(t)
+ 	rt := rv.MethodByName("ProtoType").Type().In(0)
+ 
+@@ -129,26 +127,60 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 	}
+ 
+ 	_, isFile := t.(protoreflect.FileDescriptor)
+-	rs := records{allowMulti: allowMulti}
++	rs := records{
++		allowMulti: allowMulti,
++		record:     record,
++	}
+ 	if t.IsPlaceholder() {
+ 		if isFile {
+-			rs.Append(rv, "Path", "Package", "IsPlaceholder")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
++			}...)
+ 		} else {
+-			rs.Append(rv, "FullName", "IsPlaceholder")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("FullName"), "FullName"},
++				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
++			}...)
+ 		}
+ 	} else {
+ 		switch {
+ 		case isFile:
+-			rs.Append(rv, "Syntax")
++			rs.Append(rv, methodAndName{rv.MethodByName("Syntax"), "Syntax"})
+ 		case isRoot:
+-			rs.Append(rv, "Syntax", "FullName")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Syntax"), "Syntax"},
++				{rv.MethodByName("FullName"), "FullName"},
++			}...)
+ 		default:
+-			rs.Append(rv, "Name")
++			rs.Append(rv, methodAndName{rv.MethodByName("Name"), "Name"})
+ 		}
+ 		switch t := t.(type) {
+ 		case protoreflect.FieldDescriptor:
+-			for _, s := range descriptorAccessors[rt] {
+-				switch s {
++			accessors := []methodAndName{
++				{rv.MethodByName("Number"), "Number"},
++				{rv.MethodByName("Cardinality"), "Cardinality"},
++				{rv.MethodByName("Kind"), "Kind"},
++				{rv.MethodByName("HasJSONName"), "HasJSONName"},
++				{rv.MethodByName("JSONName"), "JSONName"},
++				{rv.MethodByName("HasPresence"), "HasPresence"},
++				{rv.MethodByName("IsExtension"), "IsExtension"},
++				{rv.MethodByName("IsPacked"), "IsPacked"},
++				{rv.MethodByName("IsWeak"), "IsWeak"},
++				{rv.MethodByName("IsList"), "IsList"},
++				{rv.MethodByName("IsMap"), "IsMap"},
++				{rv.MethodByName("MapKey"), "MapKey"},
++				{rv.MethodByName("MapValue"), "MapValue"},
++				{rv.MethodByName("HasDefault"), "HasDefault"},
++				{rv.MethodByName("Default"), "Default"},
++				{rv.MethodByName("ContainingOneof"), "ContainingOneof"},
++				{rv.MethodByName("ContainingMessage"), "ContainingMessage"},
++				{rv.MethodByName("Message"), "Message"},
++				{rv.MethodByName("Enum"), "Enum"},
++			}
++			for _, s := range accessors {
++				switch s.name {
+ 				case "MapKey":
+ 					if k := t.MapKey(); k != nil {
+ 						rs.recs = append(rs.recs, [2]string{"MapKey", k.Kind().String()})
+@@ -157,20 +189,20 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 					if v := t.MapValue(); v != nil {
+ 						switch v.Kind() {
+ 						case protoreflect.EnumKind:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", string(v.Enum().FullName())})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", string(v.Enum().FullName())})
+ 						case protoreflect.MessageKind, protoreflect.GroupKind:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", string(v.Message().FullName())})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", string(v.Message().FullName())})
+ 						default:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", v.Kind().String()})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", v.Kind().String()})
+ 						}
+ 					}
+ 				case "ContainingOneof":
+ 					if od := t.ContainingOneof(); od != nil {
+-						rs.recs = append(rs.recs, [2]string{"Oneof", string(od.Name())})
++						rs.AppendRecs("ContainingOneof", [2]string{"Oneof", string(od.Name())})
+ 					}
+ 				case "ContainingMessage":
+ 					if t.IsExtension() {
+-						rs.recs = append(rs.recs, [2]string{"Extendee", string(t.ContainingMessage().FullName())})
++						rs.AppendRecs("ContainingMessage", [2]string{"Extendee", string(t.ContainingMessage().FullName())})
+ 					}
+ 				case "Message":
+ 					if !t.IsMap() {
+@@ -187,13 +219,61 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 				ss = append(ss, string(fs.Get(i).Name()))
+ 			}
+ 			if len(ss) > 0 {
+-				rs.recs = append(rs.recs, [2]string{"Fields", "[" + joinStrings(ss, false) + "]"})
++				rs.AppendRecs("Fields", [2]string{"Fields", "[" + joinStrings(ss, false) + "]"})
+ 			}
+-		default:
+-			rs.Append(rv, descriptorAccessors[rt]...)
++
++		case protoreflect.FileDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("Imports"), "Imports"},
++				{rv.MethodByName("Messages"), "Messages"},
++				{rv.MethodByName("Enums"), "Enums"},
++				{rv.MethodByName("Extensions"), "Extensions"},
++				{rv.MethodByName("Services"), "Services"},
++			}...)
++
++		case protoreflect.MessageDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("IsMapEntry"), "IsMapEntry"},
++				{rv.MethodByName("Fields"), "Fields"},
++				{rv.MethodByName("Oneofs"), "Oneofs"},
++				{rv.MethodByName("ReservedNames"), "ReservedNames"},
++				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
++				{rv.MethodByName("RequiredNumbers"), "RequiredNumbers"},
++				{rv.MethodByName("ExtensionRanges"), "ExtensionRanges"},
++				{rv.MethodByName("Messages"), "Messages"},
++				{rv.MethodByName("Enums"), "Enums"},
++				{rv.MethodByName("Extensions"), "Extensions"},
++			}...)
++
++		case protoreflect.EnumDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Values"), "Values"},
++				{rv.MethodByName("ReservedNames"), "ReservedNames"},
++				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
++			}...)
++
++		case protoreflect.EnumValueDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Number"), "Number"},
++			}...)
++
++		case protoreflect.ServiceDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Methods"), "Methods"},
++			}...)
++
++		case protoreflect.MethodDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Input"), "Input"},
++				{rv.MethodByName("Output"), "Output"},
++				{rv.MethodByName("IsStreamingClient"), "IsStreamingClient"},
++				{rv.MethodByName("IsStreamingServer"), "IsStreamingServer"},
++			}...)
+ 		}
+-		if rv.MethodByName("GoType").IsValid() {
+-			rs.Append(rv, "GoType")
++		if m := rv.MethodByName("GoType"); m.IsValid() {
++			rs.Append(rv, methodAndName{m, "GoType"})
+ 		}
+ 	}
+ 	return start + rs.Join() + end
+@@ -202,19 +282,34 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ type records struct {
+ 	recs       [][2]string
+ 	allowMulti bool
++
++	// record is a function that will be called for every Append() or
++	// AppendRecs() call, to be used for testing with the
++	// InternalFormatDescOptForTesting function.
++	record func(string)
+ }
+ 
+-func (rs *records) Append(v reflect.Value, accessors ...string) {
++func (rs *records) AppendRecs(fieldName string, newRecs [2]string) {
++	if rs.record != nil {
++		rs.record(fieldName)
++	}
++	rs.recs = append(rs.recs, newRecs)
++}
++
++func (rs *records) Append(v reflect.Value, accessors ...methodAndName) {
+ 	for _, a := range accessors {
++		if rs.record != nil {
++			rs.record(a.name)
++		}
+ 		var rv reflect.Value
+-		if m := v.MethodByName(a); m.IsValid() {
+-			rv = m.Call(nil)[0]
++		if a.method.IsValid() {
++			rv = a.method.Call(nil)[0]
+ 		}
+ 		if v.Kind() == reflect.Struct && !rv.IsValid() {
+-			rv = v.FieldByName(a)
++			rv = v.FieldByName(a.name)
+ 		}
+ 		if !rv.IsValid() {
+-			panic(fmt.Sprintf("unknown accessor: %v.%s", v.Type(), a))
++			panic(fmt.Sprintf("unknown accessor: %v.%s", v.Type(), a.name))
+ 		}
+ 		if _, ok := rv.Interface().(protoreflect.Value); ok {
+ 			rv = rv.MethodByName("Interface").Call(nil)[0]
+@@ -261,7 +356,7 @@ func (rs *records) Append(v reflect.Value, accessors ...string) {
+ 		default:
+ 			s = fmt.Sprint(v)
+ 		}
+-		rs.recs = append(rs.recs, [2]string{a, s})
++		rs.recs = append(rs.recs, [2]string{a.name, s})
+ 	}
+ }
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go b/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+new file mode 100644
+index 0000000..14656b6
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+@@ -0,0 +1,12 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Package editiondefaults contains the binary representation of the editions
++// defaults.
++package editiondefaults
++
++import _ "embed"
++
++//go:embed editions_defaults.binpb
++var Defaults []byte
+diff --git a/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb b/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+new file mode 100644
+index 0000000..18f0756
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+@@ -0,0 +1,4 @@
++
++ (0�
++ (0�
++ (0� �(�
+\ No newline at end of file
+diff --git a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+index d043a6e..d2b3ac0 100644
+--- a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
++++ b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+@@ -121,7 +121,7 @@ func (d *Decoder) Read() (Token, error) {
+ 
+ 	case ObjectClose:
+ 		if len(d.openStack) == 0 ||
+-			d.lastToken.kind == comma ||
++			d.lastToken.kind&(Name|comma) != 0 ||
+ 			d.openStack[len(d.openStack)-1] != ObjectOpen {
+ 			return Token{}, d.newSyntaxError(tok.pos, unexpectedFmt, tok.RawString())
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+index 7c3689b..8826bcf 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+@@ -21,11 +21,26 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
++// Edition is an Enum for proto2.Edition
++type Edition int32
++
++// These values align with the value of Enum in descriptor.proto which allows
++// direct conversion between the proto enum and this enum.
++const (
++	EditionUnknown     Edition = 0
++	EditionProto2      Edition = 998
++	EditionProto3      Edition = 999
++	Edition2023        Edition = 1000
++	EditionUnsupported Edition = 100000
++)
++
+ // The types in this file may have a suffix:
+ //	• L0: Contains fields common to all descriptors (except File) and
+ //	must be initialized up front.
+ //	• L1: Contains fields specific to a descriptor and
+-//	must be initialized up front.
++//	must be initialized up front. If the associated proto uses Editions, the
++//  Editions features must always be resolved. If not explicitly set, the
++//  appropriate default must be resolved and set.
+ //	• L2: Contains fields that are lazily initialized when constructing
+ //	from the raw file descriptor. When constructing as a literal, the L2
+ //	fields must be initialized up front.
+@@ -44,6 +59,7 @@ type (
+ 	}
+ 	FileL1 struct {
+ 		Syntax  protoreflect.Syntax
++		Edition Edition // Only used if Syntax == Editions
+ 		Path    string
+ 		Package protoreflect.FullName
+ 
+@@ -51,12 +67,41 @@ type (
+ 		Messages   Messages
+ 		Extensions Extensions
+ 		Services   Services
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	FileL2 struct {
+ 		Options   func() protoreflect.ProtoMessage
+ 		Imports   FileImports
+ 		Locations SourceLocations
+ 	}
++
++	EditionFeatures struct {
++		// IsFieldPresence is true if field_presence is EXPLICIT
++		// https://protobuf.dev/editions/features/#field_presence
++		IsFieldPresence bool
++		// IsFieldPresence is true if field_presence is LEGACY_REQUIRED
++		// https://protobuf.dev/editions/features/#field_presence
++		IsLegacyRequired bool
++		// IsOpenEnum is true if enum_type is OPEN
++		// https://protobuf.dev/editions/features/#enum_type
++		IsOpenEnum bool
++		// IsPacked is true if repeated_field_encoding is PACKED
++		// https://protobuf.dev/editions/features/#repeated_field_encoding
++		IsPacked bool
++		// IsUTF8Validated is true if utf_validation is VERIFY
++		// https://protobuf.dev/editions/features/#utf8_validation
++		IsUTF8Validated bool
++		// IsDelimitedEncoded is true if message_encoding is DELIMITED
++		// https://protobuf.dev/editions/features/#message_encoding
++		IsDelimitedEncoded bool
++		// IsJSONCompliant is true if json_format is ALLOW
++		// https://protobuf.dev/editions/features/#json_format
++		IsJSONCompliant bool
++		// GenerateLegacyUnmarshalJSON determines if the plugin generates the
++		// UnmarshalJSON([]byte) error method for enums.
++		GenerateLegacyUnmarshalJSON bool
++	}
+ )
+ 
+ func (fd *File) ParentFile() protoreflect.FileDescriptor { return fd }
+@@ -117,6 +162,8 @@ type (
+ 	}
+ 	EnumL1 struct {
+ 		eagerValues bool // controls whether EnumL2.Values is already populated
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	EnumL2 struct {
+ 		Options        func() protoreflect.ProtoMessage
+@@ -178,6 +225,8 @@ type (
+ 		Extensions   Extensions
+ 		IsMapEntry   bool // promoted from google.protobuf.MessageOptions
+ 		IsMessageSet bool // promoted from google.protobuf.MessageOptions
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	MessageL2 struct {
+ 		Options               func() protoreflect.ProtoMessage
+@@ -210,6 +259,8 @@ type (
+ 		ContainingOneof  protoreflect.OneofDescriptor // must be consistent with Message.Oneofs.Fields
+ 		Enum             protoreflect.EnumDescriptor
+ 		Message          protoreflect.MessageDescriptor
++
++		EditionFeatures EditionFeatures
+ 	}
+ 
+ 	Oneof struct {
+@@ -219,6 +270,8 @@ type (
+ 	OneofL1 struct {
+ 		Options func() protoreflect.ProtoMessage
+ 		Fields  OneofFields // must be consistent with Message.Fields.ContainingOneof
++
++		EditionFeatures EditionFeatures
+ 	}
+ )
+ 
+@@ -268,23 +321,36 @@ func (fd *Field) Options() protoreflect.ProtoMessage {
+ }
+ func (fd *Field) Number() protoreflect.FieldNumber      { return fd.L1.Number }
+ func (fd *Field) Cardinality() protoreflect.Cardinality { return fd.L1.Cardinality }
+-func (fd *Field) Kind() protoreflect.Kind               { return fd.L1.Kind }
+-func (fd *Field) HasJSONName() bool                     { return fd.L1.StringName.hasJSON }
+-func (fd *Field) JSONName() string                      { return fd.L1.StringName.getJSON(fd) }
+-func (fd *Field) TextName() string                      { return fd.L1.StringName.getText(fd) }
++func (fd *Field) Kind() protoreflect.Kind {
++	return fd.L1.Kind
++}
++func (fd *Field) HasJSONName() bool { return fd.L1.StringName.hasJSON }
++func (fd *Field) JSONName() string  { return fd.L1.StringName.getJSON(fd) }
++func (fd *Field) TextName() string  { return fd.L1.StringName.getText(fd) }
+ func (fd *Field) HasPresence() bool {
+-	return fd.L1.Cardinality != protoreflect.Repeated && (fd.L0.ParentFile.L1.Syntax == protoreflect.Proto2 || fd.L1.Message != nil || fd.L1.ContainingOneof != nil)
++	if fd.L1.Cardinality == protoreflect.Repeated {
++		return false
++	}
++	explicitFieldPresence := fd.Syntax() == protoreflect.Editions && fd.L1.EditionFeatures.IsFieldPresence
++	return fd.Syntax() == protoreflect.Proto2 || explicitFieldPresence || fd.L1.Message != nil || fd.L1.ContainingOneof != nil
+ }
+ func (fd *Field) HasOptionalKeyword() bool {
+ 	return (fd.L0.ParentFile.L1.Syntax == protoreflect.Proto2 && fd.L1.Cardinality == protoreflect.Optional && fd.L1.ContainingOneof == nil) || fd.L1.IsProto3Optional
+ }
+ func (fd *Field) IsPacked() bool {
+-	if !fd.L1.HasPacked && fd.L0.ParentFile.L1.Syntax != protoreflect.Proto2 && fd.L1.Cardinality == protoreflect.Repeated {
+-		switch fd.L1.Kind {
+-		case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
+-		default:
+-			return true
+-		}
++	if fd.L1.Cardinality != protoreflect.Repeated {
++		return false
++	}
++	switch fd.L1.Kind {
++	case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
++		return false
++	}
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Editions {
++		return fd.L1.EditionFeatures.IsPacked
++	}
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Proto3 {
++		// proto3 repeated fields are packed by default.
++		return !fd.L1.HasPacked || fd.L1.IsPacked
+ 	}
+ 	return fd.L1.IsPacked
+ }
+@@ -333,6 +399,9 @@ func (fd *Field) ProtoType(protoreflect.FieldDescriptor) {}
+ // WARNING: This method is exempt from the compatibility promise and may be
+ // removed in the future without warning.
+ func (fd *Field) EnforceUTF8() bool {
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Editions {
++		return fd.L1.EditionFeatures.IsUTF8Validated
++	}
+ 	if fd.L1.HasEnforceUTF8 {
+ 		return fd.L1.EnforceUTF8
+ 	}
+@@ -359,10 +428,11 @@ type (
+ 		L2 *ExtensionL2 // protected by fileDesc.once
+ 	}
+ 	ExtensionL1 struct {
+-		Number      protoreflect.FieldNumber
+-		Extendee    protoreflect.MessageDescriptor
+-		Cardinality protoreflect.Cardinality
+-		Kind        protoreflect.Kind
++		Number          protoreflect.FieldNumber
++		Extendee        protoreflect.MessageDescriptor
++		Cardinality     protoreflect.Cardinality
++		Kind            protoreflect.Kind
++		EditionFeatures EditionFeatures
+ 	}
+ 	ExtensionL2 struct {
+ 		Options          func() protoreflect.ProtoMessage
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
+index 4a1584c..237e64f 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
+@@ -5,6 +5,7 @@
+ package filedesc
+ 
+ import (
++	"fmt"
+ 	"sync"
+ 
+ 	"google.golang.org/protobuf/encoding/protowire"
+@@ -98,6 +99,7 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 	var prevField protoreflect.FieldNumber
+ 	var numEnums, numMessages, numExtensions, numServices int
+ 	var posEnums, posMessages, posExtensions, posServices int
++	var options []byte
+ 	b0 := b
+ 	for len(b) > 0 {
+ 		num, typ, n := protowire.ConsumeTag(b)
+@@ -113,6 +115,8 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 					fd.L1.Syntax = protoreflect.Proto2
+ 				case "proto3":
+ 					fd.L1.Syntax = protoreflect.Proto3
++				case "editions":
++					fd.L1.Syntax = protoreflect.Editions
+ 				default:
+ 					panic("invalid syntax")
+ 				}
+@@ -120,6 +124,8 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 				fd.L1.Path = sb.MakeString(v)
+ 			case genid.FileDescriptorProto_Package_field_number:
+ 				fd.L1.Package = protoreflect.FullName(sb.MakeString(v))
++			case genid.FileDescriptorProto_Options_field_number:
++				options = v
+ 			case genid.FileDescriptorProto_EnumType_field_number:
+ 				if prevField != genid.FileDescriptorProto_EnumType_field_number {
+ 					if numEnums > 0 {
+@@ -154,6 +160,13 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 				numServices++
+ 			}
+ 			prevField = num
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FileDescriptorProto_Edition_field_number:
++				fd.L1.Edition = Edition(v)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+@@ -166,6 +179,15 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 		fd.L1.Syntax = protoreflect.Proto2
+ 	}
+ 
++	if fd.L1.Syntax == protoreflect.Editions {
++		fd.L1.EditionFeatures = getFeaturesFor(fd.L1.Edition)
++	}
++
++	// Parse editions features from options if any
++	if options != nil {
++		fd.unmarshalSeedOptions(options)
++	}
++
+ 	// Must allocate all declarations before parsing each descriptor type
+ 	// to ensure we handled all descriptors in "flattened ordering".
+ 	if numEnums > 0 {
+@@ -219,6 +241,28 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 	}
+ }
+ 
++func (fd *File) unmarshalSeedOptions(b []byte) {
++	for b := b; len(b) > 0; {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FileOptions_Features_field_number:
++				if fd.Syntax() != protoreflect.Editions {
++					panic(fmt.Sprintf("invalid descriptor: using edition features in a proto with syntax %s", fd.Syntax()))
++				}
++				fd.L1.EditionFeatures = unmarshalFeatureSet(v, fd.L1.EditionFeatures)
++			}
++		default:
++			m := protowire.ConsumeFieldValue(num, typ, b)
++			b = b[m:]
++		}
++	}
++}
++
+ func (ed *Enum) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protoreflect.Descriptor, i int) {
+ 	ed.L0.ParentFile = pf
+ 	ed.L0.Parent = pd
+@@ -275,6 +319,7 @@ func (md *Message) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protor
+ 	md.L0.ParentFile = pf
+ 	md.L0.Parent = pd
+ 	md.L0.Index = i
++	md.L1.EditionFeatures = featuresFromParentDesc(md.Parent())
+ 
+ 	var prevField protoreflect.FieldNumber
+ 	var numEnums, numMessages, numExtensions int
+@@ -380,6 +425,13 @@ func (md *Message) unmarshalSeedOptions(b []byte) {
+ 			case genid.MessageOptions_MessageSetWireFormat_field_number:
+ 				md.L1.IsMessageSet = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.MessageOptions_Features_field_number:
++				md.L1.EditionFeatures = unmarshalFeatureSet(v, md.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+index 736a19a..482a61c 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+@@ -414,6 +414,7 @@ func (fd *Field) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ 	fd.L0.ParentFile = pf
+ 	fd.L0.Parent = pd
+ 	fd.L0.Index = i
++	fd.L1.EditionFeatures = featuresFromParentDesc(fd.Parent())
+ 
+ 	var rawTypeName []byte
+ 	var rawOptions []byte
+@@ -465,6 +466,12 @@ func (fd *Field) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ 			b = b[m:]
+ 		}
+ 	}
++	if fd.Syntax() == protoreflect.Editions && fd.L1.Kind == protoreflect.MessageKind && fd.L1.EditionFeatures.IsDelimitedEncoded {
++		fd.L1.Kind = protoreflect.GroupKind
++	}
++	if fd.Syntax() == protoreflect.Editions && fd.L1.EditionFeatures.IsLegacyRequired {
++		fd.L1.Cardinality = protoreflect.Required
++	}
+ 	if rawTypeName != nil {
+ 		name := makeFullName(sb, rawTypeName)
+ 		switch fd.L1.Kind {
+@@ -497,6 +504,13 @@ func (fd *Field) unmarshalOptions(b []byte) {
+ 				fd.L1.HasEnforceUTF8 = true
+ 				fd.L1.EnforceUTF8 = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FieldOptions_Features_field_number:
++				fd.L1.EditionFeatures = unmarshalFeatureSet(v, fd.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+@@ -534,6 +548,7 @@ func (od *Oneof) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ func (xd *Extension) unmarshalFull(b []byte, sb *strs.Builder) {
+ 	var rawTypeName []byte
+ 	var rawOptions []byte
++	xd.L1.EditionFeatures = featuresFromParentDesc(xd.L1.Extendee)
+ 	xd.L2 = new(ExtensionL2)
+ 	for len(b) > 0 {
+ 		num, typ, n := protowire.ConsumeTag(b)
+@@ -565,6 +580,12 @@ func (xd *Extension) unmarshalFull(b []byte, sb *strs.Builder) {
+ 			b = b[m:]
+ 		}
+ 	}
++	if xd.Syntax() == protoreflect.Editions && xd.L1.Kind == protoreflect.MessageKind && xd.L1.EditionFeatures.IsDelimitedEncoded {
++		xd.L1.Kind = protoreflect.GroupKind
++	}
++	if xd.Syntax() == protoreflect.Editions && xd.L1.EditionFeatures.IsLegacyRequired {
++		xd.L1.Cardinality = protoreflect.Required
++	}
+ 	if rawTypeName != nil {
+ 		name := makeFullName(sb, rawTypeName)
+ 		switch xd.L1.Kind {
+@@ -589,6 +610,13 @@ func (xd *Extension) unmarshalOptions(b []byte) {
+ 			case genid.FieldOptions_Packed_field_number:
+ 				xd.L2.IsPacked = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FieldOptions_Features_field_number:
++				xd.L1.EditionFeatures = unmarshalFeatureSet(v, xd.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/editions.go b/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+new file mode 100644
+index 0000000..0375a49
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+@@ -0,0 +1,142 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package filedesc
++
++import (
++	"fmt"
++
++	"google.golang.org/protobuf/encoding/protowire"
++	"google.golang.org/protobuf/internal/editiondefaults"
++	"google.golang.org/protobuf/internal/genid"
++	"google.golang.org/protobuf/reflect/protoreflect"
++)
++
++var defaultsCache = make(map[Edition]EditionFeatures)
++
++func init() {
++	unmarshalEditionDefaults(editiondefaults.Defaults)
++}
++
++func unmarshalGoFeature(b []byte, parent EditionFeatures) EditionFeatures {
++	for len(b) > 0 {
++		num, _, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch num {
++		case genid.GoFeatures_LegacyUnmarshalJsonEnum_field_number:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			parent.GenerateLegacyUnmarshalJSON = protowire.DecodeBool(v)
++		default:
++			panic(fmt.Sprintf("unkown field number %d while unmarshalling GoFeatures", num))
++		}
++	}
++	return parent
++}
++
++func unmarshalFeatureSet(b []byte, parent EditionFeatures) EditionFeatures {
++	for len(b) > 0 {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSet_FieldPresence_field_number:
++				parent.IsFieldPresence = v == genid.FeatureSet_EXPLICIT_enum_value || v == genid.FeatureSet_LEGACY_REQUIRED_enum_value
++				parent.IsLegacyRequired = v == genid.FeatureSet_LEGACY_REQUIRED_enum_value
++			case genid.FeatureSet_EnumType_field_number:
++				parent.IsOpenEnum = v == genid.FeatureSet_OPEN_enum_value
++			case genid.FeatureSet_RepeatedFieldEncoding_field_number:
++				parent.IsPacked = v == genid.FeatureSet_PACKED_enum_value
++			case genid.FeatureSet_Utf8Validation_field_number:
++				parent.IsUTF8Validated = v == genid.FeatureSet_VERIFY_enum_value
++			case genid.FeatureSet_MessageEncoding_field_number:
++				parent.IsDelimitedEncoded = v == genid.FeatureSet_DELIMITED_enum_value
++			case genid.FeatureSet_JsonFormat_field_number:
++				parent.IsJSONCompliant = v == genid.FeatureSet_ALLOW_enum_value
++			default:
++				panic(fmt.Sprintf("unkown field number %d while unmarshalling FeatureSet", num))
++			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.GoFeatures_LegacyUnmarshalJsonEnum_field_number:
++				parent = unmarshalGoFeature(v, parent)
++			}
++		}
++	}
++
++	return parent
++}
++
++func featuresFromParentDesc(parentDesc protoreflect.Descriptor) EditionFeatures {
++	var parentFS EditionFeatures
++	switch p := parentDesc.(type) {
++	case *File:
++		parentFS = p.L1.EditionFeatures
++	case *Message:
++		parentFS = p.L1.EditionFeatures
++	default:
++		panic(fmt.Sprintf("unknown parent type %T", parentDesc))
++	}
++	return parentFS
++}
++
++func unmarshalEditionDefault(b []byte) {
++	var ed Edition
++	var fs EditionFeatures
++	for len(b) > 0 {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_number:
++				ed = Edition(v)
++			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSetDefaults_FeatureSetEditionDefault_Features_field_number:
++				fs = unmarshalFeatureSet(v, fs)
++			}
++		}
++	}
++	defaultsCache[ed] = fs
++}
++
++func unmarshalEditionDefaults(b []byte) {
++	for len(b) > 0 {
++		num, _, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch num {
++		case genid.FeatureSetDefaults_Defaults_field_number:
++			def, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			unmarshalEditionDefault(def)
++		case genid.FeatureSetDefaults_MinimumEdition_field_number,
++			genid.FeatureSetDefaults_MaximumEdition_field_number:
++			// We don't care about the minimum and maximum editions. If the
++			// edition we are looking for later on is not in the cache we know
++			// it is outside of the range between minimum and maximum edition.
++			_, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++		default:
++			panic(fmt.Sprintf("unkown field number %d while unmarshalling EditionDefault", num))
++		}
++	}
++}
++
++func getFeaturesFor(ed Edition) EditionFeatures {
++	if def, ok := defaultsCache[ed]; ok {
++		return def
++	}
++	panic(fmt.Sprintf("unsupported edition: %v", ed))
++}
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+index 136f1b2..40272c8 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+@@ -12,6 +12,27 @@ import (
+ 
+ const File_google_protobuf_descriptor_proto = "google/protobuf/descriptor.proto"
+ 
++// Full and short names for google.protobuf.Edition.
++const (
++	Edition_enum_fullname = "google.protobuf.Edition"
++	Edition_enum_name     = "Edition"
++)
++
++// Enum values for google.protobuf.Edition.
++const (
++	Edition_EDITION_UNKNOWN_enum_value         = 0
++	Edition_EDITION_PROTO2_enum_value          = 998
++	Edition_EDITION_PROTO3_enum_value          = 999
++	Edition_EDITION_2023_enum_value            = 1000
++	Edition_EDITION_2024_enum_value            = 1001
++	Edition_EDITION_1_TEST_ONLY_enum_value     = 1
++	Edition_EDITION_2_TEST_ONLY_enum_value     = 2
++	Edition_EDITION_99997_TEST_ONLY_enum_value = 99997
++	Edition_EDITION_99998_TEST_ONLY_enum_value = 99998
++	Edition_EDITION_99999_TEST_ONLY_enum_value = 99999
++	Edition_EDITION_MAX_enum_value             = 2147483647
++)
++
+ // Names for google.protobuf.FileDescriptorSet.
+ const (
+ 	FileDescriptorSet_message_name     protoreflect.Name     = "FileDescriptorSet"
+@@ -81,7 +102,7 @@ const (
+ 	FileDescriptorProto_Options_field_number          protoreflect.FieldNumber = 8
+ 	FileDescriptorProto_SourceCodeInfo_field_number   protoreflect.FieldNumber = 9
+ 	FileDescriptorProto_Syntax_field_number           protoreflect.FieldNumber = 12
+-	FileDescriptorProto_Edition_field_number          protoreflect.FieldNumber = 13
++	FileDescriptorProto_Edition_field_number          protoreflect.FieldNumber = 14
+ )
+ 
+ // Names for google.protobuf.DescriptorProto.
+@@ -184,10 +205,12 @@ const (
+ const (
+ 	ExtensionRangeOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 	ExtensionRangeOptions_Declaration_field_name         protoreflect.Name = "declaration"
++	ExtensionRangeOptions_Features_field_name            protoreflect.Name = "features"
+ 	ExtensionRangeOptions_Verification_field_name        protoreflect.Name = "verification"
+ 
+ 	ExtensionRangeOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.uninterpreted_option"
+ 	ExtensionRangeOptions_Declaration_field_fullname         protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.declaration"
++	ExtensionRangeOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.features"
+ 	ExtensionRangeOptions_Verification_field_fullname        protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.verification"
+ )
+ 
+@@ -195,6 +218,7 @@ const (
+ const (
+ 	ExtensionRangeOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ 	ExtensionRangeOptions_Declaration_field_number         protoreflect.FieldNumber = 2
++	ExtensionRangeOptions_Features_field_number            protoreflect.FieldNumber = 50
+ 	ExtensionRangeOptions_Verification_field_number        protoreflect.FieldNumber = 3
+ )
+ 
+@@ -204,6 +228,12 @@ const (
+ 	ExtensionRangeOptions_VerificationState_enum_name     = "VerificationState"
+ )
+ 
++// Enum values for google.protobuf.ExtensionRangeOptions.VerificationState.
++const (
++	ExtensionRangeOptions_DECLARATION_enum_value = 0
++	ExtensionRangeOptions_UNVERIFIED_enum_value  = 1
++)
++
+ // Names for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+ 	ExtensionRangeOptions_Declaration_message_name     protoreflect.Name     = "Declaration"
+@@ -212,29 +242,26 @@ const (
+ 
+ // Field names for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+-	ExtensionRangeOptions_Declaration_Number_field_name     protoreflect.Name = "number"
+-	ExtensionRangeOptions_Declaration_FullName_field_name   protoreflect.Name = "full_name"
+-	ExtensionRangeOptions_Declaration_Type_field_name       protoreflect.Name = "type"
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_name protoreflect.Name = "is_repeated"
+-	ExtensionRangeOptions_Declaration_Reserved_field_name   protoreflect.Name = "reserved"
+-	ExtensionRangeOptions_Declaration_Repeated_field_name   protoreflect.Name = "repeated"
++	ExtensionRangeOptions_Declaration_Number_field_name   protoreflect.Name = "number"
++	ExtensionRangeOptions_Declaration_FullName_field_name protoreflect.Name = "full_name"
++	ExtensionRangeOptions_Declaration_Type_field_name     protoreflect.Name = "type"
++	ExtensionRangeOptions_Declaration_Reserved_field_name protoreflect.Name = "reserved"
++	ExtensionRangeOptions_Declaration_Repeated_field_name protoreflect.Name = "repeated"
+ 
+-	ExtensionRangeOptions_Declaration_Number_field_fullname     protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.number"
+-	ExtensionRangeOptions_Declaration_FullName_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.full_name"
+-	ExtensionRangeOptions_Declaration_Type_field_fullname       protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.type"
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.is_repeated"
+-	ExtensionRangeOptions_Declaration_Reserved_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.reserved"
+-	ExtensionRangeOptions_Declaration_Repeated_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.repeated"
++	ExtensionRangeOptions_Declaration_Number_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.number"
++	ExtensionRangeOptions_Declaration_FullName_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.full_name"
++	ExtensionRangeOptions_Declaration_Type_field_fullname     protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.type"
++	ExtensionRangeOptions_Declaration_Reserved_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.reserved"
++	ExtensionRangeOptions_Declaration_Repeated_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.repeated"
+ )
+ 
+ // Field numbers for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+-	ExtensionRangeOptions_Declaration_Number_field_number     protoreflect.FieldNumber = 1
+-	ExtensionRangeOptions_Declaration_FullName_field_number   protoreflect.FieldNumber = 2
+-	ExtensionRangeOptions_Declaration_Type_field_number       protoreflect.FieldNumber = 3
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_number protoreflect.FieldNumber = 4
+-	ExtensionRangeOptions_Declaration_Reserved_field_number   protoreflect.FieldNumber = 5
+-	ExtensionRangeOptions_Declaration_Repeated_field_number   protoreflect.FieldNumber = 6
++	ExtensionRangeOptions_Declaration_Number_field_number   protoreflect.FieldNumber = 1
++	ExtensionRangeOptions_Declaration_FullName_field_number protoreflect.FieldNumber = 2
++	ExtensionRangeOptions_Declaration_Type_field_number     protoreflect.FieldNumber = 3
++	ExtensionRangeOptions_Declaration_Reserved_field_number protoreflect.FieldNumber = 5
++	ExtensionRangeOptions_Declaration_Repeated_field_number protoreflect.FieldNumber = 6
+ )
+ 
+ // Names for google.protobuf.FieldDescriptorProto.
+@@ -291,12 +318,41 @@ const (
+ 	FieldDescriptorProto_Type_enum_name     = "Type"
+ )
+ 
++// Enum values for google.protobuf.FieldDescriptorProto.Type.
++const (
++	FieldDescriptorProto_TYPE_DOUBLE_enum_value   = 1
++	FieldDescriptorProto_TYPE_FLOAT_enum_value    = 2
++	FieldDescriptorProto_TYPE_INT64_enum_value    = 3
++	FieldDescriptorProto_TYPE_UINT64_enum_value   = 4
++	FieldDescriptorProto_TYPE_INT32_enum_value    = 5
++	FieldDescriptorProto_TYPE_FIXED64_enum_value  = 6
++	FieldDescriptorProto_TYPE_FIXED32_enum_value  = 7
++	FieldDescriptorProto_TYPE_BOOL_enum_value     = 8
++	FieldDescriptorProto_TYPE_STRING_enum_value   = 9
++	FieldDescriptorProto_TYPE_GROUP_enum_value    = 10
++	FieldDescriptorProto_TYPE_MESSAGE_enum_value  = 11
++	FieldDescriptorProto_TYPE_BYTES_enum_value    = 12
++	FieldDescriptorProto_TYPE_UINT32_enum_value   = 13
++	FieldDescriptorProto_TYPE_ENUM_enum_value     = 14
++	FieldDescriptorProto_TYPE_SFIXED32_enum_value = 15
++	FieldDescriptorProto_TYPE_SFIXED64_enum_value = 16
++	FieldDescriptorProto_TYPE_SINT32_enum_value   = 17
++	FieldDescriptorProto_TYPE_SINT64_enum_value   = 18
++)
++
+ // Full and short names for google.protobuf.FieldDescriptorProto.Label.
+ const (
+ 	FieldDescriptorProto_Label_enum_fullname = "google.protobuf.FieldDescriptorProto.Label"
+ 	FieldDescriptorProto_Label_enum_name     = "Label"
+ )
+ 
++// Enum values for google.protobuf.FieldDescriptorProto.Label.
++const (
++	FieldDescriptorProto_LABEL_OPTIONAL_enum_value = 1
++	FieldDescriptorProto_LABEL_REPEATED_enum_value = 3
++	FieldDescriptorProto_LABEL_REQUIRED_enum_value = 2
++)
++
+ // Names for google.protobuf.OneofDescriptorProto.
+ const (
+ 	OneofDescriptorProto_message_name     protoreflect.Name     = "OneofDescriptorProto"
+@@ -468,7 +524,6 @@ const (
+ 	FileOptions_CcGenericServices_field_name         protoreflect.Name = "cc_generic_services"
+ 	FileOptions_JavaGenericServices_field_name       protoreflect.Name = "java_generic_services"
+ 	FileOptions_PyGenericServices_field_name         protoreflect.Name = "py_generic_services"
+-	FileOptions_PhpGenericServices_field_name        protoreflect.Name = "php_generic_services"
+ 	FileOptions_Deprecated_field_name                protoreflect.Name = "deprecated"
+ 	FileOptions_CcEnableArenas_field_name            protoreflect.Name = "cc_enable_arenas"
+ 	FileOptions_ObjcClassPrefix_field_name           protoreflect.Name = "objc_class_prefix"
+@@ -478,6 +533,7 @@ const (
+ 	FileOptions_PhpNamespace_field_name              protoreflect.Name = "php_namespace"
+ 	FileOptions_PhpMetadataNamespace_field_name      protoreflect.Name = "php_metadata_namespace"
+ 	FileOptions_RubyPackage_field_name               protoreflect.Name = "ruby_package"
++	FileOptions_Features_field_name                  protoreflect.Name = "features"
+ 	FileOptions_UninterpretedOption_field_name       protoreflect.Name = "uninterpreted_option"
+ 
+ 	FileOptions_JavaPackage_field_fullname               protoreflect.FullName = "google.protobuf.FileOptions.java_package"
+@@ -490,7 +546,6 @@ const (
+ 	FileOptions_CcGenericServices_field_fullname         protoreflect.FullName = "google.protobuf.FileOptions.cc_generic_services"
+ 	FileOptions_JavaGenericServices_field_fullname       protoreflect.FullName = "google.protobuf.FileOptions.java_generic_services"
+ 	FileOptions_PyGenericServices_field_fullname         protoreflect.FullName = "google.protobuf.FileOptions.py_generic_services"
+-	FileOptions_PhpGenericServices_field_fullname        protoreflect.FullName = "google.protobuf.FileOptions.php_generic_services"
+ 	FileOptions_Deprecated_field_fullname                protoreflect.FullName = "google.protobuf.FileOptions.deprecated"
+ 	FileOptions_CcEnableArenas_field_fullname            protoreflect.FullName = "google.protobuf.FileOptions.cc_enable_arenas"
+ 	FileOptions_ObjcClassPrefix_field_fullname           protoreflect.FullName = "google.protobuf.FileOptions.objc_class_prefix"
+@@ -500,6 +555,7 @@ const (
+ 	FileOptions_PhpNamespace_field_fullname              protoreflect.FullName = "google.protobuf.FileOptions.php_namespace"
+ 	FileOptions_PhpMetadataNamespace_field_fullname      protoreflect.FullName = "google.protobuf.FileOptions.php_metadata_namespace"
+ 	FileOptions_RubyPackage_field_fullname               protoreflect.FullName = "google.protobuf.FileOptions.ruby_package"
++	FileOptions_Features_field_fullname                  protoreflect.FullName = "google.protobuf.FileOptions.features"
+ 	FileOptions_UninterpretedOption_field_fullname       protoreflect.FullName = "google.protobuf.FileOptions.uninterpreted_option"
+ )
+ 
+@@ -515,7 +571,6 @@ const (
+ 	FileOptions_CcGenericServices_field_number         protoreflect.FieldNumber = 16
+ 	FileOptions_JavaGenericServices_field_number       protoreflect.FieldNumber = 17
+ 	FileOptions_PyGenericServices_field_number         protoreflect.FieldNumber = 18
+-	FileOptions_PhpGenericServices_field_number        protoreflect.FieldNumber = 42
+ 	FileOptions_Deprecated_field_number                protoreflect.FieldNumber = 23
+ 	FileOptions_CcEnableArenas_field_number            protoreflect.FieldNumber = 31
+ 	FileOptions_ObjcClassPrefix_field_number           protoreflect.FieldNumber = 36
+@@ -525,6 +580,7 @@ const (
+ 	FileOptions_PhpNamespace_field_number              protoreflect.FieldNumber = 41
+ 	FileOptions_PhpMetadataNamespace_field_number      protoreflect.FieldNumber = 44
+ 	FileOptions_RubyPackage_field_number               protoreflect.FieldNumber = 45
++	FileOptions_Features_field_number                  protoreflect.FieldNumber = 50
+ 	FileOptions_UninterpretedOption_field_number       protoreflect.FieldNumber = 999
+ )
+ 
+@@ -534,6 +590,13 @@ const (
+ 	FileOptions_OptimizeMode_enum_name     = "OptimizeMode"
+ )
+ 
++// Enum values for google.protobuf.FileOptions.OptimizeMode.
++const (
++	FileOptions_SPEED_enum_value        = 1
++	FileOptions_CODE_SIZE_enum_value    = 2
++	FileOptions_LITE_RUNTIME_enum_value = 3
++)
++
+ // Names for google.protobuf.MessageOptions.
+ const (
+ 	MessageOptions_message_name     protoreflect.Name     = "MessageOptions"
+@@ -547,6 +610,7 @@ const (
+ 	MessageOptions_Deprecated_field_name                         protoreflect.Name = "deprecated"
+ 	MessageOptions_MapEntry_field_name                           protoreflect.Name = "map_entry"
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_name protoreflect.Name = "deprecated_legacy_json_field_conflicts"
++	MessageOptions_Features_field_name                           protoreflect.Name = "features"
+ 	MessageOptions_UninterpretedOption_field_name                protoreflect.Name = "uninterpreted_option"
+ 
+ 	MessageOptions_MessageSetWireFormat_field_fullname               protoreflect.FullName = "google.protobuf.MessageOptions.message_set_wire_format"
+@@ -554,6 +618,7 @@ const (
+ 	MessageOptions_Deprecated_field_fullname                         protoreflect.FullName = "google.protobuf.MessageOptions.deprecated"
+ 	MessageOptions_MapEntry_field_fullname                           protoreflect.FullName = "google.protobuf.MessageOptions.map_entry"
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_fullname protoreflect.FullName = "google.protobuf.MessageOptions.deprecated_legacy_json_field_conflicts"
++	MessageOptions_Features_field_fullname                           protoreflect.FullName = "google.protobuf.MessageOptions.features"
+ 	MessageOptions_UninterpretedOption_field_fullname                protoreflect.FullName = "google.protobuf.MessageOptions.uninterpreted_option"
+ )
+ 
+@@ -564,6 +629,7 @@ const (
+ 	MessageOptions_Deprecated_field_number                         protoreflect.FieldNumber = 3
+ 	MessageOptions_MapEntry_field_number                           protoreflect.FieldNumber = 7
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_number protoreflect.FieldNumber = 11
++	MessageOptions_Features_field_number                           protoreflect.FieldNumber = 12
+ 	MessageOptions_UninterpretedOption_field_number                protoreflect.FieldNumber = 999
+ )
+ 
+@@ -584,8 +650,9 @@ const (
+ 	FieldOptions_Weak_field_name                protoreflect.Name = "weak"
+ 	FieldOptions_DebugRedact_field_name         protoreflect.Name = "debug_redact"
+ 	FieldOptions_Retention_field_name           protoreflect.Name = "retention"
+-	FieldOptions_Target_field_name              protoreflect.Name = "target"
+ 	FieldOptions_Targets_field_name             protoreflect.Name = "targets"
++	FieldOptions_EditionDefaults_field_name     protoreflect.Name = "edition_defaults"
++	FieldOptions_Features_field_name            protoreflect.Name = "features"
+ 	FieldOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	FieldOptions_Ctype_field_fullname               protoreflect.FullName = "google.protobuf.FieldOptions.ctype"
+@@ -597,8 +664,9 @@ const (
+ 	FieldOptions_Weak_field_fullname                protoreflect.FullName = "google.protobuf.FieldOptions.weak"
+ 	FieldOptions_DebugRedact_field_fullname         protoreflect.FullName = "google.protobuf.FieldOptions.debug_redact"
+ 	FieldOptions_Retention_field_fullname           protoreflect.FullName = "google.protobuf.FieldOptions.retention"
+-	FieldOptions_Target_field_fullname              protoreflect.FullName = "google.protobuf.FieldOptions.target"
+ 	FieldOptions_Targets_field_fullname             protoreflect.FullName = "google.protobuf.FieldOptions.targets"
++	FieldOptions_EditionDefaults_field_fullname     protoreflect.FullName = "google.protobuf.FieldOptions.edition_defaults"
++	FieldOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.FieldOptions.features"
+ 	FieldOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.FieldOptions.uninterpreted_option"
+ )
+ 
+@@ -613,8 +681,9 @@ const (
+ 	FieldOptions_Weak_field_number                protoreflect.FieldNumber = 10
+ 	FieldOptions_DebugRedact_field_number         protoreflect.FieldNumber = 16
+ 	FieldOptions_Retention_field_number           protoreflect.FieldNumber = 17
+-	FieldOptions_Target_field_number              protoreflect.FieldNumber = 18
+ 	FieldOptions_Targets_field_number             protoreflect.FieldNumber = 19
++	FieldOptions_EditionDefaults_field_number     protoreflect.FieldNumber = 20
++	FieldOptions_Features_field_number            protoreflect.FieldNumber = 21
+ 	FieldOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -624,24 +693,80 @@ const (
+ 	FieldOptions_CType_enum_name     = "CType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.CType.
++const (
++	FieldOptions_STRING_enum_value       = 0
++	FieldOptions_CORD_enum_value         = 1
++	FieldOptions_STRING_PIECE_enum_value = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.JSType.
+ const (
+ 	FieldOptions_JSType_enum_fullname = "google.protobuf.FieldOptions.JSType"
+ 	FieldOptions_JSType_enum_name     = "JSType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.JSType.
++const (
++	FieldOptions_JS_NORMAL_enum_value = 0
++	FieldOptions_JS_STRING_enum_value = 1
++	FieldOptions_JS_NUMBER_enum_value = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.OptionRetention.
+ const (
+ 	FieldOptions_OptionRetention_enum_fullname = "google.protobuf.FieldOptions.OptionRetention"
+ 	FieldOptions_OptionRetention_enum_name     = "OptionRetention"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.OptionRetention.
++const (
++	FieldOptions_RETENTION_UNKNOWN_enum_value = 0
++	FieldOptions_RETENTION_RUNTIME_enum_value = 1
++	FieldOptions_RETENTION_SOURCE_enum_value  = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.OptionTargetType.
+ const (
+ 	FieldOptions_OptionTargetType_enum_fullname = "google.protobuf.FieldOptions.OptionTargetType"
+ 	FieldOptions_OptionTargetType_enum_name     = "OptionTargetType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.OptionTargetType.
++const (
++	FieldOptions_TARGET_TYPE_UNKNOWN_enum_value         = 0
++	FieldOptions_TARGET_TYPE_FILE_enum_value            = 1
++	FieldOptions_TARGET_TYPE_EXTENSION_RANGE_enum_value = 2
++	FieldOptions_TARGET_TYPE_MESSAGE_enum_value         = 3
++	FieldOptions_TARGET_TYPE_FIELD_enum_value           = 4
++	FieldOptions_TARGET_TYPE_ONEOF_enum_value           = 5
++	FieldOptions_TARGET_TYPE_ENUM_enum_value            = 6
++	FieldOptions_TARGET_TYPE_ENUM_ENTRY_enum_value      = 7
++	FieldOptions_TARGET_TYPE_SERVICE_enum_value         = 8
++	FieldOptions_TARGET_TYPE_METHOD_enum_value          = 9
++)
++
++// Names for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_message_name     protoreflect.Name     = "EditionDefault"
++	FieldOptions_EditionDefault_message_fullname protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault"
++)
++
++// Field names for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_Edition_field_name protoreflect.Name = "edition"
++	FieldOptions_EditionDefault_Value_field_name   protoreflect.Name = "value"
++
++	FieldOptions_EditionDefault_Edition_field_fullname protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault.edition"
++	FieldOptions_EditionDefault_Value_field_fullname   protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault.value"
++)
++
++// Field numbers for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_Edition_field_number protoreflect.FieldNumber = 3
++	FieldOptions_EditionDefault_Value_field_number   protoreflect.FieldNumber = 2
++)
++
+ // Names for google.protobuf.OneofOptions.
+ const (
+ 	OneofOptions_message_name     protoreflect.Name     = "OneofOptions"
+@@ -650,13 +775,16 @@ const (
+ 
+ // Field names for google.protobuf.OneofOptions.
+ const (
++	OneofOptions_Features_field_name            protoreflect.Name = "features"
+ 	OneofOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
++	OneofOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.OneofOptions.features"
+ 	OneofOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.OneofOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.OneofOptions.
+ const (
++	OneofOptions_Features_field_number            protoreflect.FieldNumber = 1
+ 	OneofOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -671,11 +799,13 @@ const (
+ 	EnumOptions_AllowAlias_field_name                         protoreflect.Name = "allow_alias"
+ 	EnumOptions_Deprecated_field_name                         protoreflect.Name = "deprecated"
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_name protoreflect.Name = "deprecated_legacy_json_field_conflicts"
++	EnumOptions_Features_field_name                           protoreflect.Name = "features"
+ 	EnumOptions_UninterpretedOption_field_name                protoreflect.Name = "uninterpreted_option"
+ 
+ 	EnumOptions_AllowAlias_field_fullname                         protoreflect.FullName = "google.protobuf.EnumOptions.allow_alias"
+ 	EnumOptions_Deprecated_field_fullname                         protoreflect.FullName = "google.protobuf.EnumOptions.deprecated"
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_fullname protoreflect.FullName = "google.protobuf.EnumOptions.deprecated_legacy_json_field_conflicts"
++	EnumOptions_Features_field_fullname                           protoreflect.FullName = "google.protobuf.EnumOptions.features"
+ 	EnumOptions_UninterpretedOption_field_fullname                protoreflect.FullName = "google.protobuf.EnumOptions.uninterpreted_option"
+ )
+ 
+@@ -684,6 +814,7 @@ const (
+ 	EnumOptions_AllowAlias_field_number                         protoreflect.FieldNumber = 2
+ 	EnumOptions_Deprecated_field_number                         protoreflect.FieldNumber = 3
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_number protoreflect.FieldNumber = 6
++	EnumOptions_Features_field_number                           protoreflect.FieldNumber = 7
+ 	EnumOptions_UninterpretedOption_field_number                protoreflect.FieldNumber = 999
+ )
+ 
+@@ -696,15 +827,21 @@ const (
+ // Field names for google.protobuf.EnumValueOptions.
+ const (
+ 	EnumValueOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
++	EnumValueOptions_Features_field_name            protoreflect.Name = "features"
++	EnumValueOptions_DebugRedact_field_name         protoreflect.Name = "debug_redact"
+ 	EnumValueOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	EnumValueOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.EnumValueOptions.deprecated"
++	EnumValueOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.EnumValueOptions.features"
++	EnumValueOptions_DebugRedact_field_fullname         protoreflect.FullName = "google.protobuf.EnumValueOptions.debug_redact"
+ 	EnumValueOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.EnumValueOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.EnumValueOptions.
+ const (
+ 	EnumValueOptions_Deprecated_field_number          protoreflect.FieldNumber = 1
++	EnumValueOptions_Features_field_number            protoreflect.FieldNumber = 2
++	EnumValueOptions_DebugRedact_field_number         protoreflect.FieldNumber = 3
+ 	EnumValueOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -716,15 +853,18 @@ const (
+ 
+ // Field names for google.protobuf.ServiceOptions.
+ const (
++	ServiceOptions_Features_field_name            protoreflect.Name = "features"
+ 	ServiceOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
+ 	ServiceOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
++	ServiceOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.ServiceOptions.features"
+ 	ServiceOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.ServiceOptions.deprecated"
+ 	ServiceOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.ServiceOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.ServiceOptions.
+ const (
++	ServiceOptions_Features_field_number            protoreflect.FieldNumber = 34
+ 	ServiceOptions_Deprecated_field_number          protoreflect.FieldNumber = 33
+ 	ServiceOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+@@ -739,10 +879,12 @@ const (
+ const (
+ 	MethodOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
+ 	MethodOptions_IdempotencyLevel_field_name    protoreflect.Name = "idempotency_level"
++	MethodOptions_Features_field_name            protoreflect.Name = "features"
+ 	MethodOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	MethodOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.MethodOptions.deprecated"
+ 	MethodOptions_IdempotencyLevel_field_fullname    protoreflect.FullName = "google.protobuf.MethodOptions.idempotency_level"
++	MethodOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.MethodOptions.features"
+ 	MethodOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.MethodOptions.uninterpreted_option"
+ )
+ 
+@@ -750,6 +892,7 @@ const (
+ const (
+ 	MethodOptions_Deprecated_field_number          protoreflect.FieldNumber = 33
+ 	MethodOptions_IdempotencyLevel_field_number    protoreflect.FieldNumber = 34
++	MethodOptions_Features_field_number            protoreflect.FieldNumber = 35
+ 	MethodOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -759,6 +902,13 @@ const (
+ 	MethodOptions_IdempotencyLevel_enum_name     = "IdempotencyLevel"
+ )
+ 
++// Enum values for google.protobuf.MethodOptions.IdempotencyLevel.
++const (
++	MethodOptions_IDEMPOTENCY_UNKNOWN_enum_value = 0
++	MethodOptions_NO_SIDE_EFFECTS_enum_value     = 1
++	MethodOptions_IDEMPOTENT_enum_value          = 2
++)
++
+ // Names for google.protobuf.UninterpretedOption.
+ const (
+ 	UninterpretedOption_message_name     protoreflect.Name     = "UninterpretedOption"
+@@ -816,6 +966,163 @@ const (
+ 	UninterpretedOption_NamePart_IsExtension_field_number protoreflect.FieldNumber = 2
+ )
+ 
++// Names for google.protobuf.FeatureSet.
++const (
++	FeatureSet_message_name     protoreflect.Name     = "FeatureSet"
++	FeatureSet_message_fullname protoreflect.FullName = "google.protobuf.FeatureSet"
++)
++
++// Field names for google.protobuf.FeatureSet.
++const (
++	FeatureSet_FieldPresence_field_name         protoreflect.Name = "field_presence"
++	FeatureSet_EnumType_field_name              protoreflect.Name = "enum_type"
++	FeatureSet_RepeatedFieldEncoding_field_name protoreflect.Name = "repeated_field_encoding"
++	FeatureSet_Utf8Validation_field_name        protoreflect.Name = "utf8_validation"
++	FeatureSet_MessageEncoding_field_name       protoreflect.Name = "message_encoding"
++	FeatureSet_JsonFormat_field_name            protoreflect.Name = "json_format"
++
++	FeatureSet_FieldPresence_field_fullname         protoreflect.FullName = "google.protobuf.FeatureSet.field_presence"
++	FeatureSet_EnumType_field_fullname              protoreflect.FullName = "google.protobuf.FeatureSet.enum_type"
++	FeatureSet_RepeatedFieldEncoding_field_fullname protoreflect.FullName = "google.protobuf.FeatureSet.repeated_field_encoding"
++	FeatureSet_Utf8Validation_field_fullname        protoreflect.FullName = "google.protobuf.FeatureSet.utf8_validation"
++	FeatureSet_MessageEncoding_field_fullname       protoreflect.FullName = "google.protobuf.FeatureSet.message_encoding"
++	FeatureSet_JsonFormat_field_fullname            protoreflect.FullName = "google.protobuf.FeatureSet.json_format"
++)
++
++// Field numbers for google.protobuf.FeatureSet.
++const (
++	FeatureSet_FieldPresence_field_number         protoreflect.FieldNumber = 1
++	FeatureSet_EnumType_field_number              protoreflect.FieldNumber = 2
++	FeatureSet_RepeatedFieldEncoding_field_number protoreflect.FieldNumber = 3
++	FeatureSet_Utf8Validation_field_number        protoreflect.FieldNumber = 4
++	FeatureSet_MessageEncoding_field_number       protoreflect.FieldNumber = 5
++	FeatureSet_JsonFormat_field_number            protoreflect.FieldNumber = 6
++)
++
++// Full and short names for google.protobuf.FeatureSet.FieldPresence.
++const (
++	FeatureSet_FieldPresence_enum_fullname = "google.protobuf.FeatureSet.FieldPresence"
++	FeatureSet_FieldPresence_enum_name     = "FieldPresence"
++)
++
++// Enum values for google.protobuf.FeatureSet.FieldPresence.
++const (
++	FeatureSet_FIELD_PRESENCE_UNKNOWN_enum_value = 0
++	FeatureSet_EXPLICIT_enum_value               = 1
++	FeatureSet_IMPLICIT_enum_value               = 2
++	FeatureSet_LEGACY_REQUIRED_enum_value        = 3
++)
++
++// Full and short names for google.protobuf.FeatureSet.EnumType.
++const (
++	FeatureSet_EnumType_enum_fullname = "google.protobuf.FeatureSet.EnumType"
++	FeatureSet_EnumType_enum_name     = "EnumType"
++)
++
++// Enum values for google.protobuf.FeatureSet.EnumType.
++const (
++	FeatureSet_ENUM_TYPE_UNKNOWN_enum_value = 0
++	FeatureSet_OPEN_enum_value              = 1
++	FeatureSet_CLOSED_enum_value            = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.RepeatedFieldEncoding.
++const (
++	FeatureSet_RepeatedFieldEncoding_enum_fullname = "google.protobuf.FeatureSet.RepeatedFieldEncoding"
++	FeatureSet_RepeatedFieldEncoding_enum_name     = "RepeatedFieldEncoding"
++)
++
++// Enum values for google.protobuf.FeatureSet.RepeatedFieldEncoding.
++const (
++	FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN_enum_value = 0
++	FeatureSet_PACKED_enum_value                          = 1
++	FeatureSet_EXPANDED_enum_value                        = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.Utf8Validation.
++const (
++	FeatureSet_Utf8Validation_enum_fullname = "google.protobuf.FeatureSet.Utf8Validation"
++	FeatureSet_Utf8Validation_enum_name     = "Utf8Validation"
++)
++
++// Enum values for google.protobuf.FeatureSet.Utf8Validation.
++const (
++	FeatureSet_UTF8_VALIDATION_UNKNOWN_enum_value = 0
++	FeatureSet_VERIFY_enum_value                  = 2
++	FeatureSet_NONE_enum_value                    = 3
++)
++
++// Full and short names for google.protobuf.FeatureSet.MessageEncoding.
++const (
++	FeatureSet_MessageEncoding_enum_fullname = "google.protobuf.FeatureSet.MessageEncoding"
++	FeatureSet_MessageEncoding_enum_name     = "MessageEncoding"
++)
++
++// Enum values for google.protobuf.FeatureSet.MessageEncoding.
++const (
++	FeatureSet_MESSAGE_ENCODING_UNKNOWN_enum_value = 0
++	FeatureSet_LENGTH_PREFIXED_enum_value          = 1
++	FeatureSet_DELIMITED_enum_value                = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.JsonFormat.
++const (
++	FeatureSet_JsonFormat_enum_fullname = "google.protobuf.FeatureSet.JsonFormat"
++	FeatureSet_JsonFormat_enum_name     = "JsonFormat"
++)
++
++// Enum values for google.protobuf.FeatureSet.JsonFormat.
++const (
++	FeatureSet_JSON_FORMAT_UNKNOWN_enum_value = 0
++	FeatureSet_ALLOW_enum_value               = 1
++	FeatureSet_LEGACY_BEST_EFFORT_enum_value  = 2
++)
++
++// Names for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_message_name     protoreflect.Name     = "FeatureSetDefaults"
++	FeatureSetDefaults_message_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults"
++)
++
++// Field names for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_Defaults_field_name       protoreflect.Name = "defaults"
++	FeatureSetDefaults_MinimumEdition_field_name protoreflect.Name = "minimum_edition"
++	FeatureSetDefaults_MaximumEdition_field_name protoreflect.Name = "maximum_edition"
++
++	FeatureSetDefaults_Defaults_field_fullname       protoreflect.FullName = "google.protobuf.FeatureSetDefaults.defaults"
++	FeatureSetDefaults_MinimumEdition_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.minimum_edition"
++	FeatureSetDefaults_MaximumEdition_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.maximum_edition"
++)
++
++// Field numbers for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_Defaults_field_number       protoreflect.FieldNumber = 1
++	FeatureSetDefaults_MinimumEdition_field_number protoreflect.FieldNumber = 4
++	FeatureSetDefaults_MaximumEdition_field_number protoreflect.FieldNumber = 5
++)
++
++// Names for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_message_name     protoreflect.Name     = "FeatureSetEditionDefault"
++	FeatureSetDefaults_FeatureSetEditionDefault_message_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault"
++)
++
++// Field names for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_name  protoreflect.Name = "edition"
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_name protoreflect.Name = "features"
++
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_fullname  protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.edition"
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.features"
++)
++
++// Field numbers for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_number  protoreflect.FieldNumber = 3
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_number protoreflect.FieldNumber = 2
++)
++
+ // Names for google.protobuf.SourceCodeInfo.
+ const (
+ 	SourceCodeInfo_message_name     protoreflect.Name     = "SourceCodeInfo"
+@@ -917,3 +1224,10 @@ const (
+ 	GeneratedCodeInfo_Annotation_Semantic_enum_fullname = "google.protobuf.GeneratedCodeInfo.Annotation.Semantic"
+ 	GeneratedCodeInfo_Annotation_Semantic_enum_name     = "Semantic"
+ )
++
++// Enum values for google.protobuf.GeneratedCodeInfo.Annotation.Semantic.
++const (
++	GeneratedCodeInfo_Annotation_NONE_enum_value  = 0
++	GeneratedCodeInfo_Annotation_SET_enum_value   = 1
++	GeneratedCodeInfo_Annotation_ALIAS_enum_value = 2
++)
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go b/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+new file mode 100644
+index 0000000..fd9015e
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+@@ -0,0 +1,31 @@
++// Copyright 2019 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Code generated by generate-protos. DO NOT EDIT.
++
++package genid
++
++import (
++	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
++)
++
++const File_reflect_protodesc_proto_go_features_proto = "reflect/protodesc/proto/go_features.proto"
++
++// Names for google.protobuf.GoFeatures.
++const (
++	GoFeatures_message_name     protoreflect.Name     = "GoFeatures"
++	GoFeatures_message_fullname protoreflect.FullName = "google.protobuf.GoFeatures"
++)
++
++// Field names for google.protobuf.GoFeatures.
++const (
++	GoFeatures_LegacyUnmarshalJsonEnum_field_name protoreflect.Name = "legacy_unmarshal_json_enum"
++
++	GoFeatures_LegacyUnmarshalJsonEnum_field_fullname protoreflect.FullName = "google.protobuf.GoFeatures.legacy_unmarshal_json_enum"
++)
++
++// Field numbers for google.protobuf.GoFeatures.
++const (
++	GoFeatures_LegacyUnmarshalJsonEnum_field_number protoreflect.FieldNumber = 1
++)
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go b/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
+index 1a38944..ad6f80c 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
+@@ -18,6 +18,11 @@ const (
+ 	NullValue_enum_name     = "NullValue"
+ )
+ 
++// Enum values for google.protobuf.NullValue.
++const (
++	NullValue_NULL_VALUE_enum_value = 0
++)
++
+ // Names for google.protobuf.Struct.
+ const (
+ 	Struct_message_name     protoreflect.Name     = "Struct"
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/type_gen.go b/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
+index e0f75fe..49bc73e 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
+@@ -18,6 +18,13 @@ const (
+ 	Syntax_enum_name     = "Syntax"
+ )
+ 
++// Enum values for google.protobuf.Syntax.
++const (
++	Syntax_SYNTAX_PROTO2_enum_value   = 0
++	Syntax_SYNTAX_PROTO3_enum_value   = 1
++	Syntax_SYNTAX_EDITIONS_enum_value = 2
++)
++
+ // Names for google.protobuf.Type.
+ const (
+ 	Type_message_name     protoreflect.Name     = "Type"
+@@ -105,12 +112,43 @@ const (
+ 	Field_Kind_enum_name     = "Kind"
+ )
+ 
++// Enum values for google.protobuf.Field.Kind.
++const (
++	Field_TYPE_UNKNOWN_enum_value  = 0
++	Field_TYPE_DOUBLE_enum_value   = 1
++	Field_TYPE_FLOAT_enum_value    = 2
++	Field_TYPE_INT64_enum_value    = 3
++	Field_TYPE_UINT64_enum_value   = 4
++	Field_TYPE_INT32_enum_value    = 5
++	Field_TYPE_FIXED64_enum_value  = 6
++	Field_TYPE_FIXED32_enum_value  = 7
++	Field_TYPE_BOOL_enum_value     = 8
++	Field_TYPE_STRING_enum_value   = 9
++	Field_TYPE_GROUP_enum_value    = 10
++	Field_TYPE_MESSAGE_enum_value  = 11
++	Field_TYPE_BYTES_enum_value    = 12
++	Field_TYPE_UINT32_enum_value   = 13
++	Field_TYPE_ENUM_enum_value     = 14
++	Field_TYPE_SFIXED32_enum_value = 15
++	Field_TYPE_SFIXED64_enum_value = 16
++	Field_TYPE_SINT32_enum_value   = 17
++	Field_TYPE_SINT64_enum_value   = 18
++)
++
+ // Full and short names for google.protobuf.Field.Cardinality.
+ const (
+ 	Field_Cardinality_enum_fullname = "google.protobuf.Field.Cardinality"
+ 	Field_Cardinality_enum_name     = "Cardinality"
+ )
+ 
++// Enum values for google.protobuf.Field.Cardinality.
++const (
++	Field_CARDINALITY_UNKNOWN_enum_value  = 0
++	Field_CARDINALITY_OPTIONAL_enum_value = 1
++	Field_CARDINALITY_REQUIRED_enum_value = 2
++	Field_CARDINALITY_REPEATED_enum_value = 3
++)
++
+ // Names for google.protobuf.Enum.
+ const (
+ 	Enum_message_name     protoreflect.Name     = "Enum"
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go b/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
+index e74cefd..2b8f122 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
+@@ -21,26 +21,18 @@ type extensionFieldInfo struct {
+ 	validation          validationInfo
+ }
+ 
+-var legacyExtensionFieldInfoCache sync.Map // map[protoreflect.ExtensionType]*extensionFieldInfo
+-
+ func getExtensionFieldInfo(xt protoreflect.ExtensionType) *extensionFieldInfo {
+ 	if xi, ok := xt.(*ExtensionInfo); ok {
+ 		xi.lazyInit()
+ 		return xi.info
+ 	}
+-	return legacyLoadExtensionFieldInfo(xt)
+-}
+-
+-// legacyLoadExtensionFieldInfo dynamically loads a *ExtensionInfo for xt.
+-func legacyLoadExtensionFieldInfo(xt protoreflect.ExtensionType) *extensionFieldInfo {
+-	if xi, ok := legacyExtensionFieldInfoCache.Load(xt); ok {
+-		return xi.(*extensionFieldInfo)
+-	}
+-	e := makeExtensionFieldInfo(xt.TypeDescriptor())
+-	if e, ok := legacyMessageTypeCache.LoadOrStore(xt, e); ok {
+-		return e.(*extensionFieldInfo)
+-	}
+-	return e
++	// Ideally we'd cache the resulting *extensionFieldInfo so we don't have to
++	// recompute this metadata repeatedly. But without support for something like
++	// weak references, such a cache would pin temporary values (like dynamic
++	// extension types, constructed for the duration of a user request) to the
++	// heap forever, causing memory usage of the cache to grow unbounded.
++	// See discussion in https://github.com/golang/protobuf/issues/1521.
++	return makeExtensionFieldInfo(xt.TypeDescriptor())
+ }
+ 
+ func makeExtensionFieldInfo(xd protoreflect.ExtensionDescriptor) *extensionFieldInfo {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go b/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
+index 1a509b6..f55dc01 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
+@@ -162,11 +162,20 @@ func appendBoolSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptions
+ func consumeBoolSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.BoolSlice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growBoolSlice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -732,11 +741,20 @@ func appendInt32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeInt32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1138,11 +1156,20 @@ func appendSint32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeSint32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1544,11 +1571,20 @@ func appendUint32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeUint32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growUint32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1950,11 +1986,20 @@ func appendInt64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeInt64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -2356,11 +2401,20 @@ func appendSint64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeSint64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -2762,11 +2816,20 @@ func appendUint64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeUint64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growUint64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -3145,11 +3208,15 @@ func appendSfixed32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpt
+ func consumeSfixed32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -3461,11 +3528,15 @@ func appendFixed32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpti
+ func consumeFixed32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growUint32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -3777,11 +3848,15 @@ func appendFloatSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeFloatSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Float32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growFloat32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -4093,11 +4168,15 @@ func appendSfixed64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpt
+ func consumeSfixed64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+@@ -4409,11 +4488,15 @@ func appendFixed64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpti
+ func consumeFixed64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growUint64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+@@ -4725,11 +4808,15 @@ func appendDoubleSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeDoubleSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Float64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growFloat64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go b/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
+index 576dcf3..1307775 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
+@@ -197,7 +197,7 @@ func fieldCoder(fd protoreflect.FieldDescriptor, ft reflect.Type) (*MessageInfo,
+ 		return getMessageInfo(ft), makeMessageFieldCoder(fd, ft)
+ 	case fd.Kind() == protoreflect.GroupKind:
+ 		return getMessageInfo(ft), makeGroupFieldCoder(fd, ft)
+-	case fd.Syntax() == protoreflect.Proto3 && fd.ContainingOneof() == nil:
++	case !fd.HasPresence() && fd.ContainingOneof() == nil:
+ 		// Populated oneof fields always encode even if set to the zero value,
+ 		// which normally are not encoded in proto3.
+ 		switch fd.Kind() {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go b/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
+index 61c483f..2ab2c62 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
+@@ -206,13 +206,18 @@ func aberrantLoadMessageDescReentrant(t reflect.Type, name protoreflect.FullName
+ 
+ 	// Obtain a list of oneof wrapper types.
+ 	var oneofWrappers []reflect.Type
+-	for _, method := range []string{"XXX_OneofFuncs", "XXX_OneofWrappers"} {
+-		if fn, ok := t.MethodByName(method); ok {
+-			for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
+-				if vs, ok := v.Interface().([]interface{}); ok {
+-					for _, v := range vs {
+-						oneofWrappers = append(oneofWrappers, reflect.TypeOf(v))
+-					}
++	methods := make([]reflect.Method, 0, 2)
++	if m, ok := t.MethodByName("XXX_OneofFuncs"); ok {
++		methods = append(methods, m)
++	}
++	if m, ok := t.MethodByName("XXX_OneofWrappers"); ok {
++		methods = append(methods, m)
++	}
++	for _, fn := range methods {
++		for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
++			if vs, ok := v.Interface().([]interface{}); ok {
++				for _, v := range vs {
++					oneofWrappers = append(oneofWrappers, reflect.TypeOf(v))
+ 				}
+ 			}
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/message.go b/vendor/google.golang.org/protobuf/internal/impl/message.go
+index 4f5fb67..629bacd 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/message.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/message.go
+@@ -192,12 +192,17 @@ fieldLoop:
+ 
+ 	// Derive a mapping of oneof wrappers to fields.
+ 	oneofWrappers := mi.OneofWrappers
+-	for _, method := range []string{"XXX_OneofFuncs", "XXX_OneofWrappers"} {
+-		if fn, ok := reflect.PtrTo(t).MethodByName(method); ok {
+-			for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
+-				if vs, ok := v.Interface().([]interface{}); ok {
+-					oneofWrappers = vs
+-				}
++	methods := make([]reflect.Method, 0, 2)
++	if m, ok := reflect.PtrTo(t).MethodByName("XXX_OneofFuncs"); ok {
++		methods = append(methods, m)
++	}
++	if m, ok := reflect.PtrTo(t).MethodByName("XXX_OneofWrappers"); ok {
++		methods = append(methods, m)
++	}
++	for _, fn := range methods {
++		for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
++			if vs, ok := v.Interface().([]interface{}); ok {
++				oneofWrappers = vs
+ 			}
+ 		}
+ 	}
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go b/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
+index 5e736c6..986322b 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
+@@ -538,6 +538,6 @@ func isZero(v reflect.Value) bool {
+ 		}
+ 		return true
+ 	default:
+-		panic(&reflect.ValueError{"reflect.Value.IsZero", v.Kind()})
++		panic(&reflect.ValueError{Method: "reflect.Value.IsZero", Kind: v.Kind()})
+ 	}
+ }
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go b/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
+index 4c491bd..517e944 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
+@@ -159,6 +159,42 @@ func (p pointer) SetPointer(v pointer) {
+ 	p.v.Elem().Set(v.v)
+ }
+ 
++func growSlice(p pointer, addCap int) {
++	// TODO: Once we only support Go 1.20 and newer, use reflect.Grow.
++	in := p.v.Elem()
++	out := reflect.MakeSlice(in.Type(), in.Len(), in.Len()+addCap)
++	reflect.Copy(out, in)
++	p.v.Elem().Set(out)
++}
++
++func (p pointer) growBoolSlice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growInt32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growUint32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growInt64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growUint64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growFloat64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growFloat32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
+ func (Export) MessageStateOf(p Pointer) *messageState     { panic("not supported") }
+ func (ms *messageState) pointer() pointer                 { panic("not supported") }
+ func (ms *messageState) messageInfo() *MessageInfo        { panic("not supported") }
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go b/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
+index ee0e057..4b020e3 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
+@@ -138,6 +138,46 @@ func (p pointer) SetPointer(v pointer) {
+ 	*(*unsafe.Pointer)(p.p) = (unsafe.Pointer)(v.p)
+ }
+ 
++func (p pointer) growBoolSlice(addCap int) {
++	sp := p.BoolSlice()
++	s := make([]bool, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growInt32Slice(addCap int) {
++	sp := p.Int32Slice()
++	s := make([]int32, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growUint32Slice(addCap int) {
++	p.growInt32Slice(addCap)
++}
++
++func (p pointer) growFloat32Slice(addCap int) {
++	p.growInt32Slice(addCap)
++}
++
++func (p pointer) growInt64Slice(addCap int) {
++	sp := p.Int64Slice()
++	s := make([]int64, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growUint64Slice(addCap int) {
++	p.growInt64Slice(addCap)
++}
++
++func (p pointer) growFloat64Slice(addCap int) {
++	p.growInt64Slice(addCap)
++}
++
+ // Static check that MessageState does not exceed the size of a pointer.
+ const _ = uint(unsafe.Sizeof(unsafe.Pointer(nil)) - unsafe.Sizeof(MessageState{}))
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings.go b/vendor/google.golang.org/protobuf/internal/strs/strings.go
+index 0b74e76..a6e7df2 100644
+--- a/vendor/google.golang.org/protobuf/internal/strs/strings.go
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings.go
+@@ -17,7 +17,7 @@ import (
+ 
+ // EnforceUTF8 reports whether to enforce strict UTF-8 validation.
+ func EnforceUTF8(fd protoreflect.FieldDescriptor) bool {
+-	if flags.ProtoLegacy {
++	if flags.ProtoLegacy || fd.Syntax() == protoreflect.Editions {
+ 		if fd, ok := fd.(interface{ EnforceUTF8() bool }); ok {
+ 			return fd.EnforceUTF8()
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+similarity index 96%
+rename from vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
+rename to vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+index 61a84d3..a008acd 100644
+--- a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !purego && !appengine
+-// +build !purego,!appengine
++//go:build !purego && !appengine && !go1.21
++// +build !purego,!appengine,!go1.21
+ 
+ package strs
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+new file mode 100644
+index 0000000..60166f2
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+@@ -0,0 +1,74 @@
++// Copyright 2018 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !purego && !appengine && go1.21
++// +build !purego,!appengine,go1.21
++
++package strs
++
++import (
++	"unsafe"
++
++	"google.golang.org/protobuf/reflect/protoreflect"
++)
++
++// UnsafeString returns an unsafe string reference of b.
++// The caller must treat the input slice as immutable.
++//
++// WARNING: Use carefully. The returned result must not leak to the end user
++// unless the input slice is provably immutable.
++func UnsafeString(b []byte) string {
++	return unsafe.String(unsafe.SliceData(b), len(b))
++}
++
++// UnsafeBytes returns an unsafe bytes slice reference of s.
++// The caller must treat returned slice as immutable.
++//
++// WARNING: Use carefully. The returned result must not leak to the end user.
++func UnsafeBytes(s string) []byte {
++	return unsafe.Slice(unsafe.StringData(s), len(s))
++}
++
++// Builder builds a set of strings with shared lifetime.
++// This differs from strings.Builder, which is for building a single string.
++type Builder struct {
++	buf []byte
++}
++
++// AppendFullName is equivalent to protoreflect.FullName.Append,
++// but optimized for large batches where each name has a shared lifetime.
++func (sb *Builder) AppendFullName(prefix protoreflect.FullName, name protoreflect.Name) protoreflect.FullName {
++	n := len(prefix) + len(".") + len(name)
++	if len(prefix) == 0 {
++		n -= len(".")
++	}
++	sb.grow(n)
++	sb.buf = append(sb.buf, prefix...)
++	sb.buf = append(sb.buf, '.')
++	sb.buf = append(sb.buf, name...)
++	return protoreflect.FullName(sb.last(n))
++}
++
++// MakeString is equivalent to string(b), but optimized for large batches
++// with a shared lifetime.
++func (sb *Builder) MakeString(b []byte) string {
++	sb.grow(len(b))
++	sb.buf = append(sb.buf, b...)
++	return sb.last(len(b))
++}
++
++func (sb *Builder) grow(n int) {
++	if cap(sb.buf)-len(sb.buf) >= n {
++		return
++	}
++
++	// Unlike strings.Builder, we do not need to copy over the contents
++	// of the old buffer since our builder provides no API for
++	// retrieving previously created strings.
++	sb.buf = make([]byte, 0, 2*(cap(sb.buf)+n))
++}
++
++func (sb *Builder) last(n int) string {
++	return UnsafeString(sb.buf[len(sb.buf)-n:])
++}
+diff --git a/vendor/google.golang.org/protobuf/internal/version/version.go b/vendor/google.golang.org/protobuf/internal/version/version.go
+index 0999f29..a50fcfb 100644
+--- a/vendor/google.golang.org/protobuf/internal/version/version.go
++++ b/vendor/google.golang.org/protobuf/internal/version/version.go
+@@ -51,7 +51,7 @@ import (
+ //  10. Send out the CL for review and submit it.
+ const (
+ 	Major      = 1
+-	Minor      = 31
++	Minor      = 33
+ 	Patch      = 0
+ 	PreRelease = ""
+ )
+diff --git a/vendor/google.golang.org/protobuf/proto/decode.go b/vendor/google.golang.org/protobuf/proto/decode.go
+index 48d4794..e5b03b5 100644
+--- a/vendor/google.golang.org/protobuf/proto/decode.go
++++ b/vendor/google.golang.org/protobuf/proto/decode.go
+@@ -69,7 +69,7 @@ func (o UnmarshalOptions) Unmarshal(b []byte, m Message) error {
+ // UnmarshalState parses a wire-format message and places the result in m.
+ //
+ // This method permits fine-grained control over the unmarshaler.
+-// Most users should use Unmarshal instead.
++// Most users should use [Unmarshal] instead.
+ func (o UnmarshalOptions) UnmarshalState(in protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+ 	if o.RecursionLimit == 0 {
+ 		o.RecursionLimit = protowire.DefaultRecursionLimit
+diff --git a/vendor/google.golang.org/protobuf/proto/doc.go b/vendor/google.golang.org/protobuf/proto/doc.go
+index ec71e71..80ed16a 100644
+--- a/vendor/google.golang.org/protobuf/proto/doc.go
++++ b/vendor/google.golang.org/protobuf/proto/doc.go
+@@ -18,27 +18,27 @@
+ // This package contains functions to convert to and from the wire format,
+ // an efficient binary serialization of protocol buffers.
+ //
+-// • Size reports the size of a message in the wire format.
++//   - [Size] reports the size of a message in the wire format.
+ //
+-// • Marshal converts a message to the wire format.
+-// The MarshalOptions type provides more control over wire marshaling.
++//   - [Marshal] converts a message to the wire format.
++//     The [MarshalOptions] type provides more control over wire marshaling.
+ //
+-// • Unmarshal converts a message from the wire format.
+-// The UnmarshalOptions type provides more control over wire unmarshaling.
++//   - [Unmarshal] converts a message from the wire format.
++//     The [UnmarshalOptions] type provides more control over wire unmarshaling.
+ //
+ // # Basic message operations
+ //
+-// • Clone makes a deep copy of a message.
++//   - [Clone] makes a deep copy of a message.
+ //
+-// • Merge merges the content of a message into another.
++//   - [Merge] merges the content of a message into another.
+ //
+-// • Equal compares two messages. For more control over comparisons
+-// and detailed reporting of differences, see package
+-// "google.golang.org/protobuf/testing/protocmp".
++//   - [Equal] compares two messages. For more control over comparisons
++//     and detailed reporting of differences, see package
++//     [google.golang.org/protobuf/testing/protocmp].
+ //
+-// • Reset clears the content of a message.
++//   - [Reset] clears the content of a message.
+ //
+-// • CheckInitialized reports whether all required fields in a message are set.
++//   - [CheckInitialized] reports whether all required fields in a message are set.
+ //
+ // # Optional scalar constructors
+ //
+@@ -46,9 +46,9 @@
+ // as pointers to a value. For example, an optional string field has the
+ // Go type *string.
+ //
+-// • Bool, Int32, Int64, Uint32, Uint64, Float32, Float64, and String
+-// take a value and return a pointer to a new instance of it,
+-// to simplify construction of optional field values.
++//   - [Bool], [Int32], [Int64], [Uint32], [Uint64], [Float32], [Float64], and [String]
++//     take a value and return a pointer to a new instance of it,
++//     to simplify construction of optional field values.
+ //
+ // Generated enum types usually have an Enum method which performs the
+ // same operation.
+@@ -57,29 +57,29 @@
+ //
+ // # Extension accessors
+ //
+-// • HasExtension, GetExtension, SetExtension, and ClearExtension
+-// access extension field values in a protocol buffer message.
++//   - [HasExtension], [GetExtension], [SetExtension], and [ClearExtension]
++//     access extension field values in a protocol buffer message.
+ //
+ // Extension fields are only supported in proto2.
+ //
+ // # Related packages
+ //
+-// • Package "google.golang.org/protobuf/encoding/protojson" converts messages to
+-// and from JSON.
++//   - Package [google.golang.org/protobuf/encoding/protojson] converts messages to
++//     and from JSON.
+ //
+-// • Package "google.golang.org/protobuf/encoding/prototext" converts messages to
+-// and from the text format.
++//   - Package [google.golang.org/protobuf/encoding/prototext] converts messages to
++//     and from the text format.
+ //
+-// • Package "google.golang.org/protobuf/reflect/protoreflect" provides a
+-// reflection interface for protocol buffer data types.
++//   - Package [google.golang.org/protobuf/reflect/protoreflect] provides a
++//     reflection interface for protocol buffer data types.
+ //
+-// • Package "google.golang.org/protobuf/testing/protocmp" provides features
+-// to compare protocol buffer messages with the "github.com/google/go-cmp/cmp"
+-// package.
++//   - Package [google.golang.org/protobuf/testing/protocmp] provides features
++//     to compare protocol buffer messages with the [github.com/google/go-cmp/cmp]
++//     package.
+ //
+-// • Package "google.golang.org/protobuf/types/dynamicpb" provides a dynamic
+-// message type, suitable for working with messages where the protocol buffer
+-// type is only known at runtime.
++//   - Package [google.golang.org/protobuf/types/dynamicpb] provides a dynamic
++//     message type, suitable for working with messages where the protocol buffer
++//     type is only known at runtime.
+ //
+ // This module contains additional packages for more specialized use cases.
+ // Consult the individual package documentation for details.
+diff --git a/vendor/google.golang.org/protobuf/proto/encode.go b/vendor/google.golang.org/protobuf/proto/encode.go
+index bf7f816..4fed202 100644
+--- a/vendor/google.golang.org/protobuf/proto/encode.go
++++ b/vendor/google.golang.org/protobuf/proto/encode.go
+@@ -129,7 +129,7 @@ func (o MarshalOptions) MarshalAppend(b []byte, m Message) ([]byte, error) {
+ // MarshalState returns the wire-format encoding of a message.
+ //
+ // This method permits fine-grained control over the marshaler.
+-// Most users should use Marshal instead.
++// Most users should use [Marshal] instead.
+ func (o MarshalOptions) MarshalState(in protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+ 	return o.marshal(in.Buf, in.Message)
+ }
+diff --git a/vendor/google.golang.org/protobuf/proto/extension.go b/vendor/google.golang.org/protobuf/proto/extension.go
+index 5f293cd..17899a3 100644
+--- a/vendor/google.golang.org/protobuf/proto/extension.go
++++ b/vendor/google.golang.org/protobuf/proto/extension.go
+@@ -26,7 +26,7 @@ func HasExtension(m Message, xt protoreflect.ExtensionType) bool {
+ }
+ 
+ // ClearExtension clears an extension field such that subsequent
+-// HasExtension calls return false.
++// [HasExtension] calls return false.
+ // It panics if m is invalid or if xt does not extend m.
+ func ClearExtension(m Message, xt protoreflect.ExtensionType) {
+ 	m.ProtoReflect().Clear(xt.TypeDescriptor())
+diff --git a/vendor/google.golang.org/protobuf/proto/merge.go b/vendor/google.golang.org/protobuf/proto/merge.go
+index d761ab3..3c6fe57 100644
+--- a/vendor/google.golang.org/protobuf/proto/merge.go
++++ b/vendor/google.golang.org/protobuf/proto/merge.go
+@@ -21,7 +21,7 @@ import (
+ // The unknown fields of src are appended to the unknown fields of dst.
+ //
+ // It is semantically equivalent to unmarshaling the encoded form of src
+-// into dst with the UnmarshalOptions.Merge option specified.
++// into dst with the [UnmarshalOptions.Merge] option specified.
+ func Merge(dst, src Message) {
+ 	// TODO: Should nil src be treated as semantically equivalent to a
+ 	// untyped, read-only, empty message? What about a nil dst?
+diff --git a/vendor/google.golang.org/protobuf/proto/proto.go b/vendor/google.golang.org/protobuf/proto/proto.go
+index 1f0d183..7543ee6 100644
+--- a/vendor/google.golang.org/protobuf/proto/proto.go
++++ b/vendor/google.golang.org/protobuf/proto/proto.go
+@@ -15,18 +15,20 @@ import (
+ // protobuf module that accept a Message, except where otherwise specified.
+ //
+ // This is the v2 interface definition for protobuf messages.
+-// The v1 interface definition is "github.com/golang/protobuf/proto".Message.
++// The v1 interface definition is [github.com/golang/protobuf/proto.Message].
+ //
+-// To convert a v1 message to a v2 message,
+-// use "github.com/golang/protobuf/proto".MessageV2.
+-// To convert a v2 message to a v1 message,
+-// use "github.com/golang/protobuf/proto".MessageV1.
++//   - To convert a v1 message to a v2 message,
++//     use [google.golang.org/protobuf/protoadapt.MessageV2Of].
++//   - To convert a v2 message to a v1 message,
++//     use [google.golang.org/protobuf/protoadapt.MessageV1Of].
+ type Message = protoreflect.ProtoMessage
+ 
+-// Error matches all errors produced by packages in the protobuf module.
++// Error matches all errors produced by packages in the protobuf module
++// according to [errors.Is].
+ //
+-// That is, errors.Is(err, Error) reports whether an error is produced
+-// by this module.
++// Example usage:
++//
++//	if errors.Is(err, proto.Error) { ... }
+ var Error error
+ 
+ func init() {
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+index e4dfb12..baa0cc6 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+@@ -3,11 +3,11 @@
+ // license that can be found in the LICENSE file.
+ 
+ // Package protodesc provides functionality for converting
+-// FileDescriptorProto messages to/from protoreflect.FileDescriptor values.
++// FileDescriptorProto messages to/from [protoreflect.FileDescriptor] values.
+ //
+ // The google.protobuf.FileDescriptorProto is a protobuf message that describes
+ // the type information for a .proto file in a form that is easily serializable.
+-// The protoreflect.FileDescriptor is a more structured representation of
++// The [protoreflect.FileDescriptor] is a more structured representation of
+ // the FileDescriptorProto message where references and remote dependencies
+ // can be directly followed.
+ package protodesc
+@@ -24,11 +24,11 @@ import (
+ 	"google.golang.org/protobuf/types/descriptorpb"
+ )
+ 
+-// Resolver is the resolver used by NewFile to resolve dependencies.
++// Resolver is the resolver used by [NewFile] to resolve dependencies.
+ // The enums and messages provided must belong to some parent file,
+ // which is also registered.
+ //
+-// It is implemented by protoregistry.Files.
++// It is implemented by [protoregistry.Files].
+ type Resolver interface {
+ 	FindFileByPath(string) (protoreflect.FileDescriptor, error)
+ 	FindDescriptorByName(protoreflect.FullName) (protoreflect.Descriptor, error)
+@@ -61,19 +61,19 @@ type FileOptions struct {
+ 	AllowUnresolvable bool
+ }
+ 
+-// NewFile creates a new protoreflect.FileDescriptor from the provided
+-// file descriptor message. See FileOptions.New for more information.
++// NewFile creates a new [protoreflect.FileDescriptor] from the provided
++// file descriptor message. See [FileOptions.New] for more information.
+ func NewFile(fd *descriptorpb.FileDescriptorProto, r Resolver) (protoreflect.FileDescriptor, error) {
+ 	return FileOptions{}.New(fd, r)
+ }
+ 
+-// NewFiles creates a new protoregistry.Files from the provided
+-// FileDescriptorSet message. See FileOptions.NewFiles for more information.
++// NewFiles creates a new [protoregistry.Files] from the provided
++// FileDescriptorSet message. See [FileOptions.NewFiles] for more information.
+ func NewFiles(fd *descriptorpb.FileDescriptorSet) (*protoregistry.Files, error) {
+ 	return FileOptions{}.NewFiles(fd)
+ }
+ 
+-// New creates a new protoreflect.FileDescriptor from the provided
++// New creates a new [protoreflect.FileDescriptor] from the provided
+ // file descriptor message. The file must represent a valid proto file according
+ // to protobuf semantics. The returned descriptor is a deep copy of the input.
+ //
+@@ -93,9 +93,15 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
+ 		f.L1.Syntax = protoreflect.Proto2
+ 	case "proto3":
+ 		f.L1.Syntax = protoreflect.Proto3
++	case "editions":
++		f.L1.Syntax = protoreflect.Editions
++		f.L1.Edition = fromEditionProto(fd.GetEdition())
+ 	default:
+ 		return nil, errors.New("invalid syntax: %q", fd.GetSyntax())
+ 	}
++	if f.L1.Syntax == protoreflect.Editions && (fd.GetEdition() < SupportedEditionsMinimum || fd.GetEdition() > SupportedEditionsMaximum) {
++		return nil, errors.New("use of edition %v not yet supported by the Go Protobuf runtime", fd.GetEdition())
++	}
+ 	f.L1.Path = fd.GetName()
+ 	if f.L1.Path == "" {
+ 		return nil, errors.New("file path must be populated")
+@@ -108,6 +114,9 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
+ 		opts = proto.Clone(opts).(*descriptorpb.FileOptions)
+ 		f.L2.Options = func() protoreflect.ProtoMessage { return opts }
+ 	}
++	if f.L1.Syntax == protoreflect.Editions {
++		initFileDescFromFeatureSet(f, fd.GetOptions().GetFeatures())
++	}
+ 
+ 	f.L2.Imports = make(filedesc.FileImports, len(fd.GetDependency()))
+ 	for _, i := range fd.GetPublicDependency() {
+@@ -231,7 +240,7 @@ func (is importSet) importPublic(imps protoreflect.FileImports) {
+ 	}
+ }
+ 
+-// NewFiles creates a new protoregistry.Files from the provided
++// NewFiles creates a new [protoregistry.Files] from the provided
+ // FileDescriptorSet message. The descriptor set must include only
+ // valid files according to protobuf semantics. The returned descriptors
+ // are a deep copy of the input.
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
+index 37efda1..b327816 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
+@@ -28,6 +28,7 @@ func (r descsByName) initEnumDeclarations(eds []*descriptorpb.EnumDescriptorProt
+ 			opts = proto.Clone(opts).(*descriptorpb.EnumOptions)
+ 			e.L2.Options = func() protoreflect.ProtoMessage { return opts }
+ 		}
++		e.L1.EditionFeatures = mergeEditionFeatures(parent, ed.GetOptions().GetFeatures())
+ 		for _, s := range ed.GetReservedName() {
+ 			e.L2.ReservedNames.List = append(e.L2.ReservedNames.List, protoreflect.Name(s))
+ 		}
+@@ -68,6 +69,9 @@ func (r descsByName) initMessagesDeclarations(mds []*descriptorpb.DescriptorProt
+ 		if m.L0, err = r.makeBase(m, parent, md.GetName(), i, sb); err != nil {
+ 			return nil, err
+ 		}
++		if m.Base.L0.ParentFile.Syntax() == protoreflect.Editions {
++			m.L1.EditionFeatures = mergeEditionFeatures(parent, md.GetOptions().GetFeatures())
++		}
+ 		if opts := md.GetOptions(); opts != nil {
+ 			opts = proto.Clone(opts).(*descriptorpb.MessageOptions)
+ 			m.L2.Options = func() protoreflect.ProtoMessage { return opts }
+@@ -114,6 +118,27 @@ func (r descsByName) initMessagesDeclarations(mds []*descriptorpb.DescriptorProt
+ 	return ms, nil
+ }
+ 
++// canBePacked returns whether the field can use packed encoding:
++// https://protobuf.dev/programming-guides/encoding/#packed
++func canBePacked(fd *descriptorpb.FieldDescriptorProto) bool {
++	if fd.GetLabel() != descriptorpb.FieldDescriptorProto_LABEL_REPEATED {
++		return false // not a repeated field
++	}
++
++	switch protoreflect.Kind(fd.GetType()) {
++	case protoreflect.MessageKind, protoreflect.GroupKind:
++		return false // not a scalar type field
++
++	case protoreflect.StringKind, protoreflect.BytesKind:
++		// string and bytes can explicitly not be declared as packed,
++		// see https://protobuf.dev/programming-guides/encoding/#packed
++		return false
++
++	default:
++		return true
++	}
++}
++
+ func (r descsByName) initFieldsFromDescriptorProto(fds []*descriptorpb.FieldDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (fs []filedesc.Field, err error) {
+ 	fs = make([]filedesc.Field, len(fds)) // allocate up-front to ensure stable pointers
+ 	for i, fd := range fds {
+@@ -137,6 +162,34 @@ func (r descsByName) initFieldsFromDescriptorProto(fds []*descriptorpb.FieldDesc
+ 		if fd.JsonName != nil {
+ 			f.L1.StringName.InitJSON(fd.GetJsonName())
+ 		}
++
++		if f.Base.L0.ParentFile.Syntax() == protoreflect.Editions {
++			f.L1.EditionFeatures = mergeEditionFeatures(parent, fd.GetOptions().GetFeatures())
++
++			if f.L1.EditionFeatures.IsLegacyRequired {
++				f.L1.Cardinality = protoreflect.Required
++			}
++			// We reuse the existing field because the old option `[packed =
++			// true]` is mutually exclusive with the editions feature.
++			if canBePacked(fd) {
++				f.L1.HasPacked = true
++				f.L1.IsPacked = f.L1.EditionFeatures.IsPacked
++			}
++
++			// We pretend this option is always explicitly set because the only
++			// use of HasEnforceUTF8 is to determine whether to use EnforceUTF8
++			// or to return the appropriate default.
++			// When using editions we either parse the option or resolve the
++			// appropriate default here (instead of later when this option is
++			// requested from the descriptor).
++			// In proto2/proto3 syntax HasEnforceUTF8 might be false.
++			f.L1.HasEnforceUTF8 = true
++			f.L1.EnforceUTF8 = f.L1.EditionFeatures.IsUTF8Validated
++
++			if f.L1.Kind == protoreflect.MessageKind && f.L1.EditionFeatures.IsDelimitedEncoded {
++				f.L1.Kind = protoreflect.GroupKind
++			}
++		}
+ 	}
+ 	return fs, nil
+ }
+@@ -151,6 +204,9 @@ func (r descsByName) initOneofsFromDescriptorProto(ods []*descriptorpb.OneofDesc
+ 		if opts := od.GetOptions(); opts != nil {
+ 			opts = proto.Clone(opts).(*descriptorpb.OneofOptions)
+ 			o.L1.Options = func() protoreflect.ProtoMessage { return opts }
++			if parent.Syntax() == protoreflect.Editions {
++				o.L1.EditionFeatures = mergeEditionFeatures(parent, opts.GetFeatures())
++			}
+ 		}
+ 	}
+ 	return os, nil
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
+index 27d7e35..254ca58 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
+@@ -276,8 +276,8 @@ func unmarshalDefault(s string, fd protoreflect.FieldDescriptor, allowUnresolvab
+ 	} else if err != nil {
+ 		return v, ev, err
+ 	}
+-	if fd.Syntax() == protoreflect.Proto3 {
+-		return v, ev, errors.New("cannot be specified under proto3 semantics")
++	if !fd.HasPresence() {
++		return v, ev, errors.New("cannot be specified with implicit field presence")
+ 	}
+ 	if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind || fd.Cardinality() == protoreflect.Repeated {
+ 		return v, ev, errors.New("cannot be specified on composite types")
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
+index 9af1d56..e4dcaf8 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
+@@ -107,7 +107,7 @@ func validateMessageDeclarations(ms []filedesc.Message, mds []*descriptorpb.Desc
+ 		if isMessageSet && !flags.ProtoLegacy {
+ 			return errors.New("message %q is a MessageSet, which is a legacy proto1 feature that is no longer supported", m.FullName())
+ 		}
+-		if isMessageSet && (m.Syntax() != protoreflect.Proto2 || m.Fields().Len() > 0 || m.ExtensionRanges().Len() == 0) {
++		if isMessageSet && (m.Syntax() == protoreflect.Proto3 || m.Fields().Len() > 0 || m.ExtensionRanges().Len() == 0) {
+ 			return errors.New("message %q is an invalid proto1 MessageSet", m.FullName())
+ 		}
+ 		if m.Syntax() == protoreflect.Proto3 {
+@@ -314,8 +314,8 @@ func checkValidGroup(fd protoreflect.FieldDescriptor) error {
+ 	switch {
+ 	case fd.Kind() != protoreflect.GroupKind:
+ 		return nil
+-	case fd.Syntax() != protoreflect.Proto2:
+-		return errors.New("invalid under proto2 semantics")
++	case fd.Syntax() == protoreflect.Proto3:
++		return errors.New("invalid under proto3 semantics")
+ 	case md == nil || md.IsPlaceholder():
+ 		return errors.New("message must be resolvable")
+ 	case fd.FullName().Parent() != md.FullName().Parent():
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go b/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+new file mode 100644
+index 0000000..2a6b29d
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+@@ -0,0 +1,148 @@
++// Copyright 2019 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package protodesc
++
++import (
++	"fmt"
++	"os"
++	"sync"
++
++	"google.golang.org/protobuf/internal/editiondefaults"
++	"google.golang.org/protobuf/internal/filedesc"
++	"google.golang.org/protobuf/proto"
++	"google.golang.org/protobuf/reflect/protoreflect"
++	"google.golang.org/protobuf/types/descriptorpb"
++	gofeaturespb "google.golang.org/protobuf/types/gofeaturespb"
++)
++
++const (
++	SupportedEditionsMinimum = descriptorpb.Edition_EDITION_PROTO2
++	SupportedEditionsMaximum = descriptorpb.Edition_EDITION_2023
++)
++
++var defaults = &descriptorpb.FeatureSetDefaults{}
++var defaultsCacheMu sync.Mutex
++var defaultsCache = make(map[filedesc.Edition]*descriptorpb.FeatureSet)
++
++func init() {
++	err := proto.Unmarshal(editiondefaults.Defaults, defaults)
++	if err != nil {
++		fmt.Fprintf(os.Stderr, "unmarshal editions defaults: %v\n", err)
++		os.Exit(1)
++	}
++}
++
++func fromEditionProto(epb descriptorpb.Edition) filedesc.Edition {
++	return filedesc.Edition(epb)
++}
++
++func toEditionProto(ed filedesc.Edition) descriptorpb.Edition {
++	switch ed {
++	case filedesc.EditionUnknown:
++		return descriptorpb.Edition_EDITION_UNKNOWN
++	case filedesc.EditionProto2:
++		return descriptorpb.Edition_EDITION_PROTO2
++	case filedesc.EditionProto3:
++		return descriptorpb.Edition_EDITION_PROTO3
++	case filedesc.Edition2023:
++		return descriptorpb.Edition_EDITION_2023
++	default:
++		panic(fmt.Sprintf("unknown value for edition: %v", ed))
++	}
++}
++
++func getFeatureSetFor(ed filedesc.Edition) *descriptorpb.FeatureSet {
++	defaultsCacheMu.Lock()
++	defer defaultsCacheMu.Unlock()
++	if def, ok := defaultsCache[ed]; ok {
++		return def
++	}
++	edpb := toEditionProto(ed)
++	if defaults.GetMinimumEdition() > edpb || defaults.GetMaximumEdition() < edpb {
++		// This should never happen protodesc.(FileOptions).New would fail when
++		// initializing the file descriptor.
++		// This most likely means the embedded defaults were not updated.
++		fmt.Fprintf(os.Stderr, "internal error: unsupported edition %v (did you forget to update the embedded defaults (i.e. the bootstrap descriptor proto)?)\n", edpb)
++		os.Exit(1)
++	}
++	fs := defaults.GetDefaults()[0].GetFeatures()
++	// Using a linear search for now.
++	// Editions are guaranteed to be sorted and thus we could use a binary search.
++	// Given that there are only a handful of editions (with one more per year)
++	// there is not much reason to use a binary search.
++	for _, def := range defaults.GetDefaults() {
++		if def.GetEdition() <= edpb {
++			fs = def.GetFeatures()
++		} else {
++			break
++		}
++	}
++	defaultsCache[ed] = fs
++	return fs
++}
++
++// mergeEditionFeatures merges the parent and child feature sets. This function
++// should be used when initializing Go descriptors from descriptor protos which
++// is why the parent is a filedesc.EditionsFeatures (Go representation) while
++// the child is a descriptorproto.FeatureSet (protoc representation).
++// Any feature set by the child overwrites what is set by the parent.
++func mergeEditionFeatures(parentDesc protoreflect.Descriptor, child *descriptorpb.FeatureSet) filedesc.EditionFeatures {
++	var parentFS filedesc.EditionFeatures
++	switch p := parentDesc.(type) {
++	case *filedesc.File:
++		parentFS = p.L1.EditionFeatures
++	case *filedesc.Message:
++		parentFS = p.L1.EditionFeatures
++	default:
++		panic(fmt.Sprintf("unknown parent type %T", parentDesc))
++	}
++	if child == nil {
++		return parentFS
++	}
++	if fp := child.FieldPresence; fp != nil {
++		parentFS.IsFieldPresence = *fp == descriptorpb.FeatureSet_LEGACY_REQUIRED ||
++			*fp == descriptorpb.FeatureSet_EXPLICIT
++		parentFS.IsLegacyRequired = *fp == descriptorpb.FeatureSet_LEGACY_REQUIRED
++	}
++	if et := child.EnumType; et != nil {
++		parentFS.IsOpenEnum = *et == descriptorpb.FeatureSet_OPEN
++	}
++
++	if rfe := child.RepeatedFieldEncoding; rfe != nil {
++		parentFS.IsPacked = *rfe == descriptorpb.FeatureSet_PACKED
++	}
++
++	if utf8val := child.Utf8Validation; utf8val != nil {
++		parentFS.IsUTF8Validated = *utf8val == descriptorpb.FeatureSet_VERIFY
++	}
++
++	if me := child.MessageEncoding; me != nil {
++		parentFS.IsDelimitedEncoded = *me == descriptorpb.FeatureSet_DELIMITED
++	}
++
++	if jf := child.JsonFormat; jf != nil {
++		parentFS.IsJSONCompliant = *jf == descriptorpb.FeatureSet_ALLOW
++	}
++
++	if goFeatures, ok := proto.GetExtension(child, gofeaturespb.E_Go).(*gofeaturespb.GoFeatures); ok && goFeatures != nil {
++		if luje := goFeatures.LegacyUnmarshalJsonEnum; luje != nil {
++			parentFS.GenerateLegacyUnmarshalJSON = *luje
++		}
++	}
++
++	return parentFS
++}
++
++// initFileDescFromFeatureSet initializes editions related fields in fd based
++// on fs. If fs is nil it is assumed to be an empty featureset and all fields
++// will be initialized with the appropriate default. fd.L1.Edition must be set
++// before calling this function.
++func initFileDescFromFeatureSet(fd *filedesc.File, fs *descriptorpb.FeatureSet) {
++	dfs := getFeatureSetFor(fd.L1.Edition)
++	// initialize the featureset with the defaults
++	fd.L1.EditionFeatures = mergeEditionFeatures(fd, dfs)
++	// overwrite any options explicitly specified
++	fd.L1.EditionFeatures = mergeEditionFeatures(fd, fs)
++}
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go b/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
+index a7c5cef..9d6e054 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
+@@ -16,7 +16,7 @@ import (
+ 	"google.golang.org/protobuf/types/descriptorpb"
+ )
+ 
+-// ToFileDescriptorProto copies a protoreflect.FileDescriptor into a
++// ToFileDescriptorProto copies a [protoreflect.FileDescriptor] into a
+ // google.protobuf.FileDescriptorProto message.
+ func ToFileDescriptorProto(file protoreflect.FileDescriptor) *descriptorpb.FileDescriptorProto {
+ 	p := &descriptorpb.FileDescriptorProto{
+@@ -70,13 +70,13 @@ func ToFileDescriptorProto(file protoreflect.FileDescriptor) *descriptorpb.FileD
+ 	for i, exts := 0, file.Extensions(); i < exts.Len(); i++ {
+ 		p.Extension = append(p.Extension, ToFieldDescriptorProto(exts.Get(i)))
+ 	}
+-	if syntax := file.Syntax(); syntax != protoreflect.Proto2 {
++	if syntax := file.Syntax(); syntax != protoreflect.Proto2 && syntax.IsValid() {
+ 		p.Syntax = proto.String(file.Syntax().String())
+ 	}
+ 	return p
+ }
+ 
+-// ToDescriptorProto copies a protoreflect.MessageDescriptor into a
++// ToDescriptorProto copies a [protoreflect.MessageDescriptor] into a
+ // google.protobuf.DescriptorProto message.
+ func ToDescriptorProto(message protoreflect.MessageDescriptor) *descriptorpb.DescriptorProto {
+ 	p := &descriptorpb.DescriptorProto{
+@@ -119,7 +119,7 @@ func ToDescriptorProto(message protoreflect.MessageDescriptor) *descriptorpb.Des
+ 	return p
+ }
+ 
+-// ToFieldDescriptorProto copies a protoreflect.FieldDescriptor into a
++// ToFieldDescriptorProto copies a [protoreflect.FieldDescriptor] into a
+ // google.protobuf.FieldDescriptorProto message.
+ func ToFieldDescriptorProto(field protoreflect.FieldDescriptor) *descriptorpb.FieldDescriptorProto {
+ 	p := &descriptorpb.FieldDescriptorProto{
+@@ -168,7 +168,7 @@ func ToFieldDescriptorProto(field protoreflect.FieldDescriptor) *descriptorpb.Fi
+ 	return p
+ }
+ 
+-// ToOneofDescriptorProto copies a protoreflect.OneofDescriptor into a
++// ToOneofDescriptorProto copies a [protoreflect.OneofDescriptor] into a
+ // google.protobuf.OneofDescriptorProto message.
+ func ToOneofDescriptorProto(oneof protoreflect.OneofDescriptor) *descriptorpb.OneofDescriptorProto {
+ 	return &descriptorpb.OneofDescriptorProto{
+@@ -177,7 +177,7 @@ func ToOneofDescriptorProto(oneof protoreflect.OneofDescriptor) *descriptorpb.On
+ 	}
+ }
+ 
+-// ToEnumDescriptorProto copies a protoreflect.EnumDescriptor into a
++// ToEnumDescriptorProto copies a [protoreflect.EnumDescriptor] into a
+ // google.protobuf.EnumDescriptorProto message.
+ func ToEnumDescriptorProto(enum protoreflect.EnumDescriptor) *descriptorpb.EnumDescriptorProto {
+ 	p := &descriptorpb.EnumDescriptorProto{
+@@ -200,7 +200,7 @@ func ToEnumDescriptorProto(enum protoreflect.EnumDescriptor) *descriptorpb.EnumD
+ 	return p
+ }
+ 
+-// ToEnumValueDescriptorProto copies a protoreflect.EnumValueDescriptor into a
++// ToEnumValueDescriptorProto copies a [protoreflect.EnumValueDescriptor] into a
+ // google.protobuf.EnumValueDescriptorProto message.
+ func ToEnumValueDescriptorProto(value protoreflect.EnumValueDescriptor) *descriptorpb.EnumValueDescriptorProto {
+ 	return &descriptorpb.EnumValueDescriptorProto{
+@@ -210,7 +210,7 @@ func ToEnumValueDescriptorProto(value protoreflect.EnumValueDescriptor) *descrip
+ 	}
+ }
+ 
+-// ToServiceDescriptorProto copies a protoreflect.ServiceDescriptor into a
++// ToServiceDescriptorProto copies a [protoreflect.ServiceDescriptor] into a
+ // google.protobuf.ServiceDescriptorProto message.
+ func ToServiceDescriptorProto(service protoreflect.ServiceDescriptor) *descriptorpb.ServiceDescriptorProto {
+ 	p := &descriptorpb.ServiceDescriptorProto{
+@@ -223,7 +223,7 @@ func ToServiceDescriptorProto(service protoreflect.ServiceDescriptor) *descripto
+ 	return p
+ }
+ 
+-// ToMethodDescriptorProto copies a protoreflect.MethodDescriptor into a
++// ToMethodDescriptorProto copies a [protoreflect.MethodDescriptor] into a
+ // google.protobuf.MethodDescriptorProto message.
+ func ToMethodDescriptorProto(method protoreflect.MethodDescriptor) *descriptorpb.MethodDescriptorProto {
+ 	p := &descriptorpb.MethodDescriptorProto{
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
+index 55aa149..00b01fb 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
+@@ -10,46 +10,46 @@
+ //
+ // # Protocol Buffer Descriptors
+ //
+-// Protobuf descriptors (e.g., EnumDescriptor or MessageDescriptor)
++// Protobuf descriptors (e.g., [EnumDescriptor] or [MessageDescriptor])
+ // are immutable objects that represent protobuf type information.
+ // They are wrappers around the messages declared in descriptor.proto.
+ // Protobuf descriptors alone lack any information regarding Go types.
+ //
+-// Enums and messages generated by this module implement Enum and ProtoMessage,
++// Enums and messages generated by this module implement [Enum] and [ProtoMessage],
+ // where the Descriptor and ProtoReflect.Descriptor accessors respectively
+ // return the protobuf descriptor for the values.
+ //
+ // The protobuf descriptor interfaces are not meant to be implemented by
+ // user code since they might need to be extended in the future to support
+ // additions to the protobuf language.
+-// The "google.golang.org/protobuf/reflect/protodesc" package converts between
++// The [google.golang.org/protobuf/reflect/protodesc] package converts between
+ // google.protobuf.DescriptorProto messages and protobuf descriptors.
+ //
+ // # Go Type Descriptors
+ //
+-// A type descriptor (e.g., EnumType or MessageType) is a constructor for
++// A type descriptor (e.g., [EnumType] or [MessageType]) is a constructor for
+ // a concrete Go type that represents the associated protobuf descriptor.
+ // There is commonly a one-to-one relationship between protobuf descriptors and
+ // Go type descriptors, but it can potentially be a one-to-many relationship.
+ //
+-// Enums and messages generated by this module implement Enum and ProtoMessage,
++// Enums and messages generated by this module implement [Enum] and [ProtoMessage],
+ // where the Type and ProtoReflect.Type accessors respectively
+ // return the protobuf descriptor for the values.
+ //
+-// The "google.golang.org/protobuf/types/dynamicpb" package can be used to
++// The [google.golang.org/protobuf/types/dynamicpb] package can be used to
+ // create Go type descriptors from protobuf descriptors.
+ //
+ // # Value Interfaces
+ //
+-// The Enum and Message interfaces provide a reflective view over an
++// The [Enum] and [Message] interfaces provide a reflective view over an
+ // enum or message instance. For enums, it provides the ability to retrieve
+ // the enum value number for any concrete enum type. For messages, it provides
+ // the ability to access or manipulate fields of the message.
+ //
+-// To convert a proto.Message to a protoreflect.Message, use the
++// To convert a [google.golang.org/protobuf/proto.Message] to a [protoreflect.Message], use the
+ // former's ProtoReflect method. Since the ProtoReflect method is new to the
+ // v2 message interface, it may not be present on older message implementations.
+-// The "github.com/golang/protobuf/proto".MessageReflect function can be used
++// The [github.com/golang/protobuf/proto.MessageReflect] function can be used
+ // to obtain a reflective view on older messages.
+ //
+ // # Relationships
+@@ -71,12 +71,12 @@
+ //	      │                                 │
+ //	      └────────────────── Type() ───────┘
+ //
+-// • An EnumType describes a concrete Go enum type.
++// • An [EnumType] describes a concrete Go enum type.
+ // It has an EnumDescriptor and can construct an Enum instance.
+ //
+-// • An EnumDescriptor describes an abstract protobuf enum type.
++// • An [EnumDescriptor] describes an abstract protobuf enum type.
+ //
+-// • An Enum is a concrete enum instance. Generated enums implement Enum.
++// • An [Enum] is a concrete enum instance. Generated enums implement Enum.
+ //
+ //	  ┌──────────────── New() ─────────────────┐
+ //	  │                                        │
+@@ -90,24 +90,26 @@
+ //	       │                                    │
+ //	       └─────────────────── Type() ─────────┘
+ //
+-// • A MessageType describes a concrete Go message type.
+-// It has a MessageDescriptor and can construct a Message instance.
+-// Just as how Go's reflect.Type is a reflective description of a Go type,
+-// a MessageType is a reflective description of a Go type for a protobuf message.
++// • A [MessageType] describes a concrete Go message type.
++// It has a [MessageDescriptor] and can construct a [Message] instance.
++// Just as how Go's [reflect.Type] is a reflective description of a Go type,
++// a [MessageType] is a reflective description of a Go type for a protobuf message.
+ //
+-// • A MessageDescriptor describes an abstract protobuf message type.
+-// It has no understanding of Go types. In order to construct a MessageType
+-// from just a MessageDescriptor, you can consider looking up the message type
+-// in the global registry using protoregistry.GlobalTypes.FindMessageByName
+-// or constructing a dynamic MessageType using dynamicpb.NewMessageType.
++// • A [MessageDescriptor] describes an abstract protobuf message type.
++// It has no understanding of Go types. In order to construct a [MessageType]
++// from just a [MessageDescriptor], you can consider looking up the message type
++// in the global registry using the FindMessageByName method on
++// [google.golang.org/protobuf/reflect/protoregistry.GlobalTypes]
++// or constructing a dynamic [MessageType] using
++// [google.golang.org/protobuf/types/dynamicpb.NewMessageType].
+ //
+-// • A Message is a reflective view over a concrete message instance.
+-// Generated messages implement ProtoMessage, which can convert to a Message.
+-// Just as how Go's reflect.Value is a reflective view over a Go value,
+-// a Message is a reflective view over a concrete protobuf message instance.
+-// Using Go reflection as an analogy, the ProtoReflect method is similar to
+-// calling reflect.ValueOf, and the Message.Interface method is similar to
+-// calling reflect.Value.Interface.
++// • A [Message] is a reflective view over a concrete message instance.
++// Generated messages implement [ProtoMessage], which can convert to a [Message].
++// Just as how Go's [reflect.Value] is a reflective view over a Go value,
++// a [Message] is a reflective view over a concrete protobuf message instance.
++// Using Go reflection as an analogy, the [ProtoMessage.ProtoReflect] method is similar to
++// calling [reflect.ValueOf], and the [Message.Interface] method is similar to
++// calling [reflect.Value.Interface].
+ //
+ //	      ┌── TypeDescriptor() ──┐    ┌───── Descriptor() ─────┐
+ //	      │                      V    │                        V
+@@ -119,15 +121,15 @@
+ //	                                 │                          │
+ //	                                 └────── implements ────────┘
+ //
+-// • An ExtensionType describes a concrete Go implementation of an extension.
+-// It has an ExtensionTypeDescriptor and can convert to/from
+-// abstract Values and Go values.
++// • An [ExtensionType] describes a concrete Go implementation of an extension.
++// It has an [ExtensionTypeDescriptor] and can convert to/from
++// an abstract [Value] and a Go value.
+ //
+-// • An ExtensionTypeDescriptor is an ExtensionDescriptor
+-// which also has an ExtensionType.
++// • An [ExtensionTypeDescriptor] is an [ExtensionDescriptor]
++// which also has an [ExtensionType].
+ //
+-// • An ExtensionDescriptor describes an abstract protobuf extension field and
+-// may not always be an ExtensionTypeDescriptor.
++// • An [ExtensionDescriptor] describes an abstract protobuf extension field and
++// may not always be an [ExtensionTypeDescriptor].
+ package protoreflect
+ 
+ import (
+@@ -142,7 +144,7 @@ type doNotImplement pragma.DoNotImplement
+ 
+ // ProtoMessage is the top-level interface that all proto messages implement.
+ // This is declared in the protoreflect package to avoid a cyclic dependency;
+-// use the proto.Message type instead, which aliases this type.
++// use the [google.golang.org/protobuf/proto.Message] type instead, which aliases this type.
+ type ProtoMessage interface{ ProtoReflect() Message }
+ 
+ // Syntax is the language version of the proto file.
+@@ -151,8 +153,9 @@ type Syntax syntax
+ type syntax int8 // keep exact type opaque as the int type may change
+ 
+ const (
+-	Proto2 Syntax = 2
+-	Proto3 Syntax = 3
++	Proto2   Syntax = 2
++	Proto3   Syntax = 3
++	Editions Syntax = 4
+ )
+ 
+ // IsValid reports whether the syntax is valid.
+@@ -172,6 +175,8 @@ func (s Syntax) String() string {
+ 		return "proto2"
+ 	case Proto3:
+ 		return "proto3"
++	case Editions:
++		return "editions"
+ 	default:
+ 		return fmt.Sprintf("<unknown:%d>", s)
+ 	}
+@@ -436,7 +441,7 @@ type Names interface {
+ // FullName is a qualified name that uniquely identifies a proto declaration.
+ // A qualified name is the concatenation of the proto package along with the
+ // fully-declared name (i.e., name of parent preceding the name of the child),
+-// with a '.' delimiter placed between each Name.
++// with a '.' delimiter placed between each [Name].
+ //
+ // This should not have any leading or trailing dots.
+ type FullName string // e.g., "google.protobuf.Field.Kind"
+@@ -480,7 +485,7 @@ func isLetterDigit(c byte) bool {
+ }
+ 
+ // Name returns the short name, which is the last identifier segment.
+-// A single segment FullName is the Name itself.
++// A single segment FullName is the [Name] itself.
+ func (n FullName) Name() Name {
+ 	if i := strings.LastIndexByte(string(n), '.'); i >= 0 {
+ 		return Name(n[i+1:])
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
+index 717b106..7dcc2ff 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
+@@ -35,7 +35,7 @@ func (p *SourcePath) appendFileDescriptorProto(b []byte) []byte {
+ 		b = p.appendSingularField(b, "source_code_info", (*SourcePath).appendSourceCodeInfo)
+ 	case 12:
+ 		b = p.appendSingularField(b, "syntax", nil)
+-	case 13:
++	case 14:
+ 		b = p.appendSingularField(b, "edition", nil)
+ 	}
+ 	return b
+@@ -160,8 +160,6 @@ func (p *SourcePath) appendFileOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "java_generic_services", nil)
+ 	case 18:
+ 		b = p.appendSingularField(b, "py_generic_services", nil)
+-	case 42:
+-		b = p.appendSingularField(b, "php_generic_services", nil)
+ 	case 23:
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 31:
+@@ -180,6 +178,8 @@ func (p *SourcePath) appendFileOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "php_metadata_namespace", nil)
+ 	case 45:
+ 		b = p.appendSingularField(b, "ruby_package", nil)
++	case 50:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -240,6 +240,8 @@ func (p *SourcePath) appendMessageOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "map_entry", nil)
+ 	case 11:
+ 		b = p.appendSingularField(b, "deprecated_legacy_json_field_conflicts", nil)
++	case 12:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -285,6 +287,8 @@ func (p *SourcePath) appendEnumOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 6:
+ 		b = p.appendSingularField(b, "deprecated_legacy_json_field_conflicts", nil)
++	case 7:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -330,6 +334,8 @@ func (p *SourcePath) appendServiceOptions(b []byte) []byte {
+ 		return b
+ 	}
+ 	switch (*p)[0] {
++	case 34:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 33:
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 999:
+@@ -361,16 +367,39 @@ func (p *SourcePath) appendFieldOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "debug_redact", nil)
+ 	case 17:
+ 		b = p.appendSingularField(b, "retention", nil)
+-	case 18:
+-		b = p.appendSingularField(b, "target", nil)
+ 	case 19:
+ 		b = p.appendRepeatedField(b, "targets", nil)
++	case 20:
++		b = p.appendRepeatedField(b, "edition_defaults", (*SourcePath).appendFieldOptions_EditionDefault)
++	case 21:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+ 	return b
+ }
+ 
++func (p *SourcePath) appendFeatureSet(b []byte) []byte {
++	if len(*p) == 0 {
++		return b
++	}
++	switch (*p)[0] {
++	case 1:
++		b = p.appendSingularField(b, "field_presence", nil)
++	case 2:
++		b = p.appendSingularField(b, "enum_type", nil)
++	case 3:
++		b = p.appendSingularField(b, "repeated_field_encoding", nil)
++	case 4:
++		b = p.appendSingularField(b, "utf8_validation", nil)
++	case 5:
++		b = p.appendSingularField(b, "message_encoding", nil)
++	case 6:
++		b = p.appendSingularField(b, "json_format", nil)
++	}
++	return b
++}
++
+ func (p *SourcePath) appendUninterpretedOption(b []byte) []byte {
+ 	if len(*p) == 0 {
+ 		return b
+@@ -422,6 +451,8 @@ func (p *SourcePath) appendExtensionRangeOptions(b []byte) []byte {
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	case 2:
+ 		b = p.appendRepeatedField(b, "declaration", (*SourcePath).appendExtensionRangeOptions_Declaration)
++	case 50:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 3:
+ 		b = p.appendSingularField(b, "verification", nil)
+ 	}
+@@ -433,6 +464,8 @@ func (p *SourcePath) appendOneofOptions(b []byte) []byte {
+ 		return b
+ 	}
+ 	switch (*p)[0] {
++	case 1:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -446,6 +479,10 @@ func (p *SourcePath) appendEnumValueOptions(b []byte) []byte {
+ 	switch (*p)[0] {
+ 	case 1:
+ 		b = p.appendSingularField(b, "deprecated", nil)
++	case 2:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
++	case 3:
++		b = p.appendSingularField(b, "debug_redact", nil)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -461,12 +498,27 @@ func (p *SourcePath) appendMethodOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 34:
+ 		b = p.appendSingularField(b, "idempotency_level", nil)
++	case 35:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+ 	return b
+ }
+ 
++func (p *SourcePath) appendFieldOptions_EditionDefault(b []byte) []byte {
++	if len(*p) == 0 {
++		return b
++	}
++	switch (*p)[0] {
++	case 3:
++		b = p.appendSingularField(b, "edition", nil)
++	case 2:
++		b = p.appendSingularField(b, "value", nil)
++	}
++	return b
++}
++
+ func (p *SourcePath) appendUninterpretedOption_NamePart(b []byte) []byte {
+ 	if len(*p) == 0 {
+ 		return b
+@@ -491,8 +543,6 @@ func (p *SourcePath) appendExtensionRangeOptions_Declaration(b []byte) []byte {
+ 		b = p.appendSingularField(b, "full_name", nil)
+ 	case 3:
+ 		b = p.appendSingularField(b, "type", nil)
+-	case 4:
+-		b = p.appendSingularField(b, "is_repeated", nil)
+ 	case 5:
+ 		b = p.appendSingularField(b, "reserved", nil)
+ 	case 6:
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
+index 3867470..60ff62b 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
+@@ -12,7 +12,7 @@ package protoreflect
+ // exactly identical. However, it is possible for the same semantically
+ // identical proto type to be represented by multiple type descriptors.
+ //
+-// For example, suppose we have t1 and t2 which are both MessageDescriptors.
++// For example, suppose we have t1 and t2 which are both an [MessageDescriptor].
+ // If t1 == t2, then the types are definitely equal and all accessors return
+ // the same information. However, if t1 != t2, then it is still possible that
+ // they still represent the same proto type (e.g., t1.FullName == t2.FullName).
+@@ -115,7 +115,7 @@ type Descriptor interface {
+ // corresponds with the google.protobuf.FileDescriptorProto message.
+ //
+ // Top-level declarations:
+-// EnumDescriptor, MessageDescriptor, FieldDescriptor, and/or ServiceDescriptor.
++// [EnumDescriptor], [MessageDescriptor], [FieldDescriptor], and/or [ServiceDescriptor].
+ type FileDescriptor interface {
+ 	Descriptor // Descriptor.FullName is identical to Package
+ 
+@@ -180,8 +180,8 @@ type FileImport struct {
+ // corresponds with the google.protobuf.DescriptorProto message.
+ //
+ // Nested declarations:
+-// FieldDescriptor, OneofDescriptor, FieldDescriptor, EnumDescriptor,
+-// and/or MessageDescriptor.
++// [FieldDescriptor], [OneofDescriptor], [FieldDescriptor], [EnumDescriptor],
++// and/or [MessageDescriptor].
+ type MessageDescriptor interface {
+ 	Descriptor
+ 
+@@ -214,7 +214,7 @@ type MessageDescriptor interface {
+ 	ExtensionRanges() FieldRanges
+ 	// ExtensionRangeOptions returns the ith extension range options.
+ 	//
+-	// To avoid a dependency cycle, this method returns a proto.Message value,
++	// To avoid a dependency cycle, this method returns a proto.Message] value,
+ 	// which always contains a google.protobuf.ExtensionRangeOptions message.
+ 	// This method returns a typed nil-pointer if no options are present.
+ 	// The caller must import the descriptorpb package to use this.
+@@ -231,9 +231,9 @@ type MessageDescriptor interface {
+ }
+ type isMessageDescriptor interface{ ProtoType(MessageDescriptor) }
+ 
+-// MessageType encapsulates a MessageDescriptor with a concrete Go implementation.
++// MessageType encapsulates a [MessageDescriptor] with a concrete Go implementation.
+ // It is recommended that implementations of this interface also implement the
+-// MessageFieldTypes interface.
++// [MessageFieldTypes] interface.
+ type MessageType interface {
+ 	// New returns a newly allocated empty message.
+ 	// It may return nil for synthetic messages representing a map entry.
+@@ -249,19 +249,19 @@ type MessageType interface {
+ 	Descriptor() MessageDescriptor
+ }
+ 
+-// MessageFieldTypes extends a MessageType by providing type information
++// MessageFieldTypes extends a [MessageType] by providing type information
+ // regarding enums and messages referenced by the message fields.
+ type MessageFieldTypes interface {
+ 	MessageType
+ 
+-	// Enum returns the EnumType for the ith field in Descriptor.Fields.
++	// Enum returns the EnumType for the ith field in MessageDescriptor.Fields.
+ 	// It returns nil if the ith field is not an enum kind.
+ 	// It panics if out of bounds.
+ 	//
+ 	// Invariant: mt.Enum(i).Descriptor() == mt.Descriptor().Fields(i).Enum()
+ 	Enum(i int) EnumType
+ 
+-	// Message returns the MessageType for the ith field in Descriptor.Fields.
++	// Message returns the MessageType for the ith field in MessageDescriptor.Fields.
+ 	// It returns nil if the ith field is not a message or group kind.
+ 	// It panics if out of bounds.
+ 	//
+@@ -286,8 +286,8 @@ type MessageDescriptors interface {
+ // corresponds with the google.protobuf.FieldDescriptorProto message.
+ //
+ // It is used for both normal fields defined within the parent message
+-// (e.g., MessageDescriptor.Fields) and fields that extend some remote message
+-// (e.g., FileDescriptor.Extensions or MessageDescriptor.Extensions).
++// (e.g., [MessageDescriptor.Fields]) and fields that extend some remote message
++// (e.g., [FileDescriptor.Extensions] or [MessageDescriptor.Extensions]).
+ type FieldDescriptor interface {
+ 	Descriptor
+ 
+@@ -344,7 +344,7 @@ type FieldDescriptor interface {
+ 	// IsMap reports whether this field represents a map,
+ 	// where the value type for the associated field is a Map.
+ 	// It is equivalent to checking whether Cardinality is Repeated,
+-	// that the Kind is MessageKind, and that Message.IsMapEntry reports true.
++	// that the Kind is MessageKind, and that MessageDescriptor.IsMapEntry reports true.
+ 	IsMap() bool
+ 
+ 	// MapKey returns the field descriptor for the key in the map entry.
+@@ -419,7 +419,7 @@ type OneofDescriptor interface {
+ 
+ 	// IsSynthetic reports whether this is a synthetic oneof created to support
+ 	// proto3 optional semantics. If true, Fields contains exactly one field
+-	// with HasOptionalKeyword specified.
++	// with FieldDescriptor.HasOptionalKeyword specified.
+ 	IsSynthetic() bool
+ 
+ 	// Fields is a list of fields belonging to this oneof.
+@@ -442,10 +442,10 @@ type OneofDescriptors interface {
+ 	doNotImplement
+ }
+ 
+-// ExtensionDescriptor is an alias of FieldDescriptor for documentation.
++// ExtensionDescriptor is an alias of [FieldDescriptor] for documentation.
+ type ExtensionDescriptor = FieldDescriptor
+ 
+-// ExtensionTypeDescriptor is an ExtensionDescriptor with an associated ExtensionType.
++// ExtensionTypeDescriptor is an [ExtensionDescriptor] with an associated [ExtensionType].
+ type ExtensionTypeDescriptor interface {
+ 	ExtensionDescriptor
+ 
+@@ -470,12 +470,12 @@ type ExtensionDescriptors interface {
+ 	doNotImplement
+ }
+ 
+-// ExtensionType encapsulates an ExtensionDescriptor with a concrete
++// ExtensionType encapsulates an [ExtensionDescriptor] with a concrete
+ // Go implementation. The nested field descriptor must be for a extension field.
+ //
+ // While a normal field is a member of the parent message that it is declared
+-// within (see Descriptor.Parent), an extension field is a member of some other
+-// target message (see ExtensionDescriptor.Extendee) and may have no
++// within (see [Descriptor.Parent]), an extension field is a member of some other
++// target message (see [FieldDescriptor.ContainingMessage]) and may have no
+ // relationship with the parent. However, the full name of an extension field is
+ // relative to the parent that it is declared within.
+ //
+@@ -532,7 +532,7 @@ type ExtensionType interface {
+ // corresponds with the google.protobuf.EnumDescriptorProto message.
+ //
+ // Nested declarations:
+-// EnumValueDescriptor.
++// [EnumValueDescriptor].
+ type EnumDescriptor interface {
+ 	Descriptor
+ 
+@@ -548,7 +548,7 @@ type EnumDescriptor interface {
+ }
+ type isEnumDescriptor interface{ ProtoType(EnumDescriptor) }
+ 
+-// EnumType encapsulates an EnumDescriptor with a concrete Go implementation.
++// EnumType encapsulates an [EnumDescriptor] with a concrete Go implementation.
+ type EnumType interface {
+ 	// New returns an instance of this enum type with its value set to n.
+ 	New(n EnumNumber) Enum
+@@ -610,7 +610,7 @@ type EnumValueDescriptors interface {
+ // ServiceDescriptor describes a service and
+ // corresponds with the google.protobuf.ServiceDescriptorProto message.
+ //
+-// Nested declarations: MethodDescriptor.
++// Nested declarations: [MethodDescriptor].
+ type ServiceDescriptor interface {
+ 	Descriptor
+ 
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
+index 37601b7..a7b0d06 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
+@@ -27,16 +27,16 @@ type Enum interface {
+ // Message is a reflective interface for a concrete message value,
+ // encapsulating both type and value information for the message.
+ //
+-// Accessor/mutators for individual fields are keyed by FieldDescriptor.
++// Accessor/mutators for individual fields are keyed by [FieldDescriptor].
+ // For non-extension fields, the descriptor must exactly match the
+ // field known by the parent message.
+-// For extension fields, the descriptor must implement ExtensionTypeDescriptor,
+-// extend the parent message (i.e., have the same message FullName), and
++// For extension fields, the descriptor must implement [ExtensionTypeDescriptor],
++// extend the parent message (i.e., have the same message [FullName]), and
+ // be within the parent's extension range.
+ //
+-// Each field Value can be a scalar or a composite type (Message, List, or Map).
+-// See Value for the Go types associated with a FieldDescriptor.
+-// Providing a Value that is invalid or of an incorrect type panics.
++// Each field [Value] can be a scalar or a composite type ([Message], [List], or [Map]).
++// See [Value] for the Go types associated with a [FieldDescriptor].
++// Providing a [Value] that is invalid or of an incorrect type panics.
+ type Message interface {
+ 	// Descriptor returns message descriptor, which contains only the protobuf
+ 	// type information for the message.
+@@ -152,7 +152,7 @@ type Message interface {
+ 	// This method may return nil.
+ 	//
+ 	// The returned methods type is identical to
+-	// "google.golang.org/protobuf/runtime/protoiface".Methods.
++	// google.golang.org/protobuf/runtime/protoiface.Methods.
+ 	// Consult the protoiface package documentation for details.
+ 	ProtoMethods() *methods
+ }
+@@ -175,8 +175,8 @@ func (b RawFields) IsValid() bool {
+ }
+ 
+ // List is a zero-indexed, ordered list.
+-// The element Value type is determined by FieldDescriptor.Kind.
+-// Providing a Value that is invalid or of an incorrect type panics.
++// The element [Value] type is determined by [FieldDescriptor.Kind].
++// Providing a [Value] that is invalid or of an incorrect type panics.
+ type List interface {
+ 	// Len reports the number of entries in the List.
+ 	// Get, Set, and Truncate panic with out of bound indexes.
+@@ -226,9 +226,9 @@ type List interface {
+ }
+ 
+ // Map is an unordered, associative map.
+-// The entry MapKey type is determined by FieldDescriptor.MapKey.Kind.
+-// The entry Value type is determined by FieldDescriptor.MapValue.Kind.
+-// Providing a MapKey or Value that is invalid or of an incorrect type panics.
++// The entry [MapKey] type is determined by [FieldDescriptor.MapKey].Kind.
++// The entry [Value] type is determined by [FieldDescriptor.MapValue].Kind.
++// Providing a [MapKey] or [Value] that is invalid or of an incorrect type panics.
+ type Map interface {
+ 	// Len reports the number of elements in the map.
+ 	Len() int
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
+index 5916525..654599d 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
+@@ -24,19 +24,19 @@ import (
+ //     Unlike the == operator, a NaN is equal to another NaN.
+ //
+ //   - Enums are equal if they contain the same number.
+-//     Since Value does not contain an enum descriptor,
++//     Since [Value] does not contain an enum descriptor,
+ //     enum values do not consider the type of the enum.
+ //
+ //   - Other scalar values are equal if they contain the same value.
+ //
+-//   - Message values are equal if they belong to the same message descriptor,
++//   - [Message] values are equal if they belong to the same message descriptor,
+ //     have the same set of populated known and extension field values,
+ //     and the same set of unknown fields values.
+ //
+-//   - Lists are equal if they are the same length and
++//   - [List] values are equal if they are the same length and
+ //     each corresponding element is equal.
+ //
+-//   - Maps are equal if they have the same set of keys and
++//   - [Map] values are equal if they have the same set of keys and
+ //     the corresponding value for each key is equal.
+ func (v1 Value) Equal(v2 Value) bool {
+ 	return equalValue(v1, v2)
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
+index 08e5ef7..1603097 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
+@@ -11,7 +11,7 @@ import (
+ 
+ // Value is a union where only one Go type may be set at a time.
+ // The Value is used to represent all possible values a field may take.
+-// The following shows which Go type is used to represent each proto Kind:
++// The following shows which Go type is used to represent each proto [Kind]:
+ //
+ //	╔════════════╤═════════════════════════════════════╗
+ //	║ Go type    │ Protobuf kind                       ║
+@@ -31,22 +31,22 @@ import (
+ //
+ // Multiple protobuf Kinds may be represented by a single Go type if the type
+ // can losslessly represent the information for the proto kind. For example,
+-// Int64Kind, Sint64Kind, and Sfixed64Kind are all represented by int64,
++// [Int64Kind], [Sint64Kind], and [Sfixed64Kind] are all represented by int64,
+ // but use different integer encoding methods.
+ //
+-// The List or Map types are used if the field cardinality is repeated.
+-// A field is a List if FieldDescriptor.IsList reports true.
+-// A field is a Map if FieldDescriptor.IsMap reports true.
++// The [List] or [Map] types are used if the field cardinality is repeated.
++// A field is a [List] if [FieldDescriptor.IsList] reports true.
++// A field is a [Map] if [FieldDescriptor.IsMap] reports true.
+ //
+ // Converting to/from a Value and a concrete Go value panics on type mismatch.
+-// For example, ValueOf("hello").Int() panics because this attempts to
++// For example, [ValueOf]("hello").Int() panics because this attempts to
+ // retrieve an int64 from a string.
+ //
+-// List, Map, and Message Values are called "composite" values.
++// [List], [Map], and [Message] Values are called "composite" values.
+ //
+ // A composite Value may alias (reference) memory at some location,
+ // such that changes to the Value updates the that location.
+-// A composite value acquired with a Mutable method, such as Message.Mutable,
++// A composite value acquired with a Mutable method, such as [Message.Mutable],
+ // always references the source object.
+ //
+ // For example:
+@@ -65,7 +65,7 @@ import (
+ //	// appending to the List here may or may not modify the message.
+ //	list.Append(protoreflect.ValueOfInt32(0))
+ //
+-// Some operations, such as Message.Get, may return an "empty, read-only"
++// Some operations, such as [Message.Get], may return an "empty, read-only"
+ // composite Value. Modifying an empty, read-only value panics.
+ type Value value
+ 
+@@ -306,7 +306,7 @@ func (v Value) Float() float64 {
+ 	}
+ }
+ 
+-// String returns v as a string. Since this method implements fmt.Stringer,
++// String returns v as a string. Since this method implements [fmt.Stringer],
+ // this returns the formatted string value for any non-string type.
+ func (v Value) String() string {
+ 	switch v.typ {
+@@ -327,7 +327,7 @@ func (v Value) Bytes() []byte {
+ 	}
+ }
+ 
+-// Enum returns v as a EnumNumber and panics if the type is not a EnumNumber.
++// Enum returns v as a [EnumNumber] and panics if the type is not a [EnumNumber].
+ func (v Value) Enum() EnumNumber {
+ 	switch v.typ {
+ 	case enumType:
+@@ -337,7 +337,7 @@ func (v Value) Enum() EnumNumber {
+ 	}
+ }
+ 
+-// Message returns v as a Message and panics if the type is not a Message.
++// Message returns v as a [Message] and panics if the type is not a [Message].
+ func (v Value) Message() Message {
+ 	switch vi := v.getIface().(type) {
+ 	case Message:
+@@ -347,7 +347,7 @@ func (v Value) Message() Message {
+ 	}
+ }
+ 
+-// List returns v as a List and panics if the type is not a List.
++// List returns v as a [List] and panics if the type is not a [List].
+ func (v Value) List() List {
+ 	switch vi := v.getIface().(type) {
+ 	case List:
+@@ -357,7 +357,7 @@ func (v Value) List() List {
+ 	}
+ }
+ 
+-// Map returns v as a Map and panics if the type is not a Map.
++// Map returns v as a [Map] and panics if the type is not a [Map].
+ func (v Value) Map() Map {
+ 	switch vi := v.getIface().(type) {
+ 	case Map:
+@@ -367,7 +367,7 @@ func (v Value) Map() Map {
+ 	}
+ }
+ 
+-// MapKey returns v as a MapKey and panics for invalid MapKey types.
++// MapKey returns v as a [MapKey] and panics for invalid [MapKey] types.
+ func (v Value) MapKey() MapKey {
+ 	switch v.typ {
+ 	case boolType, int32Type, int64Type, uint32Type, uint64Type, stringType:
+@@ -378,8 +378,8 @@ func (v Value) MapKey() MapKey {
+ }
+ 
+ // MapKey is used to index maps, where the Go type of the MapKey must match
+-// the specified key Kind (see MessageDescriptor.IsMapEntry).
+-// The following shows what Go type is used to represent each proto Kind:
++// the specified key [Kind] (see [MessageDescriptor.IsMapEntry]).
++// The following shows what Go type is used to represent each proto [Kind]:
+ //
+ //	╔═════════╤═════════════════════════════════════╗
+ //	║ Go type │ Protobuf kind                       ║
+@@ -392,13 +392,13 @@ func (v Value) MapKey() MapKey {
+ //	║ string  │ StringKind                          ║
+ //	╚═════════╧═════════════════════════════════════╝
+ //
+-// A MapKey is constructed and accessed through a Value:
++// A MapKey is constructed and accessed through a [Value]:
+ //
+ //	k := ValueOf("hash").MapKey() // convert string to MapKey
+ //	s := k.String()               // convert MapKey to string
+ //
+-// The MapKey is a strict subset of valid types used in Value;
+-// converting a Value to a MapKey with an invalid type panics.
++// The MapKey is a strict subset of valid types used in [Value];
++// converting a [Value] to a MapKey with an invalid type panics.
+ type MapKey value
+ 
+ // IsValid reports whether k is populated with a value.
+@@ -426,13 +426,13 @@ func (k MapKey) Uint() uint64 {
+ 	return Value(k).Uint()
+ }
+ 
+-// String returns k as a string. Since this method implements fmt.Stringer,
++// String returns k as a string. Since this method implements [fmt.Stringer],
+ // this returns the formatted string value for any non-string type.
+ func (k MapKey) String() string {
+ 	return Value(k).String()
+ }
+ 
+-// Value returns k as a Value.
++// Value returns k as a [Value].
+ func (k MapKey) Value() Value {
+ 	return Value(k)
+ }
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+similarity index 97%
+rename from vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
+rename to vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+index 702ddf2..b1fdbe3 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !purego && !appengine
+-// +build !purego,!appengine
++//go:build !purego && !appengine && !go1.21
++// +build !purego,!appengine,!go1.21
+ 
+ package protoreflect
+ 
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+new file mode 100644
+index 0000000..4354701
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+@@ -0,0 +1,87 @@
++// Copyright 2018 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !purego && !appengine && go1.21
++// +build !purego,!appengine,go1.21
++
++package protoreflect
++
++import (
++	"unsafe"
++
++	"google.golang.org/protobuf/internal/pragma"
++)
++
++type (
++	ifaceHeader struct {
++		_    [0]interface{} // if interfaces have greater alignment than unsafe.Pointer, this will enforce it.
++		Type unsafe.Pointer
++		Data unsafe.Pointer
++	}
++)
++
++var (
++	nilType     = typeOf(nil)
++	boolType    = typeOf(*new(bool))
++	int32Type   = typeOf(*new(int32))
++	int64Type   = typeOf(*new(int64))
++	uint32Type  = typeOf(*new(uint32))
++	uint64Type  = typeOf(*new(uint64))
++	float32Type = typeOf(*new(float32))
++	float64Type = typeOf(*new(float64))
++	stringType  = typeOf(*new(string))
++	bytesType   = typeOf(*new([]byte))
++	enumType    = typeOf(*new(EnumNumber))
++)
++
++// typeOf returns a pointer to the Go type information.
++// The pointer is comparable and equal if and only if the types are identical.
++func typeOf(t interface{}) unsafe.Pointer {
++	return (*ifaceHeader)(unsafe.Pointer(&t)).Type
++}
++
++// value is a union where only one type can be represented at a time.
++// The struct is 24B large on 64-bit systems and requires the minimum storage
++// necessary to represent each possible type.
++//
++// The Go GC needs to be able to scan variables containing pointers.
++// As such, pointers and non-pointers cannot be intermixed.
++type value struct {
++	pragma.DoNotCompare // 0B
++
++	// typ stores the type of the value as a pointer to the Go type.
++	typ unsafe.Pointer // 8B
++
++	// ptr stores the data pointer for a String, Bytes, or interface value.
++	ptr unsafe.Pointer // 8B
++
++	// num stores a Bool, Int32, Int64, Uint32, Uint64, Float32, Float64, or
++	// Enum value as a raw uint64.
++	//
++	// It is also used to store the length of a String or Bytes value;
++	// the capacity is ignored.
++	num uint64 // 8B
++}
++
++func valueOfString(v string) Value {
++	return Value{typ: stringType, ptr: unsafe.Pointer(unsafe.StringData(v)), num: uint64(len(v))}
++}
++func valueOfBytes(v []byte) Value {
++	return Value{typ: bytesType, ptr: unsafe.Pointer(unsafe.SliceData(v)), num: uint64(len(v))}
++}
++func valueOfIface(v interface{}) Value {
++	p := (*ifaceHeader)(unsafe.Pointer(&v))
++	return Value{typ: p.Type, ptr: p.Data}
++}
++
++func (v Value) getString() string {
++	return unsafe.String((*byte)(v.ptr), v.num)
++}
++func (v Value) getBytes() []byte {
++	return unsafe.Slice((*byte)(v.ptr), v.num)
++}
++func (v Value) getIface() (x interface{}) {
++	*(*ifaceHeader)(unsafe.Pointer(&x)) = ifaceHeader{Type: v.typ, Data: v.ptr}
++	return x
++}
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go b/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
+index aeb5597..6267dc5 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
+@@ -5,12 +5,12 @@
+ // Package protoregistry provides data structures to register and lookup
+ // protobuf descriptor types.
+ //
+-// The Files registry contains file descriptors and provides the ability
++// The [Files] registry contains file descriptors and provides the ability
+ // to iterate over the files or lookup a specific descriptor within the files.
+-// Files only contains protobuf descriptors and has no understanding of Go
++// [Files] only contains protobuf descriptors and has no understanding of Go
+ // type information that may be associated with each descriptor.
+ //
+-// The Types registry contains descriptor types for which there is a known
++// The [Types] registry contains descriptor types for which there is a known
+ // Go type associated with that descriptor. It provides the ability to iterate
+ // over the registered types or lookup a type by name.
+ package protoregistry
+@@ -218,7 +218,7 @@ func (r *Files) checkGenProtoConflict(path string) {
+ 
+ // FindDescriptorByName looks up a descriptor by the full name.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Files) FindDescriptorByName(name protoreflect.FullName) (protoreflect.Descriptor, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -310,7 +310,7 @@ func (s *nameSuffix) Pop() (name protoreflect.Name) {
+ 
+ // FindFileByPath looks up a file by the path.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ // This returns an error if multiple files have the same path.
+ func (r *Files) FindFileByPath(path string) (protoreflect.FileDescriptor, error) {
+ 	if r == nil {
+@@ -431,7 +431,7 @@ func rangeTopLevelDescriptors(fd protoreflect.FileDescriptor, f func(protoreflec
+ // A compliant implementation must deterministically return the same type
+ // if no error is encountered.
+ //
+-// The Types type implements this interface.
++// The [Types] type implements this interface.
+ type MessageTypeResolver interface {
+ 	// FindMessageByName looks up a message by its full name.
+ 	// E.g., "google.protobuf.Any"
+@@ -451,7 +451,7 @@ type MessageTypeResolver interface {
+ // A compliant implementation must deterministically return the same type
+ // if no error is encountered.
+ //
+-// The Types type implements this interface.
++// The [Types] type implements this interface.
+ type ExtensionTypeResolver interface {
+ 	// FindExtensionByName looks up a extension field by the field's full name.
+ 	// Note that this is the full name of the field as determined by
+@@ -590,7 +590,7 @@ func (r *Types) register(kind string, desc protoreflect.Descriptor, typ interfac
+ // FindEnumByName looks up an enum by its full name.
+ // E.g., "google.protobuf.Field.Kind".
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -611,7 +611,7 @@ func (r *Types) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumTyp
+ // FindMessageByName looks up a message by its full name,
+ // e.g. "google.protobuf.Any".
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -632,7 +632,7 @@ func (r *Types) FindMessageByName(message protoreflect.FullName) (protoreflect.M
+ // FindMessageByURL looks up a message by a URL identifier.
+ // See documentation on google.protobuf.Any.type_url for the URL format.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+ 	// This function is similar to FindMessageByName but
+ 	// truncates anything before and including '/' in the URL.
+@@ -662,7 +662,7 @@ func (r *Types) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+ // where the extension is declared and is unrelated to the full name of the
+ // message being extended.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -703,7 +703,7 @@ func (r *Types) FindExtensionByName(field protoreflect.FullName) (protoreflect.E
+ // FindExtensionByNumber looks up a extension field by the field number
+ // within some parent message, identified by full name.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+diff --git a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+index 04c00f7..78624cf 100644
+--- a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
++++ b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+@@ -48,6 +48,103 @@ import (
+ 	sync "sync"
+ )
+ 
++// The full set of known editions.
++type Edition int32
++
++const (
++	// A placeholder for an unknown edition value.
++	Edition_EDITION_UNKNOWN Edition = 0
++	// Legacy syntax "editions".  These pre-date editions, but behave much like
++	// distinct editions.  These can't be used to specify the edition of proto
++	// files, but feature definitions must supply proto2/proto3 defaults for
++	// backwards compatibility.
++	Edition_EDITION_PROTO2 Edition = 998
++	Edition_EDITION_PROTO3 Edition = 999
++	// Editions that have been released.  The specific values are arbitrary and
++	// should not be depended on, but they will always be time-ordered for easy
++	// comparison.
++	Edition_EDITION_2023 Edition = 1000
++	Edition_EDITION_2024 Edition = 1001
++	// Placeholder editions for testing feature resolution.  These should not be
++	// used or relyed on outside of tests.
++	Edition_EDITION_1_TEST_ONLY     Edition = 1
++	Edition_EDITION_2_TEST_ONLY     Edition = 2
++	Edition_EDITION_99997_TEST_ONLY Edition = 99997
++	Edition_EDITION_99998_TEST_ONLY Edition = 99998
++	Edition_EDITION_99999_TEST_ONLY Edition = 99999
++	// Placeholder for specifying unbounded edition support.  This should only
++	// ever be used by plugins that can expect to never require any changes to
++	// support a new edition.
++	Edition_EDITION_MAX Edition = 2147483647
++)
++
++// Enum value maps for Edition.
++var (
++	Edition_name = map[int32]string{
++		0:          "EDITION_UNKNOWN",
++		998:        "EDITION_PROTO2",
++		999:        "EDITION_PROTO3",
++		1000:       "EDITION_2023",
++		1001:       "EDITION_2024",
++		1:          "EDITION_1_TEST_ONLY",
++		2:          "EDITION_2_TEST_ONLY",
++		99997:      "EDITION_99997_TEST_ONLY",
++		99998:      "EDITION_99998_TEST_ONLY",
++		99999:      "EDITION_99999_TEST_ONLY",
++		2147483647: "EDITION_MAX",
++	}
++	Edition_value = map[string]int32{
++		"EDITION_UNKNOWN":         0,
++		"EDITION_PROTO2":          998,
++		"EDITION_PROTO3":          999,
++		"EDITION_2023":            1000,
++		"EDITION_2024":            1001,
++		"EDITION_1_TEST_ONLY":     1,
++		"EDITION_2_TEST_ONLY":     2,
++		"EDITION_99997_TEST_ONLY": 99997,
++		"EDITION_99998_TEST_ONLY": 99998,
++		"EDITION_99999_TEST_ONLY": 99999,
++		"EDITION_MAX":             2147483647,
++	}
++)
++
++func (x Edition) Enum() *Edition {
++	p := new(Edition)
++	*p = x
++	return p
++}
++
++func (x Edition) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (Edition) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[0].Descriptor()
++}
++
++func (Edition) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[0]
++}
++
++func (x Edition) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *Edition) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = Edition(num)
++	return nil
++}
++
++// Deprecated: Use Edition.Descriptor instead.
++func (Edition) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{0}
++}
++
+ // The verification state of the extension range.
+ type ExtensionRangeOptions_VerificationState int32
+ 
+@@ -80,11 +177,11 @@ func (x ExtensionRangeOptions_VerificationState) String() string {
+ }
+ 
+ func (ExtensionRangeOptions_VerificationState) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[0].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[1].Descriptor()
+ }
+ 
+ func (ExtensionRangeOptions_VerificationState) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[0]
++	return &file_google_protobuf_descriptor_proto_enumTypes[1]
+ }
+ 
+ func (x ExtensionRangeOptions_VerificationState) Number() protoreflect.EnumNumber {
+@@ -125,9 +222,10 @@ const (
+ 	FieldDescriptorProto_TYPE_BOOL    FieldDescriptorProto_Type = 8
+ 	FieldDescriptorProto_TYPE_STRING  FieldDescriptorProto_Type = 9
+ 	// Tag-delimited aggregate.
+-	// Group type is deprecated and not supported in proto3. However, Proto3
++	// Group type is deprecated and not supported after google.protobuf. However, Proto3
+ 	// implementations should still be able to parse the group wire format and
+-	// treat group fields as unknown fields.
++	// treat group fields as unknown fields.  In Editions, the group wire format
++	// can be enabled via the `message_encoding` feature.
+ 	FieldDescriptorProto_TYPE_GROUP   FieldDescriptorProto_Type = 10
+ 	FieldDescriptorProto_TYPE_MESSAGE FieldDescriptorProto_Type = 11 // Length-delimited aggregate.
+ 	// New in version 2.
+@@ -195,11 +293,11 @@ func (x FieldDescriptorProto_Type) String() string {
+ }
+ 
+ func (FieldDescriptorProto_Type) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[1].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[2].Descriptor()
+ }
+ 
+ func (FieldDescriptorProto_Type) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[1]
++	return &file_google_protobuf_descriptor_proto_enumTypes[2]
+ }
+ 
+ func (x FieldDescriptorProto_Type) Number() protoreflect.EnumNumber {
+@@ -226,21 +324,24 @@ type FieldDescriptorProto_Label int32
+ const (
+ 	// 0 is reserved for errors
+ 	FieldDescriptorProto_LABEL_OPTIONAL FieldDescriptorProto_Label = 1
+-	FieldDescriptorProto_LABEL_REQUIRED FieldDescriptorProto_Label = 2
+ 	FieldDescriptorProto_LABEL_REPEATED FieldDescriptorProto_Label = 3
++	// The required label is only allowed in google.protobuf.  In proto3 and Editions
++	// it's explicitly prohibited.  In Editions, the `field_presence` feature
++	// can be used to get this behavior.
++	FieldDescriptorProto_LABEL_REQUIRED FieldDescriptorProto_Label = 2
+ )
+ 
+ // Enum value maps for FieldDescriptorProto_Label.
+ var (
+ 	FieldDescriptorProto_Label_name = map[int32]string{
+ 		1: "LABEL_OPTIONAL",
+-		2: "LABEL_REQUIRED",
+ 		3: "LABEL_REPEATED",
++		2: "LABEL_REQUIRED",
+ 	}
+ 	FieldDescriptorProto_Label_value = map[string]int32{
+ 		"LABEL_OPTIONAL": 1,
+-		"LABEL_REQUIRED": 2,
+ 		"LABEL_REPEATED": 3,
++		"LABEL_REQUIRED": 2,
+ 	}
+ )
+ 
+@@ -255,11 +356,11 @@ func (x FieldDescriptorProto_Label) String() string {
+ }
+ 
+ func (FieldDescriptorProto_Label) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[2].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[3].Descriptor()
+ }
+ 
+ func (FieldDescriptorProto_Label) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[2]
++	return &file_google_protobuf_descriptor_proto_enumTypes[3]
+ }
+ 
+ func (x FieldDescriptorProto_Label) Number() protoreflect.EnumNumber {
+@@ -316,11 +417,11 @@ func (x FileOptions_OptimizeMode) String() string {
+ }
+ 
+ func (FileOptions_OptimizeMode) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[3].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[4].Descriptor()
+ }
+ 
+ func (FileOptions_OptimizeMode) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[3]
++	return &file_google_protobuf_descriptor_proto_enumTypes[4]
+ }
+ 
+ func (x FileOptions_OptimizeMode) Number() protoreflect.EnumNumber {
+@@ -382,11 +483,11 @@ func (x FieldOptions_CType) String() string {
+ }
+ 
+ func (FieldOptions_CType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[4].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[5].Descriptor()
+ }
+ 
+ func (FieldOptions_CType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[4]
++	return &file_google_protobuf_descriptor_proto_enumTypes[5]
+ }
+ 
+ func (x FieldOptions_CType) Number() protoreflect.EnumNumber {
+@@ -444,11 +545,11 @@ func (x FieldOptions_JSType) String() string {
+ }
+ 
+ func (FieldOptions_JSType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[5].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[6].Descriptor()
+ }
+ 
+ func (FieldOptions_JSType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[5]
++	return &file_google_protobuf_descriptor_proto_enumTypes[6]
+ }
+ 
+ func (x FieldOptions_JSType) Number() protoreflect.EnumNumber {
+@@ -506,11 +607,11 @@ func (x FieldOptions_OptionRetention) String() string {
+ }
+ 
+ func (FieldOptions_OptionRetention) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[6].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[7].Descriptor()
+ }
+ 
+ func (FieldOptions_OptionRetention) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[6]
++	return &file_google_protobuf_descriptor_proto_enumTypes[7]
+ }
+ 
+ func (x FieldOptions_OptionRetention) Number() protoreflect.EnumNumber {
+@@ -590,11 +691,11 @@ func (x FieldOptions_OptionTargetType) String() string {
+ }
+ 
+ func (FieldOptions_OptionTargetType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[7].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[8].Descriptor()
+ }
+ 
+ func (FieldOptions_OptionTargetType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[7]
++	return &file_google_protobuf_descriptor_proto_enumTypes[8]
+ }
+ 
+ func (x FieldOptions_OptionTargetType) Number() protoreflect.EnumNumber {
+@@ -652,11 +753,11 @@ func (x MethodOptions_IdempotencyLevel) String() string {
+ }
+ 
+ func (MethodOptions_IdempotencyLevel) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[8].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[9].Descriptor()
+ }
+ 
+ func (MethodOptions_IdempotencyLevel) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[8]
++	return &file_google_protobuf_descriptor_proto_enumTypes[9]
+ }
+ 
+ func (x MethodOptions_IdempotencyLevel) Number() protoreflect.EnumNumber {
+@@ -678,6 +779,363 @@ func (MethodOptions_IdempotencyLevel) EnumDescriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{17, 0}
+ }
+ 
++type FeatureSet_FieldPresence int32
++
++const (
++	FeatureSet_FIELD_PRESENCE_UNKNOWN FeatureSet_FieldPresence = 0
++	FeatureSet_EXPLICIT               FeatureSet_FieldPresence = 1
++	FeatureSet_IMPLICIT               FeatureSet_FieldPresence = 2
++	FeatureSet_LEGACY_REQUIRED        FeatureSet_FieldPresence = 3
++)
++
++// Enum value maps for FeatureSet_FieldPresence.
++var (
++	FeatureSet_FieldPresence_name = map[int32]string{
++		0: "FIELD_PRESENCE_UNKNOWN",
++		1: "EXPLICIT",
++		2: "IMPLICIT",
++		3: "LEGACY_REQUIRED",
++	}
++	FeatureSet_FieldPresence_value = map[string]int32{
++		"FIELD_PRESENCE_UNKNOWN": 0,
++		"EXPLICIT":               1,
++		"IMPLICIT":               2,
++		"LEGACY_REQUIRED":        3,
++	}
++)
++
++func (x FeatureSet_FieldPresence) Enum() *FeatureSet_FieldPresence {
++	p := new(FeatureSet_FieldPresence)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_FieldPresence) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_FieldPresence) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[10].Descriptor()
++}
++
++func (FeatureSet_FieldPresence) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[10]
++}
++
++func (x FeatureSet_FieldPresence) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_FieldPresence) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_FieldPresence(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_FieldPresence.Descriptor instead.
++func (FeatureSet_FieldPresence) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 0}
++}
++
++type FeatureSet_EnumType int32
++
++const (
++	FeatureSet_ENUM_TYPE_UNKNOWN FeatureSet_EnumType = 0
++	FeatureSet_OPEN              FeatureSet_EnumType = 1
++	FeatureSet_CLOSED            FeatureSet_EnumType = 2
++)
++
++// Enum value maps for FeatureSet_EnumType.
++var (
++	FeatureSet_EnumType_name = map[int32]string{
++		0: "ENUM_TYPE_UNKNOWN",
++		1: "OPEN",
++		2: "CLOSED",
++	}
++	FeatureSet_EnumType_value = map[string]int32{
++		"ENUM_TYPE_UNKNOWN": 0,
++		"OPEN":              1,
++		"CLOSED":            2,
++	}
++)
++
++func (x FeatureSet_EnumType) Enum() *FeatureSet_EnumType {
++	p := new(FeatureSet_EnumType)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_EnumType) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_EnumType) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[11].Descriptor()
++}
++
++func (FeatureSet_EnumType) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[11]
++}
++
++func (x FeatureSet_EnumType) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_EnumType) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_EnumType(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_EnumType.Descriptor instead.
++func (FeatureSet_EnumType) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 1}
++}
++
++type FeatureSet_RepeatedFieldEncoding int32
++
++const (
++	FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN FeatureSet_RepeatedFieldEncoding = 0
++	FeatureSet_PACKED                          FeatureSet_RepeatedFieldEncoding = 1
++	FeatureSet_EXPANDED                        FeatureSet_RepeatedFieldEncoding = 2
++)
++
++// Enum value maps for FeatureSet_RepeatedFieldEncoding.
++var (
++	FeatureSet_RepeatedFieldEncoding_name = map[int32]string{
++		0: "REPEATED_FIELD_ENCODING_UNKNOWN",
++		1: "PACKED",
++		2: "EXPANDED",
++	}
++	FeatureSet_RepeatedFieldEncoding_value = map[string]int32{
++		"REPEATED_FIELD_ENCODING_UNKNOWN": 0,
++		"PACKED":                          1,
++		"EXPANDED":                        2,
++	}
++)
++
++func (x FeatureSet_RepeatedFieldEncoding) Enum() *FeatureSet_RepeatedFieldEncoding {
++	p := new(FeatureSet_RepeatedFieldEncoding)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_RepeatedFieldEncoding) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_RepeatedFieldEncoding) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[12].Descriptor()
++}
++
++func (FeatureSet_RepeatedFieldEncoding) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[12]
++}
++
++func (x FeatureSet_RepeatedFieldEncoding) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_RepeatedFieldEncoding) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_RepeatedFieldEncoding(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_RepeatedFieldEncoding.Descriptor instead.
++func (FeatureSet_RepeatedFieldEncoding) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 2}
++}
++
++type FeatureSet_Utf8Validation int32
++
++const (
++	FeatureSet_UTF8_VALIDATION_UNKNOWN FeatureSet_Utf8Validation = 0
++	FeatureSet_VERIFY                  FeatureSet_Utf8Validation = 2
++	FeatureSet_NONE                    FeatureSet_Utf8Validation = 3
++)
++
++// Enum value maps for FeatureSet_Utf8Validation.
++var (
++	FeatureSet_Utf8Validation_name = map[int32]string{
++		0: "UTF8_VALIDATION_UNKNOWN",
++		2: "VERIFY",
++		3: "NONE",
++	}
++	FeatureSet_Utf8Validation_value = map[string]int32{
++		"UTF8_VALIDATION_UNKNOWN": 0,
++		"VERIFY":                  2,
++		"NONE":                    3,
++	}
++)
++
++func (x FeatureSet_Utf8Validation) Enum() *FeatureSet_Utf8Validation {
++	p := new(FeatureSet_Utf8Validation)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_Utf8Validation) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_Utf8Validation) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[13].Descriptor()
++}
++
++func (FeatureSet_Utf8Validation) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[13]
++}
++
++func (x FeatureSet_Utf8Validation) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_Utf8Validation) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_Utf8Validation(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_Utf8Validation.Descriptor instead.
++func (FeatureSet_Utf8Validation) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 3}
++}
++
++type FeatureSet_MessageEncoding int32
++
++const (
++	FeatureSet_MESSAGE_ENCODING_UNKNOWN FeatureSet_MessageEncoding = 0
++	FeatureSet_LENGTH_PREFIXED          FeatureSet_MessageEncoding = 1
++	FeatureSet_DELIMITED                FeatureSet_MessageEncoding = 2
++)
++
++// Enum value maps for FeatureSet_MessageEncoding.
++var (
++	FeatureSet_MessageEncoding_name = map[int32]string{
++		0: "MESSAGE_ENCODING_UNKNOWN",
++		1: "LENGTH_PREFIXED",
++		2: "DELIMITED",
++	}
++	FeatureSet_MessageEncoding_value = map[string]int32{
++		"MESSAGE_ENCODING_UNKNOWN": 0,
++		"LENGTH_PREFIXED":          1,
++		"DELIMITED":                2,
++	}
++)
++
++func (x FeatureSet_MessageEncoding) Enum() *FeatureSet_MessageEncoding {
++	p := new(FeatureSet_MessageEncoding)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_MessageEncoding) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_MessageEncoding) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[14].Descriptor()
++}
++
++func (FeatureSet_MessageEncoding) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[14]
++}
++
++func (x FeatureSet_MessageEncoding) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_MessageEncoding) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_MessageEncoding(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_MessageEncoding.Descriptor instead.
++func (FeatureSet_MessageEncoding) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 4}
++}
++
++type FeatureSet_JsonFormat int32
++
++const (
++	FeatureSet_JSON_FORMAT_UNKNOWN FeatureSet_JsonFormat = 0
++	FeatureSet_ALLOW               FeatureSet_JsonFormat = 1
++	FeatureSet_LEGACY_BEST_EFFORT  FeatureSet_JsonFormat = 2
++)
++
++// Enum value maps for FeatureSet_JsonFormat.
++var (
++	FeatureSet_JsonFormat_name = map[int32]string{
++		0: "JSON_FORMAT_UNKNOWN",
++		1: "ALLOW",
++		2: "LEGACY_BEST_EFFORT",
++	}
++	FeatureSet_JsonFormat_value = map[string]int32{
++		"JSON_FORMAT_UNKNOWN": 0,
++		"ALLOW":               1,
++		"LEGACY_BEST_EFFORT":  2,
++	}
++)
++
++func (x FeatureSet_JsonFormat) Enum() *FeatureSet_JsonFormat {
++	p := new(FeatureSet_JsonFormat)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_JsonFormat) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_JsonFormat) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[15].Descriptor()
++}
++
++func (FeatureSet_JsonFormat) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[15]
++}
++
++func (x FeatureSet_JsonFormat) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_JsonFormat) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_JsonFormat(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_JsonFormat.Descriptor instead.
++func (FeatureSet_JsonFormat) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 5}
++}
++
+ // Represents the identified object's effect on the element in the original
+ // .proto file.
+ type GeneratedCodeInfo_Annotation_Semantic int32
+@@ -716,11 +1174,11 @@ func (x GeneratedCodeInfo_Annotation_Semantic) String() string {
+ }
+ 
+ func (GeneratedCodeInfo_Annotation_Semantic) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[9].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[16].Descriptor()
+ }
+ 
+ func (GeneratedCodeInfo_Annotation_Semantic) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[9]
++	return &file_google_protobuf_descriptor_proto_enumTypes[16]
+ }
+ 
+ func (x GeneratedCodeInfo_Annotation_Semantic) Number() protoreflect.EnumNumber {
+@@ -739,7 +1197,7 @@ func (x *GeneratedCodeInfo_Annotation_Semantic) UnmarshalJSON(b []byte) error {
+ 
+ // Deprecated: Use GeneratedCodeInfo_Annotation_Semantic.Descriptor instead.
+ func (GeneratedCodeInfo_Annotation_Semantic) EnumDescriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22, 0, 0}
+ }
+ 
+ // The protocol compiler can output a FileDescriptorSet containing the .proto
+@@ -822,8 +1280,8 @@ type FileDescriptorProto struct {
+ 	//
+ 	// If `edition` is present, this value must be "editions".
+ 	Syntax *string `protobuf:"bytes,12,opt,name=syntax" json:"syntax,omitempty"`
+-	// The edition of the proto file, which is an opaque string.
+-	Edition *string `protobuf:"bytes,13,opt,name=edition" json:"edition,omitempty"`
++	// The edition of the proto file.
++	Edition *Edition `protobuf:"varint,14,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
+ }
+ 
+ func (x *FileDescriptorProto) Reset() {
+@@ -942,11 +1400,11 @@ func (x *FileDescriptorProto) GetSyntax() string {
+ 	return ""
+ }
+ 
+-func (x *FileDescriptorProto) GetEdition() string {
++func (x *FileDescriptorProto) GetEdition() Edition {
+ 	if x != nil && x.Edition != nil {
+ 		return *x.Edition
+ 	}
+-	return ""
++	return Edition_EDITION_UNKNOWN
+ }
+ 
+ // Describes a message type.
+@@ -1079,13 +1537,14 @@ type ExtensionRangeOptions struct {
+ 
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+-	// go/protobuf-stripping-extension-declarations
+-	// Like Metadata, but we use a repeated field to hold all extension
+-	// declarations. This should avoid the size increases of transforming a large
+-	// extension range into small ranges in generated binaries.
++	// For external users: DO NOT USE. We are in the process of open sourcing
++	// extension declaration and executing internal cleanups before it can be
++	// used externally.
+ 	Declaration []*ExtensionRangeOptions_Declaration `protobuf:"bytes,2,rep,name=declaration" json:"declaration,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,50,opt,name=features" json:"features,omitempty"`
+ 	// The verification state of the range.
+-	// TODO(b/278783756): flip the default to DECLARATION once all empty ranges
++	// TODO: flip the default to DECLARATION once all empty ranges
+ 	// are marked as UNVERIFIED.
+ 	Verification *ExtensionRangeOptions_VerificationState `protobuf:"varint,3,opt,name=verification,enum=google.protobuf.ExtensionRangeOptions_VerificationState,def=1" json:"verification,omitempty"`
+ }
+@@ -1141,6 +1600,13 @@ func (x *ExtensionRangeOptions) GetDeclaration() []*ExtensionRangeOptions_Declar
+ 	return nil
+ }
+ 
++func (x *ExtensionRangeOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *ExtensionRangeOptions) GetVerification() ExtensionRangeOptions_VerificationState {
+ 	if x != nil && x.Verification != nil {
+ 		return *x.Verification
+@@ -1186,12 +1652,12 @@ type FieldDescriptorProto struct {
+ 	// If true, this is a proto3 "optional". When a proto3 field is optional, it
+ 	// tracks presence regardless of field type.
+ 	//
+-	// When proto3_optional is true, this field must be belong to a oneof to
+-	// signal to old proto3 clients that presence is tracked for this field. This
+-	// oneof is known as a "synthetic" oneof, and this field must be its sole
+-	// member (each proto3 optional field gets its own synthetic oneof). Synthetic
+-	// oneofs exist in the descriptor only, and do not generate any API. Synthetic
+-	// oneofs must be ordered after all "real" oneofs.
++	// When proto3_optional is true, this field must belong to a oneof to signal
++	// to old proto3 clients that presence is tracked for this field. This oneof
++	// is known as a "synthetic" oneof, and this field must be its sole member
++	// (each proto3 optional field gets its own synthetic oneof). Synthetic oneofs
++	// exist in the descriptor only, and do not generate any API. Synthetic oneofs
++	// must be ordered after all "real" oneofs.
+ 	//
+ 	// For message fields, proto3_optional doesn't create any semantic change,
+ 	// since non-repeated message fields always track presence. However it still
+@@ -1738,7 +2204,6 @@ type FileOptions struct {
+ 	CcGenericServices   *bool `protobuf:"varint,16,opt,name=cc_generic_services,json=ccGenericServices,def=0" json:"cc_generic_services,omitempty"`
+ 	JavaGenericServices *bool `protobuf:"varint,17,opt,name=java_generic_services,json=javaGenericServices,def=0" json:"java_generic_services,omitempty"`
+ 	PyGenericServices   *bool `protobuf:"varint,18,opt,name=py_generic_services,json=pyGenericServices,def=0" json:"py_generic_services,omitempty"`
+-	PhpGenericServices  *bool `protobuf:"varint,42,opt,name=php_generic_services,json=phpGenericServices,def=0" json:"php_generic_services,omitempty"`
+ 	// Is this file deprecated?
+ 	// Depending on the target platform, this can emit Deprecated annotations
+ 	// for everything in the file, or it will be completely ignored; in the very
+@@ -1772,6 +2237,8 @@ type FileOptions struct {
+ 	// is empty. When this option is not set, the package name will be used for
+ 	// determining the ruby package.
+ 	RubyPackage *string `protobuf:"bytes,45,opt,name=ruby_package,json=rubyPackage" json:"ruby_package,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,50,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here.
+ 	// See the documentation for the "Options" section above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+@@ -1785,7 +2252,6 @@ const (
+ 	Default_FileOptions_CcGenericServices   = bool(false)
+ 	Default_FileOptions_JavaGenericServices = bool(false)
+ 	Default_FileOptions_PyGenericServices   = bool(false)
+-	Default_FileOptions_PhpGenericServices  = bool(false)
+ 	Default_FileOptions_Deprecated          = bool(false)
+ 	Default_FileOptions_CcEnableArenas      = bool(true)
+ )
+@@ -1893,13 +2359,6 @@ func (x *FileOptions) GetPyGenericServices() bool {
+ 	return Default_FileOptions_PyGenericServices
+ }
+ 
+-func (x *FileOptions) GetPhpGenericServices() bool {
+-	if x != nil && x.PhpGenericServices != nil {
+-		return *x.PhpGenericServices
+-	}
+-	return Default_FileOptions_PhpGenericServices
+-}
+-
+ func (x *FileOptions) GetDeprecated() bool {
+ 	if x != nil && x.Deprecated != nil {
+ 		return *x.Deprecated
+@@ -1963,6 +2422,13 @@ func (x *FileOptions) GetRubyPackage() string {
+ 	return ""
+ }
+ 
++func (x *FileOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *FileOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2006,10 +2472,6 @@ type MessageOptions struct {
+ 	// for the message, or it will be completely ignored; in the very least,
+ 	// this is a formalization for deprecating messages.
+ 	Deprecated *bool `protobuf:"varint,3,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
+-	// NOTE: Do not set the option in .proto files. Always use the maps syntax
+-	// instead. The option should only be implicitly set by the proto compiler
+-	// parser.
+-	//
+ 	// Whether the message is an automatically generated map entry type for the
+ 	// maps field.
+ 	//
+@@ -2030,6 +2492,10 @@ type MessageOptions struct {
+ 	// use a native map in the target language to hold the keys and values.
+ 	// The reflection APIs in such implementations still need to work as
+ 	// if the field is a repeated message field.
++	//
++	// NOTE: Do not set the option in .proto files. Always use the maps syntax
++	// instead. The option should only be implicitly set by the proto compiler
++	// parser.
+ 	MapEntry *bool `protobuf:"varint,7,opt,name=map_entry,json=mapEntry" json:"map_entry,omitempty"`
+ 	// Enable the legacy handling of JSON field name conflicts.  This lowercases
+ 	// and strips underscored from the fields before comparison in proto3 only.
+@@ -2039,11 +2505,13 @@ type MessageOptions struct {
+ 	// This should only be used as a temporary measure against broken builds due
+ 	// to the change in behavior for JSON field name conflicts.
+ 	//
+-	// TODO(b/261750190) This is legacy behavior we plan to remove once downstream
++	// TODO This is legacy behavior we plan to remove once downstream
+ 	// teams have had time to migrate.
+ 	//
+ 	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+ 	DeprecatedLegacyJsonFieldConflicts *bool `protobuf:"varint,11,opt,name=deprecated_legacy_json_field_conflicts,json=deprecatedLegacyJsonFieldConflicts" json:"deprecated_legacy_json_field_conflicts,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,12,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2123,6 +2591,13 @@ func (x *MessageOptions) GetDeprecatedLegacyJsonFieldConflicts() bool {
+ 	return false
+ }
+ 
++func (x *MessageOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *MessageOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2147,7 +2622,9 @@ type FieldOptions struct {
+ 	// a more efficient representation on the wire. Rather than repeatedly
+ 	// writing the tag and type for each element, the entire array is encoded as
+ 	// a single length-delimited blob. In proto3, only explicit setting it to
+-	// false will avoid using packed encoding.
++	// false will avoid using packed encoding.  This option is prohibited in
++	// Editions, but the `repeated_field_encoding` feature can be used to control
++	// the behavior.
+ 	Packed *bool `protobuf:"varint,2,opt,name=packed" json:"packed,omitempty"`
+ 	// The jstype option determines the JavaScript type used for values of the
+ 	// field.  The option is permitted only for 64 bit integral and fixed types
+@@ -2178,19 +2655,11 @@ type FieldOptions struct {
+ 	// call from multiple threads concurrently, while non-const methods continue
+ 	// to require exclusive access.
+ 	//
+-	// Note that implementations may choose not to check required fields within
+-	// a lazy sub-message.  That is, calling IsInitialized() on the outer message
+-	// may return true even if the inner message has missing required fields.
+-	// This is necessary because otherwise the inner message would have to be
+-	// parsed in order to perform the check, defeating the purpose of lazy
+-	// parsing.  An implementation which chooses not to check required fields
+-	// must be consistent about it.  That is, for any particular sub-message, the
+-	// implementation must either *always* check its required fields, or *never*
+-	// check its required fields, regardless of whether or not the message has
+-	// been parsed.
+-	//
+-	// As of May 2022, lazy verifies the contents of the byte stream during
+-	// parsing.  An invalid byte stream will cause the overall parsing to fail.
++	// Note that lazy message fields are still eagerly verified to check
++	// ill-formed wireformat or missing required fields. Calling IsInitialized()
++	// on the outer message would fail if the inner message has missing required
++	// fields. Failed verification would result in parsing failure (except when
++	// uninitialized messages are acceptable).
+ 	Lazy *bool `protobuf:"varint,5,opt,name=lazy,def=0" json:"lazy,omitempty"`
+ 	// unverified_lazy does no correctness checks on the byte stream. This should
+ 	// only be used where lazy with verification is prohibitive for performance
+@@ -2205,11 +2674,12 @@ type FieldOptions struct {
+ 	Weak *bool `protobuf:"varint,10,opt,name=weak,def=0" json:"weak,omitempty"`
+ 	// Indicate that the field value should not be printed out when using debug
+ 	// formats, e.g. when the field contains sensitive credentials.
+-	DebugRedact *bool                         `protobuf:"varint,16,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
+-	Retention   *FieldOptions_OptionRetention `protobuf:"varint,17,opt,name=retention,enum=google.protobuf.FieldOptions_OptionRetention" json:"retention,omitempty"`
+-	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-	Target  *FieldOptions_OptionTargetType  `protobuf:"varint,18,opt,name=target,enum=google.protobuf.FieldOptions_OptionTargetType" json:"target,omitempty"`
+-	Targets []FieldOptions_OptionTargetType `protobuf:"varint,19,rep,name=targets,enum=google.protobuf.FieldOptions_OptionTargetType" json:"targets,omitempty"`
++	DebugRedact     *bool                           `protobuf:"varint,16,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
++	Retention       *FieldOptions_OptionRetention   `protobuf:"varint,17,opt,name=retention,enum=google.protobuf.FieldOptions_OptionRetention" json:"retention,omitempty"`
++	Targets         []FieldOptions_OptionTargetType `protobuf:"varint,19,rep,name=targets,enum=google.protobuf.FieldOptions_OptionTargetType" json:"targets,omitempty"`
++	EditionDefaults []*FieldOptions_EditionDefault  `protobuf:"bytes,20,rep,name=edition_defaults,json=editionDefaults" json:"edition_defaults,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,21,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2320,17 +2790,23 @@ func (x *FieldOptions) GetRetention() FieldOptions_OptionRetention {
+ 	return FieldOptions_RETENTION_UNKNOWN
+ }
+ 
+-// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-func (x *FieldOptions) GetTarget() FieldOptions_OptionTargetType {
+-	if x != nil && x.Target != nil {
+-		return *x.Target
++func (x *FieldOptions) GetTargets() []FieldOptions_OptionTargetType {
++	if x != nil {
++		return x.Targets
+ 	}
+-	return FieldOptions_TARGET_TYPE_UNKNOWN
++	return nil
+ }
+ 
+-func (x *FieldOptions) GetTargets() []FieldOptions_OptionTargetType {
++func (x *FieldOptions) GetEditionDefaults() []*FieldOptions_EditionDefault {
+ 	if x != nil {
+-		return x.Targets
++		return x.EditionDefaults
++	}
++	return nil
++}
++
++func (x *FieldOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
+ 	}
+ 	return nil
+ }
+@@ -2348,6 +2824,8 @@ type OneofOptions struct {
+ 	unknownFields   protoimpl.UnknownFields
+ 	extensionFields protoimpl.ExtensionFields
+ 
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,1,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2384,6 +2862,13 @@ func (*OneofOptions) Descriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{13}
+ }
+ 
++func (x *OneofOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *OneofOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2409,11 +2894,13 @@ type EnumOptions struct {
+ 	// and strips underscored from the fields before comparison in proto3 only.
+ 	// The new behavior takes `json_name` into account and applies to proto2 as
+ 	// well.
+-	// TODO(b/261750190) Remove this legacy behavior once downstream teams have
++	// TODO Remove this legacy behavior once downstream teams have
+ 	// had time to migrate.
+ 	//
+ 	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+ 	DeprecatedLegacyJsonFieldConflicts *bool `protobuf:"varint,6,opt,name=deprecated_legacy_json_field_conflicts,json=deprecatedLegacyJsonFieldConflicts" json:"deprecated_legacy_json_field_conflicts,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,7,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2477,6 +2964,13 @@ func (x *EnumOptions) GetDeprecatedLegacyJsonFieldConflicts() bool {
+ 	return false
+ }
+ 
++func (x *EnumOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *EnumOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2495,13 +2989,20 @@ type EnumValueOptions struct {
+ 	// for the enum value, or it will be completely ignored; in the very least,
+ 	// this is a formalization for deprecating enum values.
+ 	Deprecated *bool `protobuf:"varint,1,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,2,opt,name=features" json:"features,omitempty"`
++	// Indicate that fields annotated with this enum value should not be printed
++	// out when using debug formats, e.g. when the field contains sensitive
++	// credentials.
++	DebugRedact *bool `protobuf:"varint,3,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+ 
+ // Default values for EnumValueOptions fields.
+ const (
+-	Default_EnumValueOptions_Deprecated = bool(false)
++	Default_EnumValueOptions_Deprecated  = bool(false)
++	Default_EnumValueOptions_DebugRedact = bool(false)
+ )
+ 
+ func (x *EnumValueOptions) Reset() {
+@@ -2543,6 +3044,20 @@ func (x *EnumValueOptions) GetDeprecated() bool {
+ 	return Default_EnumValueOptions_Deprecated
+ }
+ 
++func (x *EnumValueOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
++func (x *EnumValueOptions) GetDebugRedact() bool {
++	if x != nil && x.DebugRedact != nil {
++		return *x.DebugRedact
++	}
++	return Default_EnumValueOptions_DebugRedact
++}
++
+ func (x *EnumValueOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2556,6 +3071,8 @@ type ServiceOptions struct {
+ 	unknownFields   protoimpl.UnknownFields
+ 	extensionFields protoimpl.ExtensionFields
+ 
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,34,opt,name=features" json:"features,omitempty"`
+ 	// Is this service deprecated?
+ 	// Depending on the target platform, this can emit Deprecated annotations
+ 	// for the service, or it will be completely ignored; in the very least,
+@@ -2602,6 +3119,13 @@ func (*ServiceOptions) Descriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{16}
+ }
+ 
++func (x *ServiceOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *ServiceOptions) GetDeprecated() bool {
+ 	if x != nil && x.Deprecated != nil {
+ 		return *x.Deprecated
+@@ -2628,6 +3152,8 @@ type MethodOptions struct {
+ 	// this is a formalization for deprecating methods.
+ 	Deprecated       *bool                           `protobuf:"varint,33,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
+ 	IdempotencyLevel *MethodOptions_IdempotencyLevel `protobuf:"varint,34,opt,name=idempotency_level,json=idempotencyLevel,enum=google.protobuf.MethodOptions_IdempotencyLevel,def=0" json:"idempotency_level,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,35,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2684,6 +3210,13 @@ func (x *MethodOptions) GetIdempotencyLevel() MethodOptions_IdempotencyLevel {
+ 	return Default_MethodOptions_IdempotencyLevel
+ }
+ 
++func (x *MethodOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *MethodOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2770,28 +3303,193 @@ func (x *UninterpretedOption) GetNegativeIntValue() int64 {
+ 	if x != nil && x.NegativeIntValue != nil {
+ 		return *x.NegativeIntValue
+ 	}
+-	return 0
++	return 0
++}
++
++func (x *UninterpretedOption) GetDoubleValue() float64 {
++	if x != nil && x.DoubleValue != nil {
++		return *x.DoubleValue
++	}
++	return 0
++}
++
++func (x *UninterpretedOption) GetStringValue() []byte {
++	if x != nil {
++		return x.StringValue
++	}
++	return nil
++}
++
++func (x *UninterpretedOption) GetAggregateValue() string {
++	if x != nil && x.AggregateValue != nil {
++		return *x.AggregateValue
++	}
++	return ""
++}
++
++// TODO Enums in C++ gencode (and potentially other languages) are
++// not well scoped.  This means that each of the feature enums below can clash
++// with each other.  The short names we've chosen maximize call-site
++// readability, but leave us very open to this scenario.  A future feature will
++// be designed and implemented to handle this, hopefully before we ever hit a
++// conflict here.
++type FeatureSet struct {
++	state           protoimpl.MessageState
++	sizeCache       protoimpl.SizeCache
++	unknownFields   protoimpl.UnknownFields
++	extensionFields protoimpl.ExtensionFields
++
++	FieldPresence         *FeatureSet_FieldPresence         `protobuf:"varint,1,opt,name=field_presence,json=fieldPresence,enum=google.protobuf.FeatureSet_FieldPresence" json:"field_presence,omitempty"`
++	EnumType              *FeatureSet_EnumType              `protobuf:"varint,2,opt,name=enum_type,json=enumType,enum=google.protobuf.FeatureSet_EnumType" json:"enum_type,omitempty"`
++	RepeatedFieldEncoding *FeatureSet_RepeatedFieldEncoding `protobuf:"varint,3,opt,name=repeated_field_encoding,json=repeatedFieldEncoding,enum=google.protobuf.FeatureSet_RepeatedFieldEncoding" json:"repeated_field_encoding,omitempty"`
++	Utf8Validation        *FeatureSet_Utf8Validation        `protobuf:"varint,4,opt,name=utf8_validation,json=utf8Validation,enum=google.protobuf.FeatureSet_Utf8Validation" json:"utf8_validation,omitempty"`
++	MessageEncoding       *FeatureSet_MessageEncoding       `protobuf:"varint,5,opt,name=message_encoding,json=messageEncoding,enum=google.protobuf.FeatureSet_MessageEncoding" json:"message_encoding,omitempty"`
++	JsonFormat            *FeatureSet_JsonFormat            `protobuf:"varint,6,opt,name=json_format,json=jsonFormat,enum=google.protobuf.FeatureSet_JsonFormat" json:"json_format,omitempty"`
++}
++
++func (x *FeatureSet) Reset() {
++	*x = FeatureSet{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSet) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSet) ProtoMessage() {}
++
++func (x *FeatureSet) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FeatureSet.ProtoReflect.Descriptor instead.
++func (*FeatureSet) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19}
++}
++
++func (x *FeatureSet) GetFieldPresence() FeatureSet_FieldPresence {
++	if x != nil && x.FieldPresence != nil {
++		return *x.FieldPresence
++	}
++	return FeatureSet_FIELD_PRESENCE_UNKNOWN
++}
++
++func (x *FeatureSet) GetEnumType() FeatureSet_EnumType {
++	if x != nil && x.EnumType != nil {
++		return *x.EnumType
++	}
++	return FeatureSet_ENUM_TYPE_UNKNOWN
++}
++
++func (x *FeatureSet) GetRepeatedFieldEncoding() FeatureSet_RepeatedFieldEncoding {
++	if x != nil && x.RepeatedFieldEncoding != nil {
++		return *x.RepeatedFieldEncoding
++	}
++	return FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN
++}
++
++func (x *FeatureSet) GetUtf8Validation() FeatureSet_Utf8Validation {
++	if x != nil && x.Utf8Validation != nil {
++		return *x.Utf8Validation
++	}
++	return FeatureSet_UTF8_VALIDATION_UNKNOWN
++}
++
++func (x *FeatureSet) GetMessageEncoding() FeatureSet_MessageEncoding {
++	if x != nil && x.MessageEncoding != nil {
++		return *x.MessageEncoding
++	}
++	return FeatureSet_MESSAGE_ENCODING_UNKNOWN
++}
++
++func (x *FeatureSet) GetJsonFormat() FeatureSet_JsonFormat {
++	if x != nil && x.JsonFormat != nil {
++		return *x.JsonFormat
++	}
++	return FeatureSet_JSON_FORMAT_UNKNOWN
++}
++
++// A compiled specification for the defaults of a set of features.  These
++// messages are generated from FeatureSet extensions and can be used to seed
++// feature resolution. The resolution with this object becomes a simple search
++// for the closest matching edition, followed by proto merges.
++type FeatureSetDefaults struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Defaults []*FeatureSetDefaults_FeatureSetEditionDefault `protobuf:"bytes,1,rep,name=defaults" json:"defaults,omitempty"`
++	// The minimum supported edition (inclusive) when this was constructed.
++	// Editions before this will not have defaults.
++	MinimumEdition *Edition `protobuf:"varint,4,opt,name=minimum_edition,json=minimumEdition,enum=google.protobuf.Edition" json:"minimum_edition,omitempty"`
++	// The maximum known edition (inclusive) when this was constructed. Editions
++	// after this will not have reliable defaults.
++	MaximumEdition *Edition `protobuf:"varint,5,opt,name=maximum_edition,json=maximumEdition,enum=google.protobuf.Edition" json:"maximum_edition,omitempty"`
++}
++
++func (x *FeatureSetDefaults) Reset() {
++	*x = FeatureSetDefaults{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSetDefaults) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSetDefaults) ProtoMessage() {}
++
++func (x *FeatureSetDefaults) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
+ }
+ 
+-func (x *UninterpretedOption) GetDoubleValue() float64 {
+-	if x != nil && x.DoubleValue != nil {
+-		return *x.DoubleValue
+-	}
+-	return 0
++// Deprecated: Use FeatureSetDefaults.ProtoReflect.Descriptor instead.
++func (*FeatureSetDefaults) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20}
+ }
+ 
+-func (x *UninterpretedOption) GetStringValue() []byte {
++func (x *FeatureSetDefaults) GetDefaults() []*FeatureSetDefaults_FeatureSetEditionDefault {
+ 	if x != nil {
+-		return x.StringValue
++		return x.Defaults
+ 	}
+ 	return nil
+ }
+ 
+-func (x *UninterpretedOption) GetAggregateValue() string {
+-	if x != nil && x.AggregateValue != nil {
+-		return *x.AggregateValue
++func (x *FeatureSetDefaults) GetMinimumEdition() Edition {
++	if x != nil && x.MinimumEdition != nil {
++		return *x.MinimumEdition
+ 	}
+-	return ""
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FeatureSetDefaults) GetMaximumEdition() Edition {
++	if x != nil && x.MaximumEdition != nil {
++		return *x.MaximumEdition
++	}
++	return Edition_EDITION_UNKNOWN
+ }
+ 
+ // Encapsulates information about the original source file from which a
+@@ -2855,7 +3553,7 @@ type SourceCodeInfo struct {
+ func (x *SourceCodeInfo) Reset() {
+ 	*x = SourceCodeInfo{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2868,7 +3566,7 @@ func (x *SourceCodeInfo) String() string {
+ func (*SourceCodeInfo) ProtoMessage() {}
+ 
+ func (x *SourceCodeInfo) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -2881,7 +3579,7 @@ func (x *SourceCodeInfo) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use SourceCodeInfo.ProtoReflect.Descriptor instead.
+ func (*SourceCodeInfo) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{21}
+ }
+ 
+ func (x *SourceCodeInfo) GetLocation() []*SourceCodeInfo_Location {
+@@ -2907,7 +3605,7 @@ type GeneratedCodeInfo struct {
+ func (x *GeneratedCodeInfo) Reset() {
+ 	*x = GeneratedCodeInfo{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2920,7 +3618,7 @@ func (x *GeneratedCodeInfo) String() string {
+ func (*GeneratedCodeInfo) ProtoMessage() {}
+ 
+ func (x *GeneratedCodeInfo) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -2933,7 +3631,7 @@ func (x *GeneratedCodeInfo) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use GeneratedCodeInfo.ProtoReflect.Descriptor instead.
+ func (*GeneratedCodeInfo) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22}
+ }
+ 
+ func (x *GeneratedCodeInfo) GetAnnotation() []*GeneratedCodeInfo_Annotation {
+@@ -2956,7 +3654,7 @@ type DescriptorProto_ExtensionRange struct {
+ func (x *DescriptorProto_ExtensionRange) Reset() {
+ 	*x = DescriptorProto_ExtensionRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2969,7 +3667,7 @@ func (x *DescriptorProto_ExtensionRange) String() string {
+ func (*DescriptorProto_ExtensionRange) ProtoMessage() {}
+ 
+ func (x *DescriptorProto_ExtensionRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3021,7 +3719,7 @@ type DescriptorProto_ReservedRange struct {
+ func (x *DescriptorProto_ReservedRange) Reset() {
+ 	*x = DescriptorProto_ReservedRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3034,7 +3732,7 @@ func (x *DescriptorProto_ReservedRange) String() string {
+ func (*DescriptorProto_ReservedRange) ProtoMessage() {}
+ 
+ func (x *DescriptorProto_ReservedRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3078,10 +3776,6 @@ type ExtensionRangeOptions_Declaration struct {
+ 	// Metadata.type, Declaration.type must have a leading dot for messages
+ 	// and enums.
+ 	Type *string `protobuf:"bytes,3,opt,name=type" json:"type,omitempty"`
+-	// Deprecated. Please use "repeated".
+-	//
+-	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-	IsRepeated *bool `protobuf:"varint,4,opt,name=is_repeated,json=isRepeated" json:"is_repeated,omitempty"`
+ 	// If true, indicates that the number is reserved in the extension range,
+ 	// and any extension field with the number will fail to compile. Set this
+ 	// when a declared extension field is deleted.
+@@ -3094,7 +3788,7 @@ type ExtensionRangeOptions_Declaration struct {
+ func (x *ExtensionRangeOptions_Declaration) Reset() {
+ 	*x = ExtensionRangeOptions_Declaration{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3107,7 +3801,7 @@ func (x *ExtensionRangeOptions_Declaration) String() string {
+ func (*ExtensionRangeOptions_Declaration) ProtoMessage() {}
+ 
+ func (x *ExtensionRangeOptions_Declaration) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3144,14 +3838,6 @@ func (x *ExtensionRangeOptions_Declaration) GetType() string {
+ 	return ""
+ }
+ 
+-// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-func (x *ExtensionRangeOptions_Declaration) GetIsRepeated() bool {
+-	if x != nil && x.IsRepeated != nil {
+-		return *x.IsRepeated
+-	}
+-	return false
+-}
+-
+ func (x *ExtensionRangeOptions_Declaration) GetReserved() bool {
+ 	if x != nil && x.Reserved != nil {
+ 		return *x.Reserved
+@@ -3184,7 +3870,7 @@ type EnumDescriptorProto_EnumReservedRange struct {
+ func (x *EnumDescriptorProto_EnumReservedRange) Reset() {
+ 	*x = EnumDescriptorProto_EnumReservedRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3197,7 +3883,7 @@ func (x *EnumDescriptorProto_EnumReservedRange) String() string {
+ func (*EnumDescriptorProto_EnumReservedRange) ProtoMessage() {}
+ 
+ func (x *EnumDescriptorProto_EnumReservedRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3227,6 +3913,61 @@ func (x *EnumDescriptorProto_EnumReservedRange) GetEnd() int32 {
+ 	return 0
+ }
+ 
++type FieldOptions_EditionDefault struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Edition *Edition `protobuf:"varint,3,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
++	Value   *string  `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"` // Textproto value.
++}
++
++func (x *FieldOptions_EditionDefault) Reset() {
++	*x = FieldOptions_EditionDefault{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FieldOptions_EditionDefault) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FieldOptions_EditionDefault) ProtoMessage() {}
++
++func (x *FieldOptions_EditionDefault) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FieldOptions_EditionDefault.ProtoReflect.Descriptor instead.
++func (*FieldOptions_EditionDefault) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{12, 0}
++}
++
++func (x *FieldOptions_EditionDefault) GetEdition() Edition {
++	if x != nil && x.Edition != nil {
++		return *x.Edition
++	}
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FieldOptions_EditionDefault) GetValue() string {
++	if x != nil && x.Value != nil {
++		return *x.Value
++	}
++	return ""
++}
++
+ // The name of the uninterpreted option.  Each string represents a segment in
+ // a dot-separated name.  is_extension is true iff a segment represents an
+ // extension (denoted with parentheses in options specs in .proto files).
+@@ -3244,7 +3985,7 @@ type UninterpretedOption_NamePart struct {
+ func (x *UninterpretedOption_NamePart) Reset() {
+ 	*x = UninterpretedOption_NamePart{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[28]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3257,7 +3998,7 @@ func (x *UninterpretedOption_NamePart) String() string {
+ func (*UninterpretedOption_NamePart) ProtoMessage() {}
+ 
+ func (x *UninterpretedOption_NamePart) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[28]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3287,6 +4028,65 @@ func (x *UninterpretedOption_NamePart) GetIsExtension() bool {
+ 	return false
+ }
+ 
++// A map from every known edition with a unique set of defaults to its
++// defaults. Not all editions may be contained here.  For a given edition,
++// the defaults at the closest matching edition ordered at or before it should
++// be used.  This field must be in strict ascending order by edition.
++type FeatureSetDefaults_FeatureSetEditionDefault struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Edition  *Edition    `protobuf:"varint,3,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
++	Features *FeatureSet `protobuf:"bytes,2,opt,name=features" json:"features,omitempty"`
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) Reset() {
++	*x = FeatureSetDefaults_FeatureSetEditionDefault{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[29]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSetDefaults_FeatureSetEditionDefault) ProtoMessage() {}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[29]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FeatureSetDefaults_FeatureSetEditionDefault.ProtoReflect.Descriptor instead.
++func (*FeatureSetDefaults_FeatureSetEditionDefault) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0}
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) GetEdition() Edition {
++	if x != nil && x.Edition != nil {
++		return *x.Edition
++	}
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ type SourceCodeInfo_Location struct {
+ 	state         protoimpl.MessageState
+ 	sizeCache     protoimpl.SizeCache
+@@ -3296,7 +4096,7 @@ type SourceCodeInfo_Location struct {
+ 	// location.
+ 	//
+ 	// Each element is a field number or an index.  They form a path from
+-	// the root FileDescriptorProto to the place where the definition occurs.
++	// the root FileDescriptorProto to the place where the definition appears.
+ 	// For example, this path:
+ 	//
+ 	//	[ 4, 3, 2, 7, 1 ]
+@@ -3388,7 +4188,7 @@ type SourceCodeInfo_Location struct {
+ func (x *SourceCodeInfo_Location) Reset() {
+ 	*x = SourceCodeInfo_Location{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[30]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3401,7 +4201,7 @@ func (x *SourceCodeInfo_Location) String() string {
+ func (*SourceCodeInfo_Location) ProtoMessage() {}
+ 
+ func (x *SourceCodeInfo_Location) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[30]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3414,7 +4214,7 @@ func (x *SourceCodeInfo_Location) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use SourceCodeInfo_Location.ProtoReflect.Descriptor instead.
+ func (*SourceCodeInfo_Location) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{21, 0}
+ }
+ 
+ func (x *SourceCodeInfo_Location) GetPath() []int32 {
+@@ -3475,7 +4275,7 @@ type GeneratedCodeInfo_Annotation struct {
+ func (x *GeneratedCodeInfo_Annotation) Reset() {
+ 	*x = GeneratedCodeInfo_Annotation{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[31]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3488,7 +4288,7 @@ func (x *GeneratedCodeInfo_Annotation) String() string {
+ func (*GeneratedCodeInfo_Annotation) ProtoMessage() {}
+ 
+ func (x *GeneratedCodeInfo_Annotation) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[31]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3501,7 +4301,7 @@ func (x *GeneratedCodeInfo_Annotation) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use GeneratedCodeInfo_Annotation.ProtoReflect.Descriptor instead.
+ func (*GeneratedCodeInfo_Annotation) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22, 0}
+ }
+ 
+ func (x *GeneratedCodeInfo_Annotation) GetPath() []int32 {
+@@ -3550,7 +4350,7 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+ 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73,
+ 	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x04, 0x66, 0x69,
+-	0x6c, 0x65, 0x22, 0xfe, 0x04, 0x0a, 0x13, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72,
++	0x6c, 0x65, 0x22, 0x98, 0x05, 0x0a, 0x13, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72,
+ 	0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61,
+ 	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x18,
+ 	0x0a, 0x07, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+@@ -3588,250 +4388,250 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
+ 	0x6f, 0x52, 0x0e, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
+ 	0x6f, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x18, 0x0c, 0x20, 0x01, 0x28,
+-	0x09, 0x52, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x12, 0x18, 0x0a, 0x07, 0x65, 0x64, 0x69,
+-	0x74, 0x69, 0x6f, 0x6e, 0x18, 0x0d, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74,
+-	0x69, 0x6f, 0x6e, 0x22, 0xb9, 0x06, 0x0a, 0x0f, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
+-	0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
+-	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3b, 0x0a, 0x05, 0x66,
+-	0x69, 0x65, 0x6c, 0x64, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f,
+-	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65,
+-	0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
+-	0x6f, 0x52, 0x05, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x12, 0x43, 0x0a, 0x09, 0x65, 0x78, 0x74, 0x65,
+-	0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69,
+-	0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
+-	0x74, 0x6f, 0x52, 0x09, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a,
+-	0x0b, 0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x03,
+-	0x28, 0x0b, 0x32, 0x20, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+-	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
+-	0x72, 0x6f, 0x74, 0x6f, 0x52, 0x0a, 0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x54, 0x79, 0x70, 0x65,
+-	0x12, 0x41, 0x0a, 0x09, 0x65, 0x6e, 0x75, 0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x04, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
+-	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54,
+-	0x79, 0x70, 0x65, 0x12, 0x58, 0x0a, 0x0f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e,
+-	0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x67,
++	0x09, 0x52, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x12, 0x32, 0x0a, 0x07, 0x65, 0x64, 0x69,
++	0x74, 0x69, 0x6f, 0x6e, 0x18, 0x0e, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69,
++	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0xb9, 0x06,
++	0x0a, 0x0f, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3b, 0x0a, 0x05, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x18, 0x02,
++	0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63,
++	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05, 0x66, 0x69, 0x65,
++	0x6c, 0x64, 0x12, 0x43, 0x0a, 0x09, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18,
++	0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73,
++	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x09, 0x65, 0x78,
++	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a, 0x0b, 0x6e, 0x65, 0x73, 0x74, 0x65,
++	0x64, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x20, 0x2e, 0x67,
+ 	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45,
+-	0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0e, 0x65,
+-	0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x44, 0x0a,
+-	0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x64, 0x65, 0x63, 0x6c, 0x18, 0x08, 0x20, 0x03, 0x28,
+-	0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+-	0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x09, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x44,
+-	0x65, 0x63, 0x6c, 0x12, 0x39, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x07,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x55,
+-	0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65,
+-	0x18, 0x09, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x0a,
++	0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x54, 0x79, 0x70, 0x65, 0x12, 0x41, 0x0a, 0x09, 0x65, 0x6e,
++	0x75, 0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72,
++	0x6f, 0x74, 0x6f, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54, 0x79, 0x70, 0x65, 0x12, 0x58, 0x0a,
++	0x0f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65,
++	0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+ 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
++	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69,
++	0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0e, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69,
++	0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x44, 0x0a, 0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66,
++	0x5f, 0x64, 0x65, 0x63, 0x6c, 0x18, 0x08, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e,
++	0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
++	0x74, 0x6f, 0x52, 0x09, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x63, 0x6c, 0x12, 0x39, 0x0a,
++	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52,
++	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x55, 0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65,
++	0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x09, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
++	0x74, 0x6f, 0x2e, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65,
++	0x52, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12,
++	0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65,
++	0x18, 0x0a, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64,
++	0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x7a, 0x0a, 0x0e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
++	0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18,
++	0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03,
++	0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x12, 0x40,
++	0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
++	0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x1a, 0x37, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67,
++	0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05,
++	0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02,
++	0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0xcc, 0x04, 0x0a, 0x15, 0x45, 0x78,
++	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
++	0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03,
++	0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x59, 0x0a,
++	0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x03,
++	0x28, 0x0b, 0x32, 0x32, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61,
++	0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x44, 0x65, 0x63, 0x6c, 0x61,
++	0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x03, 0x88, 0x01, 0x02, 0x52, 0x0b, 0x64, 0x65, 0x63,
++	0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x73, 0x18, 0x32, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x12, 0x6d, 0x0a, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f,
++	0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x38, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73,
++	0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
++	0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74,
++	0x65, 0x3a, 0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x42, 0x03, 0x88,
++	0x01, 0x02, 0x52, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x1a, 0x94, 0x01, 0x0a, 0x0b, 0x44, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05,
++	0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x1b, 0x0a, 0x09, 0x66, 0x75, 0x6c, 0x6c,
++	0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x66, 0x75, 0x6c,
++	0x6c, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20,
++	0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73,
++	0x65, 0x72, 0x76, 0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x73,
++	0x65, 0x72, 0x76, 0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65,
++	0x64, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65,
++	0x64, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x22, 0x34, 0x0a, 0x11, 0x56, 0x65, 0x72, 0x69, 0x66,
++	0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x0f, 0x0a, 0x0b,
++	0x44, 0x45, 0x43, 0x4c, 0x41, 0x52, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x10, 0x00, 0x12, 0x0e, 0x0a,
++	0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x01, 0x2a, 0x09, 0x08,
++	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0xc1, 0x06, 0x0a, 0x14, 0x46, 0x69, 0x65,
++	0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18,
++	0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x41, 0x0a,
++	0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
++	0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72,
++	0x6f, 0x74, 0x6f, 0x2e, 0x4c, 0x61, 0x62, 0x65, 0x6c, 0x52, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c,
++	0x12, 0x3e, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2a,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72,
++	0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x54, 0x79, 0x70, 0x65, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65,
++	0x12, 0x1b, 0x0a, 0x09, 0x74, 0x79, 0x70, 0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x06, 0x20,
++	0x01, 0x28, 0x09, 0x52, 0x08, 0x74, 0x79, 0x70, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1a, 0x0a,
++	0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x64, 0x65, 0x66,
++	0x61, 0x75, 0x6c, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09,
++	0x52, 0x0c, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x1f,
++	0x0a, 0x0b, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x69, 0x6e, 0x64, 0x65, 0x78, 0x18, 0x09, 0x20,
++	0x01, 0x28, 0x05, 0x52, 0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12,
++	0x1b, 0x0a, 0x09, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x08, 0x6a, 0x73, 0x6f, 0x6e, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x27, 0x0a, 0x0f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x18, 0x11, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x22, 0xb6,
++	0x02, 0x0a, 0x04, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x44, 0x4f, 0x55, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x46, 0x4c, 0x4f, 0x41, 0x54, 0x10, 0x02, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x03, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x55, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x04, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x05, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34, 0x10, 0x06, 0x12, 0x10, 0x0a, 0x0c, 0x54,
++	0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32, 0x10, 0x07, 0x12, 0x0d, 0x0a,
++	0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x4f, 0x4f, 0x4c, 0x10, 0x08, 0x12, 0x0f, 0x0a, 0x0b,
++	0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x09, 0x12, 0x0e, 0x0a,
++	0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x47, 0x52, 0x4f, 0x55, 0x50, 0x10, 0x0a, 0x12, 0x10, 0x0a,
++	0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x10, 0x0b, 0x12,
++	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x59, 0x54, 0x45, 0x53, 0x10, 0x0c, 0x12,
++	0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x0d,
++	0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x10, 0x0e, 0x12,
++	0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32,
++	0x10, 0x0f, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45,
++	0x44, 0x36, 0x34, 0x10, 0x10, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49,
++	0x4e, 0x54, 0x33, 0x32, 0x10, 0x11, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53,
++	0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x12, 0x22, 0x43, 0x0a, 0x05, 0x4c, 0x61, 0x62, 0x65, 0x6c,
++	0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x4f, 0x50, 0x54, 0x49, 0x4f, 0x4e,
++	0x41, 0x4c, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45,
++	0x50, 0x45, 0x41, 0x54, 0x45, 0x44, 0x10, 0x03, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45,
++	0x4c, 0x5f, 0x52, 0x45, 0x51, 0x55, 0x49, 0x52, 0x45, 0x44, 0x10, 0x02, 0x22, 0x63, 0x0a, 0x14,
++	0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
++	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f,
++	0x66, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x73, 0x22, 0xe3, 0x02, 0x0a, 0x13, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
++	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d,
++	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3f, 0x0a,
++	0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x29, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45,
++	0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
++	0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x36,
++	0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
++	0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x5d, 0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
++	0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x36,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+ 	0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64,
+ 	0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65,
+-	0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x7a, 0x0a, 0x0e, 0x45, 0x78,
+-	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05,
+-	0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61,
+-	0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52,
+-	0x03, 0x65, 0x6e, 0x64, 0x12, 0x40, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18,
+-	0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
+-	0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x1a, 0x37, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a,
+-	0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22,
+-	0xad, 0x04, 0x0a, 0x15, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e,
+-	0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+-	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x12, 0x59, 0x0a, 0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69,
+-	0x6f, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x32, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e,
+-	0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+-	0x2e, 0x44, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x03, 0x88, 0x01,
+-	0x02, 0x52, 0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x68,
+-	0x0a, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x0e, 0x32, 0x38, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e,
+-	0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x56, 0x65, 0x72,
+-	0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x3a, 0x0a,
+-	0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x52, 0x0c, 0x76, 0x65, 0x72, 0x69,
+-	0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xb3, 0x01, 0x0a, 0x0b, 0x44, 0x65, 0x63,
+-	0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62,
+-	0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72,
+-	0x12, 0x1b, 0x0a, 0x09, 0x66, 0x75, 0x6c, 0x6c, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20,
+-	0x01, 0x28, 0x09, 0x52, 0x08, 0x66, 0x75, 0x6c, 0x6c, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x12, 0x0a,
+-	0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70,
+-	0x65, 0x12, 0x23, 0x0a, 0x0b, 0x69, 0x73, 0x5f, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64,
+-	0x18, 0x04, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x0a, 0x69, 0x73, 0x52, 0x65,
+-	0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x18, 0x06,
+-	0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x22, 0x34,
+-	0x0a, 0x11, 0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74,
+-	0x61, 0x74, 0x65, 0x12, 0x0f, 0x0a, 0x0b, 0x44, 0x45, 0x43, 0x4c, 0x41, 0x52, 0x41, 0x54, 0x49,
+-	0x4f, 0x4e, 0x10, 0x00, 0x12, 0x0e, 0x0a, 0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49,
+-	0x45, 0x44, 0x10, 0x01, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22,
+-	0xc1, 0x06, 0x0a, 0x14, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06,
+-	0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75,
+-	0x6d, 0x62, 0x65, 0x72, 0x12, 0x41, 0x0a, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x18, 0x04, 0x20,
+-	0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72,
+-	0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x4c, 0x61, 0x62, 0x65, 0x6c,
+-	0x52, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x12, 0x3e, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18,
+-	0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73,
+-	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x54, 0x79, 0x70,
+-	0x65, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1b, 0x0a, 0x09, 0x74, 0x79, 0x70, 0x65, 0x5f,
+-	0x6e, 0x61, 0x6d, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x74, 0x79, 0x70, 0x65,
+-	0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65,
+-	0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65,
+-	0x12, 0x23, 0x0a, 0x0d, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75,
+-	0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0c, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74,
+-	0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x69,
+-	0x6e, 0x64, 0x65, 0x78, 0x18, 0x09, 0x20, 0x01, 0x28, 0x05, 0x52, 0x0a, 0x6f, 0x6e, 0x65, 0x6f,
+-	0x66, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12, 0x1b, 0x0a, 0x09, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x6a, 0x73, 0x6f, 0x6e, 0x4e,
+-	0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x08,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69,
+-	0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x27, 0x0a, 0x0f,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x18,
+-	0x11, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x22, 0xb6, 0x02, 0x0a, 0x04, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0f,
+-	0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x44, 0x4f, 0x55, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12,
+-	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x4c, 0x4f, 0x41, 0x54, 0x10, 0x02, 0x12,
+-	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x03, 0x12,
+-	0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x04,
+-	0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x05,
+-	0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34,
+-	0x10, 0x06, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44,
+-	0x33, 0x32, 0x10, 0x07, 0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x4f, 0x4f,
+-	0x4c, 0x10, 0x08, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x54, 0x52, 0x49,
+-	0x4e, 0x47, 0x10, 0x09, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x47, 0x52, 0x4f,
+-	0x55, 0x50, 0x10, 0x0a, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53,
+-	0x53, 0x41, 0x47, 0x45, 0x10, 0x0b, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42,
+-	0x59, 0x54, 0x45, 0x53, 0x10, 0x0c, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55,
+-	0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x0d, 0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f,
+-	0x45, 0x4e, 0x55, 0x4d, 0x10, 0x0e, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53,
+-	0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32, 0x10, 0x0f, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34, 0x10, 0x10, 0x12, 0x0f, 0x0a, 0x0b,
+-	0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x11, 0x12, 0x0f, 0x0a,
+-	0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x12, 0x22, 0x43,
+-	0x0a, 0x05, 0x4c, 0x61, 0x62, 0x65, 0x6c, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c,
+-	0x5f, 0x4f, 0x50, 0x54, 0x49, 0x4f, 0x4e, 0x41, 0x4c, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c,
+-	0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45, 0x51, 0x55, 0x49, 0x52, 0x45, 0x44, 0x10, 0x02, 0x12,
+-	0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45, 0x50, 0x45, 0x41, 0x54, 0x45,
+-	0x44, 0x10, 0x03, 0x22, 0x63, 0x0a, 0x14, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b,
+-	0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
+-	0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52,
+-	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0xe3, 0x02, 0x0a, 0x13, 0x45, 0x6e, 0x75,
+-	0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f,
+-	0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04,
+-	0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3f, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05,
+-	0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x36, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+-	0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x5d, 0x0a,
+-	0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18,
+-	0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x36, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x6e, 0x75, 0x6d,
+-	0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0d, 0x72,
+-	0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d,
+-	0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x05, 0x20,
+-	0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d,
+-	0x65, 0x1a, 0x3b, 0x0a, 0x11, 0x45, 0x6e, 0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18,
+-	0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03,
+-	0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0x83,
+-	0x01, 0x0a, 0x18, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52,
+-	0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x3b, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56,
+-	0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x22, 0xa7, 0x01, 0x0a, 0x16, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+-	0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12,
+-	0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x12, 0x3e, 0x0a, 0x06, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x18, 0x02, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x06, 0x6d, 0x65, 0x74,
+-	0x68, 0x6f, 0x64, 0x12, 0x39, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0x89,
+-	0x02, 0x0a, 0x15, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
++	0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x05, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65,
++	0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x3b, 0x0a, 0x11, 0x45, 0x6e,
++	0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12,
++	0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05,
++	0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01,
++	0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0x83, 0x01, 0x0a, 0x18, 0x45, 0x6e, 0x75, 0x6d,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62,
++	0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72,
++	0x12, 0x3b, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28,
++	0x0b, 0x32, 0x21, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74,
++	0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0xa7, 0x01,
++	0x0a, 0x16, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+ 	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1d, 0x0a, 0x0a,
+-	0x69, 0x6e, 0x70, 0x75, 0x74, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x09, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f,
+-	0x75, 0x74, 0x70, 0x75, 0x74, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x0a, 0x6f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x38, 0x0a, 0x07,
+-	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e,
++	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3e, 0x0a, 0x06,
++	0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d,
++	0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x52, 0x06, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x12, 0x39, 0x0a, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e,
+ 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+-	0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x30, 0x0a, 0x10, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74,
+-	0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08,
+-	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0f, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x53,
+-	0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x12, 0x30, 0x0a, 0x10, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x72, 0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x06, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0f, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x72, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x22, 0x91, 0x09, 0x0a, 0x0b, 0x46,
+-	0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x21, 0x0a, 0x0c, 0x6a, 0x61,
+-	0x76, 0x61, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x0b, 0x6a, 0x61, 0x76, 0x61, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x30, 0x0a,
+-	0x14, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6f, 0x75, 0x74, 0x65, 0x72, 0x5f, 0x63, 0x6c, 0x61, 0x73,
+-	0x73, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x6a, 0x61, 0x76,
+-	0x61, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x43, 0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x35, 0x0a, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65,
+-	0x5f, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x11, 0x6a, 0x61, 0x76, 0x61, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c,
+-	0x65, 0x46, 0x69, 0x6c, 0x65, 0x73, 0x12, 0x44, 0x0a, 0x1d, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67,
+-	0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x5f, 0x61,
+-	0x6e, 0x64, 0x5f, 0x68, 0x61, 0x73, 0x68, 0x18, 0x14, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18,
+-	0x01, 0x52, 0x19, 0x6a, 0x61, 0x76, 0x61, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x45,
+-	0x71, 0x75, 0x61, 0x6c, 0x73, 0x41, 0x6e, 0x64, 0x48, 0x61, 0x73, 0x68, 0x12, 0x3a, 0x0a, 0x16,
+-	0x6a, 0x61, 0x76, 0x61, 0x5f, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x68, 0x65, 0x63,
+-	0x6b, 0x5f, 0x75, 0x74, 0x66, 0x38, 0x18, 0x1b, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43,
+-	0x68, 0x65, 0x63, 0x6b, 0x55, 0x74, 0x66, 0x38, 0x12, 0x53, 0x0a, 0x0c, 0x6f, 0x70, 0x74, 0x69,
+-	0x6d, 0x69, 0x7a, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x29,
+-	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+-	0x2e, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74,
+-	0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64, 0x65, 0x3a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44,
+-	0x52, 0x0b, 0x6f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x46, 0x6f, 0x72, 0x12, 0x1d, 0x0a,
+-	0x0a, 0x67, 0x6f, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x0b, 0x20, 0x01, 0x28,
+-	0x09, 0x52, 0x09, 0x67, 0x6f, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x35, 0x0a, 0x13,
+-	0x63, 0x63, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69,
+-	0x63, 0x65, 0x73, 0x18, 0x10, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
+-	0x52, 0x11, 0x63, 0x63, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69,
+-	0x63, 0x65, 0x73, 0x12, 0x39, 0x0a, 0x15, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65,
+-	0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x11, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x47,
+-	0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x35,
+-	0x0a, 0x13, 0x70, 0x79, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72,
+-	0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x12, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
+-	0x73, 0x65, 0x52, 0x11, 0x70, 0x79, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72,
+-	0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x37, 0x0a, 0x14, 0x70, 0x68, 0x70, 0x5f, 0x67, 0x65, 0x6e,
+-	0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x2a, 0x20,
+-	0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x12, 0x70, 0x68, 0x70, 0x47,
++	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0x89, 0x02, 0x0a, 0x15, 0x4d, 0x65, 0x74, 0x68,
++	0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1d, 0x0a, 0x0a, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x5f, 0x74,
++	0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x69, 0x6e, 0x70, 0x75, 0x74,
++	0x54, 0x79, 0x70, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x5f, 0x74,
++	0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x6f, 0x75, 0x74, 0x70, 0x75,
++	0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x38, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12,
++	0x30, 0x0a, 0x10, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d,
++	0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x0f, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e,
++	0x67, 0x12, 0x30, 0x0a, 0x10, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x5f, 0x73, 0x74, 0x72, 0x65,
++	0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x0f, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d,
++	0x69, 0x6e, 0x67, 0x22, 0x97, 0x09, 0x0a, 0x0b, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x21, 0x0a, 0x0c, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x70, 0x61, 0x63, 0x6b,
++	0x61, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x6a, 0x61, 0x76, 0x61, 0x50,
++	0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x30, 0x0a, 0x14, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6f,
++	0x75, 0x74, 0x65, 0x72, 0x5f, 0x63, 0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x08,
++	0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x6a, 0x61, 0x76, 0x61, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x43,
++	0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x35, 0x0a, 0x13, 0x6a, 0x61, 0x76, 0x61,
++	0x5f, 0x6d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x5f, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x18,
++	0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x6a, 0x61,
++	0x76, 0x61, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x73, 0x12,
++	0x44, 0x0a, 0x1d, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
++	0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x5f, 0x61, 0x6e, 0x64, 0x5f, 0x68, 0x61, 0x73, 0x68,
++	0x18, 0x14, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x19, 0x6a, 0x61, 0x76, 0x61,
++	0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x45, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x41, 0x6e,
++	0x64, 0x48, 0x61, 0x73, 0x68, 0x12, 0x3a, 0x0a, 0x16, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x73, 0x74,
++	0x72, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x5f, 0x75, 0x74, 0x66, 0x38, 0x18,
++	0x1b, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61,
++	0x76, 0x61, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x55, 0x74, 0x66,
++	0x38, 0x12, 0x53, 0x0a, 0x0c, 0x6f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x5f, 0x66, 0x6f,
++	0x72, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f,
++	0x64, 0x65, 0x3a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44, 0x52, 0x0b, 0x6f, 0x70, 0x74, 0x69, 0x6d,
++	0x69, 0x7a, 0x65, 0x46, 0x6f, 0x72, 0x12, 0x1d, 0x0a, 0x0a, 0x67, 0x6f, 0x5f, 0x70, 0x61, 0x63,
++	0x6b, 0x61, 0x67, 0x65, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x67, 0x6f, 0x50, 0x61,
++	0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x35, 0x0a, 0x13, 0x63, 0x63, 0x5f, 0x67, 0x65, 0x6e, 0x65,
++	0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x10, 0x20, 0x01,
++	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x63, 0x63, 0x47, 0x65, 0x6e,
++	0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x39, 0x0a, 0x15,
++	0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72,
++	0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x11, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53,
++	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x35, 0x0a, 0x13, 0x70, 0x79, 0x5f, 0x67, 0x65,
++	0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x12,
++	0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x70, 0x79, 0x47,
+ 	0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x25,
+ 	0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x17, 0x20, 0x01,
+ 	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65,
+@@ -3856,259 +4656,419 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x70, 0x68, 0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x4e, 0x61, 0x6d, 0x65, 0x73,
+ 	0x70, 0x61, 0x63, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x72, 0x75, 0x62, 0x79, 0x5f, 0x70, 0x61, 0x63,
+ 	0x6b, 0x61, 0x67, 0x65, 0x18, 0x2d, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x72, 0x75, 0x62, 0x79,
+-	0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18,
+-	0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72,
+-	0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e,
+-	0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x22, 0x3a, 0x0a, 0x0c, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64,
+-	0x65, 0x12, 0x09, 0x0a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09,
+-	0x43, 0x4f, 0x44, 0x45, 0x5f, 0x53, 0x49, 0x5a, 0x45, 0x10, 0x02, 0x12, 0x10, 0x0a, 0x0c, 0x4c,
+-	0x49, 0x54, 0x45, 0x5f, 0x52, 0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x03, 0x2a, 0x09, 0x08,
+-	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x26, 0x10, 0x27, 0x22, 0xbb,
+-	0x03, 0x0a, 0x0e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x73, 0x12, 0x3c, 0x0a, 0x17, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x65, 0x74,
+-	0x5f, 0x77, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x01, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x14, 0x6d, 0x65, 0x73, 0x73, 0x61,
+-	0x67, 0x65, 0x53, 0x65, 0x74, 0x57, 0x69, 0x72, 0x65, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12,
+-	0x4c, 0x0a, 0x1f, 0x6e, 0x6f, 0x5f, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x5f, 0x64,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73,
+-	0x6f, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
+-	0x1c, 0x6e, 0x6f, 0x53, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72,
+-	0x69, 0x70, 0x74, 0x6f, 0x72, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f, 0x72, 0x12, 0x25, 0x0a,
+-	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28,
+-	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63,
+-	0x61, 0x74, 0x65, 0x64, 0x12, 0x1b, 0x0a, 0x09, 0x6d, 0x61, 0x70, 0x5f, 0x65, 0x6e, 0x74, 0x72,
+-	0x79, 0x18, 0x07, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x6d, 0x61, 0x70, 0x45, 0x6e, 0x74, 0x72,
+-	0x79, 0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f,
+-	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c,
+-	0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28,
+-	0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+-	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x04, 0x10, 0x05, 0x4a, 0x04, 0x08, 0x05, 0x10, 0x06, 0x4a, 0x04, 0x08, 0x06, 0x10, 0x07,
+-	0x4a, 0x04, 0x08, 0x08, 0x10, 0x09, 0x4a, 0x04, 0x08, 0x09, 0x10, 0x0a, 0x22, 0x85, 0x09, 0x0a,
+-	0x0c, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x41, 0x0a,
+-	0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x23, 0x2e, 0x67,
+-	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
+-	0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x43, 0x54, 0x79, 0x70,
+-	0x65, 0x3a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x52, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65,
+-	0x12, 0x16, 0x0a, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08,
+-	0x52, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x12, 0x47, 0x0a, 0x06, 0x6a, 0x73, 0x74, 0x79,
+-	0x70, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x09,
+-	0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x52, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70,
+-	0x65, 0x12, 0x19, 0x0a, 0x04, 0x6c, 0x61, 0x7a, 0x79, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a,
+-	0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04, 0x6c, 0x61, 0x7a, 0x79, 0x12, 0x2e, 0x0a, 0x0f,
+-	0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64, 0x5f, 0x6c, 0x61, 0x7a, 0x79, 0x18,
+-	0x0f, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0e, 0x75, 0x6e,
+-	0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64, 0x4c, 0x61, 0x7a, 0x79, 0x12, 0x25, 0x0a, 0x0a,
++	0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75,
++	0x72, 0x65, 0x73, 0x18, 0x32, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
++	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73,
++	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
++	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
++	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
++	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x3a, 0x0a, 0x0c, 0x4f, 0x70,
++	0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64, 0x65, 0x12, 0x09, 0x0a, 0x05, 0x53, 0x50,
++	0x45, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x43, 0x4f, 0x44, 0x45, 0x5f, 0x53, 0x49,
++	0x5a, 0x45, 0x10, 0x02, 0x12, 0x10, 0x0a, 0x0c, 0x4c, 0x49, 0x54, 0x45, 0x5f, 0x52, 0x55, 0x4e,
++	0x54, 0x49, 0x4d, 0x45, 0x10, 0x03, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80,
++	0x02, 0x4a, 0x04, 0x08, 0x2a, 0x10, 0x2b, 0x4a, 0x04, 0x08, 0x26, 0x10, 0x27, 0x22, 0xf4, 0x03,
++	0x0a, 0x0e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x12, 0x3c, 0x0a, 0x17, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x65, 0x74, 0x5f,
++	0x77, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28,
++	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x14, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67,
++	0x65, 0x53, 0x65, 0x74, 0x57, 0x69, 0x72, 0x65, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12, 0x4c,
++	0x0a, 0x1f, 0x6e, 0x6f, 0x5f, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x5f, 0x64, 0x65,
++	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f,
++	0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x1c,
++	0x6e, 0x6f, 0x53, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
++	0x70, 0x74, 0x6f, 0x72, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f, 0x72, 0x12, 0x25, 0x0a, 0x0a,
+ 	0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08,
+ 	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
+-	0x74, 0x65, 0x64, 0x12, 0x19, 0x0a, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x18, 0x0a, 0x20, 0x01, 0x28,
+-	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x12, 0x28,
+-	0x0a, 0x0c, 0x64, 0x65, 0x62, 0x75, 0x67, 0x5f, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x10,
+-	0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62,
+-	0x75, 0x67, 0x52, 0x65, 0x64, 0x61, 0x63, 0x74, 0x12, 0x4b, 0x0a, 0x09, 0x72, 0x65, 0x74, 0x65,
+-	0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x11, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2d, 0x2e, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69,
+-	0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x09, 0x72, 0x65, 0x74, 0x65,
+-	0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x4a, 0x0a, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x18,
+-	0x12, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65,
+-	0x74, 0x54, 0x79, 0x70, 0x65, 0x42, 0x02, 0x18, 0x01, 0x52, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65,
+-	0x74, 0x12, 0x48, 0x0a, 0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x18, 0x13, 0x20, 0x03,
+-	0x28, 0x0e, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+-	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79,
+-	0x70, 0x65, 0x52, 0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75,
+-	0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f,
+-	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x2f, 0x0a, 0x05, 0x43, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0a,
+-	0x0a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x43, 0x4f,
+-	0x52, 0x44, 0x10, 0x01, 0x12, 0x10, 0x0a, 0x0c, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x5f, 0x50,
+-	0x49, 0x45, 0x43, 0x45, 0x10, 0x02, 0x22, 0x35, 0x0a, 0x06, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65,
+-	0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x10, 0x00, 0x12,
+-	0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x01, 0x12, 0x0d,
+-	0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x55, 0x4d, 0x42, 0x45, 0x52, 0x10, 0x02, 0x22, 0x55, 0x0a,
+-	0x0f, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e,
+-	0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e,
+-	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e,
+-	0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x52, 0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x01, 0x12, 0x14,
+-	0x0a, 0x10, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x4f, 0x55, 0x52,
+-	0x43, 0x45, 0x10, 0x02, 0x22, 0x8c, 0x02, 0x0a, 0x10, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54,
+-	0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e,
+-	0x10, 0x00, 0x12, 0x14, 0x0a, 0x10, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x46, 0x49, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x1f, 0x0a, 0x1b, 0x54, 0x41, 0x52, 0x47,
+-	0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f,
+-	0x4e, 0x5f, 0x52, 0x41, 0x4e, 0x47, 0x45, 0x10, 0x02, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45,
+-	0x10, 0x03, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x46, 0x49, 0x45, 0x4c, 0x44, 0x10, 0x04, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4f, 0x4e, 0x45, 0x4f, 0x46, 0x10, 0x05,
+-	0x12, 0x14, 0x0a, 0x10, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
+-	0x45, 0x4e, 0x55, 0x4d, 0x10, 0x06, 0x12, 0x1a, 0x0a, 0x16, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54,
+-	0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x45, 0x4e, 0x54, 0x52, 0x59,
+-	0x10, 0x07, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x53, 0x45, 0x52, 0x56, 0x49, 0x43, 0x45, 0x10, 0x08, 0x12, 0x16, 0x0a, 0x12, 0x54,
+-	0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x54, 0x48, 0x4f,
+-	0x44, 0x10, 0x09, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x04, 0x10, 0x05, 0x22, 0x73, 0x0a, 0x0c, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
+-	0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65,
+-	0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09,
+-	0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x98, 0x02, 0x0a, 0x0b, 0x45, 0x6e,
+-	0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x6c, 0x6c,
+-	0x6f, 0x77, 0x5f, 0x61, 0x6c, 0x69, 0x61, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0a,
+-	0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x41, 0x6c, 0x69, 0x61, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65,
+-	0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05,
+-	0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f,
+-	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c,
+-	0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28,
+-	0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
++	0x74, 0x65, 0x64, 0x12, 0x1b, 0x0a, 0x09, 0x6d, 0x61, 0x70, 0x5f, 0x65, 0x6e, 0x74, 0x72, 0x79,
++	0x18, 0x07, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x6d, 0x61, 0x70, 0x45, 0x6e, 0x74, 0x72, 0x79,
++	0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x6c,
++	0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c, 0x64,
++	0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x08,
++	0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64,
++	0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43,
++	0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x73, 0x18, 0x0c, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07,
++	0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x4a, 0x04, 0x08, 0x05,
++	0x10, 0x06, 0x4a, 0x04, 0x08, 0x06, 0x10, 0x07, 0x4a, 0x04, 0x08, 0x08, 0x10, 0x09, 0x4a, 0x04,
++	0x08, 0x09, 0x10, 0x0a, 0x22, 0xad, 0x0a, 0x0a, 0x0c, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x41, 0x0a, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01,
++	0x20, 0x01, 0x28, 0x0e, 0x32, 0x23, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x2e, 0x43, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e,
++	0x47, 0x52, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x70, 0x61, 0x63, 0x6b,
++	0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64,
++	0x12, 0x47, 0x0a, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e,
++	0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
++	0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41,
++	0x4c, 0x52, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70, 0x65, 0x12, 0x19, 0x0a, 0x04, 0x6c, 0x61, 0x7a,
++	0x79, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04,
++	0x6c, 0x61, 0x7a, 0x79, 0x12, 0x2e, 0x0a, 0x0f, 0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69,
++	0x65, 0x64, 0x5f, 0x6c, 0x61, 0x7a, 0x79, 0x18, 0x0f, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66,
++	0x61, 0x6c, 0x73, 0x65, 0x52, 0x0e, 0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64,
++	0x4c, 0x61, 0x7a, 0x79, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74,
++	0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
++	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x19, 0x0a, 0x04, 0x77,
++	0x65, 0x61, 0x6b, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x12, 0x28, 0x0a, 0x0c, 0x64, 0x65, 0x62, 0x75, 0x67, 0x5f,
++	0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x10, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
++	0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62, 0x75, 0x67, 0x52, 0x65, 0x64, 0x61, 0x63, 0x74,
++	0x12, 0x4b, 0x0a, 0x09, 0x72, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x11, 0x20,
++	0x01, 0x28, 0x0e, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69,
++	0x6f, 0x6e, 0x52, 0x09, 0x72, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x48, 0x0a,
++	0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x18, 0x13, 0x20, 0x03, 0x28, 0x0e, 0x32, 0x2e,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79, 0x70, 0x65, 0x52, 0x07,
++	0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x12, 0x57, 0x0a, 0x10, 0x65, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x5f, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x18, 0x14, 0x20, 0x03, 0x28,
++	0x0b, 0x32, 0x2c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x52,
++	0x0f, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73,
++	0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x15, 0x20, 0x01,
++	0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52,
++	0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+ 	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+ 	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+ 	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+ 	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+ 	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x05, 0x10, 0x06, 0x22, 0x9e, 0x01, 0x0a, 0x10, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c,
+-	0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70,
+-	0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66,
+-	0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64,
+-	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
+-	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
+-	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
+-	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
+-	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10,
+-	0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x9c, 0x01, 0x0a, 0x0e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63,
+-	0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72,
+-	0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12,
+-	0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
+-	0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24,
+-	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+-	0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65,
+-	0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80,
+-	0x80, 0x80, 0x80, 0x02, 0x22, 0xe0, 0x02, 0x0a, 0x0d, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63,
+-	0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73,
+-	0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x71, 0x0a,
+-	0x11, 0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x5f, 0x6c, 0x65, 0x76,
+-	0x65, 0x6c, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f,
+-	0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74,
+-	0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x3a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50,
+-	0x4f, 0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x52, 0x10,
+-	0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c,
+-	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
+-	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
+-	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
+-	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
+-	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x50, 0x0a, 0x10, 0x49, 0x64,
+-	0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12, 0x17,
+-	0x0a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e,
+-	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a, 0x0f, 0x4e, 0x4f, 0x5f, 0x53, 0x49,
+-	0x44, 0x45, 0x5f, 0x45, 0x46, 0x46, 0x45, 0x43, 0x54, 0x53, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a,
+-	0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45, 0x4e, 0x54, 0x10, 0x02, 0x2a, 0x09, 0x08, 0xe8,
+-	0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x9a, 0x03, 0x0a, 0x13, 0x55, 0x6e, 0x69, 0x6e,
+-	0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12,
+-	0x41, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e,
++	0x69, 0x6f, 0x6e, 0x1a, 0x5a, 0x0a, 0x0e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65,
++	0x66, 0x61, 0x75, 0x6c, 0x74, 0x12, 0x32, 0x0a, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e,
++	0x18, 0x03, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e,
++	0x52, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c,
++	0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x22,
++	0x2f, 0x0a, 0x05, 0x43, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x54, 0x52, 0x49,
++	0x4e, 0x47, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x43, 0x4f, 0x52, 0x44, 0x10, 0x01, 0x12, 0x10,
++	0x0a, 0x0c, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x5f, 0x50, 0x49, 0x45, 0x43, 0x45, 0x10, 0x02,
++	0x22, 0x35, 0x0a, 0x06, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53,
++	0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x10, 0x00, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f,
++	0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e,
++	0x55, 0x4d, 0x42, 0x45, 0x52, 0x10, 0x02, 0x22, 0x55, 0x0a, 0x0f, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45,
++	0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10,
++	0x00, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x52,
++	0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x01, 0x12, 0x14, 0x0a, 0x10, 0x52, 0x45, 0x54, 0x45,
++	0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x4f, 0x55, 0x52, 0x43, 0x45, 0x10, 0x02, 0x22, 0x8c,
++	0x02, 0x0a, 0x10, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54,
++	0x79, 0x70, 0x65, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x14, 0x0a, 0x10,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x4c, 0x45,
++	0x10, 0x01, 0x12, 0x1f, 0x0a, 0x1b, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x45, 0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f, 0x4e, 0x5f, 0x52, 0x41, 0x4e, 0x47,
++	0x45, 0x10, 0x02, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x10, 0x03, 0x12, 0x15, 0x0a, 0x11,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x45, 0x4c,
++	0x44, 0x10, 0x04, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x4f, 0x4e, 0x45, 0x4f, 0x46, 0x10, 0x05, 0x12, 0x14, 0x0a, 0x10, 0x54, 0x41,
++	0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x10, 0x06,
++	0x12, 0x1a, 0x0a, 0x16, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x45, 0x4e, 0x54, 0x52, 0x59, 0x10, 0x07, 0x12, 0x17, 0x0a, 0x13,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x45, 0x52, 0x56,
++	0x49, 0x43, 0x45, 0x10, 0x08, 0x12, 0x16, 0x0a, 0x12, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f,
++	0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x54, 0x48, 0x4f, 0x44, 0x10, 0x09, 0x2a, 0x09, 0x08,
++	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x4a, 0x04,
++	0x08, 0x12, 0x10, 0x13, 0x22, 0xac, 0x01, 0x0a, 0x0c, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72,
++	0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58,
++	0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
+ 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+ 	0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x52, 0x04, 0x6e, 0x61,
+-	0x6d, 0x65, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72,
+-	0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x69, 0x64,
+-	0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a,
+-	0x12, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76, 0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61,
+-	0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04, 0x52, 0x10, 0x70, 0x6f, 0x73, 0x69, 0x74,
+-	0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x6e,
+-	0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75,
+-	0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52, 0x10, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76,
+-	0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x64, 0x6f, 0x75,
+-	0x62, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x52,
+-	0x0b, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c,
+-	0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01,
+-	0x28, 0x0c, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12,
+-	0x27, 0x0a, 0x0f, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x5f, 0x76, 0x61, 0x6c,
+-	0x75, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67,
+-	0x61, 0x74, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x1a, 0x4a, 0x0a, 0x08, 0x4e, 0x61, 0x6d, 0x65,
+-	0x50, 0x61, 0x72, 0x74, 0x12, 0x1b, 0x0a, 0x09, 0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x70, 0x61, 0x72,
+-	0x74, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09, 0x52, 0x08, 0x6e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72,
+-	0x74, 0x12, 0x21, 0x0a, 0x0c, 0x69, 0x73, 0x5f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
+-	0x6e, 0x18, 0x02, 0x20, 0x02, 0x28, 0x08, 0x52, 0x0b, 0x69, 0x73, 0x45, 0x78, 0x74, 0x65, 0x6e,
+-	0x73, 0x69, 0x6f, 0x6e, 0x22, 0xa7, 0x02, 0x0a, 0x0e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43,
+-	0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x44, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x28, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
+-	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72,
+-	0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x4c, 0x6f, 0x63, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x52, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xce, 0x01,
+-	0x0a, 0x08, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61,
+-	0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61,
+-	0x74, 0x68, 0x12, 0x16, 0x0a, 0x04, 0x73, 0x70, 0x61, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x05,
+-	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x73, 0x70, 0x61, 0x6e, 0x12, 0x29, 0x0a, 0x10, 0x6c, 0x65,
+-	0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d,
+-	0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x2b, 0x0a, 0x11, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e,
+-	0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x10, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e,
+-	0x74, 0x73, 0x12, 0x3a, 0x0a, 0x19, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x65,
+-	0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18,
+-	0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x17, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x44, 0x65,
+-	0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22, 0xd0,
+-	0x02, 0x0a, 0x11, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65,
+-	0x49, 0x6e, 0x66, 0x6f, 0x12, 0x4d, 0x0a, 0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69,
+-	0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72,
+-	0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e,
+-	0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x1a, 0xeb, 0x01, 0x0a, 0x0a, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69,
++	0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80,
++	0x80, 0x80, 0x02, 0x22, 0xd1, 0x02, 0x0a, 0x0b, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x5f, 0x61, 0x6c, 0x69,
++	0x61, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0a, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x41,
++	0x6c, 0x69, 0x61, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74,
++	0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
++	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x56, 0x0a, 0x26, 0x64,
++	0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79,
++	0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66,
++	0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52,
++	0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x4c, 0x65, 0x67, 0x61, 0x63,
++	0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69,
++	0x63, 0x74, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14,
++	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e,
++	0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80,
++	0x02, 0x4a, 0x04, 0x08, 0x05, 0x10, 0x06, 0x22, 0x81, 0x02, 0x0a, 0x10, 0x45, 0x6e, 0x75, 0x6d,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a,
++	0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08,
++	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
++	0x74, 0x65, 0x64, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x28, 0x0a, 0x0c,
++	0x64, 0x65, 0x62, 0x75, 0x67, 0x5f, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x03, 0x20, 0x01,
++	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62, 0x75, 0x67,
++	0x52, 0x65, 0x64, 0x61, 0x63, 0x74, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7,
++	0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69,
++	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0xd5, 0x01, 0x0a, 0x0e,
++	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x37,
++	0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0b,
++	0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66,
++	0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65,
++	0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x58,
++	0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
++	0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80,
++	0x80, 0x80, 0x02, 0x22, 0x99, 0x03, 0x0a, 0x0d, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
++	0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x71, 0x0a, 0x11,
++	0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x5f, 0x6c, 0x65, 0x76, 0x65,
++	0x6c, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65,
++	0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x3a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f,
++	0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x52, 0x10, 0x69,
++	0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12,
++	0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x23, 0x20, 0x01, 0x28,
++	0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08,
++	0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e,
++	0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75,
++	0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x22, 0x50, 0x0a, 0x10, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63,
++	0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12, 0x17, 0x0a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f,
++	0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12,
++	0x13, 0x0a, 0x0f, 0x4e, 0x4f, 0x5f, 0x53, 0x49, 0x44, 0x45, 0x5f, 0x45, 0x46, 0x46, 0x45, 0x43,
++	0x54, 0x53, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45,
++	0x4e, 0x54, 0x10, 0x02, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22,
++	0x9a, 0x03, 0x0a, 0x13, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
++	0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
++	0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65,
++	0x50, 0x61, 0x72, 0x74, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x64,
++	0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03,
++	0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76,
++	0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28,
++	0x04, 0x52, 0x10, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61,
++	0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x5f,
++	0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52,
++	0x10, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75,
++	0x65, 0x12, 0x21, 0x0a, 0x0c, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75,
++	0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x52, 0x0b, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x56,
++	0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76,
++	0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69,
++	0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x27, 0x0a, 0x0f, 0x61, 0x67, 0x67, 0x72, 0x65,
++	0x67, 0x61, 0x74, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09,
++	0x52, 0x0e, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65,
++	0x1a, 0x4a, 0x0a, 0x08, 0x4e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x12, 0x1b, 0x0a, 0x09,
++	0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x70, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09, 0x52,
++	0x08, 0x6e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x12, 0x21, 0x0a, 0x0c, 0x69, 0x73, 0x5f,
++	0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x02, 0x28, 0x08, 0x52,
++	0x0b, 0x69, 0x73, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x8c, 0x0a, 0x0a,
++	0x0a, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x12, 0x8b, 0x01, 0x0a, 0x0e,
++	0x66, 0x69, 0x65, 0x6c, 0x64, 0x5f, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x18, 0x01,
++	0x20, 0x01, 0x28, 0x0e, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x42,
++	0x39, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45,
++	0x58, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x49,
++	0x4d, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe7, 0x07, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45,
++	0x58, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe8, 0x07, 0x52, 0x0d, 0x66, 0x69, 0x65, 0x6c,
++	0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x66, 0x0a, 0x09, 0x65, 0x6e, 0x75,
++	0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x24, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
++	0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x54, 0x79,
++	0x70, 0x65, 0x42, 0x23, 0x88, 0x01, 0x01, 0x98, 0x01, 0x06, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x0b,
++	0x12, 0x06, 0x43, 0x4c, 0x4f, 0x53, 0x45, 0x44, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x09, 0x12, 0x04,
++	0x4f, 0x50, 0x45, 0x4e, 0x18, 0xe7, 0x07, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54, 0x79, 0x70,
++	0x65, 0x12, 0x92, 0x01, 0x0a, 0x17, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x66,
++	0x69, 0x65, 0x6c, 0x64, 0x5f, 0x65, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x18, 0x03, 0x20,
++	0x01, 0x28, 0x0e, 0x32, 0x31, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74,
++	0x2e, 0x52, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x45, 0x6e,
++	0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x42, 0x27, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98, 0x01,
++	0x01, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45, 0x58, 0x50, 0x41, 0x4e, 0x44, 0x45, 0x44, 0x18, 0xe6,
++	0x07, 0xa2, 0x01, 0x0b, 0x12, 0x06, 0x50, 0x41, 0x43, 0x4b, 0x45, 0x44, 0x18, 0xe7, 0x07, 0x52,
++	0x15, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x45, 0x6e,
++	0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x78, 0x0a, 0x0f, 0x75, 0x74, 0x66, 0x38, 0x5f, 0x76,
++	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0e, 0x32,
++	0x2a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x55, 0x74, 0x66,
++	0x38, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x23, 0x88, 0x01, 0x01,
++	0x98, 0x01, 0x04, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x09, 0x12, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x18,
++	0xe6, 0x07, 0xa2, 0x01, 0x0b, 0x12, 0x06, 0x56, 0x45, 0x52, 0x49, 0x46, 0x59, 0x18, 0xe7, 0x07,
++	0x52, 0x0e, 0x75, 0x74, 0x66, 0x38, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x12, 0x78, 0x0a, 0x10, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x65, 0x6e, 0x63, 0x6f,
++	0x64, 0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x45,
++	0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x42, 0x20, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98,
++	0x01, 0x01, 0xa2, 0x01, 0x14, 0x12, 0x0f, 0x4c, 0x45, 0x4e, 0x47, 0x54, 0x48, 0x5f, 0x50, 0x52,
++	0x45, 0x46, 0x49, 0x58, 0x45, 0x44, 0x18, 0xe6, 0x07, 0x52, 0x0f, 0x6d, 0x65, 0x73, 0x73, 0x61,
++	0x67, 0x65, 0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x7c, 0x0a, 0x0b, 0x6a, 0x73,
++	0x6f, 0x6e, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e, 0x32,
++	0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x4a, 0x73, 0x6f,
++	0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x42, 0x33, 0x88, 0x01, 0x01, 0x98, 0x01, 0x03, 0x98,
++	0x01, 0x06, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x17, 0x12, 0x12, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59,
++	0x5f, 0x42, 0x45, 0x53, 0x54, 0x5f, 0x45, 0x46, 0x46, 0x4f, 0x52, 0x54, 0x18, 0xe6, 0x07, 0xa2,
++	0x01, 0x0a, 0x12, 0x05, 0x41, 0x4c, 0x4c, 0x4f, 0x57, 0x18, 0xe7, 0x07, 0x52, 0x0a, 0x6a, 0x73,
++	0x6f, 0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x22, 0x5c, 0x0a, 0x0d, 0x46, 0x69, 0x65, 0x6c,
++	0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x1a, 0x0a, 0x16, 0x46, 0x49, 0x45,
++	0x4c, 0x44, 0x5f, 0x50, 0x52, 0x45, 0x53, 0x45, 0x4e, 0x43, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e,
++	0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0c, 0x0a, 0x08, 0x45, 0x58, 0x50, 0x4c, 0x49, 0x43, 0x49,
++	0x54, 0x10, 0x01, 0x12, 0x0c, 0x0a, 0x08, 0x49, 0x4d, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x10,
++	0x02, 0x12, 0x13, 0x0a, 0x0f, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59, 0x5f, 0x52, 0x45, 0x51, 0x55,
++	0x49, 0x52, 0x45, 0x44, 0x10, 0x03, 0x22, 0x37, 0x0a, 0x08, 0x45, 0x6e, 0x75, 0x6d, 0x54, 0x79,
++	0x70, 0x65, 0x12, 0x15, 0x0a, 0x11, 0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x4f, 0x50, 0x45,
++	0x4e, 0x10, 0x01, 0x12, 0x0a, 0x0a, 0x06, 0x43, 0x4c, 0x4f, 0x53, 0x45, 0x44, 0x10, 0x02, 0x22,
++	0x56, 0x0a, 0x15, 0x52, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64,
++	0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x23, 0x0a, 0x1f, 0x52, 0x45, 0x50, 0x45,
++	0x41, 0x54, 0x45, 0x44, 0x5f, 0x46, 0x49, 0x45, 0x4c, 0x44, 0x5f, 0x45, 0x4e, 0x43, 0x4f, 0x44,
++	0x49, 0x4e, 0x47, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a,
++	0x06, 0x50, 0x41, 0x43, 0x4b, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0c, 0x0a, 0x08, 0x45, 0x58, 0x50,
++	0x41, 0x4e, 0x44, 0x45, 0x44, 0x10, 0x02, 0x22, 0x43, 0x0a, 0x0e, 0x55, 0x74, 0x66, 0x38, 0x56,
++	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x1b, 0x0a, 0x17, 0x55, 0x54, 0x46,
++	0x38, 0x5f, 0x56, 0x41, 0x4c, 0x49, 0x44, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e, 0x4b,
++	0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x56, 0x45, 0x52, 0x49, 0x46, 0x59,
++	0x10, 0x02, 0x12, 0x08, 0x0a, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x03, 0x22, 0x53, 0x0a, 0x0f,
++	0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12,
++	0x1c, 0x0a, 0x18, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x5f, 0x45, 0x4e, 0x43, 0x4f, 0x44,
++	0x49, 0x4e, 0x47, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a,
++	0x0f, 0x4c, 0x45, 0x4e, 0x47, 0x54, 0x48, 0x5f, 0x50, 0x52, 0x45, 0x46, 0x49, 0x58, 0x45, 0x44,
++	0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x44, 0x45, 0x4c, 0x49, 0x4d, 0x49, 0x54, 0x45, 0x44, 0x10,
++	0x02, 0x22, 0x48, 0x0a, 0x0a, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12,
++	0x17, 0x0a, 0x13, 0x4a, 0x53, 0x4f, 0x4e, 0x5f, 0x46, 0x4f, 0x52, 0x4d, 0x41, 0x54, 0x5f, 0x55,
++	0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x4c, 0x4c, 0x4f,
++	0x57, 0x10, 0x01, 0x12, 0x16, 0x0a, 0x12, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59, 0x5f, 0x42, 0x45,
++	0x53, 0x54, 0x5f, 0x45, 0x46, 0x46, 0x4f, 0x52, 0x54, 0x10, 0x02, 0x2a, 0x06, 0x08, 0xe8, 0x07,
++	0x10, 0xe9, 0x07, 0x2a, 0x06, 0x08, 0xe9, 0x07, 0x10, 0xea, 0x07, 0x2a, 0x06, 0x08, 0xea, 0x07,
++	0x10, 0xeb, 0x07, 0x2a, 0x06, 0x08, 0x8b, 0x4e, 0x10, 0x90, 0x4e, 0x2a, 0x06, 0x08, 0x90, 0x4e,
++	0x10, 0x91, 0x4e, 0x4a, 0x06, 0x08, 0xe7, 0x07, 0x10, 0xe8, 0x07, 0x22, 0xfe, 0x02, 0x0a, 0x12,
++	0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c,
++	0x74, 0x73, 0x12, 0x58, 0x0a, 0x08, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x18, 0x01,
++	0x20, 0x03, 0x28, 0x0b, 0x32, 0x3c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72,
++	0x65, 0x53, 0x65, 0x74, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75,
++	0x6c, 0x74, 0x52, 0x08, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x12, 0x41, 0x0a, 0x0f,
++	0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x5f, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x18,
++	0x04, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x52,
++	0x0e, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12,
++	0x41, 0x0a, 0x0f, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x5f, 0x65, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
++	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x52, 0x0e, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x45, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x1a, 0x87, 0x01, 0x0a, 0x18, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x12,
++	0x32, 0x0a, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0e,
++	0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74,
++	0x69, 0x6f, 0x6e, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x22, 0xa7, 0x02, 0x0a,
++	0x0e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12,
++	0x44, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28,
++	0x0b, 0x32, 0x28, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e,
++	0x66, 0x6f, 0x2e, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x08, 0x6c, 0x6f, 0x63,
++	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xce, 0x01, 0x0a, 0x08, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69,
+ 	0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61, 0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05,
+-	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x12, 0x1f, 0x0a, 0x0b, 0x73, 0x6f,
+-	0x75, 0x72, 0x63, 0x65, 0x5f, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+-	0x0a, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x62,
+-	0x65, 0x67, 0x69, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x62, 0x65, 0x67, 0x69,
+-	0x6e, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03,
+-	0x65, 0x6e, 0x64, 0x12, 0x52, 0x0a, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18,
+-	0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x36, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
+-	0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61,
+-	0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x52, 0x08, 0x73,
+-	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x22, 0x28, 0x0a, 0x08, 0x53, 0x65, 0x6d, 0x61, 0x6e,
+-	0x74, 0x69, 0x63, 0x12, 0x08, 0x0a, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x07, 0x0a,
+-	0x03, 0x53, 0x45, 0x54, 0x10, 0x01, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x4c, 0x49, 0x41, 0x53, 0x10,
+-	0x02, 0x42, 0x7e, 0x0a, 0x13, 0x63, 0x6f, 0x6d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x42, 0x10, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
+-	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x73, 0x48, 0x01, 0x5a, 0x2d, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2f, 0x64,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x70, 0x62, 0xf8, 0x01, 0x01, 0xa2, 0x02,
+-	0x03, 0x47, 0x50, 0x42, 0xaa, 0x02, 0x1a, 0x47, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x50, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x52, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f,
+-	0x6e,
++	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x12, 0x16, 0x0a, 0x04, 0x73, 0x70,
++	0x61, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x73, 0x70,
++	0x61, 0x6e, 0x12, 0x29, 0x0a, 0x10, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f,
++	0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6c, 0x65,
++	0x61, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x2b, 0x0a,
++	0x11, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e,
++	0x74, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69,
++	0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x3a, 0x0a, 0x19, 0x6c, 0x65,
++	0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x65, 0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x5f, 0x63,
++	0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x17, 0x6c,
++	0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x44, 0x65, 0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x43, 0x6f,
++	0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22, 0xd0, 0x02, 0x0a, 0x11, 0x47, 0x65, 0x6e, 0x65, 0x72,
++	0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x4d, 0x0a, 0x0a,
++	0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65,
++	0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52,
++	0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xeb, 0x01, 0x0a, 0x0a,
++	0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61,
++	0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61,
++	0x74, 0x68, 0x12, 0x1f, 0x0a, 0x0b, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x66, 0x69, 0x6c,
++	0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x46,
++	0x69, 0x6c, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x62, 0x65, 0x67, 0x69, 0x6e, 0x18, 0x03, 0x20, 0x01,
++	0x28, 0x05, 0x52, 0x05, 0x62, 0x65, 0x67, 0x69, 0x6e, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64,
++	0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x12, 0x52, 0x0a, 0x08, 0x73,
++	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x36, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
++	0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x53, 0x65, 0x6d,
++	0x61, 0x6e, 0x74, 0x69, 0x63, 0x52, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x22,
++	0x28, 0x0a, 0x08, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x12, 0x08, 0x0a, 0x04, 0x4e,
++	0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x07, 0x0a, 0x03, 0x53, 0x45, 0x54, 0x10, 0x01, 0x12, 0x09,
++	0x0a, 0x05, 0x41, 0x4c, 0x49, 0x41, 0x53, 0x10, 0x02, 0x2a, 0x92, 0x02, 0x0a, 0x07, 0x45, 0x64,
++	0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x13, 0x0a, 0x0f, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e,
++	0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a, 0x0e, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x50, 0x52, 0x4f, 0x54, 0x4f, 0x32, 0x10, 0xe6, 0x07, 0x12,
++	0x13, 0x0a, 0x0e, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x50, 0x52, 0x4f, 0x54, 0x4f,
++	0x33, 0x10, 0xe7, 0x07, 0x12, 0x11, 0x0a, 0x0c, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f,
++	0x32, 0x30, 0x32, 0x33, 0x10, 0xe8, 0x07, 0x12, 0x11, 0x0a, 0x0c, 0x45, 0x44, 0x49, 0x54, 0x49,
++	0x4f, 0x4e, 0x5f, 0x32, 0x30, 0x32, 0x34, 0x10, 0xe9, 0x07, 0x12, 0x17, 0x0a, 0x13, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x31, 0x5f, 0x54, 0x45, 0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c,
++	0x59, 0x10, 0x01, 0x12, 0x17, 0x0a, 0x13, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x32,
++	0x5f, 0x54, 0x45, 0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x02, 0x12, 0x1d, 0x0a, 0x17,
++	0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x37, 0x5f, 0x54, 0x45,
++	0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9d, 0x8d, 0x06, 0x12, 0x1d, 0x0a, 0x17, 0x45,
++	0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x38, 0x5f, 0x54, 0x45, 0x53,
++	0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9e, 0x8d, 0x06, 0x12, 0x1d, 0x0a, 0x17, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x39, 0x5f, 0x54, 0x45, 0x53, 0x54,
++	0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9f, 0x8d, 0x06, 0x12, 0x13, 0x0a, 0x0b, 0x45, 0x44, 0x49,
++	0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x4d, 0x41, 0x58, 0x10, 0xff, 0xff, 0xff, 0xff, 0x07, 0x42, 0x7e,
++	0x0a, 0x13, 0x63, 0x6f, 0x6d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x42, 0x10, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f,
++	0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x73, 0x48, 0x01, 0x5a, 0x2d, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
++	0x65, 0x2e, 0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2f, 0x64, 0x65, 0x73, 0x63,
++	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x70, 0x62, 0xf8, 0x01, 0x01, 0xa2, 0x02, 0x03, 0x47, 0x50,
++	0x42, 0xaa, 0x02, 0x1a, 0x47, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x50, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x52, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e,
+ }
+ 
+ var (
+@@ -4123,103 +5083,136 @@ func file_google_protobuf_descriptor_proto_rawDescGZIP() []byte {
+ 	return file_google_protobuf_descriptor_proto_rawDescData
+ }
+ 
+-var file_google_protobuf_descriptor_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+-var file_google_protobuf_descriptor_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
++var file_google_protobuf_descriptor_proto_enumTypes = make([]protoimpl.EnumInfo, 17)
++var file_google_protobuf_descriptor_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+ var file_google_protobuf_descriptor_proto_goTypes = []interface{}{
+-	(ExtensionRangeOptions_VerificationState)(0),  // 0: google.protobuf.ExtensionRangeOptions.VerificationState
+-	(FieldDescriptorProto_Type)(0),                // 1: google.protobuf.FieldDescriptorProto.Type
+-	(FieldDescriptorProto_Label)(0),               // 2: google.protobuf.FieldDescriptorProto.Label
+-	(FileOptions_OptimizeMode)(0),                 // 3: google.protobuf.FileOptions.OptimizeMode
+-	(FieldOptions_CType)(0),                       // 4: google.protobuf.FieldOptions.CType
+-	(FieldOptions_JSType)(0),                      // 5: google.protobuf.FieldOptions.JSType
+-	(FieldOptions_OptionRetention)(0),             // 6: google.protobuf.FieldOptions.OptionRetention
+-	(FieldOptions_OptionTargetType)(0),            // 7: google.protobuf.FieldOptions.OptionTargetType
+-	(MethodOptions_IdempotencyLevel)(0),           // 8: google.protobuf.MethodOptions.IdempotencyLevel
+-	(GeneratedCodeInfo_Annotation_Semantic)(0),    // 9: google.protobuf.GeneratedCodeInfo.Annotation.Semantic
+-	(*FileDescriptorSet)(nil),                     // 10: google.protobuf.FileDescriptorSet
+-	(*FileDescriptorProto)(nil),                   // 11: google.protobuf.FileDescriptorProto
+-	(*DescriptorProto)(nil),                       // 12: google.protobuf.DescriptorProto
+-	(*ExtensionRangeOptions)(nil),                 // 13: google.protobuf.ExtensionRangeOptions
+-	(*FieldDescriptorProto)(nil),                  // 14: google.protobuf.FieldDescriptorProto
+-	(*OneofDescriptorProto)(nil),                  // 15: google.protobuf.OneofDescriptorProto
+-	(*EnumDescriptorProto)(nil),                   // 16: google.protobuf.EnumDescriptorProto
+-	(*EnumValueDescriptorProto)(nil),              // 17: google.protobuf.EnumValueDescriptorProto
+-	(*ServiceDescriptorProto)(nil),                // 18: google.protobuf.ServiceDescriptorProto
+-	(*MethodDescriptorProto)(nil),                 // 19: google.protobuf.MethodDescriptorProto
+-	(*FileOptions)(nil),                           // 20: google.protobuf.FileOptions
+-	(*MessageOptions)(nil),                        // 21: google.protobuf.MessageOptions
+-	(*FieldOptions)(nil),                          // 22: google.protobuf.FieldOptions
+-	(*OneofOptions)(nil),                          // 23: google.protobuf.OneofOptions
+-	(*EnumOptions)(nil),                           // 24: google.protobuf.EnumOptions
+-	(*EnumValueOptions)(nil),                      // 25: google.protobuf.EnumValueOptions
+-	(*ServiceOptions)(nil),                        // 26: google.protobuf.ServiceOptions
+-	(*MethodOptions)(nil),                         // 27: google.protobuf.MethodOptions
+-	(*UninterpretedOption)(nil),                   // 28: google.protobuf.UninterpretedOption
+-	(*SourceCodeInfo)(nil),                        // 29: google.protobuf.SourceCodeInfo
+-	(*GeneratedCodeInfo)(nil),                     // 30: google.protobuf.GeneratedCodeInfo
+-	(*DescriptorProto_ExtensionRange)(nil),        // 31: google.protobuf.DescriptorProto.ExtensionRange
+-	(*DescriptorProto_ReservedRange)(nil),         // 32: google.protobuf.DescriptorProto.ReservedRange
+-	(*ExtensionRangeOptions_Declaration)(nil),     // 33: google.protobuf.ExtensionRangeOptions.Declaration
+-	(*EnumDescriptorProto_EnumReservedRange)(nil), // 34: google.protobuf.EnumDescriptorProto.EnumReservedRange
+-	(*UninterpretedOption_NamePart)(nil),          // 35: google.protobuf.UninterpretedOption.NamePart
+-	(*SourceCodeInfo_Location)(nil),               // 36: google.protobuf.SourceCodeInfo.Location
+-	(*GeneratedCodeInfo_Annotation)(nil),          // 37: google.protobuf.GeneratedCodeInfo.Annotation
++	(Edition)(0), // 0: google.protobuf.Edition
++	(ExtensionRangeOptions_VerificationState)(0),        // 1: google.protobuf.ExtensionRangeOptions.VerificationState
++	(FieldDescriptorProto_Type)(0),                      // 2: google.protobuf.FieldDescriptorProto.Type
++	(FieldDescriptorProto_Label)(0),                     // 3: google.protobuf.FieldDescriptorProto.Label
++	(FileOptions_OptimizeMode)(0),                       // 4: google.protobuf.FileOptions.OptimizeMode
++	(FieldOptions_CType)(0),                             // 5: google.protobuf.FieldOptions.CType
++	(FieldOptions_JSType)(0),                            // 6: google.protobuf.FieldOptions.JSType
++	(FieldOptions_OptionRetention)(0),                   // 7: google.protobuf.FieldOptions.OptionRetention
++	(FieldOptions_OptionTargetType)(0),                  // 8: google.protobuf.FieldOptions.OptionTargetType
++	(MethodOptions_IdempotencyLevel)(0),                 // 9: google.protobuf.MethodOptions.IdempotencyLevel
++	(FeatureSet_FieldPresence)(0),                       // 10: google.protobuf.FeatureSet.FieldPresence
++	(FeatureSet_EnumType)(0),                            // 11: google.protobuf.FeatureSet.EnumType
++	(FeatureSet_RepeatedFieldEncoding)(0),               // 12: google.protobuf.FeatureSet.RepeatedFieldEncoding
++	(FeatureSet_Utf8Validation)(0),                      // 13: google.protobuf.FeatureSet.Utf8Validation
++	(FeatureSet_MessageEncoding)(0),                     // 14: google.protobuf.FeatureSet.MessageEncoding
++	(FeatureSet_JsonFormat)(0),                          // 15: google.protobuf.FeatureSet.JsonFormat
++	(GeneratedCodeInfo_Annotation_Semantic)(0),          // 16: google.protobuf.GeneratedCodeInfo.Annotation.Semantic
++	(*FileDescriptorSet)(nil),                           // 17: google.protobuf.FileDescriptorSet
++	(*FileDescriptorProto)(nil),                         // 18: google.protobuf.FileDescriptorProto
++	(*DescriptorProto)(nil),                             // 19: google.protobuf.DescriptorProto
++	(*ExtensionRangeOptions)(nil),                       // 20: google.protobuf.ExtensionRangeOptions
++	(*FieldDescriptorProto)(nil),                        // 21: google.protobuf.FieldDescriptorProto
++	(*OneofDescriptorProto)(nil),                        // 22: google.protobuf.OneofDescriptorProto
++	(*EnumDescriptorProto)(nil),                         // 23: google.protobuf.EnumDescriptorProto
++	(*EnumValueDescriptorProto)(nil),                    // 24: google.protobuf.EnumValueDescriptorProto
++	(*ServiceDescriptorProto)(nil),                      // 25: google.protobuf.ServiceDescriptorProto
++	(*MethodDescriptorProto)(nil),                       // 26: google.protobuf.MethodDescriptorProto
++	(*FileOptions)(nil),                                 // 27: google.protobuf.FileOptions
++	(*MessageOptions)(nil),                              // 28: google.protobuf.MessageOptions
++	(*FieldOptions)(nil),                                // 29: google.protobuf.FieldOptions
++	(*OneofOptions)(nil),                                // 30: google.protobuf.OneofOptions
++	(*EnumOptions)(nil),                                 // 31: google.protobuf.EnumOptions
++	(*EnumValueOptions)(nil),                            // 32: google.protobuf.EnumValueOptions
++	(*ServiceOptions)(nil),                              // 33: google.protobuf.ServiceOptions
++	(*MethodOptions)(nil),                               // 34: google.protobuf.MethodOptions
++	(*UninterpretedOption)(nil),                         // 35: google.protobuf.UninterpretedOption
++	(*FeatureSet)(nil),                                  // 36: google.protobuf.FeatureSet
++	(*FeatureSetDefaults)(nil),                          // 37: google.protobuf.FeatureSetDefaults
++	(*SourceCodeInfo)(nil),                              // 38: google.protobuf.SourceCodeInfo
++	(*GeneratedCodeInfo)(nil),                           // 39: google.protobuf.GeneratedCodeInfo
++	(*DescriptorProto_ExtensionRange)(nil),              // 40: google.protobuf.DescriptorProto.ExtensionRange
++	(*DescriptorProto_ReservedRange)(nil),               // 41: google.protobuf.DescriptorProto.ReservedRange
++	(*ExtensionRangeOptions_Declaration)(nil),           // 42: google.protobuf.ExtensionRangeOptions.Declaration
++	(*EnumDescriptorProto_EnumReservedRange)(nil),       // 43: google.protobuf.EnumDescriptorProto.EnumReservedRange
++	(*FieldOptions_EditionDefault)(nil),                 // 44: google.protobuf.FieldOptions.EditionDefault
++	(*UninterpretedOption_NamePart)(nil),                // 45: google.protobuf.UninterpretedOption.NamePart
++	(*FeatureSetDefaults_FeatureSetEditionDefault)(nil), // 46: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
++	(*SourceCodeInfo_Location)(nil),                     // 47: google.protobuf.SourceCodeInfo.Location
++	(*GeneratedCodeInfo_Annotation)(nil),                // 48: google.protobuf.GeneratedCodeInfo.Annotation
+ }
+ var file_google_protobuf_descriptor_proto_depIdxs = []int32{
+-	11, // 0: google.protobuf.FileDescriptorSet.file:type_name -> google.protobuf.FileDescriptorProto
+-	12, // 1: google.protobuf.FileDescriptorProto.message_type:type_name -> google.protobuf.DescriptorProto
+-	16, // 2: google.protobuf.FileDescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
+-	18, // 3: google.protobuf.FileDescriptorProto.service:type_name -> google.protobuf.ServiceDescriptorProto
+-	14, // 4: google.protobuf.FileDescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
+-	20, // 5: google.protobuf.FileDescriptorProto.options:type_name -> google.protobuf.FileOptions
+-	29, // 6: google.protobuf.FileDescriptorProto.source_code_info:type_name -> google.protobuf.SourceCodeInfo
+-	14, // 7: google.protobuf.DescriptorProto.field:type_name -> google.protobuf.FieldDescriptorProto
+-	14, // 8: google.protobuf.DescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
+-	12, // 9: google.protobuf.DescriptorProto.nested_type:type_name -> google.protobuf.DescriptorProto
+-	16, // 10: google.protobuf.DescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
+-	31, // 11: google.protobuf.DescriptorProto.extension_range:type_name -> google.protobuf.DescriptorProto.ExtensionRange
+-	15, // 12: google.protobuf.DescriptorProto.oneof_decl:type_name -> google.protobuf.OneofDescriptorProto
+-	21, // 13: google.protobuf.DescriptorProto.options:type_name -> google.protobuf.MessageOptions
+-	32, // 14: google.protobuf.DescriptorProto.reserved_range:type_name -> google.protobuf.DescriptorProto.ReservedRange
+-	28, // 15: google.protobuf.ExtensionRangeOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	33, // 16: google.protobuf.ExtensionRangeOptions.declaration:type_name -> google.protobuf.ExtensionRangeOptions.Declaration
+-	0,  // 17: google.protobuf.ExtensionRangeOptions.verification:type_name -> google.protobuf.ExtensionRangeOptions.VerificationState
+-	2,  // 18: google.protobuf.FieldDescriptorProto.label:type_name -> google.protobuf.FieldDescriptorProto.Label
+-	1,  // 19: google.protobuf.FieldDescriptorProto.type:type_name -> google.protobuf.FieldDescriptorProto.Type
+-	22, // 20: google.protobuf.FieldDescriptorProto.options:type_name -> google.protobuf.FieldOptions
+-	23, // 21: google.protobuf.OneofDescriptorProto.options:type_name -> google.protobuf.OneofOptions
+-	17, // 22: google.protobuf.EnumDescriptorProto.value:type_name -> google.protobuf.EnumValueDescriptorProto
+-	24, // 23: google.protobuf.EnumDescriptorProto.options:type_name -> google.protobuf.EnumOptions
+-	34, // 24: google.protobuf.EnumDescriptorProto.reserved_range:type_name -> google.protobuf.EnumDescriptorProto.EnumReservedRange
+-	25, // 25: google.protobuf.EnumValueDescriptorProto.options:type_name -> google.protobuf.EnumValueOptions
+-	19, // 26: google.protobuf.ServiceDescriptorProto.method:type_name -> google.protobuf.MethodDescriptorProto
+-	26, // 27: google.protobuf.ServiceDescriptorProto.options:type_name -> google.protobuf.ServiceOptions
+-	27, // 28: google.protobuf.MethodDescriptorProto.options:type_name -> google.protobuf.MethodOptions
+-	3,  // 29: google.protobuf.FileOptions.optimize_for:type_name -> google.protobuf.FileOptions.OptimizeMode
+-	28, // 30: google.protobuf.FileOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 31: google.protobuf.MessageOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	4,  // 32: google.protobuf.FieldOptions.ctype:type_name -> google.protobuf.FieldOptions.CType
+-	5,  // 33: google.protobuf.FieldOptions.jstype:type_name -> google.protobuf.FieldOptions.JSType
+-	6,  // 34: google.protobuf.FieldOptions.retention:type_name -> google.protobuf.FieldOptions.OptionRetention
+-	7,  // 35: google.protobuf.FieldOptions.target:type_name -> google.protobuf.FieldOptions.OptionTargetType
+-	7,  // 36: google.protobuf.FieldOptions.targets:type_name -> google.protobuf.FieldOptions.OptionTargetType
+-	28, // 37: google.protobuf.FieldOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 38: google.protobuf.OneofOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 39: google.protobuf.EnumOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 40: google.protobuf.EnumValueOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 41: google.protobuf.ServiceOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	8,  // 42: google.protobuf.MethodOptions.idempotency_level:type_name -> google.protobuf.MethodOptions.IdempotencyLevel
+-	28, // 43: google.protobuf.MethodOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	35, // 44: google.protobuf.UninterpretedOption.name:type_name -> google.protobuf.UninterpretedOption.NamePart
+-	36, // 45: google.protobuf.SourceCodeInfo.location:type_name -> google.protobuf.SourceCodeInfo.Location
+-	37, // 46: google.protobuf.GeneratedCodeInfo.annotation:type_name -> google.protobuf.GeneratedCodeInfo.Annotation
+-	13, // 47: google.protobuf.DescriptorProto.ExtensionRange.options:type_name -> google.protobuf.ExtensionRangeOptions
+-	9,  // 48: google.protobuf.GeneratedCodeInfo.Annotation.semantic:type_name -> google.protobuf.GeneratedCodeInfo.Annotation.Semantic
+-	49, // [49:49] is the sub-list for method output_type
+-	49, // [49:49] is the sub-list for method input_type
+-	49, // [49:49] is the sub-list for extension type_name
+-	49, // [49:49] is the sub-list for extension extendee
+-	0,  // [0:49] is the sub-list for field type_name
++	18, // 0: google.protobuf.FileDescriptorSet.file:type_name -> google.protobuf.FileDescriptorProto
++	19, // 1: google.protobuf.FileDescriptorProto.message_type:type_name -> google.protobuf.DescriptorProto
++	23, // 2: google.protobuf.FileDescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
++	25, // 3: google.protobuf.FileDescriptorProto.service:type_name -> google.protobuf.ServiceDescriptorProto
++	21, // 4: google.protobuf.FileDescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
++	27, // 5: google.protobuf.FileDescriptorProto.options:type_name -> google.protobuf.FileOptions
++	38, // 6: google.protobuf.FileDescriptorProto.source_code_info:type_name -> google.protobuf.SourceCodeInfo
++	0,  // 7: google.protobuf.FileDescriptorProto.edition:type_name -> google.protobuf.Edition
++	21, // 8: google.protobuf.DescriptorProto.field:type_name -> google.protobuf.FieldDescriptorProto
++	21, // 9: google.protobuf.DescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
++	19, // 10: google.protobuf.DescriptorProto.nested_type:type_name -> google.protobuf.DescriptorProto
++	23, // 11: google.protobuf.DescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
++	40, // 12: google.protobuf.DescriptorProto.extension_range:type_name -> google.protobuf.DescriptorProto.ExtensionRange
++	22, // 13: google.protobuf.DescriptorProto.oneof_decl:type_name -> google.protobuf.OneofDescriptorProto
++	28, // 14: google.protobuf.DescriptorProto.options:type_name -> google.protobuf.MessageOptions
++	41, // 15: google.protobuf.DescriptorProto.reserved_range:type_name -> google.protobuf.DescriptorProto.ReservedRange
++	35, // 16: google.protobuf.ExtensionRangeOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	42, // 17: google.protobuf.ExtensionRangeOptions.declaration:type_name -> google.protobuf.ExtensionRangeOptions.Declaration
++	36, // 18: google.protobuf.ExtensionRangeOptions.features:type_name -> google.protobuf.FeatureSet
++	1,  // 19: google.protobuf.ExtensionRangeOptions.verification:type_name -> google.protobuf.ExtensionRangeOptions.VerificationState
++	3,  // 20: google.protobuf.FieldDescriptorProto.label:type_name -> google.protobuf.FieldDescriptorProto.Label
++	2,  // 21: google.protobuf.FieldDescriptorProto.type:type_name -> google.protobuf.FieldDescriptorProto.Type
++	29, // 22: google.protobuf.FieldDescriptorProto.options:type_name -> google.protobuf.FieldOptions
++	30, // 23: google.protobuf.OneofDescriptorProto.options:type_name -> google.protobuf.OneofOptions
++	24, // 24: google.protobuf.EnumDescriptorProto.value:type_name -> google.protobuf.EnumValueDescriptorProto
++	31, // 25: google.protobuf.EnumDescriptorProto.options:type_name -> google.protobuf.EnumOptions
++	43, // 26: google.protobuf.EnumDescriptorProto.reserved_range:type_name -> google.protobuf.EnumDescriptorProto.EnumReservedRange
++	32, // 27: google.protobuf.EnumValueDescriptorProto.options:type_name -> google.protobuf.EnumValueOptions
++	26, // 28: google.protobuf.ServiceDescriptorProto.method:type_name -> google.protobuf.MethodDescriptorProto
++	33, // 29: google.protobuf.ServiceDescriptorProto.options:type_name -> google.protobuf.ServiceOptions
++	34, // 30: google.protobuf.MethodDescriptorProto.options:type_name -> google.protobuf.MethodOptions
++	4,  // 31: google.protobuf.FileOptions.optimize_for:type_name -> google.protobuf.FileOptions.OptimizeMode
++	36, // 32: google.protobuf.FileOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 33: google.protobuf.FileOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 34: google.protobuf.MessageOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 35: google.protobuf.MessageOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	5,  // 36: google.protobuf.FieldOptions.ctype:type_name -> google.protobuf.FieldOptions.CType
++	6,  // 37: google.protobuf.FieldOptions.jstype:type_name -> google.protobuf.FieldOptions.JSType
++	7,  // 38: google.protobuf.FieldOptions.retention:type_name -> google.protobuf.FieldOptions.OptionRetention
++	8,  // 39: google.protobuf.FieldOptions.targets:type_name -> google.protobuf.FieldOptions.OptionTargetType
++	44, // 40: google.protobuf.FieldOptions.edition_defaults:type_name -> google.protobuf.FieldOptions.EditionDefault
++	36, // 41: google.protobuf.FieldOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 42: google.protobuf.FieldOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 43: google.protobuf.OneofOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 44: google.protobuf.OneofOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 45: google.protobuf.EnumOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 46: google.protobuf.EnumOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 47: google.protobuf.EnumValueOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 48: google.protobuf.EnumValueOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 49: google.protobuf.ServiceOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 50: google.protobuf.ServiceOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	9,  // 51: google.protobuf.MethodOptions.idempotency_level:type_name -> google.protobuf.MethodOptions.IdempotencyLevel
++	36, // 52: google.protobuf.MethodOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 53: google.protobuf.MethodOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	45, // 54: google.protobuf.UninterpretedOption.name:type_name -> google.protobuf.UninterpretedOption.NamePart
++	10, // 55: google.protobuf.FeatureSet.field_presence:type_name -> google.protobuf.FeatureSet.FieldPresence
++	11, // 56: google.protobuf.FeatureSet.enum_type:type_name -> google.protobuf.FeatureSet.EnumType
++	12, // 57: google.protobuf.FeatureSet.repeated_field_encoding:type_name -> google.protobuf.FeatureSet.RepeatedFieldEncoding
++	13, // 58: google.protobuf.FeatureSet.utf8_validation:type_name -> google.protobuf.FeatureSet.Utf8Validation
++	14, // 59: google.protobuf.FeatureSet.message_encoding:type_name -> google.protobuf.FeatureSet.MessageEncoding
++	15, // 60: google.protobuf.FeatureSet.json_format:type_name -> google.protobuf.FeatureSet.JsonFormat
++	46, // 61: google.protobuf.FeatureSetDefaults.defaults:type_name -> google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
++	0,  // 62: google.protobuf.FeatureSetDefaults.minimum_edition:type_name -> google.protobuf.Edition
++	0,  // 63: google.protobuf.FeatureSetDefaults.maximum_edition:type_name -> google.protobuf.Edition
++	47, // 64: google.protobuf.SourceCodeInfo.location:type_name -> google.protobuf.SourceCodeInfo.Location
++	48, // 65: google.protobuf.GeneratedCodeInfo.annotation:type_name -> google.protobuf.GeneratedCodeInfo.Annotation
++	20, // 66: google.protobuf.DescriptorProto.ExtensionRange.options:type_name -> google.protobuf.ExtensionRangeOptions
++	0,  // 67: google.protobuf.FieldOptions.EditionDefault.edition:type_name -> google.protobuf.Edition
++	0,  // 68: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.edition:type_name -> google.protobuf.Edition
++	36, // 69: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.features:type_name -> google.protobuf.FeatureSet
++	16, // 70: google.protobuf.GeneratedCodeInfo.Annotation.semantic:type_name -> google.protobuf.GeneratedCodeInfo.Annotation.Semantic
++	71, // [71:71] is the sub-list for method output_type
++	71, // [71:71] is the sub-list for method input_type
++	71, // [71:71] is the sub-list for extension type_name
++	71, // [71:71] is the sub-list for extension extendee
++	0,  // [0:71] is the sub-list for field type_name
+ }
+ 
+ func init() { file_google_protobuf_descriptor_proto_init() }
+@@ -4475,19 +5468,21 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*SourceCodeInfo); i {
++			switch v := v.(*FeatureSet); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+ 				return &v.sizeCache
+ 			case 2:
+ 				return &v.unknownFields
++			case 3:
++				return &v.extensionFields
+ 			default:
+ 				return nil
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*GeneratedCodeInfo); i {
++			switch v := v.(*FeatureSetDefaults); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4499,7 +5494,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*DescriptorProto_ExtensionRange); i {
++			switch v := v.(*SourceCodeInfo); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4511,7 +5506,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*DescriptorProto_ReservedRange); i {
++			switch v := v.(*GeneratedCodeInfo); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4523,7 +5518,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*ExtensionRangeOptions_Declaration); i {
++			switch v := v.(*DescriptorProto_ExtensionRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4535,7 +5530,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*EnumDescriptorProto_EnumReservedRange); i {
++			switch v := v.(*DescriptorProto_ReservedRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4547,7 +5542,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*UninterpretedOption_NamePart); i {
++			switch v := v.(*ExtensionRangeOptions_Declaration); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4559,7 +5554,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*SourceCodeInfo_Location); i {
++			switch v := v.(*EnumDescriptorProto_EnumReservedRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4571,6 +5566,54 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*FieldOptions_EditionDefault); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*UninterpretedOption_NamePart); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*FeatureSetDefaults_FeatureSetEditionDefault); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*SourceCodeInfo_Location); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
+ 			switch v := v.(*GeneratedCodeInfo_Annotation); i {
+ 			case 0:
+ 				return &v.state
+@@ -4588,8 +5631,8 @@ func file_google_protobuf_descriptor_proto_init() {
+ 		File: protoimpl.DescBuilder{
+ 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
+ 			RawDescriptor: file_google_protobuf_descriptor_proto_rawDesc,
+-			NumEnums:      10,
+-			NumMessages:   28,
++			NumEnums:      17,
++			NumMessages:   32,
+ 			NumExtensions: 0,
+ 			NumServices:   0,
+ 		},
+diff --git a/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+new file mode 100644
+index 0000000..25de5ae
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+@@ -0,0 +1,177 @@
++// Protocol Buffers - Google's data interchange format
++// Copyright 2023 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++// Code generated by protoc-gen-go. DO NOT EDIT.
++// source: reflect/protodesc/proto/go_features.proto
++
++package proto
++
++import (
++	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
++	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
++	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
++	reflect "reflect"
++	sync "sync"
++)
++
++type GoFeatures struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	// Whether or not to generate the deprecated UnmarshalJSON method for enums.
++	LegacyUnmarshalJsonEnum *bool `protobuf:"varint,1,opt,name=legacy_unmarshal_json_enum,json=legacyUnmarshalJsonEnum" json:"legacy_unmarshal_json_enum,omitempty"`
++}
++
++func (x *GoFeatures) Reset() {
++	*x = GoFeatures{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_reflect_protodesc_proto_go_features_proto_msgTypes[0]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *GoFeatures) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*GoFeatures) ProtoMessage() {}
++
++func (x *GoFeatures) ProtoReflect() protoreflect.Message {
++	mi := &file_reflect_protodesc_proto_go_features_proto_msgTypes[0]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use GoFeatures.ProtoReflect.Descriptor instead.
++func (*GoFeatures) Descriptor() ([]byte, []int) {
++	return file_reflect_protodesc_proto_go_features_proto_rawDescGZIP(), []int{0}
++}
++
++func (x *GoFeatures) GetLegacyUnmarshalJsonEnum() bool {
++	if x != nil && x.LegacyUnmarshalJsonEnum != nil {
++		return *x.LegacyUnmarshalJsonEnum
++	}
++	return false
++}
++
++var file_reflect_protodesc_proto_go_features_proto_extTypes = []protoimpl.ExtensionInfo{
++	{
++		ExtendedType:  (*descriptorpb.FeatureSet)(nil),
++		ExtensionType: (*GoFeatures)(nil),
++		Field:         1002,
++		Name:          "google.protobuf.go",
++		Tag:           "bytes,1002,opt,name=go",
++		Filename:      "reflect/protodesc/proto/go_features.proto",
++	},
++}
++
++// Extension fields to descriptorpb.FeatureSet.
++var (
++	// optional google.protobuf.GoFeatures go = 1002;
++	E_Go = &file_reflect_protodesc_proto_go_features_proto_extTypes[0]
++)
++
++var File_reflect_protodesc_proto_go_features_proto protoreflect.FileDescriptor
++
++var file_reflect_protodesc_proto_go_features_proto_rawDesc = []byte{
++	0x0a, 0x29, 0x72, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x64,
++	0x65, 0x73, 0x63, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x67, 0x6f, 0x5f, 0x66, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x0f, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x1a, 0x20, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x64, 0x65,
++	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x6a,
++	0x0a, 0x0a, 0x47, 0x6f, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x5c, 0x0a, 0x1a,
++	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x75, 0x6e, 0x6d, 0x61, 0x72, 0x73, 0x68, 0x61, 0x6c,
++	0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x65, 0x6e, 0x75, 0x6d, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08,
++	0x42, 0x1f, 0x88, 0x01, 0x01, 0x98, 0x01, 0x06, 0xa2, 0x01, 0x09, 0x12, 0x04, 0x74, 0x72, 0x75,
++	0x65, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x0a, 0x12, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x18, 0xe7,
++	0x07, 0x52, 0x17, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x55, 0x6e, 0x6d, 0x61, 0x72, 0x73, 0x68,
++	0x61, 0x6c, 0x4a, 0x73, 0x6f, 0x6e, 0x45, 0x6e, 0x75, 0x6d, 0x3a, 0x49, 0x0a, 0x02, 0x67, 0x6f,
++	0x12, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x18, 0xea, 0x07,
++	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x6f, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x52, 0x02, 0x67, 0x6f, 0x42, 0x34, 0x5a, 0x32, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2f, 0x72, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x64, 0x65, 0x73, 0x63, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++}
++
++var (
++	file_reflect_protodesc_proto_go_features_proto_rawDescOnce sync.Once
++	file_reflect_protodesc_proto_go_features_proto_rawDescData = file_reflect_protodesc_proto_go_features_proto_rawDesc
++)
++
++func file_reflect_protodesc_proto_go_features_proto_rawDescGZIP() []byte {
++	file_reflect_protodesc_proto_go_features_proto_rawDescOnce.Do(func() {
++		file_reflect_protodesc_proto_go_features_proto_rawDescData = protoimpl.X.CompressGZIP(file_reflect_protodesc_proto_go_features_proto_rawDescData)
++	})
++	return file_reflect_protodesc_proto_go_features_proto_rawDescData
++}
++
++var file_reflect_protodesc_proto_go_features_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
++var file_reflect_protodesc_proto_go_features_proto_goTypes = []interface{}{
++	(*GoFeatures)(nil),              // 0: google.protobuf.GoFeatures
++	(*descriptorpb.FeatureSet)(nil), // 1: google.protobuf.FeatureSet
++}
++var file_reflect_protodesc_proto_go_features_proto_depIdxs = []int32{
++	1, // 0: google.protobuf.go:extendee -> google.protobuf.FeatureSet
++	0, // 1: google.protobuf.go:type_name -> google.protobuf.GoFeatures
++	2, // [2:2] is the sub-list for method output_type
++	2, // [2:2] is the sub-list for method input_type
++	1, // [1:2] is the sub-list for extension type_name
++	0, // [0:1] is the sub-list for extension extendee
++	0, // [0:0] is the sub-list for field type_name
++}
++
++func init() { file_reflect_protodesc_proto_go_features_proto_init() }
++func file_reflect_protodesc_proto_go_features_proto_init() {
++	if File_reflect_protodesc_proto_go_features_proto != nil {
++		return
++	}
++	if !protoimpl.UnsafeEnabled {
++		file_reflect_protodesc_proto_go_features_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*GoFeatures); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++	}
++	type x struct{}
++	out := protoimpl.TypeBuilder{
++		File: protoimpl.DescBuilder{
++			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
++			RawDescriptor: file_reflect_protodesc_proto_go_features_proto_rawDesc,
++			NumEnums:      0,
++			NumMessages:   1,
++			NumExtensions: 1,
++			NumServices:   0,
++		},
++		GoTypes:           file_reflect_protodesc_proto_go_features_proto_goTypes,
++		DependencyIndexes: file_reflect_protodesc_proto_go_features_proto_depIdxs,
++		MessageInfos:      file_reflect_protodesc_proto_go_features_proto_msgTypes,
++		ExtensionInfos:    file_reflect_protodesc_proto_go_features_proto_extTypes,
++	}.Build()
++	File_reflect_protodesc_proto_go_features_proto = out.File
++	file_reflect_protodesc_proto_go_features_proto_rawDesc = nil
++	file_reflect_protodesc_proto_go_features_proto_goTypes = nil
++	file_reflect_protodesc_proto_go_features_proto_depIdxs = nil
++}
+diff --git a/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+new file mode 100644
+index 0000000..d246571
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+@@ -0,0 +1,28 @@
++// Protocol Buffers - Google's data interchange format
++// Copyright 2023 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++syntax = "proto2";
++
++package google.protobuf;
++
++import "google/protobuf/descriptor.proto";
++
++option go_package = "google.golang.org/protobuf/types/gofeaturespb";
++
++extend google.protobuf.FeatureSet {
++  optional GoFeatures go = 1002;
++}
++
++message GoFeatures {
++  // Whether or not to generate the deprecated UnmarshalJSON method for enums.
++  optional bool legacy_unmarshal_json_enum = 1 [
++    retention = RETENTION_RUNTIME,
++    targets = TARGET_TYPE_ENUM,
++    edition_defaults = { edition: EDITION_PROTO2, value: "true" },
++    edition_defaults = { edition: EDITION_PROTO3, value: "false" }
++  ];
++}
+diff --git a/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go b/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
+index 580b232..9de51be 100644
+--- a/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
++++ b/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
+@@ -237,7 +237,8 @@ type Any struct {
+ 	//
+ 	// Note: this functionality is not currently available in the official
+ 	// protobuf release, and it is not used for type URLs beginning with
+-	// type.googleapis.com.
++	// type.googleapis.com. As of May 2023, there are no widely used type server
++	// implementations and no plans to implement one.
+ 	//
+ 	// Schemes other than `http`, `https` (or the empty scheme) might be
+ 	// used with implementation specific semantics.
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index f3db441..e57446f 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -29,8 +29,8 @@ github.com/gogo/protobuf/sortkeys
+ ## explicit; go 1.11
+ github.com/golang/mock/gomock
+ github.com/golang/mock/mockgen/model
+-# github.com/golang/protobuf v1.5.3
+-## explicit; go 1.9
++# github.com/golang/protobuf v1.5.4
++## explicit; go 1.17
+ github.com/golang/protobuf/descriptor
+ github.com/golang/protobuf/jsonpb
+ github.com/golang/protobuf/proto
+@@ -218,14 +218,15 @@ google.golang.org/grpc/serviceconfig
+ google.golang.org/grpc/stats
+ google.golang.org/grpc/status
+ google.golang.org/grpc/tap
+-# google.golang.org/protobuf v1.31.0
+-## explicit; go 1.11
++# google.golang.org/protobuf v1.33.0
++## explicit; go 1.17
+ google.golang.org/protobuf/encoding/protojson
+ google.golang.org/protobuf/encoding/prototext
+ google.golang.org/protobuf/encoding/protowire
+ google.golang.org/protobuf/internal/descfmt
+ google.golang.org/protobuf/internal/descopts
+ google.golang.org/protobuf/internal/detrand
++google.golang.org/protobuf/internal/editiondefaults
+ google.golang.org/protobuf/internal/encoding/defval
+ google.golang.org/protobuf/internal/encoding/json
+ google.golang.org/protobuf/internal/encoding/messageset
+@@ -249,6 +250,7 @@ google.golang.org/protobuf/reflect/protoregistry
+ google.golang.org/protobuf/runtime/protoiface
+ google.golang.org/protobuf/runtime/protoimpl
+ google.golang.org/protobuf/types/descriptorpb
++google.golang.org/protobuf/types/gofeaturespb
+ google.golang.org/protobuf/types/known/anypb
+ google.golang.org/protobuf/types/known/durationpb
+ google.golang.org/protobuf/types/known/timestamppb
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/livenessprobe/1-28/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-28/CHECKSUMS
@@ -1,3 +1,3 @@
-d6969295d34e8eff3c87c9d9ace64f4817b5163a175d8be4384238266757ac28  _output/1-28/bin/livenessprobe/linux-amd64/livenessprobe
-23dd70fa11a9c2e0c83eccd1b4c8eecdf5d7c7ba55f8c50b6a3a88545b2998b6  _output/1-28/bin/livenessprobe/linux-arm64/livenessprobe
-d981c39b4089a15067100c9408f44898dc9d5c332716bd904c29dc44cd019b59  _output/1-28/bin/livenessprobe/windows-amd64/livenessprobe.exe
+f22ddc72b7428124f72945a6a6ffae35f17ecf71ebe35e1cbb356048bf216b20  _output/1-28/bin/livenessprobe/linux-amd64/livenessprobe
+d855e1a5d85f62483f89761693933b4a08cc98aa465248a23b4d98bd0c677885  _output/1-28/bin/livenessprobe/linux-arm64/livenessprobe
+062bdd08c21daf93a62469e7e09a88e4c514082cc9e0baa7de260ff1ee4d09eb  _output/1-28/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-28/patches/0001-Bump-protobuf-to-resolve-CVE-2024-24786-for-Liveness.patch
+++ b/projects/kubernetes-csi/livenessprobe/1-28/patches/0001-Bump-protobuf-to-resolve-CVE-2024-24786-for-Liveness.patch
@@ -1,0 +1,8141 @@
+From 787b5e4818b71783774e36f358a57150abad5983 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Mon, 18 Mar 2024 17:37:01 +0000
+Subject: [PATCH] Bump protobuf to resolve CVE-2024-24786 for Liveness-Probe
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |    4 +-
+ go.sum                                        |   12 +-
+ .../golang/protobuf/jsonpb/decode.go          |    1 +
+ .../golang/protobuf/jsonpb/encode.go          |    1 +
+ .../protoc-gen-go/descriptor/descriptor.pb.go |  128 +-
+ .../github.com/golang/protobuf/ptypes/any.go  |    7 +-
+ .../protobuf/encoding/protojson/decode.go     |   38 +-
+ .../protobuf/encoding/protojson/doc.go        |    2 +-
+ .../protobuf/encoding/protojson/encode.go     |   39 +-
+ .../encoding/protojson/well_known_types.go    |   59 +-
+ .../protobuf/encoding/prototext/decode.go     |    8 +-
+ .../protobuf/encoding/prototext/encode.go     |    4 +-
+ .../protobuf/encoding/protowire/wire.go       |   28 +-
+ .../protobuf/internal/descfmt/stringer.go     |  183 +-
+ .../internal/editiondefaults/defaults.go      |   12 +
+ .../editiondefaults/editions_defaults.binpb   |    4 +
+ .../protobuf/internal/encoding/json/decode.go |    2 +-
+ .../protobuf/internal/filedesc/desc.go        |  102 +-
+ .../protobuf/internal/filedesc/desc_init.go   |   52 +
+ .../protobuf/internal/filedesc/desc_lazy.go   |   28 +
+ .../protobuf/internal/filedesc/editions.go    |  142 +
+ .../protobuf/internal/genid/descriptor_gen.go |  364 ++-
+ .../internal/genid/go_features_gen.go         |   31 +
+ .../protobuf/internal/genid/struct_gen.go     |    5 +
+ .../protobuf/internal/genid/type_gen.go       |   38 +
+ .../protobuf/internal/impl/codec_extension.go |   22 +-
+ .../protobuf/internal/impl/codec_gen.go       |  113 +-
+ .../protobuf/internal/impl/codec_tables.go    |    2 +-
+ .../protobuf/internal/impl/legacy_message.go  |   19 +-
+ .../protobuf/internal/impl/message.go         |   17 +-
+ .../internal/impl/message_reflect_field.go    |    2 +-
+ .../protobuf/internal/impl/pointer_reflect.go |   36 +
+ .../protobuf/internal/impl/pointer_unsafe.go  |   40 +
+ .../protobuf/internal/strs/strings.go         |    2 +-
+ ...ings_unsafe.go => strings_unsafe_go120.go} |    4 +-
+ .../internal/strs/strings_unsafe_go121.go     |   74 +
+ .../protobuf/internal/version/version.go      |    2 +-
+ .../protobuf/proto/decode.go                  |    2 +-
+ .../google.golang.org/protobuf/proto/doc.go   |   58 +-
+ .../protobuf/proto/encode.go                  |    2 +-
+ .../protobuf/proto/extension.go               |    2 +-
+ .../google.golang.org/protobuf/proto/merge.go |    2 +-
+ .../google.golang.org/protobuf/proto/proto.go |   18 +-
+ .../protobuf/reflect/protodesc/desc.go        |   29 +-
+ .../protobuf/reflect/protodesc/desc_init.go   |   56 +
+ .../reflect/protodesc/desc_resolve.go         |    4 +-
+ .../reflect/protodesc/desc_validate.go        |    6 +-
+ .../protobuf/reflect/protodesc/editions.go    |  148 +
+ .../protobuf/reflect/protodesc/proto.go       |   18 +-
+ .../protobuf/reflect/protoreflect/proto.go    |   85 +-
+ .../reflect/protoreflect/source_gen.go        |   64 +-
+ .../protobuf/reflect/protoreflect/type.go     |   44 +-
+ .../protobuf/reflect/protoreflect/value.go    |   24 +-
+ .../reflect/protoreflect/value_equal.go       |    8 +-
+ .../reflect/protoreflect/value_union.go       |   44 +-
+ ...{value_unsafe.go => value_unsafe_go120.go} |    4 +-
+ .../protoreflect/value_unsafe_go121.go        |   87 +
+ .../reflect/protoregistry/registry.go         |   24 +-
+ .../types/descriptorpb/descriptor.pb.go       | 2475 ++++++++++++-----
+ .../types/gofeaturespb/go_features.pb.go      |  177 ++
+ .../types/gofeaturespb/go_features.proto      |   28 +
+ .../protobuf/types/known/anypb/any.pb.go      |    3 +-
+ vendor/modules.txt                            |   10 +-
+ 63 files changed, 3921 insertions(+), 1128 deletions(-)
+ create mode 100644 vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+ create mode 100644 vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+ create mode 100644 vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+ create mode 100644 vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+ rename vendor/google.golang.org/protobuf/internal/strs/{strings_unsafe.go => strings_unsafe_go120.go} (96%)
+ create mode 100644 vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+ create mode 100644 vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+ rename vendor/google.golang.org/protobuf/reflect/protoreflect/{value_unsafe.go => value_unsafe_go120.go} (97%)
+ create mode 100644 vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+ create mode 100644 vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+ create mode 100644 vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+
+diff --git a/go.mod b/go.mod
+index 66f1999..1e1128d 100644
+--- a/go.mod
++++ b/go.mod
+@@ -19,7 +19,7 @@ require (
+ 	github.com/go-logr/stdr v1.2.2 // indirect
+ 	github.com/go-logr/zapr v1.2.3 // indirect
+ 	github.com/gogo/protobuf v1.3.2 // indirect
+-	github.com/golang/protobuf v1.5.3 // indirect
++	github.com/golang/protobuf v1.5.4 // indirect
+ 	github.com/google/go-cmp v0.6.0 // indirect
+ 	github.com/google/gofuzz v1.2.0 // indirect
+ 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+@@ -46,7 +46,7 @@ require (
+ 	golang.org/x/text v0.14.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
+ 	google.golang.org/grpc v1.60.1 // indirect
+-	google.golang.org/protobuf v1.31.0 // indirect
++	google.golang.org/protobuf v1.33.0 // indirect
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+ 	gopkg.in/yaml.v2 v2.4.0 // indirect
+ 	k8s.io/apimachinery v0.29.0 // indirect
+diff --git a/go.sum b/go.sum
+index 37e6f06..8d87ecd 100644
+--- a/go.sum
++++ b/go.sum
+@@ -33,10 +33,8 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
+ github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+ github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
++github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
++github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+@@ -169,10 +167,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 h1:
+ google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17/go.mod h1:oQ5rr10WTTMvP4A36n8JpR1OrO1BEiV4f78CneXZxkA=
+ google.golang.org/grpc v1.60.1 h1:26+wFr+cNqSGFcOXcabYC0lUVJVRa2Sb2ortSK7VrEU=
+ google.golang.org/grpc v1.60.1/go.mod h1:OlCHIeLYqSSsLi6i49B5QGdzaMZK9+M7LXN2FKz4eGM=
+-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
++google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
++google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+diff --git a/vendor/github.com/golang/protobuf/jsonpb/decode.go b/vendor/github.com/golang/protobuf/jsonpb/decode.go
+index 6c16c25..c6f66f1 100644
+--- a/vendor/github.com/golang/protobuf/jsonpb/decode.go
++++ b/vendor/github.com/golang/protobuf/jsonpb/decode.go
+@@ -56,6 +56,7 @@ type Unmarshaler struct {
+ // implement JSONPBMarshaler so that the custom format can be produced.
+ //
+ // The JSON unmarshaling must follow the JSON to proto specification:
++//
+ //	https://developers.google.com/protocol-buffers/docs/proto3#json
+ //
+ // Deprecated: Custom types should implement protobuf reflection instead.
+diff --git a/vendor/github.com/golang/protobuf/jsonpb/encode.go b/vendor/github.com/golang/protobuf/jsonpb/encode.go
+index 685c80a..e9438a9 100644
+--- a/vendor/github.com/golang/protobuf/jsonpb/encode.go
++++ b/vendor/github.com/golang/protobuf/jsonpb/encode.go
+@@ -55,6 +55,7 @@ type Marshaler struct {
+ // implement JSONPBUnmarshaler so that the custom format can be parsed.
+ //
+ // The JSON marshaling must follow the proto to JSON specification:
++//
+ //	https://developers.google.com/protocol-buffers/docs/proto3#json
+ //
+ // Deprecated: Custom types should implement protobuf reflection instead.
+diff --git a/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go b/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
+index 63dc057..a5a1386 100644
+--- a/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
++++ b/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
+@@ -12,6 +12,31 @@ import (
+ 
+ // Symbols defined in public import of google/protobuf/descriptor.proto.
+ 
++type Edition = descriptorpb.Edition
++
++const Edition_EDITION_UNKNOWN = descriptorpb.Edition_EDITION_UNKNOWN
++const Edition_EDITION_PROTO2 = descriptorpb.Edition_EDITION_PROTO2
++const Edition_EDITION_PROTO3 = descriptorpb.Edition_EDITION_PROTO3
++const Edition_EDITION_2023 = descriptorpb.Edition_EDITION_2023
++const Edition_EDITION_2024 = descriptorpb.Edition_EDITION_2024
++const Edition_EDITION_1_TEST_ONLY = descriptorpb.Edition_EDITION_1_TEST_ONLY
++const Edition_EDITION_2_TEST_ONLY = descriptorpb.Edition_EDITION_2_TEST_ONLY
++const Edition_EDITION_99997_TEST_ONLY = descriptorpb.Edition_EDITION_99997_TEST_ONLY
++const Edition_EDITION_99998_TEST_ONLY = descriptorpb.Edition_EDITION_99998_TEST_ONLY
++const Edition_EDITION_99999_TEST_ONLY = descriptorpb.Edition_EDITION_99999_TEST_ONLY
++const Edition_EDITION_MAX = descriptorpb.Edition_EDITION_MAX
++
++var Edition_name = descriptorpb.Edition_name
++var Edition_value = descriptorpb.Edition_value
++
++type ExtensionRangeOptions_VerificationState = descriptorpb.ExtensionRangeOptions_VerificationState
++
++const ExtensionRangeOptions_DECLARATION = descriptorpb.ExtensionRangeOptions_DECLARATION
++const ExtensionRangeOptions_UNVERIFIED = descriptorpb.ExtensionRangeOptions_UNVERIFIED
++
++var ExtensionRangeOptions_VerificationState_name = descriptorpb.ExtensionRangeOptions_VerificationState_name
++var ExtensionRangeOptions_VerificationState_value = descriptorpb.ExtensionRangeOptions_VerificationState_value
++
+ type FieldDescriptorProto_Type = descriptorpb.FieldDescriptorProto_Type
+ 
+ const FieldDescriptorProto_TYPE_DOUBLE = descriptorpb.FieldDescriptorProto_TYPE_DOUBLE
+@@ -39,8 +64,8 @@ var FieldDescriptorProto_Type_value = descriptorpb.FieldDescriptorProto_Type_val
+ type FieldDescriptorProto_Label = descriptorpb.FieldDescriptorProto_Label
+ 
+ const FieldDescriptorProto_LABEL_OPTIONAL = descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL
+-const FieldDescriptorProto_LABEL_REQUIRED = descriptorpb.FieldDescriptorProto_LABEL_REQUIRED
+ const FieldDescriptorProto_LABEL_REPEATED = descriptorpb.FieldDescriptorProto_LABEL_REPEATED
++const FieldDescriptorProto_LABEL_REQUIRED = descriptorpb.FieldDescriptorProto_LABEL_REQUIRED
+ 
+ var FieldDescriptorProto_Label_name = descriptorpb.FieldDescriptorProto_Label_name
+ var FieldDescriptorProto_Label_value = descriptorpb.FieldDescriptorProto_Label_value
+@@ -72,6 +97,31 @@ const FieldOptions_JS_NUMBER = descriptorpb.FieldOptions_JS_NUMBER
+ var FieldOptions_JSType_name = descriptorpb.FieldOptions_JSType_name
+ var FieldOptions_JSType_value = descriptorpb.FieldOptions_JSType_value
+ 
++type FieldOptions_OptionRetention = descriptorpb.FieldOptions_OptionRetention
++
++const FieldOptions_RETENTION_UNKNOWN = descriptorpb.FieldOptions_RETENTION_UNKNOWN
++const FieldOptions_RETENTION_RUNTIME = descriptorpb.FieldOptions_RETENTION_RUNTIME
++const FieldOptions_RETENTION_SOURCE = descriptorpb.FieldOptions_RETENTION_SOURCE
++
++var FieldOptions_OptionRetention_name = descriptorpb.FieldOptions_OptionRetention_name
++var FieldOptions_OptionRetention_value = descriptorpb.FieldOptions_OptionRetention_value
++
++type FieldOptions_OptionTargetType = descriptorpb.FieldOptions_OptionTargetType
++
++const FieldOptions_TARGET_TYPE_UNKNOWN = descriptorpb.FieldOptions_TARGET_TYPE_UNKNOWN
++const FieldOptions_TARGET_TYPE_FILE = descriptorpb.FieldOptions_TARGET_TYPE_FILE
++const FieldOptions_TARGET_TYPE_EXTENSION_RANGE = descriptorpb.FieldOptions_TARGET_TYPE_EXTENSION_RANGE
++const FieldOptions_TARGET_TYPE_MESSAGE = descriptorpb.FieldOptions_TARGET_TYPE_MESSAGE
++const FieldOptions_TARGET_TYPE_FIELD = descriptorpb.FieldOptions_TARGET_TYPE_FIELD
++const FieldOptions_TARGET_TYPE_ONEOF = descriptorpb.FieldOptions_TARGET_TYPE_ONEOF
++const FieldOptions_TARGET_TYPE_ENUM = descriptorpb.FieldOptions_TARGET_TYPE_ENUM
++const FieldOptions_TARGET_TYPE_ENUM_ENTRY = descriptorpb.FieldOptions_TARGET_TYPE_ENUM_ENTRY
++const FieldOptions_TARGET_TYPE_SERVICE = descriptorpb.FieldOptions_TARGET_TYPE_SERVICE
++const FieldOptions_TARGET_TYPE_METHOD = descriptorpb.FieldOptions_TARGET_TYPE_METHOD
++
++var FieldOptions_OptionTargetType_name = descriptorpb.FieldOptions_OptionTargetType_name
++var FieldOptions_OptionTargetType_value = descriptorpb.FieldOptions_OptionTargetType_value
++
+ type MethodOptions_IdempotencyLevel = descriptorpb.MethodOptions_IdempotencyLevel
+ 
+ const MethodOptions_IDEMPOTENCY_UNKNOWN = descriptorpb.MethodOptions_IDEMPOTENCY_UNKNOWN
+@@ -81,10 +131,77 @@ const MethodOptions_IDEMPOTENT = descriptorpb.MethodOptions_IDEMPOTENT
+ var MethodOptions_IdempotencyLevel_name = descriptorpb.MethodOptions_IdempotencyLevel_name
+ var MethodOptions_IdempotencyLevel_value = descriptorpb.MethodOptions_IdempotencyLevel_value
+ 
++type FeatureSet_FieldPresence = descriptorpb.FeatureSet_FieldPresence
++
++const FeatureSet_FIELD_PRESENCE_UNKNOWN = descriptorpb.FeatureSet_FIELD_PRESENCE_UNKNOWN
++const FeatureSet_EXPLICIT = descriptorpb.FeatureSet_EXPLICIT
++const FeatureSet_IMPLICIT = descriptorpb.FeatureSet_IMPLICIT
++const FeatureSet_LEGACY_REQUIRED = descriptorpb.FeatureSet_LEGACY_REQUIRED
++
++var FeatureSet_FieldPresence_name = descriptorpb.FeatureSet_FieldPresence_name
++var FeatureSet_FieldPresence_value = descriptorpb.FeatureSet_FieldPresence_value
++
++type FeatureSet_EnumType = descriptorpb.FeatureSet_EnumType
++
++const FeatureSet_ENUM_TYPE_UNKNOWN = descriptorpb.FeatureSet_ENUM_TYPE_UNKNOWN
++const FeatureSet_OPEN = descriptorpb.FeatureSet_OPEN
++const FeatureSet_CLOSED = descriptorpb.FeatureSet_CLOSED
++
++var FeatureSet_EnumType_name = descriptorpb.FeatureSet_EnumType_name
++var FeatureSet_EnumType_value = descriptorpb.FeatureSet_EnumType_value
++
++type FeatureSet_RepeatedFieldEncoding = descriptorpb.FeatureSet_RepeatedFieldEncoding
++
++const FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN = descriptorpb.FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN
++const FeatureSet_PACKED = descriptorpb.FeatureSet_PACKED
++const FeatureSet_EXPANDED = descriptorpb.FeatureSet_EXPANDED
++
++var FeatureSet_RepeatedFieldEncoding_name = descriptorpb.FeatureSet_RepeatedFieldEncoding_name
++var FeatureSet_RepeatedFieldEncoding_value = descriptorpb.FeatureSet_RepeatedFieldEncoding_value
++
++type FeatureSet_Utf8Validation = descriptorpb.FeatureSet_Utf8Validation
++
++const FeatureSet_UTF8_VALIDATION_UNKNOWN = descriptorpb.FeatureSet_UTF8_VALIDATION_UNKNOWN
++const FeatureSet_VERIFY = descriptorpb.FeatureSet_VERIFY
++const FeatureSet_NONE = descriptorpb.FeatureSet_NONE
++
++var FeatureSet_Utf8Validation_name = descriptorpb.FeatureSet_Utf8Validation_name
++var FeatureSet_Utf8Validation_value = descriptorpb.FeatureSet_Utf8Validation_value
++
++type FeatureSet_MessageEncoding = descriptorpb.FeatureSet_MessageEncoding
++
++const FeatureSet_MESSAGE_ENCODING_UNKNOWN = descriptorpb.FeatureSet_MESSAGE_ENCODING_UNKNOWN
++const FeatureSet_LENGTH_PREFIXED = descriptorpb.FeatureSet_LENGTH_PREFIXED
++const FeatureSet_DELIMITED = descriptorpb.FeatureSet_DELIMITED
++
++var FeatureSet_MessageEncoding_name = descriptorpb.FeatureSet_MessageEncoding_name
++var FeatureSet_MessageEncoding_value = descriptorpb.FeatureSet_MessageEncoding_value
++
++type FeatureSet_JsonFormat = descriptorpb.FeatureSet_JsonFormat
++
++const FeatureSet_JSON_FORMAT_UNKNOWN = descriptorpb.FeatureSet_JSON_FORMAT_UNKNOWN
++const FeatureSet_ALLOW = descriptorpb.FeatureSet_ALLOW
++const FeatureSet_LEGACY_BEST_EFFORT = descriptorpb.FeatureSet_LEGACY_BEST_EFFORT
++
++var FeatureSet_JsonFormat_name = descriptorpb.FeatureSet_JsonFormat_name
++var FeatureSet_JsonFormat_value = descriptorpb.FeatureSet_JsonFormat_value
++
++type GeneratedCodeInfo_Annotation_Semantic = descriptorpb.GeneratedCodeInfo_Annotation_Semantic
++
++const GeneratedCodeInfo_Annotation_NONE = descriptorpb.GeneratedCodeInfo_Annotation_NONE
++const GeneratedCodeInfo_Annotation_SET = descriptorpb.GeneratedCodeInfo_Annotation_SET
++const GeneratedCodeInfo_Annotation_ALIAS = descriptorpb.GeneratedCodeInfo_Annotation_ALIAS
++
++var GeneratedCodeInfo_Annotation_Semantic_name = descriptorpb.GeneratedCodeInfo_Annotation_Semantic_name
++var GeneratedCodeInfo_Annotation_Semantic_value = descriptorpb.GeneratedCodeInfo_Annotation_Semantic_value
++
+ type FileDescriptorSet = descriptorpb.FileDescriptorSet
+ type FileDescriptorProto = descriptorpb.FileDescriptorProto
+ type DescriptorProto = descriptorpb.DescriptorProto
+ type ExtensionRangeOptions = descriptorpb.ExtensionRangeOptions
++
++const Default_ExtensionRangeOptions_Verification = descriptorpb.Default_ExtensionRangeOptions_Verification
++
+ type FieldDescriptorProto = descriptorpb.FieldDescriptorProto
+ type OneofDescriptorProto = descriptorpb.OneofDescriptorProto
+ type EnumDescriptorProto = descriptorpb.EnumDescriptorProto
+@@ -103,7 +220,6 @@ const Default_FileOptions_OptimizeFor = descriptorpb.Default_FileOptions_Optimiz
+ const Default_FileOptions_CcGenericServices = descriptorpb.Default_FileOptions_CcGenericServices
+ const Default_FileOptions_JavaGenericServices = descriptorpb.Default_FileOptions_JavaGenericServices
+ const Default_FileOptions_PyGenericServices = descriptorpb.Default_FileOptions_PyGenericServices
+-const Default_FileOptions_PhpGenericServices = descriptorpb.Default_FileOptions_PhpGenericServices
+ const Default_FileOptions_Deprecated = descriptorpb.Default_FileOptions_Deprecated
+ const Default_FileOptions_CcEnableArenas = descriptorpb.Default_FileOptions_CcEnableArenas
+ 
+@@ -118,8 +234,10 @@ type FieldOptions = descriptorpb.FieldOptions
+ const Default_FieldOptions_Ctype = descriptorpb.Default_FieldOptions_Ctype
+ const Default_FieldOptions_Jstype = descriptorpb.Default_FieldOptions_Jstype
+ const Default_FieldOptions_Lazy = descriptorpb.Default_FieldOptions_Lazy
++const Default_FieldOptions_UnverifiedLazy = descriptorpb.Default_FieldOptions_UnverifiedLazy
+ const Default_FieldOptions_Deprecated = descriptorpb.Default_FieldOptions_Deprecated
+ const Default_FieldOptions_Weak = descriptorpb.Default_FieldOptions_Weak
++const Default_FieldOptions_DebugRedact = descriptorpb.Default_FieldOptions_DebugRedact
+ 
+ type OneofOptions = descriptorpb.OneofOptions
+ type EnumOptions = descriptorpb.EnumOptions
+@@ -129,6 +247,7 @@ const Default_EnumOptions_Deprecated = descriptorpb.Default_EnumOptions_Deprecat
+ type EnumValueOptions = descriptorpb.EnumValueOptions
+ 
+ const Default_EnumValueOptions_Deprecated = descriptorpb.Default_EnumValueOptions_Deprecated
++const Default_EnumValueOptions_DebugRedact = descriptorpb.Default_EnumValueOptions_DebugRedact
+ 
+ type ServiceOptions = descriptorpb.ServiceOptions
+ 
+@@ -140,12 +259,17 @@ const Default_MethodOptions_Deprecated = descriptorpb.Default_MethodOptions_Depr
+ const Default_MethodOptions_IdempotencyLevel = descriptorpb.Default_MethodOptions_IdempotencyLevel
+ 
+ type UninterpretedOption = descriptorpb.UninterpretedOption
++type FeatureSet = descriptorpb.FeatureSet
++type FeatureSetDefaults = descriptorpb.FeatureSetDefaults
+ type SourceCodeInfo = descriptorpb.SourceCodeInfo
+ type GeneratedCodeInfo = descriptorpb.GeneratedCodeInfo
+ type DescriptorProto_ExtensionRange = descriptorpb.DescriptorProto_ExtensionRange
+ type DescriptorProto_ReservedRange = descriptorpb.DescriptorProto_ReservedRange
++type ExtensionRangeOptions_Declaration = descriptorpb.ExtensionRangeOptions_Declaration
+ type EnumDescriptorProto_EnumReservedRange = descriptorpb.EnumDescriptorProto_EnumReservedRange
++type FieldOptions_EditionDefault = descriptorpb.FieldOptions_EditionDefault
+ type UninterpretedOption_NamePart = descriptorpb.UninterpretedOption_NamePart
++type FeatureSetDefaults_FeatureSetEditionDefault = descriptorpb.FeatureSetDefaults_FeatureSetEditionDefault
+ type SourceCodeInfo_Location = descriptorpb.SourceCodeInfo_Location
+ type GeneratedCodeInfo_Annotation = descriptorpb.GeneratedCodeInfo_Annotation
+ 
+diff --git a/vendor/github.com/golang/protobuf/ptypes/any.go b/vendor/github.com/golang/protobuf/ptypes/any.go
+index 85f9f57..fdff3fd 100644
+--- a/vendor/github.com/golang/protobuf/ptypes/any.go
++++ b/vendor/github.com/golang/protobuf/ptypes/any.go
+@@ -127,9 +127,10 @@ func Is(any *anypb.Any, m proto.Message) bool {
+ // The allocated message is stored in the embedded proto.Message.
+ //
+ // Example:
+-//   var x ptypes.DynamicAny
+-//   if err := ptypes.UnmarshalAny(a, &x); err != nil { ... }
+-//   fmt.Printf("unmarshaled message: %v", x.Message)
++//
++//	var x ptypes.DynamicAny
++//	if err := ptypes.UnmarshalAny(a, &x); err != nil { ... }
++//	fmt.Printf("unmarshaled message: %v", x.Message)
+ //
+ // Deprecated: Use the any.UnmarshalNew method instead to unmarshal
+ // the any message contents into a new instance of the underlying message.
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/decode.go b/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
+index 5f28148..f479023 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
+@@ -11,6 +11,7 @@ import (
+ 	"strconv"
+ 	"strings"
+ 
++	"google.golang.org/protobuf/encoding/protowire"
+ 	"google.golang.org/protobuf/internal/encoding/json"
+ 	"google.golang.org/protobuf/internal/encoding/messageset"
+ 	"google.golang.org/protobuf/internal/errors"
+@@ -23,7 +24,7 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
+-// Unmarshal reads the given []byte into the given proto.Message.
++// Unmarshal reads the given []byte into the given [proto.Message].
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func Unmarshal(b []byte, m proto.Message) error {
+ 	return UnmarshalOptions{}.Unmarshal(b, m)
+@@ -37,7 +38,7 @@ type UnmarshalOptions struct {
+ 	// required fields will not return an error.
+ 	AllowPartial bool
+ 
+-	// If DiscardUnknown is set, unknown fields are ignored.
++	// If DiscardUnknown is set, unknown fields and enum name values are ignored.
+ 	DiscardUnknown bool
+ 
+ 	// Resolver is used for looking up types when unmarshaling
+@@ -47,9 +48,13 @@ type UnmarshalOptions struct {
+ 		protoregistry.MessageTypeResolver
+ 		protoregistry.ExtensionTypeResolver
+ 	}
++
++	// RecursionLimit limits how deeply messages may be nested.
++	// If zero, a default limit is applied.
++	RecursionLimit int
+ }
+ 
+-// Unmarshal reads the given []byte and populates the given proto.Message
++// Unmarshal reads the given []byte and populates the given [proto.Message]
+ // using options in the UnmarshalOptions object.
+ // It will clear the message first before setting the fields.
+ // If it returns an error, the given message may be partially set.
+@@ -67,6 +72,9 @@ func (o UnmarshalOptions) unmarshal(b []byte, m proto.Message) error {
+ 	if o.Resolver == nil {
+ 		o.Resolver = protoregistry.GlobalTypes
+ 	}
++	if o.RecursionLimit == 0 {
++		o.RecursionLimit = protowire.DefaultRecursionLimit
++	}
+ 
+ 	dec := decoder{json.NewDecoder(b), o}
+ 	if err := dec.unmarshalMessage(m.ProtoReflect(), false); err != nil {
+@@ -114,6 +122,10 @@ func (d decoder) syntaxError(pos int, f string, x ...interface{}) error {
+ 
+ // unmarshalMessage unmarshals a message into the given protoreflect.Message.
+ func (d decoder) unmarshalMessage(m protoreflect.Message, skipTypeURL bool) error {
++	d.opts.RecursionLimit--
++	if d.opts.RecursionLimit < 0 {
++		return errors.New("exceeded max recursion depth")
++	}
+ 	if unmarshal := wellKnownTypeUnmarshaler(m.Descriptor().FullName()); unmarshal != nil {
+ 		return unmarshal(d, m)
+ 	}
+@@ -266,7 +278,9 @@ func (d decoder) unmarshalSingular(m protoreflect.Message, fd protoreflect.Field
+ 	if err != nil {
+ 		return err
+ 	}
+-	m.Set(fd, val)
++	if val.IsValid() {
++		m.Set(fd, val)
++	}
+ 	return nil
+ }
+ 
+@@ -329,7 +343,7 @@ func (d decoder) unmarshalScalar(fd protoreflect.FieldDescriptor) (protoreflect.
+ 		}
+ 
+ 	case protoreflect.EnumKind:
+-		if v, ok := unmarshalEnum(tok, fd); ok {
++		if v, ok := unmarshalEnum(tok, fd, d.opts.DiscardUnknown); ok {
+ 			return v, nil
+ 		}
+ 
+@@ -474,7 +488,7 @@ func unmarshalBytes(tok json.Token) (protoreflect.Value, bool) {
+ 	return protoreflect.ValueOfBytes(b), true
+ }
+ 
+-func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor) (protoreflect.Value, bool) {
++func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor, discardUnknown bool) (protoreflect.Value, bool) {
+ 	switch tok.Kind() {
+ 	case json.String:
+ 		// Lookup EnumNumber based on name.
+@@ -482,6 +496,9 @@ func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor) (protoreflec
+ 		if enumVal := fd.Enum().Values().ByName(protoreflect.Name(s)); enumVal != nil {
+ 			return protoreflect.ValueOfEnum(enumVal.Number()), true
+ 		}
++		if discardUnknown {
++			return protoreflect.Value{}, true
++		}
+ 
+ 	case json.Number:
+ 		if n, ok := tok.Int(32); ok {
+@@ -542,7 +559,9 @@ func (d decoder) unmarshalList(list protoreflect.List, fd protoreflect.FieldDesc
+ 			if err != nil {
+ 				return err
+ 			}
+-			list.Append(val)
++			if val.IsValid() {
++				list.Append(val)
++			}
+ 		}
+ 	}
+ 
+@@ -609,8 +628,9 @@ Loop:
+ 		if err != nil {
+ 			return err
+ 		}
+-
+-		mmap.Set(pkey, pval)
++		if pval.IsValid() {
++			mmap.Set(pkey, pval)
++		}
+ 	}
+ 
+ 	return nil
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/doc.go b/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
+index 21d5d2c..ae71007 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
+@@ -6,6 +6,6 @@
+ // format. It follows the guide at
+ // https://protobuf.dev/programming-guides/proto3#json.
+ //
+-// This package produces a different output than the standard "encoding/json"
++// This package produces a different output than the standard [encoding/json]
+ // package, which does not operate correctly on protocol buffer messages.
+ package protojson
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/encode.go b/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
+index 66b9587..3f75098 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
+@@ -31,7 +31,7 @@ func Format(m proto.Message) string {
+ 	return MarshalOptions{Multiline: true}.Format(m)
+ }
+ 
+-// Marshal writes the given proto.Message in JSON format using default options.
++// Marshal writes the given [proto.Message] in JSON format using default options.
+ // Do not depend on the output being stable. It may change over time across
+ // different versions of the program.
+ func Marshal(m proto.Message) ([]byte, error) {
+@@ -81,6 +81,25 @@ type MarshalOptions struct {
+ 	//  ╚═══════╧════════════════════════════╝
+ 	EmitUnpopulated bool
+ 
++	// EmitDefaultValues specifies whether to emit default-valued primitive fields,
++	// empty lists, and empty maps. The fields affected are as follows:
++	//  ╔═══════╤════════════════════════════════════════╗
++	//  ║ JSON  │ Protobuf field                         ║
++	//  ╠═══════╪════════════════════════════════════════╣
++	//  ║ false │ non-optional scalar boolean fields     ║
++	//  ║ 0     │ non-optional scalar numeric fields     ║
++	//  ║ ""    │ non-optional scalar string/byte fields ║
++	//  ║ []    │ empty repeated fields                  ║
++	//  ║ {}    │ empty map fields                       ║
++	//  ╚═══════╧════════════════════════════════════════╝
++	//
++	// Behaves similarly to EmitUnpopulated, but does not emit "null"-value fields,
++	// i.e. presence-sensing fields that are omitted will remain omitted to preserve
++	// presence-sensing.
++	// EmitUnpopulated takes precedence over EmitDefaultValues since the former generates
++	// a strict superset of the latter.
++	EmitDefaultValues bool
++
+ 	// Resolver is used for looking up types when expanding google.protobuf.Any
+ 	// messages. If nil, this defaults to using protoregistry.GlobalTypes.
+ 	Resolver interface {
+@@ -102,7 +121,7 @@ func (o MarshalOptions) Format(m proto.Message) string {
+ 	return string(b)
+ }
+ 
+-// Marshal marshals the given proto.Message in the JSON format using options in
++// Marshal marshals the given [proto.Message] in the JSON format using options in
+ // MarshalOptions. Do not depend on the output being stable. It may change over
+ // time across different versions of the program.
+ func (o MarshalOptions) Marshal(m proto.Message) ([]byte, error) {
+@@ -178,7 +197,11 @@ func (m typeURLFieldRanger) Range(f func(protoreflect.FieldDescriptor, protorefl
+ 
+ // unpopulatedFieldRanger wraps a protoreflect.Message and modifies its Range
+ // method to additionally iterate over unpopulated fields.
+-type unpopulatedFieldRanger struct{ protoreflect.Message }
++type unpopulatedFieldRanger struct {
++	protoreflect.Message
++
++	skipNull bool
++}
+ 
+ func (m unpopulatedFieldRanger) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+ 	fds := m.Descriptor().Fields()
+@@ -192,6 +215,9 @@ func (m unpopulatedFieldRanger) Range(f func(protoreflect.FieldDescriptor, proto
+ 		isProto2Scalar := fd.Syntax() == protoreflect.Proto2 && fd.Default().IsValid()
+ 		isSingularMessage := fd.Cardinality() != protoreflect.Repeated && fd.Message() != nil
+ 		if isProto2Scalar || isSingularMessage {
++			if m.skipNull {
++				continue
++			}
+ 			v = protoreflect.Value{} // use invalid value to emit null
+ 		}
+ 		if !f(fd, v) {
+@@ -217,8 +243,11 @@ func (e encoder) marshalMessage(m protoreflect.Message, typeURL string) error {
+ 	defer e.EndObject()
+ 
+ 	var fields order.FieldRanger = m
+-	if e.opts.EmitUnpopulated {
+-		fields = unpopulatedFieldRanger{m}
++	switch {
++	case e.opts.EmitUnpopulated:
++		fields = unpopulatedFieldRanger{Message: m, skipNull: false}
++	case e.opts.EmitDefaultValues:
++		fields = unpopulatedFieldRanger{Message: m, skipNull: true}
+ 	}
+ 	if typeURL != "" {
+ 		fields = typeURLFieldRanger{fields, typeURL}
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+index 6c37d41..4b177c8 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+@@ -176,7 +176,7 @@ func (d decoder) unmarshalAny(m protoreflect.Message) error {
+ 	// Use another decoder to parse the unread bytes for @type field. This
+ 	// avoids advancing a read from current decoder because the current JSON
+ 	// object may contain the fields of the embedded type.
+-	dec := decoder{d.Clone(), UnmarshalOptions{}}
++	dec := decoder{d.Clone(), UnmarshalOptions{RecursionLimit: d.opts.RecursionLimit}}
+ 	tok, err := findTypeURL(dec)
+ 	switch err {
+ 	case errEmptyObject:
+@@ -308,48 +308,29 @@ Loop:
+ // array) in order to advance the read to the next JSON value. It relies on
+ // the decoder returning an error if the types are not in valid sequence.
+ func (d decoder) skipJSONValue() error {
+-	tok, err := d.Read()
+-	if err != nil {
+-		return err
+-	}
+-	// Only need to continue reading for objects and arrays.
+-	switch tok.Kind() {
+-	case json.ObjectOpen:
+-		for {
+-			tok, err := d.Read()
+-			if err != nil {
+-				return err
+-			}
+-			switch tok.Kind() {
+-			case json.ObjectClose:
+-				return nil
+-			case json.Name:
+-				// Skip object field value.
+-				if err := d.skipJSONValue(); err != nil {
+-					return err
+-				}
+-			}
++	var open int
++	for {
++		tok, err := d.Read()
++		if err != nil {
++			return err
+ 		}
+-
+-	case json.ArrayOpen:
+-		for {
+-			tok, err := d.Peek()
+-			if err != nil {
+-				return err
+-			}
+-			switch tok.Kind() {
+-			case json.ArrayClose:
+-				d.Read()
+-				return nil
+-			default:
+-				// Skip array item.
+-				if err := d.skipJSONValue(); err != nil {
+-					return err
+-				}
++		switch tok.Kind() {
++		case json.ObjectClose, json.ArrayClose:
++			open--
++		case json.ObjectOpen, json.ArrayOpen:
++			open++
++			if open > d.opts.RecursionLimit {
++				return errors.New("exceeded max recursion depth")
+ 			}
++		case json.EOF:
++			// This can only happen if there's a bug in Decoder.Read.
++			// Avoid an infinite loop if this does happen.
++			return errors.New("unexpected EOF")
++		}
++		if open == 0 {
++			return nil
+ 		}
+ 	}
+-	return nil
+ }
+ 
+ // unmarshalAnyValue unmarshals the given custom-type message from the JSON
+diff --git a/vendor/google.golang.org/protobuf/encoding/prototext/decode.go b/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
+index 4921b2d..a45f112 100644
+--- a/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
++++ b/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
+@@ -21,7 +21,7 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
+-// Unmarshal reads the given []byte into the given proto.Message.
++// Unmarshal reads the given []byte into the given [proto.Message].
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func Unmarshal(b []byte, m proto.Message) error {
+ 	return UnmarshalOptions{}.Unmarshal(b, m)
+@@ -51,7 +51,7 @@ type UnmarshalOptions struct {
+ 	}
+ }
+ 
+-// Unmarshal reads the given []byte and populates the given proto.Message
++// Unmarshal reads the given []byte and populates the given [proto.Message]
+ // using options in the UnmarshalOptions object.
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func (o UnmarshalOptions) Unmarshal(b []byte, m proto.Message) error {
+@@ -739,7 +739,9 @@ func (d decoder) skipValue() error {
+ 			case text.ListClose:
+ 				return nil
+ 			case text.MessageOpen:
+-				return d.skipMessageValue()
++				if err := d.skipMessageValue(); err != nil {
++					return err
++				}
+ 			default:
+ 				// Skip items. This will not validate whether skipped values are
+ 				// of the same type or not, same behavior as C++
+diff --git a/vendor/google.golang.org/protobuf/encoding/prototext/encode.go b/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
+index 722a7b4..95967e8 100644
+--- a/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
++++ b/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
+@@ -33,7 +33,7 @@ func Format(m proto.Message) string {
+ 	return MarshalOptions{Multiline: true}.Format(m)
+ }
+ 
+-// Marshal writes the given proto.Message in textproto format using default
++// Marshal writes the given [proto.Message] in textproto format using default
+ // options. Do not depend on the output being stable. It may change over time
+ // across different versions of the program.
+ func Marshal(m proto.Message) ([]byte, error) {
+@@ -97,7 +97,7 @@ func (o MarshalOptions) Format(m proto.Message) string {
+ 	return string(b)
+ }
+ 
+-// Marshal writes the given proto.Message in textproto format using options in
++// Marshal writes the given [proto.Message] in textproto format using options in
+ // MarshalOptions object. Do not depend on the output being stable. It may
+ // change over time across different versions of the program.
+ func (o MarshalOptions) Marshal(m proto.Message) ([]byte, error) {
+diff --git a/vendor/google.golang.org/protobuf/encoding/protowire/wire.go b/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
+index f4b4686..e942bc9 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
++++ b/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
+@@ -6,7 +6,7 @@
+ // See https://protobuf.dev/programming-guides/encoding.
+ //
+ // For marshaling and unmarshaling entire protobuf messages,
+-// use the "google.golang.org/protobuf/proto" package instead.
++// use the [google.golang.org/protobuf/proto] package instead.
+ package protowire
+ 
+ import (
+@@ -87,7 +87,7 @@ func ParseError(n int) error {
+ 
+ // ConsumeField parses an entire field record (both tag and value) and returns
+ // the field number, the wire type, and the total length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ //
+ // The total length includes the tag header and the end group marker (if the
+ // field is a group).
+@@ -104,8 +104,8 @@ func ConsumeField(b []byte) (Number, Type, int) {
+ }
+ 
+ // ConsumeFieldValue parses a field value and returns its length.
+-// This assumes that the field Number and wire Type have already been parsed.
+-// This returns a negative length upon an error (see ParseError).
++// This assumes that the field [Number] and wire [Type] have already been parsed.
++// This returns a negative length upon an error (see [ParseError]).
+ //
+ // When parsing a group, the length includes the end group marker and
+ // the end group is verified to match the starting field number.
+@@ -164,7 +164,7 @@ func AppendTag(b []byte, num Number, typ Type) []byte {
+ }
+ 
+ // ConsumeTag parses b as a varint-encoded tag, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeTag(b []byte) (Number, Type, int) {
+ 	v, n := ConsumeVarint(b)
+ 	if n < 0 {
+@@ -263,7 +263,7 @@ func AppendVarint(b []byte, v uint64) []byte {
+ }
+ 
+ // ConsumeVarint parses b as a varint-encoded uint64, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeVarint(b []byte) (v uint64, n int) {
+ 	var y uint64
+ 	if len(b) <= 0 {
+@@ -384,7 +384,7 @@ func AppendFixed32(b []byte, v uint32) []byte {
+ }
+ 
+ // ConsumeFixed32 parses b as a little-endian uint32, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeFixed32(b []byte) (v uint32, n int) {
+ 	if len(b) < 4 {
+ 		return 0, errCodeTruncated
+@@ -412,7 +412,7 @@ func AppendFixed64(b []byte, v uint64) []byte {
+ }
+ 
+ // ConsumeFixed64 parses b as a little-endian uint64, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeFixed64(b []byte) (v uint64, n int) {
+ 	if len(b) < 8 {
+ 		return 0, errCodeTruncated
+@@ -432,7 +432,7 @@ func AppendBytes(b []byte, v []byte) []byte {
+ }
+ 
+ // ConsumeBytes parses b as a length-prefixed bytes value, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeBytes(b []byte) (v []byte, n int) {
+ 	m, n := ConsumeVarint(b)
+ 	if n < 0 {
+@@ -456,7 +456,7 @@ func AppendString(b []byte, v string) []byte {
+ }
+ 
+ // ConsumeString parses b as a length-prefixed bytes value, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeString(b []byte) (v string, n int) {
+ 	bb, n := ConsumeBytes(b)
+ 	return string(bb), n
+@@ -471,7 +471,7 @@ func AppendGroup(b []byte, num Number, v []byte) []byte {
+ // ConsumeGroup parses b as a group value until the trailing end group marker,
+ // and verifies that the end marker matches the provided num. The value v
+ // does not contain the end marker, while the length does contain the end marker.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeGroup(num Number, b []byte) (v []byte, n int) {
+ 	n = ConsumeFieldValue(num, StartGroupType, b)
+ 	if n < 0 {
+@@ -495,8 +495,8 @@ func SizeGroup(num Number, n int) int {
+ 	return n + SizeTag(num)
+ }
+ 
+-// DecodeTag decodes the field Number and wire Type from its unified form.
+-// The Number is -1 if the decoded field number overflows int32.
++// DecodeTag decodes the field [Number] and wire [Type] from its unified form.
++// The [Number] is -1 if the decoded field number overflows int32.
+ // Other than overflow, this does not check for field number validity.
+ func DecodeTag(x uint64) (Number, Type) {
+ 	// NOTE: MessageSet allows for larger field numbers than normal.
+@@ -506,7 +506,7 @@ func DecodeTag(x uint64) (Number, Type) {
+ 	return Number(x >> 3), Type(x & 7)
+ }
+ 
+-// EncodeTag encodes the field Number and wire Type into its unified form.
++// EncodeTag encodes the field [Number] and wire [Type] into its unified form.
+ func EncodeTag(num Number, typ Type) uint64 {
+ 	return uint64(num)<<3 | uint64(typ&7)
+ }
+diff --git a/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go b/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
+index db5248e..a45625c 100644
+--- a/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
++++ b/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
+@@ -83,7 +83,13 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
+ 	case protoreflect.FileImports:
+ 		for i := 0; i < vs.Len(); i++ {
+ 			var rs records
+-			rs.Append(reflect.ValueOf(vs.Get(i)), "Path", "Package", "IsPublic", "IsWeak")
++			rv := reflect.ValueOf(vs.Get(i))
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("IsPublic"), "IsPublic"},
++				{rv.MethodByName("IsWeak"), "IsWeak"},
++			}...)
+ 			ss = append(ss, "{"+rs.Join()+"}")
+ 		}
+ 		return start + joinStrings(ss, allowMulti) + end
+@@ -92,34 +98,26 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
+ 		for i := 0; i < vs.Len(); i++ {
+ 			m := reflect.ValueOf(vs).MethodByName("Get")
+ 			v := m.Call([]reflect.Value{reflect.ValueOf(i)})[0].Interface()
+-			ss = append(ss, formatDescOpt(v.(protoreflect.Descriptor), false, allowMulti && !isEnumValue))
++			ss = append(ss, formatDescOpt(v.(protoreflect.Descriptor), false, allowMulti && !isEnumValue, nil))
+ 		}
+ 		return start + joinStrings(ss, allowMulti && isEnumValue) + end
+ 	}
+ }
+ 
+-// descriptorAccessors is a list of accessors to print for each descriptor.
+-//
+-// Do not print all accessors since some contain redundant information,
+-// while others are pointers that we do not want to follow since the descriptor
+-// is actually a cyclic graph.
+-//
+-// Using a list allows us to print the accessors in a sensible order.
+-var descriptorAccessors = map[reflect.Type][]string{
+-	reflect.TypeOf((*protoreflect.FileDescriptor)(nil)).Elem():      {"Path", "Package", "Imports", "Messages", "Enums", "Extensions", "Services"},
+-	reflect.TypeOf((*protoreflect.MessageDescriptor)(nil)).Elem():   {"IsMapEntry", "Fields", "Oneofs", "ReservedNames", "ReservedRanges", "RequiredNumbers", "ExtensionRanges", "Messages", "Enums", "Extensions"},
+-	reflect.TypeOf((*protoreflect.FieldDescriptor)(nil)).Elem():     {"Number", "Cardinality", "Kind", "HasJSONName", "JSONName", "HasPresence", "IsExtension", "IsPacked", "IsWeak", "IsList", "IsMap", "MapKey", "MapValue", "HasDefault", "Default", "ContainingOneof", "ContainingMessage", "Message", "Enum"},
+-	reflect.TypeOf((*protoreflect.OneofDescriptor)(nil)).Elem():     {"Fields"}, // not directly used; must keep in sync with formatDescOpt
+-	reflect.TypeOf((*protoreflect.EnumDescriptor)(nil)).Elem():      {"Values", "ReservedNames", "ReservedRanges"},
+-	reflect.TypeOf((*protoreflect.EnumValueDescriptor)(nil)).Elem(): {"Number"},
+-	reflect.TypeOf((*protoreflect.ServiceDescriptor)(nil)).Elem():   {"Methods"},
+-	reflect.TypeOf((*protoreflect.MethodDescriptor)(nil)).Elem():    {"Input", "Output", "IsStreamingClient", "IsStreamingServer"},
++type methodAndName struct {
++	method reflect.Value
++	name   string
+ }
+ 
+ func FormatDesc(s fmt.State, r rune, t protoreflect.Descriptor) {
+-	io.WriteString(s, formatDescOpt(t, true, r == 'v' && (s.Flag('+') || s.Flag('#'))))
++	io.WriteString(s, formatDescOpt(t, true, r == 'v' && (s.Flag('+') || s.Flag('#')), nil))
+ }
+-func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
++
++func InternalFormatDescOptForTesting(t protoreflect.Descriptor, isRoot, allowMulti bool, record func(string)) string {
++	return formatDescOpt(t, isRoot, allowMulti, record)
++}
++
++func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool, record func(string)) string {
+ 	rv := reflect.ValueOf(t)
+ 	rt := rv.MethodByName("ProtoType").Type().In(0)
+ 
+@@ -129,26 +127,60 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 	}
+ 
+ 	_, isFile := t.(protoreflect.FileDescriptor)
+-	rs := records{allowMulti: allowMulti}
++	rs := records{
++		allowMulti: allowMulti,
++		record:     record,
++	}
+ 	if t.IsPlaceholder() {
+ 		if isFile {
+-			rs.Append(rv, "Path", "Package", "IsPlaceholder")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
++			}...)
+ 		} else {
+-			rs.Append(rv, "FullName", "IsPlaceholder")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("FullName"), "FullName"},
++				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
++			}...)
+ 		}
+ 	} else {
+ 		switch {
+ 		case isFile:
+-			rs.Append(rv, "Syntax")
++			rs.Append(rv, methodAndName{rv.MethodByName("Syntax"), "Syntax"})
+ 		case isRoot:
+-			rs.Append(rv, "Syntax", "FullName")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Syntax"), "Syntax"},
++				{rv.MethodByName("FullName"), "FullName"},
++			}...)
+ 		default:
+-			rs.Append(rv, "Name")
++			rs.Append(rv, methodAndName{rv.MethodByName("Name"), "Name"})
+ 		}
+ 		switch t := t.(type) {
+ 		case protoreflect.FieldDescriptor:
+-			for _, s := range descriptorAccessors[rt] {
+-				switch s {
++			accessors := []methodAndName{
++				{rv.MethodByName("Number"), "Number"},
++				{rv.MethodByName("Cardinality"), "Cardinality"},
++				{rv.MethodByName("Kind"), "Kind"},
++				{rv.MethodByName("HasJSONName"), "HasJSONName"},
++				{rv.MethodByName("JSONName"), "JSONName"},
++				{rv.MethodByName("HasPresence"), "HasPresence"},
++				{rv.MethodByName("IsExtension"), "IsExtension"},
++				{rv.MethodByName("IsPacked"), "IsPacked"},
++				{rv.MethodByName("IsWeak"), "IsWeak"},
++				{rv.MethodByName("IsList"), "IsList"},
++				{rv.MethodByName("IsMap"), "IsMap"},
++				{rv.MethodByName("MapKey"), "MapKey"},
++				{rv.MethodByName("MapValue"), "MapValue"},
++				{rv.MethodByName("HasDefault"), "HasDefault"},
++				{rv.MethodByName("Default"), "Default"},
++				{rv.MethodByName("ContainingOneof"), "ContainingOneof"},
++				{rv.MethodByName("ContainingMessage"), "ContainingMessage"},
++				{rv.MethodByName("Message"), "Message"},
++				{rv.MethodByName("Enum"), "Enum"},
++			}
++			for _, s := range accessors {
++				switch s.name {
+ 				case "MapKey":
+ 					if k := t.MapKey(); k != nil {
+ 						rs.recs = append(rs.recs, [2]string{"MapKey", k.Kind().String()})
+@@ -157,20 +189,20 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 					if v := t.MapValue(); v != nil {
+ 						switch v.Kind() {
+ 						case protoreflect.EnumKind:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", string(v.Enum().FullName())})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", string(v.Enum().FullName())})
+ 						case protoreflect.MessageKind, protoreflect.GroupKind:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", string(v.Message().FullName())})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", string(v.Message().FullName())})
+ 						default:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", v.Kind().String()})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", v.Kind().String()})
+ 						}
+ 					}
+ 				case "ContainingOneof":
+ 					if od := t.ContainingOneof(); od != nil {
+-						rs.recs = append(rs.recs, [2]string{"Oneof", string(od.Name())})
++						rs.AppendRecs("ContainingOneof", [2]string{"Oneof", string(od.Name())})
+ 					}
+ 				case "ContainingMessage":
+ 					if t.IsExtension() {
+-						rs.recs = append(rs.recs, [2]string{"Extendee", string(t.ContainingMessage().FullName())})
++						rs.AppendRecs("ContainingMessage", [2]string{"Extendee", string(t.ContainingMessage().FullName())})
+ 					}
+ 				case "Message":
+ 					if !t.IsMap() {
+@@ -187,13 +219,61 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 				ss = append(ss, string(fs.Get(i).Name()))
+ 			}
+ 			if len(ss) > 0 {
+-				rs.recs = append(rs.recs, [2]string{"Fields", "[" + joinStrings(ss, false) + "]"})
++				rs.AppendRecs("Fields", [2]string{"Fields", "[" + joinStrings(ss, false) + "]"})
+ 			}
+-		default:
+-			rs.Append(rv, descriptorAccessors[rt]...)
++
++		case protoreflect.FileDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("Imports"), "Imports"},
++				{rv.MethodByName("Messages"), "Messages"},
++				{rv.MethodByName("Enums"), "Enums"},
++				{rv.MethodByName("Extensions"), "Extensions"},
++				{rv.MethodByName("Services"), "Services"},
++			}...)
++
++		case protoreflect.MessageDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("IsMapEntry"), "IsMapEntry"},
++				{rv.MethodByName("Fields"), "Fields"},
++				{rv.MethodByName("Oneofs"), "Oneofs"},
++				{rv.MethodByName("ReservedNames"), "ReservedNames"},
++				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
++				{rv.MethodByName("RequiredNumbers"), "RequiredNumbers"},
++				{rv.MethodByName("ExtensionRanges"), "ExtensionRanges"},
++				{rv.MethodByName("Messages"), "Messages"},
++				{rv.MethodByName("Enums"), "Enums"},
++				{rv.MethodByName("Extensions"), "Extensions"},
++			}...)
++
++		case protoreflect.EnumDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Values"), "Values"},
++				{rv.MethodByName("ReservedNames"), "ReservedNames"},
++				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
++			}...)
++
++		case protoreflect.EnumValueDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Number"), "Number"},
++			}...)
++
++		case protoreflect.ServiceDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Methods"), "Methods"},
++			}...)
++
++		case protoreflect.MethodDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Input"), "Input"},
++				{rv.MethodByName("Output"), "Output"},
++				{rv.MethodByName("IsStreamingClient"), "IsStreamingClient"},
++				{rv.MethodByName("IsStreamingServer"), "IsStreamingServer"},
++			}...)
+ 		}
+-		if rv.MethodByName("GoType").IsValid() {
+-			rs.Append(rv, "GoType")
++		if m := rv.MethodByName("GoType"); m.IsValid() {
++			rs.Append(rv, methodAndName{m, "GoType"})
+ 		}
+ 	}
+ 	return start + rs.Join() + end
+@@ -202,19 +282,34 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ type records struct {
+ 	recs       [][2]string
+ 	allowMulti bool
++
++	// record is a function that will be called for every Append() or
++	// AppendRecs() call, to be used for testing with the
++	// InternalFormatDescOptForTesting function.
++	record func(string)
+ }
+ 
+-func (rs *records) Append(v reflect.Value, accessors ...string) {
++func (rs *records) AppendRecs(fieldName string, newRecs [2]string) {
++	if rs.record != nil {
++		rs.record(fieldName)
++	}
++	rs.recs = append(rs.recs, newRecs)
++}
++
++func (rs *records) Append(v reflect.Value, accessors ...methodAndName) {
+ 	for _, a := range accessors {
++		if rs.record != nil {
++			rs.record(a.name)
++		}
+ 		var rv reflect.Value
+-		if m := v.MethodByName(a); m.IsValid() {
+-			rv = m.Call(nil)[0]
++		if a.method.IsValid() {
++			rv = a.method.Call(nil)[0]
+ 		}
+ 		if v.Kind() == reflect.Struct && !rv.IsValid() {
+-			rv = v.FieldByName(a)
++			rv = v.FieldByName(a.name)
+ 		}
+ 		if !rv.IsValid() {
+-			panic(fmt.Sprintf("unknown accessor: %v.%s", v.Type(), a))
++			panic(fmt.Sprintf("unknown accessor: %v.%s", v.Type(), a.name))
+ 		}
+ 		if _, ok := rv.Interface().(protoreflect.Value); ok {
+ 			rv = rv.MethodByName("Interface").Call(nil)[0]
+@@ -261,7 +356,7 @@ func (rs *records) Append(v reflect.Value, accessors ...string) {
+ 		default:
+ 			s = fmt.Sprint(v)
+ 		}
+-		rs.recs = append(rs.recs, [2]string{a, s})
++		rs.recs = append(rs.recs, [2]string{a.name, s})
+ 	}
+ }
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go b/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+new file mode 100644
+index 0000000..14656b6
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+@@ -0,0 +1,12 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Package editiondefaults contains the binary representation of the editions
++// defaults.
++package editiondefaults
++
++import _ "embed"
++
++//go:embed editions_defaults.binpb
++var Defaults []byte
+diff --git a/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb b/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+new file mode 100644
+index 0000000..18f0756
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+@@ -0,0 +1,4 @@
++
++ (0�
++ (0�
++ (0� �(�
+\ No newline at end of file
+diff --git a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+index d043a6e..d2b3ac0 100644
+--- a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
++++ b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+@@ -121,7 +121,7 @@ func (d *Decoder) Read() (Token, error) {
+ 
+ 	case ObjectClose:
+ 		if len(d.openStack) == 0 ||
+-			d.lastToken.kind == comma ||
++			d.lastToken.kind&(Name|comma) != 0 ||
+ 			d.openStack[len(d.openStack)-1] != ObjectOpen {
+ 			return Token{}, d.newSyntaxError(tok.pos, unexpectedFmt, tok.RawString())
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+index 7c3689b..8826bcf 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+@@ -21,11 +21,26 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
++// Edition is an Enum for proto2.Edition
++type Edition int32
++
++// These values align with the value of Enum in descriptor.proto which allows
++// direct conversion between the proto enum and this enum.
++const (
++	EditionUnknown     Edition = 0
++	EditionProto2      Edition = 998
++	EditionProto3      Edition = 999
++	Edition2023        Edition = 1000
++	EditionUnsupported Edition = 100000
++)
++
+ // The types in this file may have a suffix:
+ //	• L0: Contains fields common to all descriptors (except File) and
+ //	must be initialized up front.
+ //	• L1: Contains fields specific to a descriptor and
+-//	must be initialized up front.
++//	must be initialized up front. If the associated proto uses Editions, the
++//  Editions features must always be resolved. If not explicitly set, the
++//  appropriate default must be resolved and set.
+ //	• L2: Contains fields that are lazily initialized when constructing
+ //	from the raw file descriptor. When constructing as a literal, the L2
+ //	fields must be initialized up front.
+@@ -44,6 +59,7 @@ type (
+ 	}
+ 	FileL1 struct {
+ 		Syntax  protoreflect.Syntax
++		Edition Edition // Only used if Syntax == Editions
+ 		Path    string
+ 		Package protoreflect.FullName
+ 
+@@ -51,12 +67,41 @@ type (
+ 		Messages   Messages
+ 		Extensions Extensions
+ 		Services   Services
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	FileL2 struct {
+ 		Options   func() protoreflect.ProtoMessage
+ 		Imports   FileImports
+ 		Locations SourceLocations
+ 	}
++
++	EditionFeatures struct {
++		// IsFieldPresence is true if field_presence is EXPLICIT
++		// https://protobuf.dev/editions/features/#field_presence
++		IsFieldPresence bool
++		// IsFieldPresence is true if field_presence is LEGACY_REQUIRED
++		// https://protobuf.dev/editions/features/#field_presence
++		IsLegacyRequired bool
++		// IsOpenEnum is true if enum_type is OPEN
++		// https://protobuf.dev/editions/features/#enum_type
++		IsOpenEnum bool
++		// IsPacked is true if repeated_field_encoding is PACKED
++		// https://protobuf.dev/editions/features/#repeated_field_encoding
++		IsPacked bool
++		// IsUTF8Validated is true if utf_validation is VERIFY
++		// https://protobuf.dev/editions/features/#utf8_validation
++		IsUTF8Validated bool
++		// IsDelimitedEncoded is true if message_encoding is DELIMITED
++		// https://protobuf.dev/editions/features/#message_encoding
++		IsDelimitedEncoded bool
++		// IsJSONCompliant is true if json_format is ALLOW
++		// https://protobuf.dev/editions/features/#json_format
++		IsJSONCompliant bool
++		// GenerateLegacyUnmarshalJSON determines if the plugin generates the
++		// UnmarshalJSON([]byte) error method for enums.
++		GenerateLegacyUnmarshalJSON bool
++	}
+ )
+ 
+ func (fd *File) ParentFile() protoreflect.FileDescriptor { return fd }
+@@ -117,6 +162,8 @@ type (
+ 	}
+ 	EnumL1 struct {
+ 		eagerValues bool // controls whether EnumL2.Values is already populated
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	EnumL2 struct {
+ 		Options        func() protoreflect.ProtoMessage
+@@ -178,6 +225,8 @@ type (
+ 		Extensions   Extensions
+ 		IsMapEntry   bool // promoted from google.protobuf.MessageOptions
+ 		IsMessageSet bool // promoted from google.protobuf.MessageOptions
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	MessageL2 struct {
+ 		Options               func() protoreflect.ProtoMessage
+@@ -210,6 +259,8 @@ type (
+ 		ContainingOneof  protoreflect.OneofDescriptor // must be consistent with Message.Oneofs.Fields
+ 		Enum             protoreflect.EnumDescriptor
+ 		Message          protoreflect.MessageDescriptor
++
++		EditionFeatures EditionFeatures
+ 	}
+ 
+ 	Oneof struct {
+@@ -219,6 +270,8 @@ type (
+ 	OneofL1 struct {
+ 		Options func() protoreflect.ProtoMessage
+ 		Fields  OneofFields // must be consistent with Message.Fields.ContainingOneof
++
++		EditionFeatures EditionFeatures
+ 	}
+ )
+ 
+@@ -268,23 +321,36 @@ func (fd *Field) Options() protoreflect.ProtoMessage {
+ }
+ func (fd *Field) Number() protoreflect.FieldNumber      { return fd.L1.Number }
+ func (fd *Field) Cardinality() protoreflect.Cardinality { return fd.L1.Cardinality }
+-func (fd *Field) Kind() protoreflect.Kind               { return fd.L1.Kind }
+-func (fd *Field) HasJSONName() bool                     { return fd.L1.StringName.hasJSON }
+-func (fd *Field) JSONName() string                      { return fd.L1.StringName.getJSON(fd) }
+-func (fd *Field) TextName() string                      { return fd.L1.StringName.getText(fd) }
++func (fd *Field) Kind() protoreflect.Kind {
++	return fd.L1.Kind
++}
++func (fd *Field) HasJSONName() bool { return fd.L1.StringName.hasJSON }
++func (fd *Field) JSONName() string  { return fd.L1.StringName.getJSON(fd) }
++func (fd *Field) TextName() string  { return fd.L1.StringName.getText(fd) }
+ func (fd *Field) HasPresence() bool {
+-	return fd.L1.Cardinality != protoreflect.Repeated && (fd.L0.ParentFile.L1.Syntax == protoreflect.Proto2 || fd.L1.Message != nil || fd.L1.ContainingOneof != nil)
++	if fd.L1.Cardinality == protoreflect.Repeated {
++		return false
++	}
++	explicitFieldPresence := fd.Syntax() == protoreflect.Editions && fd.L1.EditionFeatures.IsFieldPresence
++	return fd.Syntax() == protoreflect.Proto2 || explicitFieldPresence || fd.L1.Message != nil || fd.L1.ContainingOneof != nil
+ }
+ func (fd *Field) HasOptionalKeyword() bool {
+ 	return (fd.L0.ParentFile.L1.Syntax == protoreflect.Proto2 && fd.L1.Cardinality == protoreflect.Optional && fd.L1.ContainingOneof == nil) || fd.L1.IsProto3Optional
+ }
+ func (fd *Field) IsPacked() bool {
+-	if !fd.L1.HasPacked && fd.L0.ParentFile.L1.Syntax != protoreflect.Proto2 && fd.L1.Cardinality == protoreflect.Repeated {
+-		switch fd.L1.Kind {
+-		case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
+-		default:
+-			return true
+-		}
++	if fd.L1.Cardinality != protoreflect.Repeated {
++		return false
++	}
++	switch fd.L1.Kind {
++	case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
++		return false
++	}
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Editions {
++		return fd.L1.EditionFeatures.IsPacked
++	}
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Proto3 {
++		// proto3 repeated fields are packed by default.
++		return !fd.L1.HasPacked || fd.L1.IsPacked
+ 	}
+ 	return fd.L1.IsPacked
+ }
+@@ -333,6 +399,9 @@ func (fd *Field) ProtoType(protoreflect.FieldDescriptor) {}
+ // WARNING: This method is exempt from the compatibility promise and may be
+ // removed in the future without warning.
+ func (fd *Field) EnforceUTF8() bool {
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Editions {
++		return fd.L1.EditionFeatures.IsUTF8Validated
++	}
+ 	if fd.L1.HasEnforceUTF8 {
+ 		return fd.L1.EnforceUTF8
+ 	}
+@@ -359,10 +428,11 @@ type (
+ 		L2 *ExtensionL2 // protected by fileDesc.once
+ 	}
+ 	ExtensionL1 struct {
+-		Number      protoreflect.FieldNumber
+-		Extendee    protoreflect.MessageDescriptor
+-		Cardinality protoreflect.Cardinality
+-		Kind        protoreflect.Kind
++		Number          protoreflect.FieldNumber
++		Extendee        protoreflect.MessageDescriptor
++		Cardinality     protoreflect.Cardinality
++		Kind            protoreflect.Kind
++		EditionFeatures EditionFeatures
+ 	}
+ 	ExtensionL2 struct {
+ 		Options          func() protoreflect.ProtoMessage
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
+index 4a1584c..237e64f 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
+@@ -5,6 +5,7 @@
+ package filedesc
+ 
+ import (
++	"fmt"
+ 	"sync"
+ 
+ 	"google.golang.org/protobuf/encoding/protowire"
+@@ -98,6 +99,7 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 	var prevField protoreflect.FieldNumber
+ 	var numEnums, numMessages, numExtensions, numServices int
+ 	var posEnums, posMessages, posExtensions, posServices int
++	var options []byte
+ 	b0 := b
+ 	for len(b) > 0 {
+ 		num, typ, n := protowire.ConsumeTag(b)
+@@ -113,6 +115,8 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 					fd.L1.Syntax = protoreflect.Proto2
+ 				case "proto3":
+ 					fd.L1.Syntax = protoreflect.Proto3
++				case "editions":
++					fd.L1.Syntax = protoreflect.Editions
+ 				default:
+ 					panic("invalid syntax")
+ 				}
+@@ -120,6 +124,8 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 				fd.L1.Path = sb.MakeString(v)
+ 			case genid.FileDescriptorProto_Package_field_number:
+ 				fd.L1.Package = protoreflect.FullName(sb.MakeString(v))
++			case genid.FileDescriptorProto_Options_field_number:
++				options = v
+ 			case genid.FileDescriptorProto_EnumType_field_number:
+ 				if prevField != genid.FileDescriptorProto_EnumType_field_number {
+ 					if numEnums > 0 {
+@@ -154,6 +160,13 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 				numServices++
+ 			}
+ 			prevField = num
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FileDescriptorProto_Edition_field_number:
++				fd.L1.Edition = Edition(v)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+@@ -166,6 +179,15 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 		fd.L1.Syntax = protoreflect.Proto2
+ 	}
+ 
++	if fd.L1.Syntax == protoreflect.Editions {
++		fd.L1.EditionFeatures = getFeaturesFor(fd.L1.Edition)
++	}
++
++	// Parse editions features from options if any
++	if options != nil {
++		fd.unmarshalSeedOptions(options)
++	}
++
+ 	// Must allocate all declarations before parsing each descriptor type
+ 	// to ensure we handled all descriptors in "flattened ordering".
+ 	if numEnums > 0 {
+@@ -219,6 +241,28 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 	}
+ }
+ 
++func (fd *File) unmarshalSeedOptions(b []byte) {
++	for b := b; len(b) > 0; {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FileOptions_Features_field_number:
++				if fd.Syntax() != protoreflect.Editions {
++					panic(fmt.Sprintf("invalid descriptor: using edition features in a proto with syntax %s", fd.Syntax()))
++				}
++				fd.L1.EditionFeatures = unmarshalFeatureSet(v, fd.L1.EditionFeatures)
++			}
++		default:
++			m := protowire.ConsumeFieldValue(num, typ, b)
++			b = b[m:]
++		}
++	}
++}
++
+ func (ed *Enum) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protoreflect.Descriptor, i int) {
+ 	ed.L0.ParentFile = pf
+ 	ed.L0.Parent = pd
+@@ -275,6 +319,7 @@ func (md *Message) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protor
+ 	md.L0.ParentFile = pf
+ 	md.L0.Parent = pd
+ 	md.L0.Index = i
++	md.L1.EditionFeatures = featuresFromParentDesc(md.Parent())
+ 
+ 	var prevField protoreflect.FieldNumber
+ 	var numEnums, numMessages, numExtensions int
+@@ -380,6 +425,13 @@ func (md *Message) unmarshalSeedOptions(b []byte) {
+ 			case genid.MessageOptions_MessageSetWireFormat_field_number:
+ 				md.L1.IsMessageSet = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.MessageOptions_Features_field_number:
++				md.L1.EditionFeatures = unmarshalFeatureSet(v, md.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+index 736a19a..482a61c 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+@@ -414,6 +414,7 @@ func (fd *Field) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ 	fd.L0.ParentFile = pf
+ 	fd.L0.Parent = pd
+ 	fd.L0.Index = i
++	fd.L1.EditionFeatures = featuresFromParentDesc(fd.Parent())
+ 
+ 	var rawTypeName []byte
+ 	var rawOptions []byte
+@@ -465,6 +466,12 @@ func (fd *Field) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ 			b = b[m:]
+ 		}
+ 	}
++	if fd.Syntax() == protoreflect.Editions && fd.L1.Kind == protoreflect.MessageKind && fd.L1.EditionFeatures.IsDelimitedEncoded {
++		fd.L1.Kind = protoreflect.GroupKind
++	}
++	if fd.Syntax() == protoreflect.Editions && fd.L1.EditionFeatures.IsLegacyRequired {
++		fd.L1.Cardinality = protoreflect.Required
++	}
+ 	if rawTypeName != nil {
+ 		name := makeFullName(sb, rawTypeName)
+ 		switch fd.L1.Kind {
+@@ -497,6 +504,13 @@ func (fd *Field) unmarshalOptions(b []byte) {
+ 				fd.L1.HasEnforceUTF8 = true
+ 				fd.L1.EnforceUTF8 = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FieldOptions_Features_field_number:
++				fd.L1.EditionFeatures = unmarshalFeatureSet(v, fd.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+@@ -534,6 +548,7 @@ func (od *Oneof) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ func (xd *Extension) unmarshalFull(b []byte, sb *strs.Builder) {
+ 	var rawTypeName []byte
+ 	var rawOptions []byte
++	xd.L1.EditionFeatures = featuresFromParentDesc(xd.L1.Extendee)
+ 	xd.L2 = new(ExtensionL2)
+ 	for len(b) > 0 {
+ 		num, typ, n := protowire.ConsumeTag(b)
+@@ -565,6 +580,12 @@ func (xd *Extension) unmarshalFull(b []byte, sb *strs.Builder) {
+ 			b = b[m:]
+ 		}
+ 	}
++	if xd.Syntax() == protoreflect.Editions && xd.L1.Kind == protoreflect.MessageKind && xd.L1.EditionFeatures.IsDelimitedEncoded {
++		xd.L1.Kind = protoreflect.GroupKind
++	}
++	if xd.Syntax() == protoreflect.Editions && xd.L1.EditionFeatures.IsLegacyRequired {
++		xd.L1.Cardinality = protoreflect.Required
++	}
+ 	if rawTypeName != nil {
+ 		name := makeFullName(sb, rawTypeName)
+ 		switch xd.L1.Kind {
+@@ -589,6 +610,13 @@ func (xd *Extension) unmarshalOptions(b []byte) {
+ 			case genid.FieldOptions_Packed_field_number:
+ 				xd.L2.IsPacked = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FieldOptions_Features_field_number:
++				xd.L1.EditionFeatures = unmarshalFeatureSet(v, xd.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/editions.go b/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+new file mode 100644
+index 0000000..0375a49
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+@@ -0,0 +1,142 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package filedesc
++
++import (
++	"fmt"
++
++	"google.golang.org/protobuf/encoding/protowire"
++	"google.golang.org/protobuf/internal/editiondefaults"
++	"google.golang.org/protobuf/internal/genid"
++	"google.golang.org/protobuf/reflect/protoreflect"
++)
++
++var defaultsCache = make(map[Edition]EditionFeatures)
++
++func init() {
++	unmarshalEditionDefaults(editiondefaults.Defaults)
++}
++
++func unmarshalGoFeature(b []byte, parent EditionFeatures) EditionFeatures {
++	for len(b) > 0 {
++		num, _, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch num {
++		case genid.GoFeatures_LegacyUnmarshalJsonEnum_field_number:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			parent.GenerateLegacyUnmarshalJSON = protowire.DecodeBool(v)
++		default:
++			panic(fmt.Sprintf("unkown field number %d while unmarshalling GoFeatures", num))
++		}
++	}
++	return parent
++}
++
++func unmarshalFeatureSet(b []byte, parent EditionFeatures) EditionFeatures {
++	for len(b) > 0 {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSet_FieldPresence_field_number:
++				parent.IsFieldPresence = v == genid.FeatureSet_EXPLICIT_enum_value || v == genid.FeatureSet_LEGACY_REQUIRED_enum_value
++				parent.IsLegacyRequired = v == genid.FeatureSet_LEGACY_REQUIRED_enum_value
++			case genid.FeatureSet_EnumType_field_number:
++				parent.IsOpenEnum = v == genid.FeatureSet_OPEN_enum_value
++			case genid.FeatureSet_RepeatedFieldEncoding_field_number:
++				parent.IsPacked = v == genid.FeatureSet_PACKED_enum_value
++			case genid.FeatureSet_Utf8Validation_field_number:
++				parent.IsUTF8Validated = v == genid.FeatureSet_VERIFY_enum_value
++			case genid.FeatureSet_MessageEncoding_field_number:
++				parent.IsDelimitedEncoded = v == genid.FeatureSet_DELIMITED_enum_value
++			case genid.FeatureSet_JsonFormat_field_number:
++				parent.IsJSONCompliant = v == genid.FeatureSet_ALLOW_enum_value
++			default:
++				panic(fmt.Sprintf("unkown field number %d while unmarshalling FeatureSet", num))
++			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.GoFeatures_LegacyUnmarshalJsonEnum_field_number:
++				parent = unmarshalGoFeature(v, parent)
++			}
++		}
++	}
++
++	return parent
++}
++
++func featuresFromParentDesc(parentDesc protoreflect.Descriptor) EditionFeatures {
++	var parentFS EditionFeatures
++	switch p := parentDesc.(type) {
++	case *File:
++		parentFS = p.L1.EditionFeatures
++	case *Message:
++		parentFS = p.L1.EditionFeatures
++	default:
++		panic(fmt.Sprintf("unknown parent type %T", parentDesc))
++	}
++	return parentFS
++}
++
++func unmarshalEditionDefault(b []byte) {
++	var ed Edition
++	var fs EditionFeatures
++	for len(b) > 0 {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_number:
++				ed = Edition(v)
++			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSetDefaults_FeatureSetEditionDefault_Features_field_number:
++				fs = unmarshalFeatureSet(v, fs)
++			}
++		}
++	}
++	defaultsCache[ed] = fs
++}
++
++func unmarshalEditionDefaults(b []byte) {
++	for len(b) > 0 {
++		num, _, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch num {
++		case genid.FeatureSetDefaults_Defaults_field_number:
++			def, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			unmarshalEditionDefault(def)
++		case genid.FeatureSetDefaults_MinimumEdition_field_number,
++			genid.FeatureSetDefaults_MaximumEdition_field_number:
++			// We don't care about the minimum and maximum editions. If the
++			// edition we are looking for later on is not in the cache we know
++			// it is outside of the range between minimum and maximum edition.
++			_, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++		default:
++			panic(fmt.Sprintf("unkown field number %d while unmarshalling EditionDefault", num))
++		}
++	}
++}
++
++func getFeaturesFor(ed Edition) EditionFeatures {
++	if def, ok := defaultsCache[ed]; ok {
++		return def
++	}
++	panic(fmt.Sprintf("unsupported edition: %v", ed))
++}
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+index 136f1b2..40272c8 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+@@ -12,6 +12,27 @@ import (
+ 
+ const File_google_protobuf_descriptor_proto = "google/protobuf/descriptor.proto"
+ 
++// Full and short names for google.protobuf.Edition.
++const (
++	Edition_enum_fullname = "google.protobuf.Edition"
++	Edition_enum_name     = "Edition"
++)
++
++// Enum values for google.protobuf.Edition.
++const (
++	Edition_EDITION_UNKNOWN_enum_value         = 0
++	Edition_EDITION_PROTO2_enum_value          = 998
++	Edition_EDITION_PROTO3_enum_value          = 999
++	Edition_EDITION_2023_enum_value            = 1000
++	Edition_EDITION_2024_enum_value            = 1001
++	Edition_EDITION_1_TEST_ONLY_enum_value     = 1
++	Edition_EDITION_2_TEST_ONLY_enum_value     = 2
++	Edition_EDITION_99997_TEST_ONLY_enum_value = 99997
++	Edition_EDITION_99998_TEST_ONLY_enum_value = 99998
++	Edition_EDITION_99999_TEST_ONLY_enum_value = 99999
++	Edition_EDITION_MAX_enum_value             = 2147483647
++)
++
+ // Names for google.protobuf.FileDescriptorSet.
+ const (
+ 	FileDescriptorSet_message_name     protoreflect.Name     = "FileDescriptorSet"
+@@ -81,7 +102,7 @@ const (
+ 	FileDescriptorProto_Options_field_number          protoreflect.FieldNumber = 8
+ 	FileDescriptorProto_SourceCodeInfo_field_number   protoreflect.FieldNumber = 9
+ 	FileDescriptorProto_Syntax_field_number           protoreflect.FieldNumber = 12
+-	FileDescriptorProto_Edition_field_number          protoreflect.FieldNumber = 13
++	FileDescriptorProto_Edition_field_number          protoreflect.FieldNumber = 14
+ )
+ 
+ // Names for google.protobuf.DescriptorProto.
+@@ -184,10 +205,12 @@ const (
+ const (
+ 	ExtensionRangeOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 	ExtensionRangeOptions_Declaration_field_name         protoreflect.Name = "declaration"
++	ExtensionRangeOptions_Features_field_name            protoreflect.Name = "features"
+ 	ExtensionRangeOptions_Verification_field_name        protoreflect.Name = "verification"
+ 
+ 	ExtensionRangeOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.uninterpreted_option"
+ 	ExtensionRangeOptions_Declaration_field_fullname         protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.declaration"
++	ExtensionRangeOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.features"
+ 	ExtensionRangeOptions_Verification_field_fullname        protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.verification"
+ )
+ 
+@@ -195,6 +218,7 @@ const (
+ const (
+ 	ExtensionRangeOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ 	ExtensionRangeOptions_Declaration_field_number         protoreflect.FieldNumber = 2
++	ExtensionRangeOptions_Features_field_number            protoreflect.FieldNumber = 50
+ 	ExtensionRangeOptions_Verification_field_number        protoreflect.FieldNumber = 3
+ )
+ 
+@@ -204,6 +228,12 @@ const (
+ 	ExtensionRangeOptions_VerificationState_enum_name     = "VerificationState"
+ )
+ 
++// Enum values for google.protobuf.ExtensionRangeOptions.VerificationState.
++const (
++	ExtensionRangeOptions_DECLARATION_enum_value = 0
++	ExtensionRangeOptions_UNVERIFIED_enum_value  = 1
++)
++
+ // Names for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+ 	ExtensionRangeOptions_Declaration_message_name     protoreflect.Name     = "Declaration"
+@@ -212,29 +242,26 @@ const (
+ 
+ // Field names for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+-	ExtensionRangeOptions_Declaration_Number_field_name     protoreflect.Name = "number"
+-	ExtensionRangeOptions_Declaration_FullName_field_name   protoreflect.Name = "full_name"
+-	ExtensionRangeOptions_Declaration_Type_field_name       protoreflect.Name = "type"
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_name protoreflect.Name = "is_repeated"
+-	ExtensionRangeOptions_Declaration_Reserved_field_name   protoreflect.Name = "reserved"
+-	ExtensionRangeOptions_Declaration_Repeated_field_name   protoreflect.Name = "repeated"
++	ExtensionRangeOptions_Declaration_Number_field_name   protoreflect.Name = "number"
++	ExtensionRangeOptions_Declaration_FullName_field_name protoreflect.Name = "full_name"
++	ExtensionRangeOptions_Declaration_Type_field_name     protoreflect.Name = "type"
++	ExtensionRangeOptions_Declaration_Reserved_field_name protoreflect.Name = "reserved"
++	ExtensionRangeOptions_Declaration_Repeated_field_name protoreflect.Name = "repeated"
+ 
+-	ExtensionRangeOptions_Declaration_Number_field_fullname     protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.number"
+-	ExtensionRangeOptions_Declaration_FullName_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.full_name"
+-	ExtensionRangeOptions_Declaration_Type_field_fullname       protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.type"
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.is_repeated"
+-	ExtensionRangeOptions_Declaration_Reserved_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.reserved"
+-	ExtensionRangeOptions_Declaration_Repeated_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.repeated"
++	ExtensionRangeOptions_Declaration_Number_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.number"
++	ExtensionRangeOptions_Declaration_FullName_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.full_name"
++	ExtensionRangeOptions_Declaration_Type_field_fullname     protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.type"
++	ExtensionRangeOptions_Declaration_Reserved_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.reserved"
++	ExtensionRangeOptions_Declaration_Repeated_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.repeated"
+ )
+ 
+ // Field numbers for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+-	ExtensionRangeOptions_Declaration_Number_field_number     protoreflect.FieldNumber = 1
+-	ExtensionRangeOptions_Declaration_FullName_field_number   protoreflect.FieldNumber = 2
+-	ExtensionRangeOptions_Declaration_Type_field_number       protoreflect.FieldNumber = 3
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_number protoreflect.FieldNumber = 4
+-	ExtensionRangeOptions_Declaration_Reserved_field_number   protoreflect.FieldNumber = 5
+-	ExtensionRangeOptions_Declaration_Repeated_field_number   protoreflect.FieldNumber = 6
++	ExtensionRangeOptions_Declaration_Number_field_number   protoreflect.FieldNumber = 1
++	ExtensionRangeOptions_Declaration_FullName_field_number protoreflect.FieldNumber = 2
++	ExtensionRangeOptions_Declaration_Type_field_number     protoreflect.FieldNumber = 3
++	ExtensionRangeOptions_Declaration_Reserved_field_number protoreflect.FieldNumber = 5
++	ExtensionRangeOptions_Declaration_Repeated_field_number protoreflect.FieldNumber = 6
+ )
+ 
+ // Names for google.protobuf.FieldDescriptorProto.
+@@ -291,12 +318,41 @@ const (
+ 	FieldDescriptorProto_Type_enum_name     = "Type"
+ )
+ 
++// Enum values for google.protobuf.FieldDescriptorProto.Type.
++const (
++	FieldDescriptorProto_TYPE_DOUBLE_enum_value   = 1
++	FieldDescriptorProto_TYPE_FLOAT_enum_value    = 2
++	FieldDescriptorProto_TYPE_INT64_enum_value    = 3
++	FieldDescriptorProto_TYPE_UINT64_enum_value   = 4
++	FieldDescriptorProto_TYPE_INT32_enum_value    = 5
++	FieldDescriptorProto_TYPE_FIXED64_enum_value  = 6
++	FieldDescriptorProto_TYPE_FIXED32_enum_value  = 7
++	FieldDescriptorProto_TYPE_BOOL_enum_value     = 8
++	FieldDescriptorProto_TYPE_STRING_enum_value   = 9
++	FieldDescriptorProto_TYPE_GROUP_enum_value    = 10
++	FieldDescriptorProto_TYPE_MESSAGE_enum_value  = 11
++	FieldDescriptorProto_TYPE_BYTES_enum_value    = 12
++	FieldDescriptorProto_TYPE_UINT32_enum_value   = 13
++	FieldDescriptorProto_TYPE_ENUM_enum_value     = 14
++	FieldDescriptorProto_TYPE_SFIXED32_enum_value = 15
++	FieldDescriptorProto_TYPE_SFIXED64_enum_value = 16
++	FieldDescriptorProto_TYPE_SINT32_enum_value   = 17
++	FieldDescriptorProto_TYPE_SINT64_enum_value   = 18
++)
++
+ // Full and short names for google.protobuf.FieldDescriptorProto.Label.
+ const (
+ 	FieldDescriptorProto_Label_enum_fullname = "google.protobuf.FieldDescriptorProto.Label"
+ 	FieldDescriptorProto_Label_enum_name     = "Label"
+ )
+ 
++// Enum values for google.protobuf.FieldDescriptorProto.Label.
++const (
++	FieldDescriptorProto_LABEL_OPTIONAL_enum_value = 1
++	FieldDescriptorProto_LABEL_REPEATED_enum_value = 3
++	FieldDescriptorProto_LABEL_REQUIRED_enum_value = 2
++)
++
+ // Names for google.protobuf.OneofDescriptorProto.
+ const (
+ 	OneofDescriptorProto_message_name     protoreflect.Name     = "OneofDescriptorProto"
+@@ -468,7 +524,6 @@ const (
+ 	FileOptions_CcGenericServices_field_name         protoreflect.Name = "cc_generic_services"
+ 	FileOptions_JavaGenericServices_field_name       protoreflect.Name = "java_generic_services"
+ 	FileOptions_PyGenericServices_field_name         protoreflect.Name = "py_generic_services"
+-	FileOptions_PhpGenericServices_field_name        protoreflect.Name = "php_generic_services"
+ 	FileOptions_Deprecated_field_name                protoreflect.Name = "deprecated"
+ 	FileOptions_CcEnableArenas_field_name            protoreflect.Name = "cc_enable_arenas"
+ 	FileOptions_ObjcClassPrefix_field_name           protoreflect.Name = "objc_class_prefix"
+@@ -478,6 +533,7 @@ const (
+ 	FileOptions_PhpNamespace_field_name              protoreflect.Name = "php_namespace"
+ 	FileOptions_PhpMetadataNamespace_field_name      protoreflect.Name = "php_metadata_namespace"
+ 	FileOptions_RubyPackage_field_name               protoreflect.Name = "ruby_package"
++	FileOptions_Features_field_name                  protoreflect.Name = "features"
+ 	FileOptions_UninterpretedOption_field_name       protoreflect.Name = "uninterpreted_option"
+ 
+ 	FileOptions_JavaPackage_field_fullname               protoreflect.FullName = "google.protobuf.FileOptions.java_package"
+@@ -490,7 +546,6 @@ const (
+ 	FileOptions_CcGenericServices_field_fullname         protoreflect.FullName = "google.protobuf.FileOptions.cc_generic_services"
+ 	FileOptions_JavaGenericServices_field_fullname       protoreflect.FullName = "google.protobuf.FileOptions.java_generic_services"
+ 	FileOptions_PyGenericServices_field_fullname         protoreflect.FullName = "google.protobuf.FileOptions.py_generic_services"
+-	FileOptions_PhpGenericServices_field_fullname        protoreflect.FullName = "google.protobuf.FileOptions.php_generic_services"
+ 	FileOptions_Deprecated_field_fullname                protoreflect.FullName = "google.protobuf.FileOptions.deprecated"
+ 	FileOptions_CcEnableArenas_field_fullname            protoreflect.FullName = "google.protobuf.FileOptions.cc_enable_arenas"
+ 	FileOptions_ObjcClassPrefix_field_fullname           protoreflect.FullName = "google.protobuf.FileOptions.objc_class_prefix"
+@@ -500,6 +555,7 @@ const (
+ 	FileOptions_PhpNamespace_field_fullname              protoreflect.FullName = "google.protobuf.FileOptions.php_namespace"
+ 	FileOptions_PhpMetadataNamespace_field_fullname      protoreflect.FullName = "google.protobuf.FileOptions.php_metadata_namespace"
+ 	FileOptions_RubyPackage_field_fullname               protoreflect.FullName = "google.protobuf.FileOptions.ruby_package"
++	FileOptions_Features_field_fullname                  protoreflect.FullName = "google.protobuf.FileOptions.features"
+ 	FileOptions_UninterpretedOption_field_fullname       protoreflect.FullName = "google.protobuf.FileOptions.uninterpreted_option"
+ )
+ 
+@@ -515,7 +571,6 @@ const (
+ 	FileOptions_CcGenericServices_field_number         protoreflect.FieldNumber = 16
+ 	FileOptions_JavaGenericServices_field_number       protoreflect.FieldNumber = 17
+ 	FileOptions_PyGenericServices_field_number         protoreflect.FieldNumber = 18
+-	FileOptions_PhpGenericServices_field_number        protoreflect.FieldNumber = 42
+ 	FileOptions_Deprecated_field_number                protoreflect.FieldNumber = 23
+ 	FileOptions_CcEnableArenas_field_number            protoreflect.FieldNumber = 31
+ 	FileOptions_ObjcClassPrefix_field_number           protoreflect.FieldNumber = 36
+@@ -525,6 +580,7 @@ const (
+ 	FileOptions_PhpNamespace_field_number              protoreflect.FieldNumber = 41
+ 	FileOptions_PhpMetadataNamespace_field_number      protoreflect.FieldNumber = 44
+ 	FileOptions_RubyPackage_field_number               protoreflect.FieldNumber = 45
++	FileOptions_Features_field_number                  protoreflect.FieldNumber = 50
+ 	FileOptions_UninterpretedOption_field_number       protoreflect.FieldNumber = 999
+ )
+ 
+@@ -534,6 +590,13 @@ const (
+ 	FileOptions_OptimizeMode_enum_name     = "OptimizeMode"
+ )
+ 
++// Enum values for google.protobuf.FileOptions.OptimizeMode.
++const (
++	FileOptions_SPEED_enum_value        = 1
++	FileOptions_CODE_SIZE_enum_value    = 2
++	FileOptions_LITE_RUNTIME_enum_value = 3
++)
++
+ // Names for google.protobuf.MessageOptions.
+ const (
+ 	MessageOptions_message_name     protoreflect.Name     = "MessageOptions"
+@@ -547,6 +610,7 @@ const (
+ 	MessageOptions_Deprecated_field_name                         protoreflect.Name = "deprecated"
+ 	MessageOptions_MapEntry_field_name                           protoreflect.Name = "map_entry"
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_name protoreflect.Name = "deprecated_legacy_json_field_conflicts"
++	MessageOptions_Features_field_name                           protoreflect.Name = "features"
+ 	MessageOptions_UninterpretedOption_field_name                protoreflect.Name = "uninterpreted_option"
+ 
+ 	MessageOptions_MessageSetWireFormat_field_fullname               protoreflect.FullName = "google.protobuf.MessageOptions.message_set_wire_format"
+@@ -554,6 +618,7 @@ const (
+ 	MessageOptions_Deprecated_field_fullname                         protoreflect.FullName = "google.protobuf.MessageOptions.deprecated"
+ 	MessageOptions_MapEntry_field_fullname                           protoreflect.FullName = "google.protobuf.MessageOptions.map_entry"
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_fullname protoreflect.FullName = "google.protobuf.MessageOptions.deprecated_legacy_json_field_conflicts"
++	MessageOptions_Features_field_fullname                           protoreflect.FullName = "google.protobuf.MessageOptions.features"
+ 	MessageOptions_UninterpretedOption_field_fullname                protoreflect.FullName = "google.protobuf.MessageOptions.uninterpreted_option"
+ )
+ 
+@@ -564,6 +629,7 @@ const (
+ 	MessageOptions_Deprecated_field_number                         protoreflect.FieldNumber = 3
+ 	MessageOptions_MapEntry_field_number                           protoreflect.FieldNumber = 7
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_number protoreflect.FieldNumber = 11
++	MessageOptions_Features_field_number                           protoreflect.FieldNumber = 12
+ 	MessageOptions_UninterpretedOption_field_number                protoreflect.FieldNumber = 999
+ )
+ 
+@@ -584,8 +650,9 @@ const (
+ 	FieldOptions_Weak_field_name                protoreflect.Name = "weak"
+ 	FieldOptions_DebugRedact_field_name         protoreflect.Name = "debug_redact"
+ 	FieldOptions_Retention_field_name           protoreflect.Name = "retention"
+-	FieldOptions_Target_field_name              protoreflect.Name = "target"
+ 	FieldOptions_Targets_field_name             protoreflect.Name = "targets"
++	FieldOptions_EditionDefaults_field_name     protoreflect.Name = "edition_defaults"
++	FieldOptions_Features_field_name            protoreflect.Name = "features"
+ 	FieldOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	FieldOptions_Ctype_field_fullname               protoreflect.FullName = "google.protobuf.FieldOptions.ctype"
+@@ -597,8 +664,9 @@ const (
+ 	FieldOptions_Weak_field_fullname                protoreflect.FullName = "google.protobuf.FieldOptions.weak"
+ 	FieldOptions_DebugRedact_field_fullname         protoreflect.FullName = "google.protobuf.FieldOptions.debug_redact"
+ 	FieldOptions_Retention_field_fullname           protoreflect.FullName = "google.protobuf.FieldOptions.retention"
+-	FieldOptions_Target_field_fullname              protoreflect.FullName = "google.protobuf.FieldOptions.target"
+ 	FieldOptions_Targets_field_fullname             protoreflect.FullName = "google.protobuf.FieldOptions.targets"
++	FieldOptions_EditionDefaults_field_fullname     protoreflect.FullName = "google.protobuf.FieldOptions.edition_defaults"
++	FieldOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.FieldOptions.features"
+ 	FieldOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.FieldOptions.uninterpreted_option"
+ )
+ 
+@@ -613,8 +681,9 @@ const (
+ 	FieldOptions_Weak_field_number                protoreflect.FieldNumber = 10
+ 	FieldOptions_DebugRedact_field_number         protoreflect.FieldNumber = 16
+ 	FieldOptions_Retention_field_number           protoreflect.FieldNumber = 17
+-	FieldOptions_Target_field_number              protoreflect.FieldNumber = 18
+ 	FieldOptions_Targets_field_number             protoreflect.FieldNumber = 19
++	FieldOptions_EditionDefaults_field_number     protoreflect.FieldNumber = 20
++	FieldOptions_Features_field_number            protoreflect.FieldNumber = 21
+ 	FieldOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -624,24 +693,80 @@ const (
+ 	FieldOptions_CType_enum_name     = "CType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.CType.
++const (
++	FieldOptions_STRING_enum_value       = 0
++	FieldOptions_CORD_enum_value         = 1
++	FieldOptions_STRING_PIECE_enum_value = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.JSType.
+ const (
+ 	FieldOptions_JSType_enum_fullname = "google.protobuf.FieldOptions.JSType"
+ 	FieldOptions_JSType_enum_name     = "JSType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.JSType.
++const (
++	FieldOptions_JS_NORMAL_enum_value = 0
++	FieldOptions_JS_STRING_enum_value = 1
++	FieldOptions_JS_NUMBER_enum_value = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.OptionRetention.
+ const (
+ 	FieldOptions_OptionRetention_enum_fullname = "google.protobuf.FieldOptions.OptionRetention"
+ 	FieldOptions_OptionRetention_enum_name     = "OptionRetention"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.OptionRetention.
++const (
++	FieldOptions_RETENTION_UNKNOWN_enum_value = 0
++	FieldOptions_RETENTION_RUNTIME_enum_value = 1
++	FieldOptions_RETENTION_SOURCE_enum_value  = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.OptionTargetType.
+ const (
+ 	FieldOptions_OptionTargetType_enum_fullname = "google.protobuf.FieldOptions.OptionTargetType"
+ 	FieldOptions_OptionTargetType_enum_name     = "OptionTargetType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.OptionTargetType.
++const (
++	FieldOptions_TARGET_TYPE_UNKNOWN_enum_value         = 0
++	FieldOptions_TARGET_TYPE_FILE_enum_value            = 1
++	FieldOptions_TARGET_TYPE_EXTENSION_RANGE_enum_value = 2
++	FieldOptions_TARGET_TYPE_MESSAGE_enum_value         = 3
++	FieldOptions_TARGET_TYPE_FIELD_enum_value           = 4
++	FieldOptions_TARGET_TYPE_ONEOF_enum_value           = 5
++	FieldOptions_TARGET_TYPE_ENUM_enum_value            = 6
++	FieldOptions_TARGET_TYPE_ENUM_ENTRY_enum_value      = 7
++	FieldOptions_TARGET_TYPE_SERVICE_enum_value         = 8
++	FieldOptions_TARGET_TYPE_METHOD_enum_value          = 9
++)
++
++// Names for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_message_name     protoreflect.Name     = "EditionDefault"
++	FieldOptions_EditionDefault_message_fullname protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault"
++)
++
++// Field names for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_Edition_field_name protoreflect.Name = "edition"
++	FieldOptions_EditionDefault_Value_field_name   protoreflect.Name = "value"
++
++	FieldOptions_EditionDefault_Edition_field_fullname protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault.edition"
++	FieldOptions_EditionDefault_Value_field_fullname   protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault.value"
++)
++
++// Field numbers for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_Edition_field_number protoreflect.FieldNumber = 3
++	FieldOptions_EditionDefault_Value_field_number   protoreflect.FieldNumber = 2
++)
++
+ // Names for google.protobuf.OneofOptions.
+ const (
+ 	OneofOptions_message_name     protoreflect.Name     = "OneofOptions"
+@@ -650,13 +775,16 @@ const (
+ 
+ // Field names for google.protobuf.OneofOptions.
+ const (
++	OneofOptions_Features_field_name            protoreflect.Name = "features"
+ 	OneofOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
++	OneofOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.OneofOptions.features"
+ 	OneofOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.OneofOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.OneofOptions.
+ const (
++	OneofOptions_Features_field_number            protoreflect.FieldNumber = 1
+ 	OneofOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -671,11 +799,13 @@ const (
+ 	EnumOptions_AllowAlias_field_name                         protoreflect.Name = "allow_alias"
+ 	EnumOptions_Deprecated_field_name                         protoreflect.Name = "deprecated"
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_name protoreflect.Name = "deprecated_legacy_json_field_conflicts"
++	EnumOptions_Features_field_name                           protoreflect.Name = "features"
+ 	EnumOptions_UninterpretedOption_field_name                protoreflect.Name = "uninterpreted_option"
+ 
+ 	EnumOptions_AllowAlias_field_fullname                         protoreflect.FullName = "google.protobuf.EnumOptions.allow_alias"
+ 	EnumOptions_Deprecated_field_fullname                         protoreflect.FullName = "google.protobuf.EnumOptions.deprecated"
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_fullname protoreflect.FullName = "google.protobuf.EnumOptions.deprecated_legacy_json_field_conflicts"
++	EnumOptions_Features_field_fullname                           protoreflect.FullName = "google.protobuf.EnumOptions.features"
+ 	EnumOptions_UninterpretedOption_field_fullname                protoreflect.FullName = "google.protobuf.EnumOptions.uninterpreted_option"
+ )
+ 
+@@ -684,6 +814,7 @@ const (
+ 	EnumOptions_AllowAlias_field_number                         protoreflect.FieldNumber = 2
+ 	EnumOptions_Deprecated_field_number                         protoreflect.FieldNumber = 3
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_number protoreflect.FieldNumber = 6
++	EnumOptions_Features_field_number                           protoreflect.FieldNumber = 7
+ 	EnumOptions_UninterpretedOption_field_number                protoreflect.FieldNumber = 999
+ )
+ 
+@@ -696,15 +827,21 @@ const (
+ // Field names for google.protobuf.EnumValueOptions.
+ const (
+ 	EnumValueOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
++	EnumValueOptions_Features_field_name            protoreflect.Name = "features"
++	EnumValueOptions_DebugRedact_field_name         protoreflect.Name = "debug_redact"
+ 	EnumValueOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	EnumValueOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.EnumValueOptions.deprecated"
++	EnumValueOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.EnumValueOptions.features"
++	EnumValueOptions_DebugRedact_field_fullname         protoreflect.FullName = "google.protobuf.EnumValueOptions.debug_redact"
+ 	EnumValueOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.EnumValueOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.EnumValueOptions.
+ const (
+ 	EnumValueOptions_Deprecated_field_number          protoreflect.FieldNumber = 1
++	EnumValueOptions_Features_field_number            protoreflect.FieldNumber = 2
++	EnumValueOptions_DebugRedact_field_number         protoreflect.FieldNumber = 3
+ 	EnumValueOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -716,15 +853,18 @@ const (
+ 
+ // Field names for google.protobuf.ServiceOptions.
+ const (
++	ServiceOptions_Features_field_name            protoreflect.Name = "features"
+ 	ServiceOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
+ 	ServiceOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
++	ServiceOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.ServiceOptions.features"
+ 	ServiceOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.ServiceOptions.deprecated"
+ 	ServiceOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.ServiceOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.ServiceOptions.
+ const (
++	ServiceOptions_Features_field_number            protoreflect.FieldNumber = 34
+ 	ServiceOptions_Deprecated_field_number          protoreflect.FieldNumber = 33
+ 	ServiceOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+@@ -739,10 +879,12 @@ const (
+ const (
+ 	MethodOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
+ 	MethodOptions_IdempotencyLevel_field_name    protoreflect.Name = "idempotency_level"
++	MethodOptions_Features_field_name            protoreflect.Name = "features"
+ 	MethodOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	MethodOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.MethodOptions.deprecated"
+ 	MethodOptions_IdempotencyLevel_field_fullname    protoreflect.FullName = "google.protobuf.MethodOptions.idempotency_level"
++	MethodOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.MethodOptions.features"
+ 	MethodOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.MethodOptions.uninterpreted_option"
+ )
+ 
+@@ -750,6 +892,7 @@ const (
+ const (
+ 	MethodOptions_Deprecated_field_number          protoreflect.FieldNumber = 33
+ 	MethodOptions_IdempotencyLevel_field_number    protoreflect.FieldNumber = 34
++	MethodOptions_Features_field_number            protoreflect.FieldNumber = 35
+ 	MethodOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -759,6 +902,13 @@ const (
+ 	MethodOptions_IdempotencyLevel_enum_name     = "IdempotencyLevel"
+ )
+ 
++// Enum values for google.protobuf.MethodOptions.IdempotencyLevel.
++const (
++	MethodOptions_IDEMPOTENCY_UNKNOWN_enum_value = 0
++	MethodOptions_NO_SIDE_EFFECTS_enum_value     = 1
++	MethodOptions_IDEMPOTENT_enum_value          = 2
++)
++
+ // Names for google.protobuf.UninterpretedOption.
+ const (
+ 	UninterpretedOption_message_name     protoreflect.Name     = "UninterpretedOption"
+@@ -816,6 +966,163 @@ const (
+ 	UninterpretedOption_NamePart_IsExtension_field_number protoreflect.FieldNumber = 2
+ )
+ 
++// Names for google.protobuf.FeatureSet.
++const (
++	FeatureSet_message_name     protoreflect.Name     = "FeatureSet"
++	FeatureSet_message_fullname protoreflect.FullName = "google.protobuf.FeatureSet"
++)
++
++// Field names for google.protobuf.FeatureSet.
++const (
++	FeatureSet_FieldPresence_field_name         protoreflect.Name = "field_presence"
++	FeatureSet_EnumType_field_name              protoreflect.Name = "enum_type"
++	FeatureSet_RepeatedFieldEncoding_field_name protoreflect.Name = "repeated_field_encoding"
++	FeatureSet_Utf8Validation_field_name        protoreflect.Name = "utf8_validation"
++	FeatureSet_MessageEncoding_field_name       protoreflect.Name = "message_encoding"
++	FeatureSet_JsonFormat_field_name            protoreflect.Name = "json_format"
++
++	FeatureSet_FieldPresence_field_fullname         protoreflect.FullName = "google.protobuf.FeatureSet.field_presence"
++	FeatureSet_EnumType_field_fullname              protoreflect.FullName = "google.protobuf.FeatureSet.enum_type"
++	FeatureSet_RepeatedFieldEncoding_field_fullname protoreflect.FullName = "google.protobuf.FeatureSet.repeated_field_encoding"
++	FeatureSet_Utf8Validation_field_fullname        protoreflect.FullName = "google.protobuf.FeatureSet.utf8_validation"
++	FeatureSet_MessageEncoding_field_fullname       protoreflect.FullName = "google.protobuf.FeatureSet.message_encoding"
++	FeatureSet_JsonFormat_field_fullname            protoreflect.FullName = "google.protobuf.FeatureSet.json_format"
++)
++
++// Field numbers for google.protobuf.FeatureSet.
++const (
++	FeatureSet_FieldPresence_field_number         protoreflect.FieldNumber = 1
++	FeatureSet_EnumType_field_number              protoreflect.FieldNumber = 2
++	FeatureSet_RepeatedFieldEncoding_field_number protoreflect.FieldNumber = 3
++	FeatureSet_Utf8Validation_field_number        protoreflect.FieldNumber = 4
++	FeatureSet_MessageEncoding_field_number       protoreflect.FieldNumber = 5
++	FeatureSet_JsonFormat_field_number            protoreflect.FieldNumber = 6
++)
++
++// Full and short names for google.protobuf.FeatureSet.FieldPresence.
++const (
++	FeatureSet_FieldPresence_enum_fullname = "google.protobuf.FeatureSet.FieldPresence"
++	FeatureSet_FieldPresence_enum_name     = "FieldPresence"
++)
++
++// Enum values for google.protobuf.FeatureSet.FieldPresence.
++const (
++	FeatureSet_FIELD_PRESENCE_UNKNOWN_enum_value = 0
++	FeatureSet_EXPLICIT_enum_value               = 1
++	FeatureSet_IMPLICIT_enum_value               = 2
++	FeatureSet_LEGACY_REQUIRED_enum_value        = 3
++)
++
++// Full and short names for google.protobuf.FeatureSet.EnumType.
++const (
++	FeatureSet_EnumType_enum_fullname = "google.protobuf.FeatureSet.EnumType"
++	FeatureSet_EnumType_enum_name     = "EnumType"
++)
++
++// Enum values for google.protobuf.FeatureSet.EnumType.
++const (
++	FeatureSet_ENUM_TYPE_UNKNOWN_enum_value = 0
++	FeatureSet_OPEN_enum_value              = 1
++	FeatureSet_CLOSED_enum_value            = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.RepeatedFieldEncoding.
++const (
++	FeatureSet_RepeatedFieldEncoding_enum_fullname = "google.protobuf.FeatureSet.RepeatedFieldEncoding"
++	FeatureSet_RepeatedFieldEncoding_enum_name     = "RepeatedFieldEncoding"
++)
++
++// Enum values for google.protobuf.FeatureSet.RepeatedFieldEncoding.
++const (
++	FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN_enum_value = 0
++	FeatureSet_PACKED_enum_value                          = 1
++	FeatureSet_EXPANDED_enum_value                        = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.Utf8Validation.
++const (
++	FeatureSet_Utf8Validation_enum_fullname = "google.protobuf.FeatureSet.Utf8Validation"
++	FeatureSet_Utf8Validation_enum_name     = "Utf8Validation"
++)
++
++// Enum values for google.protobuf.FeatureSet.Utf8Validation.
++const (
++	FeatureSet_UTF8_VALIDATION_UNKNOWN_enum_value = 0
++	FeatureSet_VERIFY_enum_value                  = 2
++	FeatureSet_NONE_enum_value                    = 3
++)
++
++// Full and short names for google.protobuf.FeatureSet.MessageEncoding.
++const (
++	FeatureSet_MessageEncoding_enum_fullname = "google.protobuf.FeatureSet.MessageEncoding"
++	FeatureSet_MessageEncoding_enum_name     = "MessageEncoding"
++)
++
++// Enum values for google.protobuf.FeatureSet.MessageEncoding.
++const (
++	FeatureSet_MESSAGE_ENCODING_UNKNOWN_enum_value = 0
++	FeatureSet_LENGTH_PREFIXED_enum_value          = 1
++	FeatureSet_DELIMITED_enum_value                = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.JsonFormat.
++const (
++	FeatureSet_JsonFormat_enum_fullname = "google.protobuf.FeatureSet.JsonFormat"
++	FeatureSet_JsonFormat_enum_name     = "JsonFormat"
++)
++
++// Enum values for google.protobuf.FeatureSet.JsonFormat.
++const (
++	FeatureSet_JSON_FORMAT_UNKNOWN_enum_value = 0
++	FeatureSet_ALLOW_enum_value               = 1
++	FeatureSet_LEGACY_BEST_EFFORT_enum_value  = 2
++)
++
++// Names for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_message_name     protoreflect.Name     = "FeatureSetDefaults"
++	FeatureSetDefaults_message_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults"
++)
++
++// Field names for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_Defaults_field_name       protoreflect.Name = "defaults"
++	FeatureSetDefaults_MinimumEdition_field_name protoreflect.Name = "minimum_edition"
++	FeatureSetDefaults_MaximumEdition_field_name protoreflect.Name = "maximum_edition"
++
++	FeatureSetDefaults_Defaults_field_fullname       protoreflect.FullName = "google.protobuf.FeatureSetDefaults.defaults"
++	FeatureSetDefaults_MinimumEdition_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.minimum_edition"
++	FeatureSetDefaults_MaximumEdition_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.maximum_edition"
++)
++
++// Field numbers for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_Defaults_field_number       protoreflect.FieldNumber = 1
++	FeatureSetDefaults_MinimumEdition_field_number protoreflect.FieldNumber = 4
++	FeatureSetDefaults_MaximumEdition_field_number protoreflect.FieldNumber = 5
++)
++
++// Names for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_message_name     protoreflect.Name     = "FeatureSetEditionDefault"
++	FeatureSetDefaults_FeatureSetEditionDefault_message_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault"
++)
++
++// Field names for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_name  protoreflect.Name = "edition"
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_name protoreflect.Name = "features"
++
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_fullname  protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.edition"
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.features"
++)
++
++// Field numbers for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_number  protoreflect.FieldNumber = 3
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_number protoreflect.FieldNumber = 2
++)
++
+ // Names for google.protobuf.SourceCodeInfo.
+ const (
+ 	SourceCodeInfo_message_name     protoreflect.Name     = "SourceCodeInfo"
+@@ -917,3 +1224,10 @@ const (
+ 	GeneratedCodeInfo_Annotation_Semantic_enum_fullname = "google.protobuf.GeneratedCodeInfo.Annotation.Semantic"
+ 	GeneratedCodeInfo_Annotation_Semantic_enum_name     = "Semantic"
+ )
++
++// Enum values for google.protobuf.GeneratedCodeInfo.Annotation.Semantic.
++const (
++	GeneratedCodeInfo_Annotation_NONE_enum_value  = 0
++	GeneratedCodeInfo_Annotation_SET_enum_value   = 1
++	GeneratedCodeInfo_Annotation_ALIAS_enum_value = 2
++)
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go b/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+new file mode 100644
+index 0000000..fd9015e
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+@@ -0,0 +1,31 @@
++// Copyright 2019 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Code generated by generate-protos. DO NOT EDIT.
++
++package genid
++
++import (
++	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
++)
++
++const File_reflect_protodesc_proto_go_features_proto = "reflect/protodesc/proto/go_features.proto"
++
++// Names for google.protobuf.GoFeatures.
++const (
++	GoFeatures_message_name     protoreflect.Name     = "GoFeatures"
++	GoFeatures_message_fullname protoreflect.FullName = "google.protobuf.GoFeatures"
++)
++
++// Field names for google.protobuf.GoFeatures.
++const (
++	GoFeatures_LegacyUnmarshalJsonEnum_field_name protoreflect.Name = "legacy_unmarshal_json_enum"
++
++	GoFeatures_LegacyUnmarshalJsonEnum_field_fullname protoreflect.FullName = "google.protobuf.GoFeatures.legacy_unmarshal_json_enum"
++)
++
++// Field numbers for google.protobuf.GoFeatures.
++const (
++	GoFeatures_LegacyUnmarshalJsonEnum_field_number protoreflect.FieldNumber = 1
++)
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go b/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
+index 1a38944..ad6f80c 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
+@@ -18,6 +18,11 @@ const (
+ 	NullValue_enum_name     = "NullValue"
+ )
+ 
++// Enum values for google.protobuf.NullValue.
++const (
++	NullValue_NULL_VALUE_enum_value = 0
++)
++
+ // Names for google.protobuf.Struct.
+ const (
+ 	Struct_message_name     protoreflect.Name     = "Struct"
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/type_gen.go b/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
+index e0f75fe..49bc73e 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
+@@ -18,6 +18,13 @@ const (
+ 	Syntax_enum_name     = "Syntax"
+ )
+ 
++// Enum values for google.protobuf.Syntax.
++const (
++	Syntax_SYNTAX_PROTO2_enum_value   = 0
++	Syntax_SYNTAX_PROTO3_enum_value   = 1
++	Syntax_SYNTAX_EDITIONS_enum_value = 2
++)
++
+ // Names for google.protobuf.Type.
+ const (
+ 	Type_message_name     protoreflect.Name     = "Type"
+@@ -105,12 +112,43 @@ const (
+ 	Field_Kind_enum_name     = "Kind"
+ )
+ 
++// Enum values for google.protobuf.Field.Kind.
++const (
++	Field_TYPE_UNKNOWN_enum_value  = 0
++	Field_TYPE_DOUBLE_enum_value   = 1
++	Field_TYPE_FLOAT_enum_value    = 2
++	Field_TYPE_INT64_enum_value    = 3
++	Field_TYPE_UINT64_enum_value   = 4
++	Field_TYPE_INT32_enum_value    = 5
++	Field_TYPE_FIXED64_enum_value  = 6
++	Field_TYPE_FIXED32_enum_value  = 7
++	Field_TYPE_BOOL_enum_value     = 8
++	Field_TYPE_STRING_enum_value   = 9
++	Field_TYPE_GROUP_enum_value    = 10
++	Field_TYPE_MESSAGE_enum_value  = 11
++	Field_TYPE_BYTES_enum_value    = 12
++	Field_TYPE_UINT32_enum_value   = 13
++	Field_TYPE_ENUM_enum_value     = 14
++	Field_TYPE_SFIXED32_enum_value = 15
++	Field_TYPE_SFIXED64_enum_value = 16
++	Field_TYPE_SINT32_enum_value   = 17
++	Field_TYPE_SINT64_enum_value   = 18
++)
++
+ // Full and short names for google.protobuf.Field.Cardinality.
+ const (
+ 	Field_Cardinality_enum_fullname = "google.protobuf.Field.Cardinality"
+ 	Field_Cardinality_enum_name     = "Cardinality"
+ )
+ 
++// Enum values for google.protobuf.Field.Cardinality.
++const (
++	Field_CARDINALITY_UNKNOWN_enum_value  = 0
++	Field_CARDINALITY_OPTIONAL_enum_value = 1
++	Field_CARDINALITY_REQUIRED_enum_value = 2
++	Field_CARDINALITY_REPEATED_enum_value = 3
++)
++
+ // Names for google.protobuf.Enum.
+ const (
+ 	Enum_message_name     protoreflect.Name     = "Enum"
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go b/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
+index e74cefd..2b8f122 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
+@@ -21,26 +21,18 @@ type extensionFieldInfo struct {
+ 	validation          validationInfo
+ }
+ 
+-var legacyExtensionFieldInfoCache sync.Map // map[protoreflect.ExtensionType]*extensionFieldInfo
+-
+ func getExtensionFieldInfo(xt protoreflect.ExtensionType) *extensionFieldInfo {
+ 	if xi, ok := xt.(*ExtensionInfo); ok {
+ 		xi.lazyInit()
+ 		return xi.info
+ 	}
+-	return legacyLoadExtensionFieldInfo(xt)
+-}
+-
+-// legacyLoadExtensionFieldInfo dynamically loads a *ExtensionInfo for xt.
+-func legacyLoadExtensionFieldInfo(xt protoreflect.ExtensionType) *extensionFieldInfo {
+-	if xi, ok := legacyExtensionFieldInfoCache.Load(xt); ok {
+-		return xi.(*extensionFieldInfo)
+-	}
+-	e := makeExtensionFieldInfo(xt.TypeDescriptor())
+-	if e, ok := legacyMessageTypeCache.LoadOrStore(xt, e); ok {
+-		return e.(*extensionFieldInfo)
+-	}
+-	return e
++	// Ideally we'd cache the resulting *extensionFieldInfo so we don't have to
++	// recompute this metadata repeatedly. But without support for something like
++	// weak references, such a cache would pin temporary values (like dynamic
++	// extension types, constructed for the duration of a user request) to the
++	// heap forever, causing memory usage of the cache to grow unbounded.
++	// See discussion in https://github.com/golang/protobuf/issues/1521.
++	return makeExtensionFieldInfo(xt.TypeDescriptor())
+ }
+ 
+ func makeExtensionFieldInfo(xd protoreflect.ExtensionDescriptor) *extensionFieldInfo {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go b/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
+index 1a509b6..f55dc01 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
+@@ -162,11 +162,20 @@ func appendBoolSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptions
+ func consumeBoolSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.BoolSlice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growBoolSlice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -732,11 +741,20 @@ func appendInt32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeInt32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1138,11 +1156,20 @@ func appendSint32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeSint32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1544,11 +1571,20 @@ func appendUint32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeUint32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growUint32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1950,11 +1986,20 @@ func appendInt64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeInt64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -2356,11 +2401,20 @@ func appendSint64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeSint64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -2762,11 +2816,20 @@ func appendUint64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeUint64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growUint64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -3145,11 +3208,15 @@ func appendSfixed32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpt
+ func consumeSfixed32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -3461,11 +3528,15 @@ func appendFixed32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpti
+ func consumeFixed32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growUint32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -3777,11 +3848,15 @@ func appendFloatSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeFloatSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Float32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growFloat32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -4093,11 +4168,15 @@ func appendSfixed64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpt
+ func consumeSfixed64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+@@ -4409,11 +4488,15 @@ func appendFixed64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpti
+ func consumeFixed64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growUint64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+@@ -4725,11 +4808,15 @@ func appendDoubleSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeDoubleSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Float64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growFloat64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go b/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
+index 576dcf3..1307775 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
+@@ -197,7 +197,7 @@ func fieldCoder(fd protoreflect.FieldDescriptor, ft reflect.Type) (*MessageInfo,
+ 		return getMessageInfo(ft), makeMessageFieldCoder(fd, ft)
+ 	case fd.Kind() == protoreflect.GroupKind:
+ 		return getMessageInfo(ft), makeGroupFieldCoder(fd, ft)
+-	case fd.Syntax() == protoreflect.Proto3 && fd.ContainingOneof() == nil:
++	case !fd.HasPresence() && fd.ContainingOneof() == nil:
+ 		// Populated oneof fields always encode even if set to the zero value,
+ 		// which normally are not encoded in proto3.
+ 		switch fd.Kind() {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go b/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
+index 61c483f..2ab2c62 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
+@@ -206,13 +206,18 @@ func aberrantLoadMessageDescReentrant(t reflect.Type, name protoreflect.FullName
+ 
+ 	// Obtain a list of oneof wrapper types.
+ 	var oneofWrappers []reflect.Type
+-	for _, method := range []string{"XXX_OneofFuncs", "XXX_OneofWrappers"} {
+-		if fn, ok := t.MethodByName(method); ok {
+-			for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
+-				if vs, ok := v.Interface().([]interface{}); ok {
+-					for _, v := range vs {
+-						oneofWrappers = append(oneofWrappers, reflect.TypeOf(v))
+-					}
++	methods := make([]reflect.Method, 0, 2)
++	if m, ok := t.MethodByName("XXX_OneofFuncs"); ok {
++		methods = append(methods, m)
++	}
++	if m, ok := t.MethodByName("XXX_OneofWrappers"); ok {
++		methods = append(methods, m)
++	}
++	for _, fn := range methods {
++		for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
++			if vs, ok := v.Interface().([]interface{}); ok {
++				for _, v := range vs {
++					oneofWrappers = append(oneofWrappers, reflect.TypeOf(v))
+ 				}
+ 			}
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/message.go b/vendor/google.golang.org/protobuf/internal/impl/message.go
+index 4f5fb67..629bacd 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/message.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/message.go
+@@ -192,12 +192,17 @@ fieldLoop:
+ 
+ 	// Derive a mapping of oneof wrappers to fields.
+ 	oneofWrappers := mi.OneofWrappers
+-	for _, method := range []string{"XXX_OneofFuncs", "XXX_OneofWrappers"} {
+-		if fn, ok := reflect.PtrTo(t).MethodByName(method); ok {
+-			for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
+-				if vs, ok := v.Interface().([]interface{}); ok {
+-					oneofWrappers = vs
+-				}
++	methods := make([]reflect.Method, 0, 2)
++	if m, ok := reflect.PtrTo(t).MethodByName("XXX_OneofFuncs"); ok {
++		methods = append(methods, m)
++	}
++	if m, ok := reflect.PtrTo(t).MethodByName("XXX_OneofWrappers"); ok {
++		methods = append(methods, m)
++	}
++	for _, fn := range methods {
++		for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
++			if vs, ok := v.Interface().([]interface{}); ok {
++				oneofWrappers = vs
+ 			}
+ 		}
+ 	}
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go b/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
+index 5e736c6..986322b 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
+@@ -538,6 +538,6 @@ func isZero(v reflect.Value) bool {
+ 		}
+ 		return true
+ 	default:
+-		panic(&reflect.ValueError{"reflect.Value.IsZero", v.Kind()})
++		panic(&reflect.ValueError{Method: "reflect.Value.IsZero", Kind: v.Kind()})
+ 	}
+ }
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go b/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
+index 4c491bd..517e944 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
+@@ -159,6 +159,42 @@ func (p pointer) SetPointer(v pointer) {
+ 	p.v.Elem().Set(v.v)
+ }
+ 
++func growSlice(p pointer, addCap int) {
++	// TODO: Once we only support Go 1.20 and newer, use reflect.Grow.
++	in := p.v.Elem()
++	out := reflect.MakeSlice(in.Type(), in.Len(), in.Len()+addCap)
++	reflect.Copy(out, in)
++	p.v.Elem().Set(out)
++}
++
++func (p pointer) growBoolSlice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growInt32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growUint32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growInt64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growUint64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growFloat64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growFloat32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
+ func (Export) MessageStateOf(p Pointer) *messageState     { panic("not supported") }
+ func (ms *messageState) pointer() pointer                 { panic("not supported") }
+ func (ms *messageState) messageInfo() *MessageInfo        { panic("not supported") }
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go b/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
+index ee0e057..4b020e3 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
+@@ -138,6 +138,46 @@ func (p pointer) SetPointer(v pointer) {
+ 	*(*unsafe.Pointer)(p.p) = (unsafe.Pointer)(v.p)
+ }
+ 
++func (p pointer) growBoolSlice(addCap int) {
++	sp := p.BoolSlice()
++	s := make([]bool, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growInt32Slice(addCap int) {
++	sp := p.Int32Slice()
++	s := make([]int32, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growUint32Slice(addCap int) {
++	p.growInt32Slice(addCap)
++}
++
++func (p pointer) growFloat32Slice(addCap int) {
++	p.growInt32Slice(addCap)
++}
++
++func (p pointer) growInt64Slice(addCap int) {
++	sp := p.Int64Slice()
++	s := make([]int64, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growUint64Slice(addCap int) {
++	p.growInt64Slice(addCap)
++}
++
++func (p pointer) growFloat64Slice(addCap int) {
++	p.growInt64Slice(addCap)
++}
++
+ // Static check that MessageState does not exceed the size of a pointer.
+ const _ = uint(unsafe.Sizeof(unsafe.Pointer(nil)) - unsafe.Sizeof(MessageState{}))
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings.go b/vendor/google.golang.org/protobuf/internal/strs/strings.go
+index 0b74e76..a6e7df2 100644
+--- a/vendor/google.golang.org/protobuf/internal/strs/strings.go
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings.go
+@@ -17,7 +17,7 @@ import (
+ 
+ // EnforceUTF8 reports whether to enforce strict UTF-8 validation.
+ func EnforceUTF8(fd protoreflect.FieldDescriptor) bool {
+-	if flags.ProtoLegacy {
++	if flags.ProtoLegacy || fd.Syntax() == protoreflect.Editions {
+ 		if fd, ok := fd.(interface{ EnforceUTF8() bool }); ok {
+ 			return fd.EnforceUTF8()
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+similarity index 96%
+rename from vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
+rename to vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+index 61a84d3..a008acd 100644
+--- a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !purego && !appengine
+-// +build !purego,!appengine
++//go:build !purego && !appengine && !go1.21
++// +build !purego,!appengine,!go1.21
+ 
+ package strs
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+new file mode 100644
+index 0000000..60166f2
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+@@ -0,0 +1,74 @@
++// Copyright 2018 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !purego && !appengine && go1.21
++// +build !purego,!appengine,go1.21
++
++package strs
++
++import (
++	"unsafe"
++
++	"google.golang.org/protobuf/reflect/protoreflect"
++)
++
++// UnsafeString returns an unsafe string reference of b.
++// The caller must treat the input slice as immutable.
++//
++// WARNING: Use carefully. The returned result must not leak to the end user
++// unless the input slice is provably immutable.
++func UnsafeString(b []byte) string {
++	return unsafe.String(unsafe.SliceData(b), len(b))
++}
++
++// UnsafeBytes returns an unsafe bytes slice reference of s.
++// The caller must treat returned slice as immutable.
++//
++// WARNING: Use carefully. The returned result must not leak to the end user.
++func UnsafeBytes(s string) []byte {
++	return unsafe.Slice(unsafe.StringData(s), len(s))
++}
++
++// Builder builds a set of strings with shared lifetime.
++// This differs from strings.Builder, which is for building a single string.
++type Builder struct {
++	buf []byte
++}
++
++// AppendFullName is equivalent to protoreflect.FullName.Append,
++// but optimized for large batches where each name has a shared lifetime.
++func (sb *Builder) AppendFullName(prefix protoreflect.FullName, name protoreflect.Name) protoreflect.FullName {
++	n := len(prefix) + len(".") + len(name)
++	if len(prefix) == 0 {
++		n -= len(".")
++	}
++	sb.grow(n)
++	sb.buf = append(sb.buf, prefix...)
++	sb.buf = append(sb.buf, '.')
++	sb.buf = append(sb.buf, name...)
++	return protoreflect.FullName(sb.last(n))
++}
++
++// MakeString is equivalent to string(b), but optimized for large batches
++// with a shared lifetime.
++func (sb *Builder) MakeString(b []byte) string {
++	sb.grow(len(b))
++	sb.buf = append(sb.buf, b...)
++	return sb.last(len(b))
++}
++
++func (sb *Builder) grow(n int) {
++	if cap(sb.buf)-len(sb.buf) >= n {
++		return
++	}
++
++	// Unlike strings.Builder, we do not need to copy over the contents
++	// of the old buffer since our builder provides no API for
++	// retrieving previously created strings.
++	sb.buf = make([]byte, 0, 2*(cap(sb.buf)+n))
++}
++
++func (sb *Builder) last(n int) string {
++	return UnsafeString(sb.buf[len(sb.buf)-n:])
++}
+diff --git a/vendor/google.golang.org/protobuf/internal/version/version.go b/vendor/google.golang.org/protobuf/internal/version/version.go
+index 0999f29..a50fcfb 100644
+--- a/vendor/google.golang.org/protobuf/internal/version/version.go
++++ b/vendor/google.golang.org/protobuf/internal/version/version.go
+@@ -51,7 +51,7 @@ import (
+ //  10. Send out the CL for review and submit it.
+ const (
+ 	Major      = 1
+-	Minor      = 31
++	Minor      = 33
+ 	Patch      = 0
+ 	PreRelease = ""
+ )
+diff --git a/vendor/google.golang.org/protobuf/proto/decode.go b/vendor/google.golang.org/protobuf/proto/decode.go
+index 48d4794..e5b03b5 100644
+--- a/vendor/google.golang.org/protobuf/proto/decode.go
++++ b/vendor/google.golang.org/protobuf/proto/decode.go
+@@ -69,7 +69,7 @@ func (o UnmarshalOptions) Unmarshal(b []byte, m Message) error {
+ // UnmarshalState parses a wire-format message and places the result in m.
+ //
+ // This method permits fine-grained control over the unmarshaler.
+-// Most users should use Unmarshal instead.
++// Most users should use [Unmarshal] instead.
+ func (o UnmarshalOptions) UnmarshalState(in protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+ 	if o.RecursionLimit == 0 {
+ 		o.RecursionLimit = protowire.DefaultRecursionLimit
+diff --git a/vendor/google.golang.org/protobuf/proto/doc.go b/vendor/google.golang.org/protobuf/proto/doc.go
+index ec71e71..80ed16a 100644
+--- a/vendor/google.golang.org/protobuf/proto/doc.go
++++ b/vendor/google.golang.org/protobuf/proto/doc.go
+@@ -18,27 +18,27 @@
+ // This package contains functions to convert to and from the wire format,
+ // an efficient binary serialization of protocol buffers.
+ //
+-// • Size reports the size of a message in the wire format.
++//   - [Size] reports the size of a message in the wire format.
+ //
+-// • Marshal converts a message to the wire format.
+-// The MarshalOptions type provides more control over wire marshaling.
++//   - [Marshal] converts a message to the wire format.
++//     The [MarshalOptions] type provides more control over wire marshaling.
+ //
+-// • Unmarshal converts a message from the wire format.
+-// The UnmarshalOptions type provides more control over wire unmarshaling.
++//   - [Unmarshal] converts a message from the wire format.
++//     The [UnmarshalOptions] type provides more control over wire unmarshaling.
+ //
+ // # Basic message operations
+ //
+-// • Clone makes a deep copy of a message.
++//   - [Clone] makes a deep copy of a message.
+ //
+-// • Merge merges the content of a message into another.
++//   - [Merge] merges the content of a message into another.
+ //
+-// • Equal compares two messages. For more control over comparisons
+-// and detailed reporting of differences, see package
+-// "google.golang.org/protobuf/testing/protocmp".
++//   - [Equal] compares two messages. For more control over comparisons
++//     and detailed reporting of differences, see package
++//     [google.golang.org/protobuf/testing/protocmp].
+ //
+-// • Reset clears the content of a message.
++//   - [Reset] clears the content of a message.
+ //
+-// • CheckInitialized reports whether all required fields in a message are set.
++//   - [CheckInitialized] reports whether all required fields in a message are set.
+ //
+ // # Optional scalar constructors
+ //
+@@ -46,9 +46,9 @@
+ // as pointers to a value. For example, an optional string field has the
+ // Go type *string.
+ //
+-// • Bool, Int32, Int64, Uint32, Uint64, Float32, Float64, and String
+-// take a value and return a pointer to a new instance of it,
+-// to simplify construction of optional field values.
++//   - [Bool], [Int32], [Int64], [Uint32], [Uint64], [Float32], [Float64], and [String]
++//     take a value and return a pointer to a new instance of it,
++//     to simplify construction of optional field values.
+ //
+ // Generated enum types usually have an Enum method which performs the
+ // same operation.
+@@ -57,29 +57,29 @@
+ //
+ // # Extension accessors
+ //
+-// • HasExtension, GetExtension, SetExtension, and ClearExtension
+-// access extension field values in a protocol buffer message.
++//   - [HasExtension], [GetExtension], [SetExtension], and [ClearExtension]
++//     access extension field values in a protocol buffer message.
+ //
+ // Extension fields are only supported in proto2.
+ //
+ // # Related packages
+ //
+-// • Package "google.golang.org/protobuf/encoding/protojson" converts messages to
+-// and from JSON.
++//   - Package [google.golang.org/protobuf/encoding/protojson] converts messages to
++//     and from JSON.
+ //
+-// • Package "google.golang.org/protobuf/encoding/prototext" converts messages to
+-// and from the text format.
++//   - Package [google.golang.org/protobuf/encoding/prototext] converts messages to
++//     and from the text format.
+ //
+-// • Package "google.golang.org/protobuf/reflect/protoreflect" provides a
+-// reflection interface for protocol buffer data types.
++//   - Package [google.golang.org/protobuf/reflect/protoreflect] provides a
++//     reflection interface for protocol buffer data types.
+ //
+-// • Package "google.golang.org/protobuf/testing/protocmp" provides features
+-// to compare protocol buffer messages with the "github.com/google/go-cmp/cmp"
+-// package.
++//   - Package [google.golang.org/protobuf/testing/protocmp] provides features
++//     to compare protocol buffer messages with the [github.com/google/go-cmp/cmp]
++//     package.
+ //
+-// • Package "google.golang.org/protobuf/types/dynamicpb" provides a dynamic
+-// message type, suitable for working with messages where the protocol buffer
+-// type is only known at runtime.
++//   - Package [google.golang.org/protobuf/types/dynamicpb] provides a dynamic
++//     message type, suitable for working with messages where the protocol buffer
++//     type is only known at runtime.
+ //
+ // This module contains additional packages for more specialized use cases.
+ // Consult the individual package documentation for details.
+diff --git a/vendor/google.golang.org/protobuf/proto/encode.go b/vendor/google.golang.org/protobuf/proto/encode.go
+index bf7f816..4fed202 100644
+--- a/vendor/google.golang.org/protobuf/proto/encode.go
++++ b/vendor/google.golang.org/protobuf/proto/encode.go
+@@ -129,7 +129,7 @@ func (o MarshalOptions) MarshalAppend(b []byte, m Message) ([]byte, error) {
+ // MarshalState returns the wire-format encoding of a message.
+ //
+ // This method permits fine-grained control over the marshaler.
+-// Most users should use Marshal instead.
++// Most users should use [Marshal] instead.
+ func (o MarshalOptions) MarshalState(in protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+ 	return o.marshal(in.Buf, in.Message)
+ }
+diff --git a/vendor/google.golang.org/protobuf/proto/extension.go b/vendor/google.golang.org/protobuf/proto/extension.go
+index 5f293cd..17899a3 100644
+--- a/vendor/google.golang.org/protobuf/proto/extension.go
++++ b/vendor/google.golang.org/protobuf/proto/extension.go
+@@ -26,7 +26,7 @@ func HasExtension(m Message, xt protoreflect.ExtensionType) bool {
+ }
+ 
+ // ClearExtension clears an extension field such that subsequent
+-// HasExtension calls return false.
++// [HasExtension] calls return false.
+ // It panics if m is invalid or if xt does not extend m.
+ func ClearExtension(m Message, xt protoreflect.ExtensionType) {
+ 	m.ProtoReflect().Clear(xt.TypeDescriptor())
+diff --git a/vendor/google.golang.org/protobuf/proto/merge.go b/vendor/google.golang.org/protobuf/proto/merge.go
+index d761ab3..3c6fe57 100644
+--- a/vendor/google.golang.org/protobuf/proto/merge.go
++++ b/vendor/google.golang.org/protobuf/proto/merge.go
+@@ -21,7 +21,7 @@ import (
+ // The unknown fields of src are appended to the unknown fields of dst.
+ //
+ // It is semantically equivalent to unmarshaling the encoded form of src
+-// into dst with the UnmarshalOptions.Merge option specified.
++// into dst with the [UnmarshalOptions.Merge] option specified.
+ func Merge(dst, src Message) {
+ 	// TODO: Should nil src be treated as semantically equivalent to a
+ 	// untyped, read-only, empty message? What about a nil dst?
+diff --git a/vendor/google.golang.org/protobuf/proto/proto.go b/vendor/google.golang.org/protobuf/proto/proto.go
+index 1f0d183..7543ee6 100644
+--- a/vendor/google.golang.org/protobuf/proto/proto.go
++++ b/vendor/google.golang.org/protobuf/proto/proto.go
+@@ -15,18 +15,20 @@ import (
+ // protobuf module that accept a Message, except where otherwise specified.
+ //
+ // This is the v2 interface definition for protobuf messages.
+-// The v1 interface definition is "github.com/golang/protobuf/proto".Message.
++// The v1 interface definition is [github.com/golang/protobuf/proto.Message].
+ //
+-// To convert a v1 message to a v2 message,
+-// use "github.com/golang/protobuf/proto".MessageV2.
+-// To convert a v2 message to a v1 message,
+-// use "github.com/golang/protobuf/proto".MessageV1.
++//   - To convert a v1 message to a v2 message,
++//     use [google.golang.org/protobuf/protoadapt.MessageV2Of].
++//   - To convert a v2 message to a v1 message,
++//     use [google.golang.org/protobuf/protoadapt.MessageV1Of].
+ type Message = protoreflect.ProtoMessage
+ 
+-// Error matches all errors produced by packages in the protobuf module.
++// Error matches all errors produced by packages in the protobuf module
++// according to [errors.Is].
+ //
+-// That is, errors.Is(err, Error) reports whether an error is produced
+-// by this module.
++// Example usage:
++//
++//	if errors.Is(err, proto.Error) { ... }
+ var Error error
+ 
+ func init() {
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+index e4dfb12..baa0cc6 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+@@ -3,11 +3,11 @@
+ // license that can be found in the LICENSE file.
+ 
+ // Package protodesc provides functionality for converting
+-// FileDescriptorProto messages to/from protoreflect.FileDescriptor values.
++// FileDescriptorProto messages to/from [protoreflect.FileDescriptor] values.
+ //
+ // The google.protobuf.FileDescriptorProto is a protobuf message that describes
+ // the type information for a .proto file in a form that is easily serializable.
+-// The protoreflect.FileDescriptor is a more structured representation of
++// The [protoreflect.FileDescriptor] is a more structured representation of
+ // the FileDescriptorProto message where references and remote dependencies
+ // can be directly followed.
+ package protodesc
+@@ -24,11 +24,11 @@ import (
+ 	"google.golang.org/protobuf/types/descriptorpb"
+ )
+ 
+-// Resolver is the resolver used by NewFile to resolve dependencies.
++// Resolver is the resolver used by [NewFile] to resolve dependencies.
+ // The enums and messages provided must belong to some parent file,
+ // which is also registered.
+ //
+-// It is implemented by protoregistry.Files.
++// It is implemented by [protoregistry.Files].
+ type Resolver interface {
+ 	FindFileByPath(string) (protoreflect.FileDescriptor, error)
+ 	FindDescriptorByName(protoreflect.FullName) (protoreflect.Descriptor, error)
+@@ -61,19 +61,19 @@ type FileOptions struct {
+ 	AllowUnresolvable bool
+ }
+ 
+-// NewFile creates a new protoreflect.FileDescriptor from the provided
+-// file descriptor message. See FileOptions.New for more information.
++// NewFile creates a new [protoreflect.FileDescriptor] from the provided
++// file descriptor message. See [FileOptions.New] for more information.
+ func NewFile(fd *descriptorpb.FileDescriptorProto, r Resolver) (protoreflect.FileDescriptor, error) {
+ 	return FileOptions{}.New(fd, r)
+ }
+ 
+-// NewFiles creates a new protoregistry.Files from the provided
+-// FileDescriptorSet message. See FileOptions.NewFiles for more information.
++// NewFiles creates a new [protoregistry.Files] from the provided
++// FileDescriptorSet message. See [FileOptions.NewFiles] for more information.
+ func NewFiles(fd *descriptorpb.FileDescriptorSet) (*protoregistry.Files, error) {
+ 	return FileOptions{}.NewFiles(fd)
+ }
+ 
+-// New creates a new protoreflect.FileDescriptor from the provided
++// New creates a new [protoreflect.FileDescriptor] from the provided
+ // file descriptor message. The file must represent a valid proto file according
+ // to protobuf semantics. The returned descriptor is a deep copy of the input.
+ //
+@@ -93,9 +93,15 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
+ 		f.L1.Syntax = protoreflect.Proto2
+ 	case "proto3":
+ 		f.L1.Syntax = protoreflect.Proto3
++	case "editions":
++		f.L1.Syntax = protoreflect.Editions
++		f.L1.Edition = fromEditionProto(fd.GetEdition())
+ 	default:
+ 		return nil, errors.New("invalid syntax: %q", fd.GetSyntax())
+ 	}
++	if f.L1.Syntax == protoreflect.Editions && (fd.GetEdition() < SupportedEditionsMinimum || fd.GetEdition() > SupportedEditionsMaximum) {
++		return nil, errors.New("use of edition %v not yet supported by the Go Protobuf runtime", fd.GetEdition())
++	}
+ 	f.L1.Path = fd.GetName()
+ 	if f.L1.Path == "" {
+ 		return nil, errors.New("file path must be populated")
+@@ -108,6 +114,9 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
+ 		opts = proto.Clone(opts).(*descriptorpb.FileOptions)
+ 		f.L2.Options = func() protoreflect.ProtoMessage { return opts }
+ 	}
++	if f.L1.Syntax == protoreflect.Editions {
++		initFileDescFromFeatureSet(f, fd.GetOptions().GetFeatures())
++	}
+ 
+ 	f.L2.Imports = make(filedesc.FileImports, len(fd.GetDependency()))
+ 	for _, i := range fd.GetPublicDependency() {
+@@ -231,7 +240,7 @@ func (is importSet) importPublic(imps protoreflect.FileImports) {
+ 	}
+ }
+ 
+-// NewFiles creates a new protoregistry.Files from the provided
++// NewFiles creates a new [protoregistry.Files] from the provided
+ // FileDescriptorSet message. The descriptor set must include only
+ // valid files according to protobuf semantics. The returned descriptors
+ // are a deep copy of the input.
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
+index 37efda1..b327816 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
+@@ -28,6 +28,7 @@ func (r descsByName) initEnumDeclarations(eds []*descriptorpb.EnumDescriptorProt
+ 			opts = proto.Clone(opts).(*descriptorpb.EnumOptions)
+ 			e.L2.Options = func() protoreflect.ProtoMessage { return opts }
+ 		}
++		e.L1.EditionFeatures = mergeEditionFeatures(parent, ed.GetOptions().GetFeatures())
+ 		for _, s := range ed.GetReservedName() {
+ 			e.L2.ReservedNames.List = append(e.L2.ReservedNames.List, protoreflect.Name(s))
+ 		}
+@@ -68,6 +69,9 @@ func (r descsByName) initMessagesDeclarations(mds []*descriptorpb.DescriptorProt
+ 		if m.L0, err = r.makeBase(m, parent, md.GetName(), i, sb); err != nil {
+ 			return nil, err
+ 		}
++		if m.Base.L0.ParentFile.Syntax() == protoreflect.Editions {
++			m.L1.EditionFeatures = mergeEditionFeatures(parent, md.GetOptions().GetFeatures())
++		}
+ 		if opts := md.GetOptions(); opts != nil {
+ 			opts = proto.Clone(opts).(*descriptorpb.MessageOptions)
+ 			m.L2.Options = func() protoreflect.ProtoMessage { return opts }
+@@ -114,6 +118,27 @@ func (r descsByName) initMessagesDeclarations(mds []*descriptorpb.DescriptorProt
+ 	return ms, nil
+ }
+ 
++// canBePacked returns whether the field can use packed encoding:
++// https://protobuf.dev/programming-guides/encoding/#packed
++func canBePacked(fd *descriptorpb.FieldDescriptorProto) bool {
++	if fd.GetLabel() != descriptorpb.FieldDescriptorProto_LABEL_REPEATED {
++		return false // not a repeated field
++	}
++
++	switch protoreflect.Kind(fd.GetType()) {
++	case protoreflect.MessageKind, protoreflect.GroupKind:
++		return false // not a scalar type field
++
++	case protoreflect.StringKind, protoreflect.BytesKind:
++		// string and bytes can explicitly not be declared as packed,
++		// see https://protobuf.dev/programming-guides/encoding/#packed
++		return false
++
++	default:
++		return true
++	}
++}
++
+ func (r descsByName) initFieldsFromDescriptorProto(fds []*descriptorpb.FieldDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (fs []filedesc.Field, err error) {
+ 	fs = make([]filedesc.Field, len(fds)) // allocate up-front to ensure stable pointers
+ 	for i, fd := range fds {
+@@ -137,6 +162,34 @@ func (r descsByName) initFieldsFromDescriptorProto(fds []*descriptorpb.FieldDesc
+ 		if fd.JsonName != nil {
+ 			f.L1.StringName.InitJSON(fd.GetJsonName())
+ 		}
++
++		if f.Base.L0.ParentFile.Syntax() == protoreflect.Editions {
++			f.L1.EditionFeatures = mergeEditionFeatures(parent, fd.GetOptions().GetFeatures())
++
++			if f.L1.EditionFeatures.IsLegacyRequired {
++				f.L1.Cardinality = protoreflect.Required
++			}
++			// We reuse the existing field because the old option `[packed =
++			// true]` is mutually exclusive with the editions feature.
++			if canBePacked(fd) {
++				f.L1.HasPacked = true
++				f.L1.IsPacked = f.L1.EditionFeatures.IsPacked
++			}
++
++			// We pretend this option is always explicitly set because the only
++			// use of HasEnforceUTF8 is to determine whether to use EnforceUTF8
++			// or to return the appropriate default.
++			// When using editions we either parse the option or resolve the
++			// appropriate default here (instead of later when this option is
++			// requested from the descriptor).
++			// In proto2/proto3 syntax HasEnforceUTF8 might be false.
++			f.L1.HasEnforceUTF8 = true
++			f.L1.EnforceUTF8 = f.L1.EditionFeatures.IsUTF8Validated
++
++			if f.L1.Kind == protoreflect.MessageKind && f.L1.EditionFeatures.IsDelimitedEncoded {
++				f.L1.Kind = protoreflect.GroupKind
++			}
++		}
+ 	}
+ 	return fs, nil
+ }
+@@ -151,6 +204,9 @@ func (r descsByName) initOneofsFromDescriptorProto(ods []*descriptorpb.OneofDesc
+ 		if opts := od.GetOptions(); opts != nil {
+ 			opts = proto.Clone(opts).(*descriptorpb.OneofOptions)
+ 			o.L1.Options = func() protoreflect.ProtoMessage { return opts }
++			if parent.Syntax() == protoreflect.Editions {
++				o.L1.EditionFeatures = mergeEditionFeatures(parent, opts.GetFeatures())
++			}
+ 		}
+ 	}
+ 	return os, nil
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
+index 27d7e35..254ca58 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
+@@ -276,8 +276,8 @@ func unmarshalDefault(s string, fd protoreflect.FieldDescriptor, allowUnresolvab
+ 	} else if err != nil {
+ 		return v, ev, err
+ 	}
+-	if fd.Syntax() == protoreflect.Proto3 {
+-		return v, ev, errors.New("cannot be specified under proto3 semantics")
++	if !fd.HasPresence() {
++		return v, ev, errors.New("cannot be specified with implicit field presence")
+ 	}
+ 	if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind || fd.Cardinality() == protoreflect.Repeated {
+ 		return v, ev, errors.New("cannot be specified on composite types")
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
+index 9af1d56..e4dcaf8 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
+@@ -107,7 +107,7 @@ func validateMessageDeclarations(ms []filedesc.Message, mds []*descriptorpb.Desc
+ 		if isMessageSet && !flags.ProtoLegacy {
+ 			return errors.New("message %q is a MessageSet, which is a legacy proto1 feature that is no longer supported", m.FullName())
+ 		}
+-		if isMessageSet && (m.Syntax() != protoreflect.Proto2 || m.Fields().Len() > 0 || m.ExtensionRanges().Len() == 0) {
++		if isMessageSet && (m.Syntax() == protoreflect.Proto3 || m.Fields().Len() > 0 || m.ExtensionRanges().Len() == 0) {
+ 			return errors.New("message %q is an invalid proto1 MessageSet", m.FullName())
+ 		}
+ 		if m.Syntax() == protoreflect.Proto3 {
+@@ -314,8 +314,8 @@ func checkValidGroup(fd protoreflect.FieldDescriptor) error {
+ 	switch {
+ 	case fd.Kind() != protoreflect.GroupKind:
+ 		return nil
+-	case fd.Syntax() != protoreflect.Proto2:
+-		return errors.New("invalid under proto2 semantics")
++	case fd.Syntax() == protoreflect.Proto3:
++		return errors.New("invalid under proto3 semantics")
+ 	case md == nil || md.IsPlaceholder():
+ 		return errors.New("message must be resolvable")
+ 	case fd.FullName().Parent() != md.FullName().Parent():
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go b/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+new file mode 100644
+index 0000000..2a6b29d
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+@@ -0,0 +1,148 @@
++// Copyright 2019 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package protodesc
++
++import (
++	"fmt"
++	"os"
++	"sync"
++
++	"google.golang.org/protobuf/internal/editiondefaults"
++	"google.golang.org/protobuf/internal/filedesc"
++	"google.golang.org/protobuf/proto"
++	"google.golang.org/protobuf/reflect/protoreflect"
++	"google.golang.org/protobuf/types/descriptorpb"
++	gofeaturespb "google.golang.org/protobuf/types/gofeaturespb"
++)
++
++const (
++	SupportedEditionsMinimum = descriptorpb.Edition_EDITION_PROTO2
++	SupportedEditionsMaximum = descriptorpb.Edition_EDITION_2023
++)
++
++var defaults = &descriptorpb.FeatureSetDefaults{}
++var defaultsCacheMu sync.Mutex
++var defaultsCache = make(map[filedesc.Edition]*descriptorpb.FeatureSet)
++
++func init() {
++	err := proto.Unmarshal(editiondefaults.Defaults, defaults)
++	if err != nil {
++		fmt.Fprintf(os.Stderr, "unmarshal editions defaults: %v\n", err)
++		os.Exit(1)
++	}
++}
++
++func fromEditionProto(epb descriptorpb.Edition) filedesc.Edition {
++	return filedesc.Edition(epb)
++}
++
++func toEditionProto(ed filedesc.Edition) descriptorpb.Edition {
++	switch ed {
++	case filedesc.EditionUnknown:
++		return descriptorpb.Edition_EDITION_UNKNOWN
++	case filedesc.EditionProto2:
++		return descriptorpb.Edition_EDITION_PROTO2
++	case filedesc.EditionProto3:
++		return descriptorpb.Edition_EDITION_PROTO3
++	case filedesc.Edition2023:
++		return descriptorpb.Edition_EDITION_2023
++	default:
++		panic(fmt.Sprintf("unknown value for edition: %v", ed))
++	}
++}
++
++func getFeatureSetFor(ed filedesc.Edition) *descriptorpb.FeatureSet {
++	defaultsCacheMu.Lock()
++	defer defaultsCacheMu.Unlock()
++	if def, ok := defaultsCache[ed]; ok {
++		return def
++	}
++	edpb := toEditionProto(ed)
++	if defaults.GetMinimumEdition() > edpb || defaults.GetMaximumEdition() < edpb {
++		// This should never happen protodesc.(FileOptions).New would fail when
++		// initializing the file descriptor.
++		// This most likely means the embedded defaults were not updated.
++		fmt.Fprintf(os.Stderr, "internal error: unsupported edition %v (did you forget to update the embedded defaults (i.e. the bootstrap descriptor proto)?)\n", edpb)
++		os.Exit(1)
++	}
++	fs := defaults.GetDefaults()[0].GetFeatures()
++	// Using a linear search for now.
++	// Editions are guaranteed to be sorted and thus we could use a binary search.
++	// Given that there are only a handful of editions (with one more per year)
++	// there is not much reason to use a binary search.
++	for _, def := range defaults.GetDefaults() {
++		if def.GetEdition() <= edpb {
++			fs = def.GetFeatures()
++		} else {
++			break
++		}
++	}
++	defaultsCache[ed] = fs
++	return fs
++}
++
++// mergeEditionFeatures merges the parent and child feature sets. This function
++// should be used when initializing Go descriptors from descriptor protos which
++// is why the parent is a filedesc.EditionsFeatures (Go representation) while
++// the child is a descriptorproto.FeatureSet (protoc representation).
++// Any feature set by the child overwrites what is set by the parent.
++func mergeEditionFeatures(parentDesc protoreflect.Descriptor, child *descriptorpb.FeatureSet) filedesc.EditionFeatures {
++	var parentFS filedesc.EditionFeatures
++	switch p := parentDesc.(type) {
++	case *filedesc.File:
++		parentFS = p.L1.EditionFeatures
++	case *filedesc.Message:
++		parentFS = p.L1.EditionFeatures
++	default:
++		panic(fmt.Sprintf("unknown parent type %T", parentDesc))
++	}
++	if child == nil {
++		return parentFS
++	}
++	if fp := child.FieldPresence; fp != nil {
++		parentFS.IsFieldPresence = *fp == descriptorpb.FeatureSet_LEGACY_REQUIRED ||
++			*fp == descriptorpb.FeatureSet_EXPLICIT
++		parentFS.IsLegacyRequired = *fp == descriptorpb.FeatureSet_LEGACY_REQUIRED
++	}
++	if et := child.EnumType; et != nil {
++		parentFS.IsOpenEnum = *et == descriptorpb.FeatureSet_OPEN
++	}
++
++	if rfe := child.RepeatedFieldEncoding; rfe != nil {
++		parentFS.IsPacked = *rfe == descriptorpb.FeatureSet_PACKED
++	}
++
++	if utf8val := child.Utf8Validation; utf8val != nil {
++		parentFS.IsUTF8Validated = *utf8val == descriptorpb.FeatureSet_VERIFY
++	}
++
++	if me := child.MessageEncoding; me != nil {
++		parentFS.IsDelimitedEncoded = *me == descriptorpb.FeatureSet_DELIMITED
++	}
++
++	if jf := child.JsonFormat; jf != nil {
++		parentFS.IsJSONCompliant = *jf == descriptorpb.FeatureSet_ALLOW
++	}
++
++	if goFeatures, ok := proto.GetExtension(child, gofeaturespb.E_Go).(*gofeaturespb.GoFeatures); ok && goFeatures != nil {
++		if luje := goFeatures.LegacyUnmarshalJsonEnum; luje != nil {
++			parentFS.GenerateLegacyUnmarshalJSON = *luje
++		}
++	}
++
++	return parentFS
++}
++
++// initFileDescFromFeatureSet initializes editions related fields in fd based
++// on fs. If fs is nil it is assumed to be an empty featureset and all fields
++// will be initialized with the appropriate default. fd.L1.Edition must be set
++// before calling this function.
++func initFileDescFromFeatureSet(fd *filedesc.File, fs *descriptorpb.FeatureSet) {
++	dfs := getFeatureSetFor(fd.L1.Edition)
++	// initialize the featureset with the defaults
++	fd.L1.EditionFeatures = mergeEditionFeatures(fd, dfs)
++	// overwrite any options explicitly specified
++	fd.L1.EditionFeatures = mergeEditionFeatures(fd, fs)
++}
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go b/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
+index a7c5cef..9d6e054 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
+@@ -16,7 +16,7 @@ import (
+ 	"google.golang.org/protobuf/types/descriptorpb"
+ )
+ 
+-// ToFileDescriptorProto copies a protoreflect.FileDescriptor into a
++// ToFileDescriptorProto copies a [protoreflect.FileDescriptor] into a
+ // google.protobuf.FileDescriptorProto message.
+ func ToFileDescriptorProto(file protoreflect.FileDescriptor) *descriptorpb.FileDescriptorProto {
+ 	p := &descriptorpb.FileDescriptorProto{
+@@ -70,13 +70,13 @@ func ToFileDescriptorProto(file protoreflect.FileDescriptor) *descriptorpb.FileD
+ 	for i, exts := 0, file.Extensions(); i < exts.Len(); i++ {
+ 		p.Extension = append(p.Extension, ToFieldDescriptorProto(exts.Get(i)))
+ 	}
+-	if syntax := file.Syntax(); syntax != protoreflect.Proto2 {
++	if syntax := file.Syntax(); syntax != protoreflect.Proto2 && syntax.IsValid() {
+ 		p.Syntax = proto.String(file.Syntax().String())
+ 	}
+ 	return p
+ }
+ 
+-// ToDescriptorProto copies a protoreflect.MessageDescriptor into a
++// ToDescriptorProto copies a [protoreflect.MessageDescriptor] into a
+ // google.protobuf.DescriptorProto message.
+ func ToDescriptorProto(message protoreflect.MessageDescriptor) *descriptorpb.DescriptorProto {
+ 	p := &descriptorpb.DescriptorProto{
+@@ -119,7 +119,7 @@ func ToDescriptorProto(message protoreflect.MessageDescriptor) *descriptorpb.Des
+ 	return p
+ }
+ 
+-// ToFieldDescriptorProto copies a protoreflect.FieldDescriptor into a
++// ToFieldDescriptorProto copies a [protoreflect.FieldDescriptor] into a
+ // google.protobuf.FieldDescriptorProto message.
+ func ToFieldDescriptorProto(field protoreflect.FieldDescriptor) *descriptorpb.FieldDescriptorProto {
+ 	p := &descriptorpb.FieldDescriptorProto{
+@@ -168,7 +168,7 @@ func ToFieldDescriptorProto(field protoreflect.FieldDescriptor) *descriptorpb.Fi
+ 	return p
+ }
+ 
+-// ToOneofDescriptorProto copies a protoreflect.OneofDescriptor into a
++// ToOneofDescriptorProto copies a [protoreflect.OneofDescriptor] into a
+ // google.protobuf.OneofDescriptorProto message.
+ func ToOneofDescriptorProto(oneof protoreflect.OneofDescriptor) *descriptorpb.OneofDescriptorProto {
+ 	return &descriptorpb.OneofDescriptorProto{
+@@ -177,7 +177,7 @@ func ToOneofDescriptorProto(oneof protoreflect.OneofDescriptor) *descriptorpb.On
+ 	}
+ }
+ 
+-// ToEnumDescriptorProto copies a protoreflect.EnumDescriptor into a
++// ToEnumDescriptorProto copies a [protoreflect.EnumDescriptor] into a
+ // google.protobuf.EnumDescriptorProto message.
+ func ToEnumDescriptorProto(enum protoreflect.EnumDescriptor) *descriptorpb.EnumDescriptorProto {
+ 	p := &descriptorpb.EnumDescriptorProto{
+@@ -200,7 +200,7 @@ func ToEnumDescriptorProto(enum protoreflect.EnumDescriptor) *descriptorpb.EnumD
+ 	return p
+ }
+ 
+-// ToEnumValueDescriptorProto copies a protoreflect.EnumValueDescriptor into a
++// ToEnumValueDescriptorProto copies a [protoreflect.EnumValueDescriptor] into a
+ // google.protobuf.EnumValueDescriptorProto message.
+ func ToEnumValueDescriptorProto(value protoreflect.EnumValueDescriptor) *descriptorpb.EnumValueDescriptorProto {
+ 	return &descriptorpb.EnumValueDescriptorProto{
+@@ -210,7 +210,7 @@ func ToEnumValueDescriptorProto(value protoreflect.EnumValueDescriptor) *descrip
+ 	}
+ }
+ 
+-// ToServiceDescriptorProto copies a protoreflect.ServiceDescriptor into a
++// ToServiceDescriptorProto copies a [protoreflect.ServiceDescriptor] into a
+ // google.protobuf.ServiceDescriptorProto message.
+ func ToServiceDescriptorProto(service protoreflect.ServiceDescriptor) *descriptorpb.ServiceDescriptorProto {
+ 	p := &descriptorpb.ServiceDescriptorProto{
+@@ -223,7 +223,7 @@ func ToServiceDescriptorProto(service protoreflect.ServiceDescriptor) *descripto
+ 	return p
+ }
+ 
+-// ToMethodDescriptorProto copies a protoreflect.MethodDescriptor into a
++// ToMethodDescriptorProto copies a [protoreflect.MethodDescriptor] into a
+ // google.protobuf.MethodDescriptorProto message.
+ func ToMethodDescriptorProto(method protoreflect.MethodDescriptor) *descriptorpb.MethodDescriptorProto {
+ 	p := &descriptorpb.MethodDescriptorProto{
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
+index 55aa149..00b01fb 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
+@@ -10,46 +10,46 @@
+ //
+ // # Protocol Buffer Descriptors
+ //
+-// Protobuf descriptors (e.g., EnumDescriptor or MessageDescriptor)
++// Protobuf descriptors (e.g., [EnumDescriptor] or [MessageDescriptor])
+ // are immutable objects that represent protobuf type information.
+ // They are wrappers around the messages declared in descriptor.proto.
+ // Protobuf descriptors alone lack any information regarding Go types.
+ //
+-// Enums and messages generated by this module implement Enum and ProtoMessage,
++// Enums and messages generated by this module implement [Enum] and [ProtoMessage],
+ // where the Descriptor and ProtoReflect.Descriptor accessors respectively
+ // return the protobuf descriptor for the values.
+ //
+ // The protobuf descriptor interfaces are not meant to be implemented by
+ // user code since they might need to be extended in the future to support
+ // additions to the protobuf language.
+-// The "google.golang.org/protobuf/reflect/protodesc" package converts between
++// The [google.golang.org/protobuf/reflect/protodesc] package converts between
+ // google.protobuf.DescriptorProto messages and protobuf descriptors.
+ //
+ // # Go Type Descriptors
+ //
+-// A type descriptor (e.g., EnumType or MessageType) is a constructor for
++// A type descriptor (e.g., [EnumType] or [MessageType]) is a constructor for
+ // a concrete Go type that represents the associated protobuf descriptor.
+ // There is commonly a one-to-one relationship between protobuf descriptors and
+ // Go type descriptors, but it can potentially be a one-to-many relationship.
+ //
+-// Enums and messages generated by this module implement Enum and ProtoMessage,
++// Enums and messages generated by this module implement [Enum] and [ProtoMessage],
+ // where the Type and ProtoReflect.Type accessors respectively
+ // return the protobuf descriptor for the values.
+ //
+-// The "google.golang.org/protobuf/types/dynamicpb" package can be used to
++// The [google.golang.org/protobuf/types/dynamicpb] package can be used to
+ // create Go type descriptors from protobuf descriptors.
+ //
+ // # Value Interfaces
+ //
+-// The Enum and Message interfaces provide a reflective view over an
++// The [Enum] and [Message] interfaces provide a reflective view over an
+ // enum or message instance. For enums, it provides the ability to retrieve
+ // the enum value number for any concrete enum type. For messages, it provides
+ // the ability to access or manipulate fields of the message.
+ //
+-// To convert a proto.Message to a protoreflect.Message, use the
++// To convert a [google.golang.org/protobuf/proto.Message] to a [protoreflect.Message], use the
+ // former's ProtoReflect method. Since the ProtoReflect method is new to the
+ // v2 message interface, it may not be present on older message implementations.
+-// The "github.com/golang/protobuf/proto".MessageReflect function can be used
++// The [github.com/golang/protobuf/proto.MessageReflect] function can be used
+ // to obtain a reflective view on older messages.
+ //
+ // # Relationships
+@@ -71,12 +71,12 @@
+ //	      │                                 │
+ //	      └────────────────── Type() ───────┘
+ //
+-// • An EnumType describes a concrete Go enum type.
++// • An [EnumType] describes a concrete Go enum type.
+ // It has an EnumDescriptor and can construct an Enum instance.
+ //
+-// • An EnumDescriptor describes an abstract protobuf enum type.
++// • An [EnumDescriptor] describes an abstract protobuf enum type.
+ //
+-// • An Enum is a concrete enum instance. Generated enums implement Enum.
++// • An [Enum] is a concrete enum instance. Generated enums implement Enum.
+ //
+ //	  ┌──────────────── New() ─────────────────┐
+ //	  │                                        │
+@@ -90,24 +90,26 @@
+ //	       │                                    │
+ //	       └─────────────────── Type() ─────────┘
+ //
+-// • A MessageType describes a concrete Go message type.
+-// It has a MessageDescriptor and can construct a Message instance.
+-// Just as how Go's reflect.Type is a reflective description of a Go type,
+-// a MessageType is a reflective description of a Go type for a protobuf message.
++// • A [MessageType] describes a concrete Go message type.
++// It has a [MessageDescriptor] and can construct a [Message] instance.
++// Just as how Go's [reflect.Type] is a reflective description of a Go type,
++// a [MessageType] is a reflective description of a Go type for a protobuf message.
+ //
+-// • A MessageDescriptor describes an abstract protobuf message type.
+-// It has no understanding of Go types. In order to construct a MessageType
+-// from just a MessageDescriptor, you can consider looking up the message type
+-// in the global registry using protoregistry.GlobalTypes.FindMessageByName
+-// or constructing a dynamic MessageType using dynamicpb.NewMessageType.
++// • A [MessageDescriptor] describes an abstract protobuf message type.
++// It has no understanding of Go types. In order to construct a [MessageType]
++// from just a [MessageDescriptor], you can consider looking up the message type
++// in the global registry using the FindMessageByName method on
++// [google.golang.org/protobuf/reflect/protoregistry.GlobalTypes]
++// or constructing a dynamic [MessageType] using
++// [google.golang.org/protobuf/types/dynamicpb.NewMessageType].
+ //
+-// • A Message is a reflective view over a concrete message instance.
+-// Generated messages implement ProtoMessage, which can convert to a Message.
+-// Just as how Go's reflect.Value is a reflective view over a Go value,
+-// a Message is a reflective view over a concrete protobuf message instance.
+-// Using Go reflection as an analogy, the ProtoReflect method is similar to
+-// calling reflect.ValueOf, and the Message.Interface method is similar to
+-// calling reflect.Value.Interface.
++// • A [Message] is a reflective view over a concrete message instance.
++// Generated messages implement [ProtoMessage], which can convert to a [Message].
++// Just as how Go's [reflect.Value] is a reflective view over a Go value,
++// a [Message] is a reflective view over a concrete protobuf message instance.
++// Using Go reflection as an analogy, the [ProtoMessage.ProtoReflect] method is similar to
++// calling [reflect.ValueOf], and the [Message.Interface] method is similar to
++// calling [reflect.Value.Interface].
+ //
+ //	      ┌── TypeDescriptor() ──┐    ┌───── Descriptor() ─────┐
+ //	      │                      V    │                        V
+@@ -119,15 +121,15 @@
+ //	                                 │                          │
+ //	                                 └────── implements ────────┘
+ //
+-// • An ExtensionType describes a concrete Go implementation of an extension.
+-// It has an ExtensionTypeDescriptor and can convert to/from
+-// abstract Values and Go values.
++// • An [ExtensionType] describes a concrete Go implementation of an extension.
++// It has an [ExtensionTypeDescriptor] and can convert to/from
++// an abstract [Value] and a Go value.
+ //
+-// • An ExtensionTypeDescriptor is an ExtensionDescriptor
+-// which also has an ExtensionType.
++// • An [ExtensionTypeDescriptor] is an [ExtensionDescriptor]
++// which also has an [ExtensionType].
+ //
+-// • An ExtensionDescriptor describes an abstract protobuf extension field and
+-// may not always be an ExtensionTypeDescriptor.
++// • An [ExtensionDescriptor] describes an abstract protobuf extension field and
++// may not always be an [ExtensionTypeDescriptor].
+ package protoreflect
+ 
+ import (
+@@ -142,7 +144,7 @@ type doNotImplement pragma.DoNotImplement
+ 
+ // ProtoMessage is the top-level interface that all proto messages implement.
+ // This is declared in the protoreflect package to avoid a cyclic dependency;
+-// use the proto.Message type instead, which aliases this type.
++// use the [google.golang.org/protobuf/proto.Message] type instead, which aliases this type.
+ type ProtoMessage interface{ ProtoReflect() Message }
+ 
+ // Syntax is the language version of the proto file.
+@@ -151,8 +153,9 @@ type Syntax syntax
+ type syntax int8 // keep exact type opaque as the int type may change
+ 
+ const (
+-	Proto2 Syntax = 2
+-	Proto3 Syntax = 3
++	Proto2   Syntax = 2
++	Proto3   Syntax = 3
++	Editions Syntax = 4
+ )
+ 
+ // IsValid reports whether the syntax is valid.
+@@ -172,6 +175,8 @@ func (s Syntax) String() string {
+ 		return "proto2"
+ 	case Proto3:
+ 		return "proto3"
++	case Editions:
++		return "editions"
+ 	default:
+ 		return fmt.Sprintf("<unknown:%d>", s)
+ 	}
+@@ -436,7 +441,7 @@ type Names interface {
+ // FullName is a qualified name that uniquely identifies a proto declaration.
+ // A qualified name is the concatenation of the proto package along with the
+ // fully-declared name (i.e., name of parent preceding the name of the child),
+-// with a '.' delimiter placed between each Name.
++// with a '.' delimiter placed between each [Name].
+ //
+ // This should not have any leading or trailing dots.
+ type FullName string // e.g., "google.protobuf.Field.Kind"
+@@ -480,7 +485,7 @@ func isLetterDigit(c byte) bool {
+ }
+ 
+ // Name returns the short name, which is the last identifier segment.
+-// A single segment FullName is the Name itself.
++// A single segment FullName is the [Name] itself.
+ func (n FullName) Name() Name {
+ 	if i := strings.LastIndexByte(string(n), '.'); i >= 0 {
+ 		return Name(n[i+1:])
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
+index 717b106..7dcc2ff 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
+@@ -35,7 +35,7 @@ func (p *SourcePath) appendFileDescriptorProto(b []byte) []byte {
+ 		b = p.appendSingularField(b, "source_code_info", (*SourcePath).appendSourceCodeInfo)
+ 	case 12:
+ 		b = p.appendSingularField(b, "syntax", nil)
+-	case 13:
++	case 14:
+ 		b = p.appendSingularField(b, "edition", nil)
+ 	}
+ 	return b
+@@ -160,8 +160,6 @@ func (p *SourcePath) appendFileOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "java_generic_services", nil)
+ 	case 18:
+ 		b = p.appendSingularField(b, "py_generic_services", nil)
+-	case 42:
+-		b = p.appendSingularField(b, "php_generic_services", nil)
+ 	case 23:
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 31:
+@@ -180,6 +178,8 @@ func (p *SourcePath) appendFileOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "php_metadata_namespace", nil)
+ 	case 45:
+ 		b = p.appendSingularField(b, "ruby_package", nil)
++	case 50:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -240,6 +240,8 @@ func (p *SourcePath) appendMessageOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "map_entry", nil)
+ 	case 11:
+ 		b = p.appendSingularField(b, "deprecated_legacy_json_field_conflicts", nil)
++	case 12:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -285,6 +287,8 @@ func (p *SourcePath) appendEnumOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 6:
+ 		b = p.appendSingularField(b, "deprecated_legacy_json_field_conflicts", nil)
++	case 7:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -330,6 +334,8 @@ func (p *SourcePath) appendServiceOptions(b []byte) []byte {
+ 		return b
+ 	}
+ 	switch (*p)[0] {
++	case 34:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 33:
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 999:
+@@ -361,16 +367,39 @@ func (p *SourcePath) appendFieldOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "debug_redact", nil)
+ 	case 17:
+ 		b = p.appendSingularField(b, "retention", nil)
+-	case 18:
+-		b = p.appendSingularField(b, "target", nil)
+ 	case 19:
+ 		b = p.appendRepeatedField(b, "targets", nil)
++	case 20:
++		b = p.appendRepeatedField(b, "edition_defaults", (*SourcePath).appendFieldOptions_EditionDefault)
++	case 21:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+ 	return b
+ }
+ 
++func (p *SourcePath) appendFeatureSet(b []byte) []byte {
++	if len(*p) == 0 {
++		return b
++	}
++	switch (*p)[0] {
++	case 1:
++		b = p.appendSingularField(b, "field_presence", nil)
++	case 2:
++		b = p.appendSingularField(b, "enum_type", nil)
++	case 3:
++		b = p.appendSingularField(b, "repeated_field_encoding", nil)
++	case 4:
++		b = p.appendSingularField(b, "utf8_validation", nil)
++	case 5:
++		b = p.appendSingularField(b, "message_encoding", nil)
++	case 6:
++		b = p.appendSingularField(b, "json_format", nil)
++	}
++	return b
++}
++
+ func (p *SourcePath) appendUninterpretedOption(b []byte) []byte {
+ 	if len(*p) == 0 {
+ 		return b
+@@ -422,6 +451,8 @@ func (p *SourcePath) appendExtensionRangeOptions(b []byte) []byte {
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	case 2:
+ 		b = p.appendRepeatedField(b, "declaration", (*SourcePath).appendExtensionRangeOptions_Declaration)
++	case 50:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 3:
+ 		b = p.appendSingularField(b, "verification", nil)
+ 	}
+@@ -433,6 +464,8 @@ func (p *SourcePath) appendOneofOptions(b []byte) []byte {
+ 		return b
+ 	}
+ 	switch (*p)[0] {
++	case 1:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -446,6 +479,10 @@ func (p *SourcePath) appendEnumValueOptions(b []byte) []byte {
+ 	switch (*p)[0] {
+ 	case 1:
+ 		b = p.appendSingularField(b, "deprecated", nil)
++	case 2:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
++	case 3:
++		b = p.appendSingularField(b, "debug_redact", nil)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -461,12 +498,27 @@ func (p *SourcePath) appendMethodOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 34:
+ 		b = p.appendSingularField(b, "idempotency_level", nil)
++	case 35:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+ 	return b
+ }
+ 
++func (p *SourcePath) appendFieldOptions_EditionDefault(b []byte) []byte {
++	if len(*p) == 0 {
++		return b
++	}
++	switch (*p)[0] {
++	case 3:
++		b = p.appendSingularField(b, "edition", nil)
++	case 2:
++		b = p.appendSingularField(b, "value", nil)
++	}
++	return b
++}
++
+ func (p *SourcePath) appendUninterpretedOption_NamePart(b []byte) []byte {
+ 	if len(*p) == 0 {
+ 		return b
+@@ -491,8 +543,6 @@ func (p *SourcePath) appendExtensionRangeOptions_Declaration(b []byte) []byte {
+ 		b = p.appendSingularField(b, "full_name", nil)
+ 	case 3:
+ 		b = p.appendSingularField(b, "type", nil)
+-	case 4:
+-		b = p.appendSingularField(b, "is_repeated", nil)
+ 	case 5:
+ 		b = p.appendSingularField(b, "reserved", nil)
+ 	case 6:
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
+index 3867470..60ff62b 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
+@@ -12,7 +12,7 @@ package protoreflect
+ // exactly identical. However, it is possible for the same semantically
+ // identical proto type to be represented by multiple type descriptors.
+ //
+-// For example, suppose we have t1 and t2 which are both MessageDescriptors.
++// For example, suppose we have t1 and t2 which are both an [MessageDescriptor].
+ // If t1 == t2, then the types are definitely equal and all accessors return
+ // the same information. However, if t1 != t2, then it is still possible that
+ // they still represent the same proto type (e.g., t1.FullName == t2.FullName).
+@@ -115,7 +115,7 @@ type Descriptor interface {
+ // corresponds with the google.protobuf.FileDescriptorProto message.
+ //
+ // Top-level declarations:
+-// EnumDescriptor, MessageDescriptor, FieldDescriptor, and/or ServiceDescriptor.
++// [EnumDescriptor], [MessageDescriptor], [FieldDescriptor], and/or [ServiceDescriptor].
+ type FileDescriptor interface {
+ 	Descriptor // Descriptor.FullName is identical to Package
+ 
+@@ -180,8 +180,8 @@ type FileImport struct {
+ // corresponds with the google.protobuf.DescriptorProto message.
+ //
+ // Nested declarations:
+-// FieldDescriptor, OneofDescriptor, FieldDescriptor, EnumDescriptor,
+-// and/or MessageDescriptor.
++// [FieldDescriptor], [OneofDescriptor], [FieldDescriptor], [EnumDescriptor],
++// and/or [MessageDescriptor].
+ type MessageDescriptor interface {
+ 	Descriptor
+ 
+@@ -214,7 +214,7 @@ type MessageDescriptor interface {
+ 	ExtensionRanges() FieldRanges
+ 	// ExtensionRangeOptions returns the ith extension range options.
+ 	//
+-	// To avoid a dependency cycle, this method returns a proto.Message value,
++	// To avoid a dependency cycle, this method returns a proto.Message] value,
+ 	// which always contains a google.protobuf.ExtensionRangeOptions message.
+ 	// This method returns a typed nil-pointer if no options are present.
+ 	// The caller must import the descriptorpb package to use this.
+@@ -231,9 +231,9 @@ type MessageDescriptor interface {
+ }
+ type isMessageDescriptor interface{ ProtoType(MessageDescriptor) }
+ 
+-// MessageType encapsulates a MessageDescriptor with a concrete Go implementation.
++// MessageType encapsulates a [MessageDescriptor] with a concrete Go implementation.
+ // It is recommended that implementations of this interface also implement the
+-// MessageFieldTypes interface.
++// [MessageFieldTypes] interface.
+ type MessageType interface {
+ 	// New returns a newly allocated empty message.
+ 	// It may return nil for synthetic messages representing a map entry.
+@@ -249,19 +249,19 @@ type MessageType interface {
+ 	Descriptor() MessageDescriptor
+ }
+ 
+-// MessageFieldTypes extends a MessageType by providing type information
++// MessageFieldTypes extends a [MessageType] by providing type information
+ // regarding enums and messages referenced by the message fields.
+ type MessageFieldTypes interface {
+ 	MessageType
+ 
+-	// Enum returns the EnumType for the ith field in Descriptor.Fields.
++	// Enum returns the EnumType for the ith field in MessageDescriptor.Fields.
+ 	// It returns nil if the ith field is not an enum kind.
+ 	// It panics if out of bounds.
+ 	//
+ 	// Invariant: mt.Enum(i).Descriptor() == mt.Descriptor().Fields(i).Enum()
+ 	Enum(i int) EnumType
+ 
+-	// Message returns the MessageType for the ith field in Descriptor.Fields.
++	// Message returns the MessageType for the ith field in MessageDescriptor.Fields.
+ 	// It returns nil if the ith field is not a message or group kind.
+ 	// It panics if out of bounds.
+ 	//
+@@ -286,8 +286,8 @@ type MessageDescriptors interface {
+ // corresponds with the google.protobuf.FieldDescriptorProto message.
+ //
+ // It is used for both normal fields defined within the parent message
+-// (e.g., MessageDescriptor.Fields) and fields that extend some remote message
+-// (e.g., FileDescriptor.Extensions or MessageDescriptor.Extensions).
++// (e.g., [MessageDescriptor.Fields]) and fields that extend some remote message
++// (e.g., [FileDescriptor.Extensions] or [MessageDescriptor.Extensions]).
+ type FieldDescriptor interface {
+ 	Descriptor
+ 
+@@ -344,7 +344,7 @@ type FieldDescriptor interface {
+ 	// IsMap reports whether this field represents a map,
+ 	// where the value type for the associated field is a Map.
+ 	// It is equivalent to checking whether Cardinality is Repeated,
+-	// that the Kind is MessageKind, and that Message.IsMapEntry reports true.
++	// that the Kind is MessageKind, and that MessageDescriptor.IsMapEntry reports true.
+ 	IsMap() bool
+ 
+ 	// MapKey returns the field descriptor for the key in the map entry.
+@@ -419,7 +419,7 @@ type OneofDescriptor interface {
+ 
+ 	// IsSynthetic reports whether this is a synthetic oneof created to support
+ 	// proto3 optional semantics. If true, Fields contains exactly one field
+-	// with HasOptionalKeyword specified.
++	// with FieldDescriptor.HasOptionalKeyword specified.
+ 	IsSynthetic() bool
+ 
+ 	// Fields is a list of fields belonging to this oneof.
+@@ -442,10 +442,10 @@ type OneofDescriptors interface {
+ 	doNotImplement
+ }
+ 
+-// ExtensionDescriptor is an alias of FieldDescriptor for documentation.
++// ExtensionDescriptor is an alias of [FieldDescriptor] for documentation.
+ type ExtensionDescriptor = FieldDescriptor
+ 
+-// ExtensionTypeDescriptor is an ExtensionDescriptor with an associated ExtensionType.
++// ExtensionTypeDescriptor is an [ExtensionDescriptor] with an associated [ExtensionType].
+ type ExtensionTypeDescriptor interface {
+ 	ExtensionDescriptor
+ 
+@@ -470,12 +470,12 @@ type ExtensionDescriptors interface {
+ 	doNotImplement
+ }
+ 
+-// ExtensionType encapsulates an ExtensionDescriptor with a concrete
++// ExtensionType encapsulates an [ExtensionDescriptor] with a concrete
+ // Go implementation. The nested field descriptor must be for a extension field.
+ //
+ // While a normal field is a member of the parent message that it is declared
+-// within (see Descriptor.Parent), an extension field is a member of some other
+-// target message (see ExtensionDescriptor.Extendee) and may have no
++// within (see [Descriptor.Parent]), an extension field is a member of some other
++// target message (see [FieldDescriptor.ContainingMessage]) and may have no
+ // relationship with the parent. However, the full name of an extension field is
+ // relative to the parent that it is declared within.
+ //
+@@ -532,7 +532,7 @@ type ExtensionType interface {
+ // corresponds with the google.protobuf.EnumDescriptorProto message.
+ //
+ // Nested declarations:
+-// EnumValueDescriptor.
++// [EnumValueDescriptor].
+ type EnumDescriptor interface {
+ 	Descriptor
+ 
+@@ -548,7 +548,7 @@ type EnumDescriptor interface {
+ }
+ type isEnumDescriptor interface{ ProtoType(EnumDescriptor) }
+ 
+-// EnumType encapsulates an EnumDescriptor with a concrete Go implementation.
++// EnumType encapsulates an [EnumDescriptor] with a concrete Go implementation.
+ type EnumType interface {
+ 	// New returns an instance of this enum type with its value set to n.
+ 	New(n EnumNumber) Enum
+@@ -610,7 +610,7 @@ type EnumValueDescriptors interface {
+ // ServiceDescriptor describes a service and
+ // corresponds with the google.protobuf.ServiceDescriptorProto message.
+ //
+-// Nested declarations: MethodDescriptor.
++// Nested declarations: [MethodDescriptor].
+ type ServiceDescriptor interface {
+ 	Descriptor
+ 
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
+index 37601b7..a7b0d06 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
+@@ -27,16 +27,16 @@ type Enum interface {
+ // Message is a reflective interface for a concrete message value,
+ // encapsulating both type and value information for the message.
+ //
+-// Accessor/mutators for individual fields are keyed by FieldDescriptor.
++// Accessor/mutators for individual fields are keyed by [FieldDescriptor].
+ // For non-extension fields, the descriptor must exactly match the
+ // field known by the parent message.
+-// For extension fields, the descriptor must implement ExtensionTypeDescriptor,
+-// extend the parent message (i.e., have the same message FullName), and
++// For extension fields, the descriptor must implement [ExtensionTypeDescriptor],
++// extend the parent message (i.e., have the same message [FullName]), and
+ // be within the parent's extension range.
+ //
+-// Each field Value can be a scalar or a composite type (Message, List, or Map).
+-// See Value for the Go types associated with a FieldDescriptor.
+-// Providing a Value that is invalid or of an incorrect type panics.
++// Each field [Value] can be a scalar or a composite type ([Message], [List], or [Map]).
++// See [Value] for the Go types associated with a [FieldDescriptor].
++// Providing a [Value] that is invalid or of an incorrect type panics.
+ type Message interface {
+ 	// Descriptor returns message descriptor, which contains only the protobuf
+ 	// type information for the message.
+@@ -152,7 +152,7 @@ type Message interface {
+ 	// This method may return nil.
+ 	//
+ 	// The returned methods type is identical to
+-	// "google.golang.org/protobuf/runtime/protoiface".Methods.
++	// google.golang.org/protobuf/runtime/protoiface.Methods.
+ 	// Consult the protoiface package documentation for details.
+ 	ProtoMethods() *methods
+ }
+@@ -175,8 +175,8 @@ func (b RawFields) IsValid() bool {
+ }
+ 
+ // List is a zero-indexed, ordered list.
+-// The element Value type is determined by FieldDescriptor.Kind.
+-// Providing a Value that is invalid or of an incorrect type panics.
++// The element [Value] type is determined by [FieldDescriptor.Kind].
++// Providing a [Value] that is invalid or of an incorrect type panics.
+ type List interface {
+ 	// Len reports the number of entries in the List.
+ 	// Get, Set, and Truncate panic with out of bound indexes.
+@@ -226,9 +226,9 @@ type List interface {
+ }
+ 
+ // Map is an unordered, associative map.
+-// The entry MapKey type is determined by FieldDescriptor.MapKey.Kind.
+-// The entry Value type is determined by FieldDescriptor.MapValue.Kind.
+-// Providing a MapKey or Value that is invalid or of an incorrect type panics.
++// The entry [MapKey] type is determined by [FieldDescriptor.MapKey].Kind.
++// The entry [Value] type is determined by [FieldDescriptor.MapValue].Kind.
++// Providing a [MapKey] or [Value] that is invalid or of an incorrect type panics.
+ type Map interface {
+ 	// Len reports the number of elements in the map.
+ 	Len() int
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
+index 5916525..654599d 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
+@@ -24,19 +24,19 @@ import (
+ //     Unlike the == operator, a NaN is equal to another NaN.
+ //
+ //   - Enums are equal if they contain the same number.
+-//     Since Value does not contain an enum descriptor,
++//     Since [Value] does not contain an enum descriptor,
+ //     enum values do not consider the type of the enum.
+ //
+ //   - Other scalar values are equal if they contain the same value.
+ //
+-//   - Message values are equal if they belong to the same message descriptor,
++//   - [Message] values are equal if they belong to the same message descriptor,
+ //     have the same set of populated known and extension field values,
+ //     and the same set of unknown fields values.
+ //
+-//   - Lists are equal if they are the same length and
++//   - [List] values are equal if they are the same length and
+ //     each corresponding element is equal.
+ //
+-//   - Maps are equal if they have the same set of keys and
++//   - [Map] values are equal if they have the same set of keys and
+ //     the corresponding value for each key is equal.
+ func (v1 Value) Equal(v2 Value) bool {
+ 	return equalValue(v1, v2)
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
+index 08e5ef7..1603097 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
+@@ -11,7 +11,7 @@ import (
+ 
+ // Value is a union where only one Go type may be set at a time.
+ // The Value is used to represent all possible values a field may take.
+-// The following shows which Go type is used to represent each proto Kind:
++// The following shows which Go type is used to represent each proto [Kind]:
+ //
+ //	╔════════════╤═════════════════════════════════════╗
+ //	║ Go type    │ Protobuf kind                       ║
+@@ -31,22 +31,22 @@ import (
+ //
+ // Multiple protobuf Kinds may be represented by a single Go type if the type
+ // can losslessly represent the information for the proto kind. For example,
+-// Int64Kind, Sint64Kind, and Sfixed64Kind are all represented by int64,
++// [Int64Kind], [Sint64Kind], and [Sfixed64Kind] are all represented by int64,
+ // but use different integer encoding methods.
+ //
+-// The List or Map types are used if the field cardinality is repeated.
+-// A field is a List if FieldDescriptor.IsList reports true.
+-// A field is a Map if FieldDescriptor.IsMap reports true.
++// The [List] or [Map] types are used if the field cardinality is repeated.
++// A field is a [List] if [FieldDescriptor.IsList] reports true.
++// A field is a [Map] if [FieldDescriptor.IsMap] reports true.
+ //
+ // Converting to/from a Value and a concrete Go value panics on type mismatch.
+-// For example, ValueOf("hello").Int() panics because this attempts to
++// For example, [ValueOf]("hello").Int() panics because this attempts to
+ // retrieve an int64 from a string.
+ //
+-// List, Map, and Message Values are called "composite" values.
++// [List], [Map], and [Message] Values are called "composite" values.
+ //
+ // A composite Value may alias (reference) memory at some location,
+ // such that changes to the Value updates the that location.
+-// A composite value acquired with a Mutable method, such as Message.Mutable,
++// A composite value acquired with a Mutable method, such as [Message.Mutable],
+ // always references the source object.
+ //
+ // For example:
+@@ -65,7 +65,7 @@ import (
+ //	// appending to the List here may or may not modify the message.
+ //	list.Append(protoreflect.ValueOfInt32(0))
+ //
+-// Some operations, such as Message.Get, may return an "empty, read-only"
++// Some operations, such as [Message.Get], may return an "empty, read-only"
+ // composite Value. Modifying an empty, read-only value panics.
+ type Value value
+ 
+@@ -306,7 +306,7 @@ func (v Value) Float() float64 {
+ 	}
+ }
+ 
+-// String returns v as a string. Since this method implements fmt.Stringer,
++// String returns v as a string. Since this method implements [fmt.Stringer],
+ // this returns the formatted string value for any non-string type.
+ func (v Value) String() string {
+ 	switch v.typ {
+@@ -327,7 +327,7 @@ func (v Value) Bytes() []byte {
+ 	}
+ }
+ 
+-// Enum returns v as a EnumNumber and panics if the type is not a EnumNumber.
++// Enum returns v as a [EnumNumber] and panics if the type is not a [EnumNumber].
+ func (v Value) Enum() EnumNumber {
+ 	switch v.typ {
+ 	case enumType:
+@@ -337,7 +337,7 @@ func (v Value) Enum() EnumNumber {
+ 	}
+ }
+ 
+-// Message returns v as a Message and panics if the type is not a Message.
++// Message returns v as a [Message] and panics if the type is not a [Message].
+ func (v Value) Message() Message {
+ 	switch vi := v.getIface().(type) {
+ 	case Message:
+@@ -347,7 +347,7 @@ func (v Value) Message() Message {
+ 	}
+ }
+ 
+-// List returns v as a List and panics if the type is not a List.
++// List returns v as a [List] and panics if the type is not a [List].
+ func (v Value) List() List {
+ 	switch vi := v.getIface().(type) {
+ 	case List:
+@@ -357,7 +357,7 @@ func (v Value) List() List {
+ 	}
+ }
+ 
+-// Map returns v as a Map and panics if the type is not a Map.
++// Map returns v as a [Map] and panics if the type is not a [Map].
+ func (v Value) Map() Map {
+ 	switch vi := v.getIface().(type) {
+ 	case Map:
+@@ -367,7 +367,7 @@ func (v Value) Map() Map {
+ 	}
+ }
+ 
+-// MapKey returns v as a MapKey and panics for invalid MapKey types.
++// MapKey returns v as a [MapKey] and panics for invalid [MapKey] types.
+ func (v Value) MapKey() MapKey {
+ 	switch v.typ {
+ 	case boolType, int32Type, int64Type, uint32Type, uint64Type, stringType:
+@@ -378,8 +378,8 @@ func (v Value) MapKey() MapKey {
+ }
+ 
+ // MapKey is used to index maps, where the Go type of the MapKey must match
+-// the specified key Kind (see MessageDescriptor.IsMapEntry).
+-// The following shows what Go type is used to represent each proto Kind:
++// the specified key [Kind] (see [MessageDescriptor.IsMapEntry]).
++// The following shows what Go type is used to represent each proto [Kind]:
+ //
+ //	╔═════════╤═════════════════════════════════════╗
+ //	║ Go type │ Protobuf kind                       ║
+@@ -392,13 +392,13 @@ func (v Value) MapKey() MapKey {
+ //	║ string  │ StringKind                          ║
+ //	╚═════════╧═════════════════════════════════════╝
+ //
+-// A MapKey is constructed and accessed through a Value:
++// A MapKey is constructed and accessed through a [Value]:
+ //
+ //	k := ValueOf("hash").MapKey() // convert string to MapKey
+ //	s := k.String()               // convert MapKey to string
+ //
+-// The MapKey is a strict subset of valid types used in Value;
+-// converting a Value to a MapKey with an invalid type panics.
++// The MapKey is a strict subset of valid types used in [Value];
++// converting a [Value] to a MapKey with an invalid type panics.
+ type MapKey value
+ 
+ // IsValid reports whether k is populated with a value.
+@@ -426,13 +426,13 @@ func (k MapKey) Uint() uint64 {
+ 	return Value(k).Uint()
+ }
+ 
+-// String returns k as a string. Since this method implements fmt.Stringer,
++// String returns k as a string. Since this method implements [fmt.Stringer],
+ // this returns the formatted string value for any non-string type.
+ func (k MapKey) String() string {
+ 	return Value(k).String()
+ }
+ 
+-// Value returns k as a Value.
++// Value returns k as a [Value].
+ func (k MapKey) Value() Value {
+ 	return Value(k)
+ }
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+similarity index 97%
+rename from vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
+rename to vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+index 702ddf2..b1fdbe3 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !purego && !appengine
+-// +build !purego,!appengine
++//go:build !purego && !appengine && !go1.21
++// +build !purego,!appengine,!go1.21
+ 
+ package protoreflect
+ 
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+new file mode 100644
+index 0000000..4354701
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+@@ -0,0 +1,87 @@
++// Copyright 2018 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !purego && !appengine && go1.21
++// +build !purego,!appengine,go1.21
++
++package protoreflect
++
++import (
++	"unsafe"
++
++	"google.golang.org/protobuf/internal/pragma"
++)
++
++type (
++	ifaceHeader struct {
++		_    [0]interface{} // if interfaces have greater alignment than unsafe.Pointer, this will enforce it.
++		Type unsafe.Pointer
++		Data unsafe.Pointer
++	}
++)
++
++var (
++	nilType     = typeOf(nil)
++	boolType    = typeOf(*new(bool))
++	int32Type   = typeOf(*new(int32))
++	int64Type   = typeOf(*new(int64))
++	uint32Type  = typeOf(*new(uint32))
++	uint64Type  = typeOf(*new(uint64))
++	float32Type = typeOf(*new(float32))
++	float64Type = typeOf(*new(float64))
++	stringType  = typeOf(*new(string))
++	bytesType   = typeOf(*new([]byte))
++	enumType    = typeOf(*new(EnumNumber))
++)
++
++// typeOf returns a pointer to the Go type information.
++// The pointer is comparable and equal if and only if the types are identical.
++func typeOf(t interface{}) unsafe.Pointer {
++	return (*ifaceHeader)(unsafe.Pointer(&t)).Type
++}
++
++// value is a union where only one type can be represented at a time.
++// The struct is 24B large on 64-bit systems and requires the minimum storage
++// necessary to represent each possible type.
++//
++// The Go GC needs to be able to scan variables containing pointers.
++// As such, pointers and non-pointers cannot be intermixed.
++type value struct {
++	pragma.DoNotCompare // 0B
++
++	// typ stores the type of the value as a pointer to the Go type.
++	typ unsafe.Pointer // 8B
++
++	// ptr stores the data pointer for a String, Bytes, or interface value.
++	ptr unsafe.Pointer // 8B
++
++	// num stores a Bool, Int32, Int64, Uint32, Uint64, Float32, Float64, or
++	// Enum value as a raw uint64.
++	//
++	// It is also used to store the length of a String or Bytes value;
++	// the capacity is ignored.
++	num uint64 // 8B
++}
++
++func valueOfString(v string) Value {
++	return Value{typ: stringType, ptr: unsafe.Pointer(unsafe.StringData(v)), num: uint64(len(v))}
++}
++func valueOfBytes(v []byte) Value {
++	return Value{typ: bytesType, ptr: unsafe.Pointer(unsafe.SliceData(v)), num: uint64(len(v))}
++}
++func valueOfIface(v interface{}) Value {
++	p := (*ifaceHeader)(unsafe.Pointer(&v))
++	return Value{typ: p.Type, ptr: p.Data}
++}
++
++func (v Value) getString() string {
++	return unsafe.String((*byte)(v.ptr), v.num)
++}
++func (v Value) getBytes() []byte {
++	return unsafe.Slice((*byte)(v.ptr), v.num)
++}
++func (v Value) getIface() (x interface{}) {
++	*(*ifaceHeader)(unsafe.Pointer(&x)) = ifaceHeader{Type: v.typ, Data: v.ptr}
++	return x
++}
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go b/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
+index aeb5597..6267dc5 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
+@@ -5,12 +5,12 @@
+ // Package protoregistry provides data structures to register and lookup
+ // protobuf descriptor types.
+ //
+-// The Files registry contains file descriptors and provides the ability
++// The [Files] registry contains file descriptors and provides the ability
+ // to iterate over the files or lookup a specific descriptor within the files.
+-// Files only contains protobuf descriptors and has no understanding of Go
++// [Files] only contains protobuf descriptors and has no understanding of Go
+ // type information that may be associated with each descriptor.
+ //
+-// The Types registry contains descriptor types for which there is a known
++// The [Types] registry contains descriptor types for which there is a known
+ // Go type associated with that descriptor. It provides the ability to iterate
+ // over the registered types or lookup a type by name.
+ package protoregistry
+@@ -218,7 +218,7 @@ func (r *Files) checkGenProtoConflict(path string) {
+ 
+ // FindDescriptorByName looks up a descriptor by the full name.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Files) FindDescriptorByName(name protoreflect.FullName) (protoreflect.Descriptor, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -310,7 +310,7 @@ func (s *nameSuffix) Pop() (name protoreflect.Name) {
+ 
+ // FindFileByPath looks up a file by the path.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ // This returns an error if multiple files have the same path.
+ func (r *Files) FindFileByPath(path string) (protoreflect.FileDescriptor, error) {
+ 	if r == nil {
+@@ -431,7 +431,7 @@ func rangeTopLevelDescriptors(fd protoreflect.FileDescriptor, f func(protoreflec
+ // A compliant implementation must deterministically return the same type
+ // if no error is encountered.
+ //
+-// The Types type implements this interface.
++// The [Types] type implements this interface.
+ type MessageTypeResolver interface {
+ 	// FindMessageByName looks up a message by its full name.
+ 	// E.g., "google.protobuf.Any"
+@@ -451,7 +451,7 @@ type MessageTypeResolver interface {
+ // A compliant implementation must deterministically return the same type
+ // if no error is encountered.
+ //
+-// The Types type implements this interface.
++// The [Types] type implements this interface.
+ type ExtensionTypeResolver interface {
+ 	// FindExtensionByName looks up a extension field by the field's full name.
+ 	// Note that this is the full name of the field as determined by
+@@ -590,7 +590,7 @@ func (r *Types) register(kind string, desc protoreflect.Descriptor, typ interfac
+ // FindEnumByName looks up an enum by its full name.
+ // E.g., "google.protobuf.Field.Kind".
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -611,7 +611,7 @@ func (r *Types) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumTyp
+ // FindMessageByName looks up a message by its full name,
+ // e.g. "google.protobuf.Any".
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -632,7 +632,7 @@ func (r *Types) FindMessageByName(message protoreflect.FullName) (protoreflect.M
+ // FindMessageByURL looks up a message by a URL identifier.
+ // See documentation on google.protobuf.Any.type_url for the URL format.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+ 	// This function is similar to FindMessageByName but
+ 	// truncates anything before and including '/' in the URL.
+@@ -662,7 +662,7 @@ func (r *Types) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+ // where the extension is declared and is unrelated to the full name of the
+ // message being extended.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -703,7 +703,7 @@ func (r *Types) FindExtensionByName(field protoreflect.FullName) (protoreflect.E
+ // FindExtensionByNumber looks up a extension field by the field number
+ // within some parent message, identified by full name.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+diff --git a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+index 04c00f7..78624cf 100644
+--- a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
++++ b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+@@ -48,6 +48,103 @@ import (
+ 	sync "sync"
+ )
+ 
++// The full set of known editions.
++type Edition int32
++
++const (
++	// A placeholder for an unknown edition value.
++	Edition_EDITION_UNKNOWN Edition = 0
++	// Legacy syntax "editions".  These pre-date editions, but behave much like
++	// distinct editions.  These can't be used to specify the edition of proto
++	// files, but feature definitions must supply proto2/proto3 defaults for
++	// backwards compatibility.
++	Edition_EDITION_PROTO2 Edition = 998
++	Edition_EDITION_PROTO3 Edition = 999
++	// Editions that have been released.  The specific values are arbitrary and
++	// should not be depended on, but they will always be time-ordered for easy
++	// comparison.
++	Edition_EDITION_2023 Edition = 1000
++	Edition_EDITION_2024 Edition = 1001
++	// Placeholder editions for testing feature resolution.  These should not be
++	// used or relyed on outside of tests.
++	Edition_EDITION_1_TEST_ONLY     Edition = 1
++	Edition_EDITION_2_TEST_ONLY     Edition = 2
++	Edition_EDITION_99997_TEST_ONLY Edition = 99997
++	Edition_EDITION_99998_TEST_ONLY Edition = 99998
++	Edition_EDITION_99999_TEST_ONLY Edition = 99999
++	// Placeholder for specifying unbounded edition support.  This should only
++	// ever be used by plugins that can expect to never require any changes to
++	// support a new edition.
++	Edition_EDITION_MAX Edition = 2147483647
++)
++
++// Enum value maps for Edition.
++var (
++	Edition_name = map[int32]string{
++		0:          "EDITION_UNKNOWN",
++		998:        "EDITION_PROTO2",
++		999:        "EDITION_PROTO3",
++		1000:       "EDITION_2023",
++		1001:       "EDITION_2024",
++		1:          "EDITION_1_TEST_ONLY",
++		2:          "EDITION_2_TEST_ONLY",
++		99997:      "EDITION_99997_TEST_ONLY",
++		99998:      "EDITION_99998_TEST_ONLY",
++		99999:      "EDITION_99999_TEST_ONLY",
++		2147483647: "EDITION_MAX",
++	}
++	Edition_value = map[string]int32{
++		"EDITION_UNKNOWN":         0,
++		"EDITION_PROTO2":          998,
++		"EDITION_PROTO3":          999,
++		"EDITION_2023":            1000,
++		"EDITION_2024":            1001,
++		"EDITION_1_TEST_ONLY":     1,
++		"EDITION_2_TEST_ONLY":     2,
++		"EDITION_99997_TEST_ONLY": 99997,
++		"EDITION_99998_TEST_ONLY": 99998,
++		"EDITION_99999_TEST_ONLY": 99999,
++		"EDITION_MAX":             2147483647,
++	}
++)
++
++func (x Edition) Enum() *Edition {
++	p := new(Edition)
++	*p = x
++	return p
++}
++
++func (x Edition) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (Edition) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[0].Descriptor()
++}
++
++func (Edition) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[0]
++}
++
++func (x Edition) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *Edition) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = Edition(num)
++	return nil
++}
++
++// Deprecated: Use Edition.Descriptor instead.
++func (Edition) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{0}
++}
++
+ // The verification state of the extension range.
+ type ExtensionRangeOptions_VerificationState int32
+ 
+@@ -80,11 +177,11 @@ func (x ExtensionRangeOptions_VerificationState) String() string {
+ }
+ 
+ func (ExtensionRangeOptions_VerificationState) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[0].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[1].Descriptor()
+ }
+ 
+ func (ExtensionRangeOptions_VerificationState) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[0]
++	return &file_google_protobuf_descriptor_proto_enumTypes[1]
+ }
+ 
+ func (x ExtensionRangeOptions_VerificationState) Number() protoreflect.EnumNumber {
+@@ -125,9 +222,10 @@ const (
+ 	FieldDescriptorProto_TYPE_BOOL    FieldDescriptorProto_Type = 8
+ 	FieldDescriptorProto_TYPE_STRING  FieldDescriptorProto_Type = 9
+ 	// Tag-delimited aggregate.
+-	// Group type is deprecated and not supported in proto3. However, Proto3
++	// Group type is deprecated and not supported after google.protobuf. However, Proto3
+ 	// implementations should still be able to parse the group wire format and
+-	// treat group fields as unknown fields.
++	// treat group fields as unknown fields.  In Editions, the group wire format
++	// can be enabled via the `message_encoding` feature.
+ 	FieldDescriptorProto_TYPE_GROUP   FieldDescriptorProto_Type = 10
+ 	FieldDescriptorProto_TYPE_MESSAGE FieldDescriptorProto_Type = 11 // Length-delimited aggregate.
+ 	// New in version 2.
+@@ -195,11 +293,11 @@ func (x FieldDescriptorProto_Type) String() string {
+ }
+ 
+ func (FieldDescriptorProto_Type) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[1].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[2].Descriptor()
+ }
+ 
+ func (FieldDescriptorProto_Type) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[1]
++	return &file_google_protobuf_descriptor_proto_enumTypes[2]
+ }
+ 
+ func (x FieldDescriptorProto_Type) Number() protoreflect.EnumNumber {
+@@ -226,21 +324,24 @@ type FieldDescriptorProto_Label int32
+ const (
+ 	// 0 is reserved for errors
+ 	FieldDescriptorProto_LABEL_OPTIONAL FieldDescriptorProto_Label = 1
+-	FieldDescriptorProto_LABEL_REQUIRED FieldDescriptorProto_Label = 2
+ 	FieldDescriptorProto_LABEL_REPEATED FieldDescriptorProto_Label = 3
++	// The required label is only allowed in google.protobuf.  In proto3 and Editions
++	// it's explicitly prohibited.  In Editions, the `field_presence` feature
++	// can be used to get this behavior.
++	FieldDescriptorProto_LABEL_REQUIRED FieldDescriptorProto_Label = 2
+ )
+ 
+ // Enum value maps for FieldDescriptorProto_Label.
+ var (
+ 	FieldDescriptorProto_Label_name = map[int32]string{
+ 		1: "LABEL_OPTIONAL",
+-		2: "LABEL_REQUIRED",
+ 		3: "LABEL_REPEATED",
++		2: "LABEL_REQUIRED",
+ 	}
+ 	FieldDescriptorProto_Label_value = map[string]int32{
+ 		"LABEL_OPTIONAL": 1,
+-		"LABEL_REQUIRED": 2,
+ 		"LABEL_REPEATED": 3,
++		"LABEL_REQUIRED": 2,
+ 	}
+ )
+ 
+@@ -255,11 +356,11 @@ func (x FieldDescriptorProto_Label) String() string {
+ }
+ 
+ func (FieldDescriptorProto_Label) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[2].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[3].Descriptor()
+ }
+ 
+ func (FieldDescriptorProto_Label) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[2]
++	return &file_google_protobuf_descriptor_proto_enumTypes[3]
+ }
+ 
+ func (x FieldDescriptorProto_Label) Number() protoreflect.EnumNumber {
+@@ -316,11 +417,11 @@ func (x FileOptions_OptimizeMode) String() string {
+ }
+ 
+ func (FileOptions_OptimizeMode) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[3].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[4].Descriptor()
+ }
+ 
+ func (FileOptions_OptimizeMode) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[3]
++	return &file_google_protobuf_descriptor_proto_enumTypes[4]
+ }
+ 
+ func (x FileOptions_OptimizeMode) Number() protoreflect.EnumNumber {
+@@ -382,11 +483,11 @@ func (x FieldOptions_CType) String() string {
+ }
+ 
+ func (FieldOptions_CType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[4].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[5].Descriptor()
+ }
+ 
+ func (FieldOptions_CType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[4]
++	return &file_google_protobuf_descriptor_proto_enumTypes[5]
+ }
+ 
+ func (x FieldOptions_CType) Number() protoreflect.EnumNumber {
+@@ -444,11 +545,11 @@ func (x FieldOptions_JSType) String() string {
+ }
+ 
+ func (FieldOptions_JSType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[5].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[6].Descriptor()
+ }
+ 
+ func (FieldOptions_JSType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[5]
++	return &file_google_protobuf_descriptor_proto_enumTypes[6]
+ }
+ 
+ func (x FieldOptions_JSType) Number() protoreflect.EnumNumber {
+@@ -506,11 +607,11 @@ func (x FieldOptions_OptionRetention) String() string {
+ }
+ 
+ func (FieldOptions_OptionRetention) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[6].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[7].Descriptor()
+ }
+ 
+ func (FieldOptions_OptionRetention) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[6]
++	return &file_google_protobuf_descriptor_proto_enumTypes[7]
+ }
+ 
+ func (x FieldOptions_OptionRetention) Number() protoreflect.EnumNumber {
+@@ -590,11 +691,11 @@ func (x FieldOptions_OptionTargetType) String() string {
+ }
+ 
+ func (FieldOptions_OptionTargetType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[7].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[8].Descriptor()
+ }
+ 
+ func (FieldOptions_OptionTargetType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[7]
++	return &file_google_protobuf_descriptor_proto_enumTypes[8]
+ }
+ 
+ func (x FieldOptions_OptionTargetType) Number() protoreflect.EnumNumber {
+@@ -652,11 +753,11 @@ func (x MethodOptions_IdempotencyLevel) String() string {
+ }
+ 
+ func (MethodOptions_IdempotencyLevel) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[8].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[9].Descriptor()
+ }
+ 
+ func (MethodOptions_IdempotencyLevel) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[8]
++	return &file_google_protobuf_descriptor_proto_enumTypes[9]
+ }
+ 
+ func (x MethodOptions_IdempotencyLevel) Number() protoreflect.EnumNumber {
+@@ -678,6 +779,363 @@ func (MethodOptions_IdempotencyLevel) EnumDescriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{17, 0}
+ }
+ 
++type FeatureSet_FieldPresence int32
++
++const (
++	FeatureSet_FIELD_PRESENCE_UNKNOWN FeatureSet_FieldPresence = 0
++	FeatureSet_EXPLICIT               FeatureSet_FieldPresence = 1
++	FeatureSet_IMPLICIT               FeatureSet_FieldPresence = 2
++	FeatureSet_LEGACY_REQUIRED        FeatureSet_FieldPresence = 3
++)
++
++// Enum value maps for FeatureSet_FieldPresence.
++var (
++	FeatureSet_FieldPresence_name = map[int32]string{
++		0: "FIELD_PRESENCE_UNKNOWN",
++		1: "EXPLICIT",
++		2: "IMPLICIT",
++		3: "LEGACY_REQUIRED",
++	}
++	FeatureSet_FieldPresence_value = map[string]int32{
++		"FIELD_PRESENCE_UNKNOWN": 0,
++		"EXPLICIT":               1,
++		"IMPLICIT":               2,
++		"LEGACY_REQUIRED":        3,
++	}
++)
++
++func (x FeatureSet_FieldPresence) Enum() *FeatureSet_FieldPresence {
++	p := new(FeatureSet_FieldPresence)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_FieldPresence) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_FieldPresence) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[10].Descriptor()
++}
++
++func (FeatureSet_FieldPresence) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[10]
++}
++
++func (x FeatureSet_FieldPresence) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_FieldPresence) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_FieldPresence(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_FieldPresence.Descriptor instead.
++func (FeatureSet_FieldPresence) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 0}
++}
++
++type FeatureSet_EnumType int32
++
++const (
++	FeatureSet_ENUM_TYPE_UNKNOWN FeatureSet_EnumType = 0
++	FeatureSet_OPEN              FeatureSet_EnumType = 1
++	FeatureSet_CLOSED            FeatureSet_EnumType = 2
++)
++
++// Enum value maps for FeatureSet_EnumType.
++var (
++	FeatureSet_EnumType_name = map[int32]string{
++		0: "ENUM_TYPE_UNKNOWN",
++		1: "OPEN",
++		2: "CLOSED",
++	}
++	FeatureSet_EnumType_value = map[string]int32{
++		"ENUM_TYPE_UNKNOWN": 0,
++		"OPEN":              1,
++		"CLOSED":            2,
++	}
++)
++
++func (x FeatureSet_EnumType) Enum() *FeatureSet_EnumType {
++	p := new(FeatureSet_EnumType)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_EnumType) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_EnumType) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[11].Descriptor()
++}
++
++func (FeatureSet_EnumType) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[11]
++}
++
++func (x FeatureSet_EnumType) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_EnumType) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_EnumType(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_EnumType.Descriptor instead.
++func (FeatureSet_EnumType) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 1}
++}
++
++type FeatureSet_RepeatedFieldEncoding int32
++
++const (
++	FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN FeatureSet_RepeatedFieldEncoding = 0
++	FeatureSet_PACKED                          FeatureSet_RepeatedFieldEncoding = 1
++	FeatureSet_EXPANDED                        FeatureSet_RepeatedFieldEncoding = 2
++)
++
++// Enum value maps for FeatureSet_RepeatedFieldEncoding.
++var (
++	FeatureSet_RepeatedFieldEncoding_name = map[int32]string{
++		0: "REPEATED_FIELD_ENCODING_UNKNOWN",
++		1: "PACKED",
++		2: "EXPANDED",
++	}
++	FeatureSet_RepeatedFieldEncoding_value = map[string]int32{
++		"REPEATED_FIELD_ENCODING_UNKNOWN": 0,
++		"PACKED":                          1,
++		"EXPANDED":                        2,
++	}
++)
++
++func (x FeatureSet_RepeatedFieldEncoding) Enum() *FeatureSet_RepeatedFieldEncoding {
++	p := new(FeatureSet_RepeatedFieldEncoding)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_RepeatedFieldEncoding) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_RepeatedFieldEncoding) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[12].Descriptor()
++}
++
++func (FeatureSet_RepeatedFieldEncoding) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[12]
++}
++
++func (x FeatureSet_RepeatedFieldEncoding) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_RepeatedFieldEncoding) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_RepeatedFieldEncoding(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_RepeatedFieldEncoding.Descriptor instead.
++func (FeatureSet_RepeatedFieldEncoding) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 2}
++}
++
++type FeatureSet_Utf8Validation int32
++
++const (
++	FeatureSet_UTF8_VALIDATION_UNKNOWN FeatureSet_Utf8Validation = 0
++	FeatureSet_VERIFY                  FeatureSet_Utf8Validation = 2
++	FeatureSet_NONE                    FeatureSet_Utf8Validation = 3
++)
++
++// Enum value maps for FeatureSet_Utf8Validation.
++var (
++	FeatureSet_Utf8Validation_name = map[int32]string{
++		0: "UTF8_VALIDATION_UNKNOWN",
++		2: "VERIFY",
++		3: "NONE",
++	}
++	FeatureSet_Utf8Validation_value = map[string]int32{
++		"UTF8_VALIDATION_UNKNOWN": 0,
++		"VERIFY":                  2,
++		"NONE":                    3,
++	}
++)
++
++func (x FeatureSet_Utf8Validation) Enum() *FeatureSet_Utf8Validation {
++	p := new(FeatureSet_Utf8Validation)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_Utf8Validation) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_Utf8Validation) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[13].Descriptor()
++}
++
++func (FeatureSet_Utf8Validation) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[13]
++}
++
++func (x FeatureSet_Utf8Validation) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_Utf8Validation) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_Utf8Validation(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_Utf8Validation.Descriptor instead.
++func (FeatureSet_Utf8Validation) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 3}
++}
++
++type FeatureSet_MessageEncoding int32
++
++const (
++	FeatureSet_MESSAGE_ENCODING_UNKNOWN FeatureSet_MessageEncoding = 0
++	FeatureSet_LENGTH_PREFIXED          FeatureSet_MessageEncoding = 1
++	FeatureSet_DELIMITED                FeatureSet_MessageEncoding = 2
++)
++
++// Enum value maps for FeatureSet_MessageEncoding.
++var (
++	FeatureSet_MessageEncoding_name = map[int32]string{
++		0: "MESSAGE_ENCODING_UNKNOWN",
++		1: "LENGTH_PREFIXED",
++		2: "DELIMITED",
++	}
++	FeatureSet_MessageEncoding_value = map[string]int32{
++		"MESSAGE_ENCODING_UNKNOWN": 0,
++		"LENGTH_PREFIXED":          1,
++		"DELIMITED":                2,
++	}
++)
++
++func (x FeatureSet_MessageEncoding) Enum() *FeatureSet_MessageEncoding {
++	p := new(FeatureSet_MessageEncoding)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_MessageEncoding) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_MessageEncoding) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[14].Descriptor()
++}
++
++func (FeatureSet_MessageEncoding) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[14]
++}
++
++func (x FeatureSet_MessageEncoding) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_MessageEncoding) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_MessageEncoding(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_MessageEncoding.Descriptor instead.
++func (FeatureSet_MessageEncoding) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 4}
++}
++
++type FeatureSet_JsonFormat int32
++
++const (
++	FeatureSet_JSON_FORMAT_UNKNOWN FeatureSet_JsonFormat = 0
++	FeatureSet_ALLOW               FeatureSet_JsonFormat = 1
++	FeatureSet_LEGACY_BEST_EFFORT  FeatureSet_JsonFormat = 2
++)
++
++// Enum value maps for FeatureSet_JsonFormat.
++var (
++	FeatureSet_JsonFormat_name = map[int32]string{
++		0: "JSON_FORMAT_UNKNOWN",
++		1: "ALLOW",
++		2: "LEGACY_BEST_EFFORT",
++	}
++	FeatureSet_JsonFormat_value = map[string]int32{
++		"JSON_FORMAT_UNKNOWN": 0,
++		"ALLOW":               1,
++		"LEGACY_BEST_EFFORT":  2,
++	}
++)
++
++func (x FeatureSet_JsonFormat) Enum() *FeatureSet_JsonFormat {
++	p := new(FeatureSet_JsonFormat)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_JsonFormat) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_JsonFormat) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[15].Descriptor()
++}
++
++func (FeatureSet_JsonFormat) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[15]
++}
++
++func (x FeatureSet_JsonFormat) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_JsonFormat) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_JsonFormat(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_JsonFormat.Descriptor instead.
++func (FeatureSet_JsonFormat) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 5}
++}
++
+ // Represents the identified object's effect on the element in the original
+ // .proto file.
+ type GeneratedCodeInfo_Annotation_Semantic int32
+@@ -716,11 +1174,11 @@ func (x GeneratedCodeInfo_Annotation_Semantic) String() string {
+ }
+ 
+ func (GeneratedCodeInfo_Annotation_Semantic) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[9].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[16].Descriptor()
+ }
+ 
+ func (GeneratedCodeInfo_Annotation_Semantic) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[9]
++	return &file_google_protobuf_descriptor_proto_enumTypes[16]
+ }
+ 
+ func (x GeneratedCodeInfo_Annotation_Semantic) Number() protoreflect.EnumNumber {
+@@ -739,7 +1197,7 @@ func (x *GeneratedCodeInfo_Annotation_Semantic) UnmarshalJSON(b []byte) error {
+ 
+ // Deprecated: Use GeneratedCodeInfo_Annotation_Semantic.Descriptor instead.
+ func (GeneratedCodeInfo_Annotation_Semantic) EnumDescriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22, 0, 0}
+ }
+ 
+ // The protocol compiler can output a FileDescriptorSet containing the .proto
+@@ -822,8 +1280,8 @@ type FileDescriptorProto struct {
+ 	//
+ 	// If `edition` is present, this value must be "editions".
+ 	Syntax *string `protobuf:"bytes,12,opt,name=syntax" json:"syntax,omitempty"`
+-	// The edition of the proto file, which is an opaque string.
+-	Edition *string `protobuf:"bytes,13,opt,name=edition" json:"edition,omitempty"`
++	// The edition of the proto file.
++	Edition *Edition `protobuf:"varint,14,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
+ }
+ 
+ func (x *FileDescriptorProto) Reset() {
+@@ -942,11 +1400,11 @@ func (x *FileDescriptorProto) GetSyntax() string {
+ 	return ""
+ }
+ 
+-func (x *FileDescriptorProto) GetEdition() string {
++func (x *FileDescriptorProto) GetEdition() Edition {
+ 	if x != nil && x.Edition != nil {
+ 		return *x.Edition
+ 	}
+-	return ""
++	return Edition_EDITION_UNKNOWN
+ }
+ 
+ // Describes a message type.
+@@ -1079,13 +1537,14 @@ type ExtensionRangeOptions struct {
+ 
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+-	// go/protobuf-stripping-extension-declarations
+-	// Like Metadata, but we use a repeated field to hold all extension
+-	// declarations. This should avoid the size increases of transforming a large
+-	// extension range into small ranges in generated binaries.
++	// For external users: DO NOT USE. We are in the process of open sourcing
++	// extension declaration and executing internal cleanups before it can be
++	// used externally.
+ 	Declaration []*ExtensionRangeOptions_Declaration `protobuf:"bytes,2,rep,name=declaration" json:"declaration,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,50,opt,name=features" json:"features,omitempty"`
+ 	// The verification state of the range.
+-	// TODO(b/278783756): flip the default to DECLARATION once all empty ranges
++	// TODO: flip the default to DECLARATION once all empty ranges
+ 	// are marked as UNVERIFIED.
+ 	Verification *ExtensionRangeOptions_VerificationState `protobuf:"varint,3,opt,name=verification,enum=google.protobuf.ExtensionRangeOptions_VerificationState,def=1" json:"verification,omitempty"`
+ }
+@@ -1141,6 +1600,13 @@ func (x *ExtensionRangeOptions) GetDeclaration() []*ExtensionRangeOptions_Declar
+ 	return nil
+ }
+ 
++func (x *ExtensionRangeOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *ExtensionRangeOptions) GetVerification() ExtensionRangeOptions_VerificationState {
+ 	if x != nil && x.Verification != nil {
+ 		return *x.Verification
+@@ -1186,12 +1652,12 @@ type FieldDescriptorProto struct {
+ 	// If true, this is a proto3 "optional". When a proto3 field is optional, it
+ 	// tracks presence regardless of field type.
+ 	//
+-	// When proto3_optional is true, this field must be belong to a oneof to
+-	// signal to old proto3 clients that presence is tracked for this field. This
+-	// oneof is known as a "synthetic" oneof, and this field must be its sole
+-	// member (each proto3 optional field gets its own synthetic oneof). Synthetic
+-	// oneofs exist in the descriptor only, and do not generate any API. Synthetic
+-	// oneofs must be ordered after all "real" oneofs.
++	// When proto3_optional is true, this field must belong to a oneof to signal
++	// to old proto3 clients that presence is tracked for this field. This oneof
++	// is known as a "synthetic" oneof, and this field must be its sole member
++	// (each proto3 optional field gets its own synthetic oneof). Synthetic oneofs
++	// exist in the descriptor only, and do not generate any API. Synthetic oneofs
++	// must be ordered after all "real" oneofs.
+ 	//
+ 	// For message fields, proto3_optional doesn't create any semantic change,
+ 	// since non-repeated message fields always track presence. However it still
+@@ -1738,7 +2204,6 @@ type FileOptions struct {
+ 	CcGenericServices   *bool `protobuf:"varint,16,opt,name=cc_generic_services,json=ccGenericServices,def=0" json:"cc_generic_services,omitempty"`
+ 	JavaGenericServices *bool `protobuf:"varint,17,opt,name=java_generic_services,json=javaGenericServices,def=0" json:"java_generic_services,omitempty"`
+ 	PyGenericServices   *bool `protobuf:"varint,18,opt,name=py_generic_services,json=pyGenericServices,def=0" json:"py_generic_services,omitempty"`
+-	PhpGenericServices  *bool `protobuf:"varint,42,opt,name=php_generic_services,json=phpGenericServices,def=0" json:"php_generic_services,omitempty"`
+ 	// Is this file deprecated?
+ 	// Depending on the target platform, this can emit Deprecated annotations
+ 	// for everything in the file, or it will be completely ignored; in the very
+@@ -1772,6 +2237,8 @@ type FileOptions struct {
+ 	// is empty. When this option is not set, the package name will be used for
+ 	// determining the ruby package.
+ 	RubyPackage *string `protobuf:"bytes,45,opt,name=ruby_package,json=rubyPackage" json:"ruby_package,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,50,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here.
+ 	// See the documentation for the "Options" section above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+@@ -1785,7 +2252,6 @@ const (
+ 	Default_FileOptions_CcGenericServices   = bool(false)
+ 	Default_FileOptions_JavaGenericServices = bool(false)
+ 	Default_FileOptions_PyGenericServices   = bool(false)
+-	Default_FileOptions_PhpGenericServices  = bool(false)
+ 	Default_FileOptions_Deprecated          = bool(false)
+ 	Default_FileOptions_CcEnableArenas      = bool(true)
+ )
+@@ -1893,13 +2359,6 @@ func (x *FileOptions) GetPyGenericServices() bool {
+ 	return Default_FileOptions_PyGenericServices
+ }
+ 
+-func (x *FileOptions) GetPhpGenericServices() bool {
+-	if x != nil && x.PhpGenericServices != nil {
+-		return *x.PhpGenericServices
+-	}
+-	return Default_FileOptions_PhpGenericServices
+-}
+-
+ func (x *FileOptions) GetDeprecated() bool {
+ 	if x != nil && x.Deprecated != nil {
+ 		return *x.Deprecated
+@@ -1963,6 +2422,13 @@ func (x *FileOptions) GetRubyPackage() string {
+ 	return ""
+ }
+ 
++func (x *FileOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *FileOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2006,10 +2472,6 @@ type MessageOptions struct {
+ 	// for the message, or it will be completely ignored; in the very least,
+ 	// this is a formalization for deprecating messages.
+ 	Deprecated *bool `protobuf:"varint,3,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
+-	// NOTE: Do not set the option in .proto files. Always use the maps syntax
+-	// instead. The option should only be implicitly set by the proto compiler
+-	// parser.
+-	//
+ 	// Whether the message is an automatically generated map entry type for the
+ 	// maps field.
+ 	//
+@@ -2030,6 +2492,10 @@ type MessageOptions struct {
+ 	// use a native map in the target language to hold the keys and values.
+ 	// The reflection APIs in such implementations still need to work as
+ 	// if the field is a repeated message field.
++	//
++	// NOTE: Do not set the option in .proto files. Always use the maps syntax
++	// instead. The option should only be implicitly set by the proto compiler
++	// parser.
+ 	MapEntry *bool `protobuf:"varint,7,opt,name=map_entry,json=mapEntry" json:"map_entry,omitempty"`
+ 	// Enable the legacy handling of JSON field name conflicts.  This lowercases
+ 	// and strips underscored from the fields before comparison in proto3 only.
+@@ -2039,11 +2505,13 @@ type MessageOptions struct {
+ 	// This should only be used as a temporary measure against broken builds due
+ 	// to the change in behavior for JSON field name conflicts.
+ 	//
+-	// TODO(b/261750190) This is legacy behavior we plan to remove once downstream
++	// TODO This is legacy behavior we plan to remove once downstream
+ 	// teams have had time to migrate.
+ 	//
+ 	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+ 	DeprecatedLegacyJsonFieldConflicts *bool `protobuf:"varint,11,opt,name=deprecated_legacy_json_field_conflicts,json=deprecatedLegacyJsonFieldConflicts" json:"deprecated_legacy_json_field_conflicts,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,12,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2123,6 +2591,13 @@ func (x *MessageOptions) GetDeprecatedLegacyJsonFieldConflicts() bool {
+ 	return false
+ }
+ 
++func (x *MessageOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *MessageOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2147,7 +2622,9 @@ type FieldOptions struct {
+ 	// a more efficient representation on the wire. Rather than repeatedly
+ 	// writing the tag and type for each element, the entire array is encoded as
+ 	// a single length-delimited blob. In proto3, only explicit setting it to
+-	// false will avoid using packed encoding.
++	// false will avoid using packed encoding.  This option is prohibited in
++	// Editions, but the `repeated_field_encoding` feature can be used to control
++	// the behavior.
+ 	Packed *bool `protobuf:"varint,2,opt,name=packed" json:"packed,omitempty"`
+ 	// The jstype option determines the JavaScript type used for values of the
+ 	// field.  The option is permitted only for 64 bit integral and fixed types
+@@ -2178,19 +2655,11 @@ type FieldOptions struct {
+ 	// call from multiple threads concurrently, while non-const methods continue
+ 	// to require exclusive access.
+ 	//
+-	// Note that implementations may choose not to check required fields within
+-	// a lazy sub-message.  That is, calling IsInitialized() on the outer message
+-	// may return true even if the inner message has missing required fields.
+-	// This is necessary because otherwise the inner message would have to be
+-	// parsed in order to perform the check, defeating the purpose of lazy
+-	// parsing.  An implementation which chooses not to check required fields
+-	// must be consistent about it.  That is, for any particular sub-message, the
+-	// implementation must either *always* check its required fields, or *never*
+-	// check its required fields, regardless of whether or not the message has
+-	// been parsed.
+-	//
+-	// As of May 2022, lazy verifies the contents of the byte stream during
+-	// parsing.  An invalid byte stream will cause the overall parsing to fail.
++	// Note that lazy message fields are still eagerly verified to check
++	// ill-formed wireformat or missing required fields. Calling IsInitialized()
++	// on the outer message would fail if the inner message has missing required
++	// fields. Failed verification would result in parsing failure (except when
++	// uninitialized messages are acceptable).
+ 	Lazy *bool `protobuf:"varint,5,opt,name=lazy,def=0" json:"lazy,omitempty"`
+ 	// unverified_lazy does no correctness checks on the byte stream. This should
+ 	// only be used where lazy with verification is prohibitive for performance
+@@ -2205,11 +2674,12 @@ type FieldOptions struct {
+ 	Weak *bool `protobuf:"varint,10,opt,name=weak,def=0" json:"weak,omitempty"`
+ 	// Indicate that the field value should not be printed out when using debug
+ 	// formats, e.g. when the field contains sensitive credentials.
+-	DebugRedact *bool                         `protobuf:"varint,16,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
+-	Retention   *FieldOptions_OptionRetention `protobuf:"varint,17,opt,name=retention,enum=google.protobuf.FieldOptions_OptionRetention" json:"retention,omitempty"`
+-	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-	Target  *FieldOptions_OptionTargetType  `protobuf:"varint,18,opt,name=target,enum=google.protobuf.FieldOptions_OptionTargetType" json:"target,omitempty"`
+-	Targets []FieldOptions_OptionTargetType `protobuf:"varint,19,rep,name=targets,enum=google.protobuf.FieldOptions_OptionTargetType" json:"targets,omitempty"`
++	DebugRedact     *bool                           `protobuf:"varint,16,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
++	Retention       *FieldOptions_OptionRetention   `protobuf:"varint,17,opt,name=retention,enum=google.protobuf.FieldOptions_OptionRetention" json:"retention,omitempty"`
++	Targets         []FieldOptions_OptionTargetType `protobuf:"varint,19,rep,name=targets,enum=google.protobuf.FieldOptions_OptionTargetType" json:"targets,omitempty"`
++	EditionDefaults []*FieldOptions_EditionDefault  `protobuf:"bytes,20,rep,name=edition_defaults,json=editionDefaults" json:"edition_defaults,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,21,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2320,17 +2790,23 @@ func (x *FieldOptions) GetRetention() FieldOptions_OptionRetention {
+ 	return FieldOptions_RETENTION_UNKNOWN
+ }
+ 
+-// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-func (x *FieldOptions) GetTarget() FieldOptions_OptionTargetType {
+-	if x != nil && x.Target != nil {
+-		return *x.Target
++func (x *FieldOptions) GetTargets() []FieldOptions_OptionTargetType {
++	if x != nil {
++		return x.Targets
+ 	}
+-	return FieldOptions_TARGET_TYPE_UNKNOWN
++	return nil
+ }
+ 
+-func (x *FieldOptions) GetTargets() []FieldOptions_OptionTargetType {
++func (x *FieldOptions) GetEditionDefaults() []*FieldOptions_EditionDefault {
+ 	if x != nil {
+-		return x.Targets
++		return x.EditionDefaults
++	}
++	return nil
++}
++
++func (x *FieldOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
+ 	}
+ 	return nil
+ }
+@@ -2348,6 +2824,8 @@ type OneofOptions struct {
+ 	unknownFields   protoimpl.UnknownFields
+ 	extensionFields protoimpl.ExtensionFields
+ 
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,1,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2384,6 +2862,13 @@ func (*OneofOptions) Descriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{13}
+ }
+ 
++func (x *OneofOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *OneofOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2409,11 +2894,13 @@ type EnumOptions struct {
+ 	// and strips underscored from the fields before comparison in proto3 only.
+ 	// The new behavior takes `json_name` into account and applies to proto2 as
+ 	// well.
+-	// TODO(b/261750190) Remove this legacy behavior once downstream teams have
++	// TODO Remove this legacy behavior once downstream teams have
+ 	// had time to migrate.
+ 	//
+ 	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+ 	DeprecatedLegacyJsonFieldConflicts *bool `protobuf:"varint,6,opt,name=deprecated_legacy_json_field_conflicts,json=deprecatedLegacyJsonFieldConflicts" json:"deprecated_legacy_json_field_conflicts,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,7,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2477,6 +2964,13 @@ func (x *EnumOptions) GetDeprecatedLegacyJsonFieldConflicts() bool {
+ 	return false
+ }
+ 
++func (x *EnumOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *EnumOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2495,13 +2989,20 @@ type EnumValueOptions struct {
+ 	// for the enum value, or it will be completely ignored; in the very least,
+ 	// this is a formalization for deprecating enum values.
+ 	Deprecated *bool `protobuf:"varint,1,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,2,opt,name=features" json:"features,omitempty"`
++	// Indicate that fields annotated with this enum value should not be printed
++	// out when using debug formats, e.g. when the field contains sensitive
++	// credentials.
++	DebugRedact *bool `protobuf:"varint,3,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+ 
+ // Default values for EnumValueOptions fields.
+ const (
+-	Default_EnumValueOptions_Deprecated = bool(false)
++	Default_EnumValueOptions_Deprecated  = bool(false)
++	Default_EnumValueOptions_DebugRedact = bool(false)
+ )
+ 
+ func (x *EnumValueOptions) Reset() {
+@@ -2543,6 +3044,20 @@ func (x *EnumValueOptions) GetDeprecated() bool {
+ 	return Default_EnumValueOptions_Deprecated
+ }
+ 
++func (x *EnumValueOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
++func (x *EnumValueOptions) GetDebugRedact() bool {
++	if x != nil && x.DebugRedact != nil {
++		return *x.DebugRedact
++	}
++	return Default_EnumValueOptions_DebugRedact
++}
++
+ func (x *EnumValueOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2556,6 +3071,8 @@ type ServiceOptions struct {
+ 	unknownFields   protoimpl.UnknownFields
+ 	extensionFields protoimpl.ExtensionFields
+ 
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,34,opt,name=features" json:"features,omitempty"`
+ 	// Is this service deprecated?
+ 	// Depending on the target platform, this can emit Deprecated annotations
+ 	// for the service, or it will be completely ignored; in the very least,
+@@ -2602,6 +3119,13 @@ func (*ServiceOptions) Descriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{16}
+ }
+ 
++func (x *ServiceOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *ServiceOptions) GetDeprecated() bool {
+ 	if x != nil && x.Deprecated != nil {
+ 		return *x.Deprecated
+@@ -2628,6 +3152,8 @@ type MethodOptions struct {
+ 	// this is a formalization for deprecating methods.
+ 	Deprecated       *bool                           `protobuf:"varint,33,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
+ 	IdempotencyLevel *MethodOptions_IdempotencyLevel `protobuf:"varint,34,opt,name=idempotency_level,json=idempotencyLevel,enum=google.protobuf.MethodOptions_IdempotencyLevel,def=0" json:"idempotency_level,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,35,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2684,6 +3210,13 @@ func (x *MethodOptions) GetIdempotencyLevel() MethodOptions_IdempotencyLevel {
+ 	return Default_MethodOptions_IdempotencyLevel
+ }
+ 
++func (x *MethodOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *MethodOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2770,28 +3303,193 @@ func (x *UninterpretedOption) GetNegativeIntValue() int64 {
+ 	if x != nil && x.NegativeIntValue != nil {
+ 		return *x.NegativeIntValue
+ 	}
+-	return 0
++	return 0
++}
++
++func (x *UninterpretedOption) GetDoubleValue() float64 {
++	if x != nil && x.DoubleValue != nil {
++		return *x.DoubleValue
++	}
++	return 0
++}
++
++func (x *UninterpretedOption) GetStringValue() []byte {
++	if x != nil {
++		return x.StringValue
++	}
++	return nil
++}
++
++func (x *UninterpretedOption) GetAggregateValue() string {
++	if x != nil && x.AggregateValue != nil {
++		return *x.AggregateValue
++	}
++	return ""
++}
++
++// TODO Enums in C++ gencode (and potentially other languages) are
++// not well scoped.  This means that each of the feature enums below can clash
++// with each other.  The short names we've chosen maximize call-site
++// readability, but leave us very open to this scenario.  A future feature will
++// be designed and implemented to handle this, hopefully before we ever hit a
++// conflict here.
++type FeatureSet struct {
++	state           protoimpl.MessageState
++	sizeCache       protoimpl.SizeCache
++	unknownFields   protoimpl.UnknownFields
++	extensionFields protoimpl.ExtensionFields
++
++	FieldPresence         *FeatureSet_FieldPresence         `protobuf:"varint,1,opt,name=field_presence,json=fieldPresence,enum=google.protobuf.FeatureSet_FieldPresence" json:"field_presence,omitempty"`
++	EnumType              *FeatureSet_EnumType              `protobuf:"varint,2,opt,name=enum_type,json=enumType,enum=google.protobuf.FeatureSet_EnumType" json:"enum_type,omitempty"`
++	RepeatedFieldEncoding *FeatureSet_RepeatedFieldEncoding `protobuf:"varint,3,opt,name=repeated_field_encoding,json=repeatedFieldEncoding,enum=google.protobuf.FeatureSet_RepeatedFieldEncoding" json:"repeated_field_encoding,omitempty"`
++	Utf8Validation        *FeatureSet_Utf8Validation        `protobuf:"varint,4,opt,name=utf8_validation,json=utf8Validation,enum=google.protobuf.FeatureSet_Utf8Validation" json:"utf8_validation,omitempty"`
++	MessageEncoding       *FeatureSet_MessageEncoding       `protobuf:"varint,5,opt,name=message_encoding,json=messageEncoding,enum=google.protobuf.FeatureSet_MessageEncoding" json:"message_encoding,omitempty"`
++	JsonFormat            *FeatureSet_JsonFormat            `protobuf:"varint,6,opt,name=json_format,json=jsonFormat,enum=google.protobuf.FeatureSet_JsonFormat" json:"json_format,omitempty"`
++}
++
++func (x *FeatureSet) Reset() {
++	*x = FeatureSet{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSet) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSet) ProtoMessage() {}
++
++func (x *FeatureSet) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FeatureSet.ProtoReflect.Descriptor instead.
++func (*FeatureSet) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19}
++}
++
++func (x *FeatureSet) GetFieldPresence() FeatureSet_FieldPresence {
++	if x != nil && x.FieldPresence != nil {
++		return *x.FieldPresence
++	}
++	return FeatureSet_FIELD_PRESENCE_UNKNOWN
++}
++
++func (x *FeatureSet) GetEnumType() FeatureSet_EnumType {
++	if x != nil && x.EnumType != nil {
++		return *x.EnumType
++	}
++	return FeatureSet_ENUM_TYPE_UNKNOWN
++}
++
++func (x *FeatureSet) GetRepeatedFieldEncoding() FeatureSet_RepeatedFieldEncoding {
++	if x != nil && x.RepeatedFieldEncoding != nil {
++		return *x.RepeatedFieldEncoding
++	}
++	return FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN
++}
++
++func (x *FeatureSet) GetUtf8Validation() FeatureSet_Utf8Validation {
++	if x != nil && x.Utf8Validation != nil {
++		return *x.Utf8Validation
++	}
++	return FeatureSet_UTF8_VALIDATION_UNKNOWN
++}
++
++func (x *FeatureSet) GetMessageEncoding() FeatureSet_MessageEncoding {
++	if x != nil && x.MessageEncoding != nil {
++		return *x.MessageEncoding
++	}
++	return FeatureSet_MESSAGE_ENCODING_UNKNOWN
++}
++
++func (x *FeatureSet) GetJsonFormat() FeatureSet_JsonFormat {
++	if x != nil && x.JsonFormat != nil {
++		return *x.JsonFormat
++	}
++	return FeatureSet_JSON_FORMAT_UNKNOWN
++}
++
++// A compiled specification for the defaults of a set of features.  These
++// messages are generated from FeatureSet extensions and can be used to seed
++// feature resolution. The resolution with this object becomes a simple search
++// for the closest matching edition, followed by proto merges.
++type FeatureSetDefaults struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Defaults []*FeatureSetDefaults_FeatureSetEditionDefault `protobuf:"bytes,1,rep,name=defaults" json:"defaults,omitempty"`
++	// The minimum supported edition (inclusive) when this was constructed.
++	// Editions before this will not have defaults.
++	MinimumEdition *Edition `protobuf:"varint,4,opt,name=minimum_edition,json=minimumEdition,enum=google.protobuf.Edition" json:"minimum_edition,omitempty"`
++	// The maximum known edition (inclusive) when this was constructed. Editions
++	// after this will not have reliable defaults.
++	MaximumEdition *Edition `protobuf:"varint,5,opt,name=maximum_edition,json=maximumEdition,enum=google.protobuf.Edition" json:"maximum_edition,omitempty"`
++}
++
++func (x *FeatureSetDefaults) Reset() {
++	*x = FeatureSetDefaults{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSetDefaults) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSetDefaults) ProtoMessage() {}
++
++func (x *FeatureSetDefaults) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
+ }
+ 
+-func (x *UninterpretedOption) GetDoubleValue() float64 {
+-	if x != nil && x.DoubleValue != nil {
+-		return *x.DoubleValue
+-	}
+-	return 0
++// Deprecated: Use FeatureSetDefaults.ProtoReflect.Descriptor instead.
++func (*FeatureSetDefaults) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20}
+ }
+ 
+-func (x *UninterpretedOption) GetStringValue() []byte {
++func (x *FeatureSetDefaults) GetDefaults() []*FeatureSetDefaults_FeatureSetEditionDefault {
+ 	if x != nil {
+-		return x.StringValue
++		return x.Defaults
+ 	}
+ 	return nil
+ }
+ 
+-func (x *UninterpretedOption) GetAggregateValue() string {
+-	if x != nil && x.AggregateValue != nil {
+-		return *x.AggregateValue
++func (x *FeatureSetDefaults) GetMinimumEdition() Edition {
++	if x != nil && x.MinimumEdition != nil {
++		return *x.MinimumEdition
+ 	}
+-	return ""
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FeatureSetDefaults) GetMaximumEdition() Edition {
++	if x != nil && x.MaximumEdition != nil {
++		return *x.MaximumEdition
++	}
++	return Edition_EDITION_UNKNOWN
+ }
+ 
+ // Encapsulates information about the original source file from which a
+@@ -2855,7 +3553,7 @@ type SourceCodeInfo struct {
+ func (x *SourceCodeInfo) Reset() {
+ 	*x = SourceCodeInfo{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2868,7 +3566,7 @@ func (x *SourceCodeInfo) String() string {
+ func (*SourceCodeInfo) ProtoMessage() {}
+ 
+ func (x *SourceCodeInfo) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -2881,7 +3579,7 @@ func (x *SourceCodeInfo) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use SourceCodeInfo.ProtoReflect.Descriptor instead.
+ func (*SourceCodeInfo) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{21}
+ }
+ 
+ func (x *SourceCodeInfo) GetLocation() []*SourceCodeInfo_Location {
+@@ -2907,7 +3605,7 @@ type GeneratedCodeInfo struct {
+ func (x *GeneratedCodeInfo) Reset() {
+ 	*x = GeneratedCodeInfo{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2920,7 +3618,7 @@ func (x *GeneratedCodeInfo) String() string {
+ func (*GeneratedCodeInfo) ProtoMessage() {}
+ 
+ func (x *GeneratedCodeInfo) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -2933,7 +3631,7 @@ func (x *GeneratedCodeInfo) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use GeneratedCodeInfo.ProtoReflect.Descriptor instead.
+ func (*GeneratedCodeInfo) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22}
+ }
+ 
+ func (x *GeneratedCodeInfo) GetAnnotation() []*GeneratedCodeInfo_Annotation {
+@@ -2956,7 +3654,7 @@ type DescriptorProto_ExtensionRange struct {
+ func (x *DescriptorProto_ExtensionRange) Reset() {
+ 	*x = DescriptorProto_ExtensionRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2969,7 +3667,7 @@ func (x *DescriptorProto_ExtensionRange) String() string {
+ func (*DescriptorProto_ExtensionRange) ProtoMessage() {}
+ 
+ func (x *DescriptorProto_ExtensionRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3021,7 +3719,7 @@ type DescriptorProto_ReservedRange struct {
+ func (x *DescriptorProto_ReservedRange) Reset() {
+ 	*x = DescriptorProto_ReservedRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3034,7 +3732,7 @@ func (x *DescriptorProto_ReservedRange) String() string {
+ func (*DescriptorProto_ReservedRange) ProtoMessage() {}
+ 
+ func (x *DescriptorProto_ReservedRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3078,10 +3776,6 @@ type ExtensionRangeOptions_Declaration struct {
+ 	// Metadata.type, Declaration.type must have a leading dot for messages
+ 	// and enums.
+ 	Type *string `protobuf:"bytes,3,opt,name=type" json:"type,omitempty"`
+-	// Deprecated. Please use "repeated".
+-	//
+-	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-	IsRepeated *bool `protobuf:"varint,4,opt,name=is_repeated,json=isRepeated" json:"is_repeated,omitempty"`
+ 	// If true, indicates that the number is reserved in the extension range,
+ 	// and any extension field with the number will fail to compile. Set this
+ 	// when a declared extension field is deleted.
+@@ -3094,7 +3788,7 @@ type ExtensionRangeOptions_Declaration struct {
+ func (x *ExtensionRangeOptions_Declaration) Reset() {
+ 	*x = ExtensionRangeOptions_Declaration{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3107,7 +3801,7 @@ func (x *ExtensionRangeOptions_Declaration) String() string {
+ func (*ExtensionRangeOptions_Declaration) ProtoMessage() {}
+ 
+ func (x *ExtensionRangeOptions_Declaration) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3144,14 +3838,6 @@ func (x *ExtensionRangeOptions_Declaration) GetType() string {
+ 	return ""
+ }
+ 
+-// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-func (x *ExtensionRangeOptions_Declaration) GetIsRepeated() bool {
+-	if x != nil && x.IsRepeated != nil {
+-		return *x.IsRepeated
+-	}
+-	return false
+-}
+-
+ func (x *ExtensionRangeOptions_Declaration) GetReserved() bool {
+ 	if x != nil && x.Reserved != nil {
+ 		return *x.Reserved
+@@ -3184,7 +3870,7 @@ type EnumDescriptorProto_EnumReservedRange struct {
+ func (x *EnumDescriptorProto_EnumReservedRange) Reset() {
+ 	*x = EnumDescriptorProto_EnumReservedRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3197,7 +3883,7 @@ func (x *EnumDescriptorProto_EnumReservedRange) String() string {
+ func (*EnumDescriptorProto_EnumReservedRange) ProtoMessage() {}
+ 
+ func (x *EnumDescriptorProto_EnumReservedRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3227,6 +3913,61 @@ func (x *EnumDescriptorProto_EnumReservedRange) GetEnd() int32 {
+ 	return 0
+ }
+ 
++type FieldOptions_EditionDefault struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Edition *Edition `protobuf:"varint,3,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
++	Value   *string  `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"` // Textproto value.
++}
++
++func (x *FieldOptions_EditionDefault) Reset() {
++	*x = FieldOptions_EditionDefault{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FieldOptions_EditionDefault) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FieldOptions_EditionDefault) ProtoMessage() {}
++
++func (x *FieldOptions_EditionDefault) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FieldOptions_EditionDefault.ProtoReflect.Descriptor instead.
++func (*FieldOptions_EditionDefault) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{12, 0}
++}
++
++func (x *FieldOptions_EditionDefault) GetEdition() Edition {
++	if x != nil && x.Edition != nil {
++		return *x.Edition
++	}
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FieldOptions_EditionDefault) GetValue() string {
++	if x != nil && x.Value != nil {
++		return *x.Value
++	}
++	return ""
++}
++
+ // The name of the uninterpreted option.  Each string represents a segment in
+ // a dot-separated name.  is_extension is true iff a segment represents an
+ // extension (denoted with parentheses in options specs in .proto files).
+@@ -3244,7 +3985,7 @@ type UninterpretedOption_NamePart struct {
+ func (x *UninterpretedOption_NamePart) Reset() {
+ 	*x = UninterpretedOption_NamePart{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[28]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3257,7 +3998,7 @@ func (x *UninterpretedOption_NamePart) String() string {
+ func (*UninterpretedOption_NamePart) ProtoMessage() {}
+ 
+ func (x *UninterpretedOption_NamePart) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[28]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3287,6 +4028,65 @@ func (x *UninterpretedOption_NamePart) GetIsExtension() bool {
+ 	return false
+ }
+ 
++// A map from every known edition with a unique set of defaults to its
++// defaults. Not all editions may be contained here.  For a given edition,
++// the defaults at the closest matching edition ordered at or before it should
++// be used.  This field must be in strict ascending order by edition.
++type FeatureSetDefaults_FeatureSetEditionDefault struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Edition  *Edition    `protobuf:"varint,3,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
++	Features *FeatureSet `protobuf:"bytes,2,opt,name=features" json:"features,omitempty"`
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) Reset() {
++	*x = FeatureSetDefaults_FeatureSetEditionDefault{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[29]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSetDefaults_FeatureSetEditionDefault) ProtoMessage() {}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[29]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FeatureSetDefaults_FeatureSetEditionDefault.ProtoReflect.Descriptor instead.
++func (*FeatureSetDefaults_FeatureSetEditionDefault) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0}
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) GetEdition() Edition {
++	if x != nil && x.Edition != nil {
++		return *x.Edition
++	}
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ type SourceCodeInfo_Location struct {
+ 	state         protoimpl.MessageState
+ 	sizeCache     protoimpl.SizeCache
+@@ -3296,7 +4096,7 @@ type SourceCodeInfo_Location struct {
+ 	// location.
+ 	//
+ 	// Each element is a field number or an index.  They form a path from
+-	// the root FileDescriptorProto to the place where the definition occurs.
++	// the root FileDescriptorProto to the place where the definition appears.
+ 	// For example, this path:
+ 	//
+ 	//	[ 4, 3, 2, 7, 1 ]
+@@ -3388,7 +4188,7 @@ type SourceCodeInfo_Location struct {
+ func (x *SourceCodeInfo_Location) Reset() {
+ 	*x = SourceCodeInfo_Location{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[30]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3401,7 +4201,7 @@ func (x *SourceCodeInfo_Location) String() string {
+ func (*SourceCodeInfo_Location) ProtoMessage() {}
+ 
+ func (x *SourceCodeInfo_Location) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[30]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3414,7 +4214,7 @@ func (x *SourceCodeInfo_Location) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use SourceCodeInfo_Location.ProtoReflect.Descriptor instead.
+ func (*SourceCodeInfo_Location) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{21, 0}
+ }
+ 
+ func (x *SourceCodeInfo_Location) GetPath() []int32 {
+@@ -3475,7 +4275,7 @@ type GeneratedCodeInfo_Annotation struct {
+ func (x *GeneratedCodeInfo_Annotation) Reset() {
+ 	*x = GeneratedCodeInfo_Annotation{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[31]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3488,7 +4288,7 @@ func (x *GeneratedCodeInfo_Annotation) String() string {
+ func (*GeneratedCodeInfo_Annotation) ProtoMessage() {}
+ 
+ func (x *GeneratedCodeInfo_Annotation) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[31]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3501,7 +4301,7 @@ func (x *GeneratedCodeInfo_Annotation) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use GeneratedCodeInfo_Annotation.ProtoReflect.Descriptor instead.
+ func (*GeneratedCodeInfo_Annotation) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22, 0}
+ }
+ 
+ func (x *GeneratedCodeInfo_Annotation) GetPath() []int32 {
+@@ -3550,7 +4350,7 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+ 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73,
+ 	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x04, 0x66, 0x69,
+-	0x6c, 0x65, 0x22, 0xfe, 0x04, 0x0a, 0x13, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72,
++	0x6c, 0x65, 0x22, 0x98, 0x05, 0x0a, 0x13, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72,
+ 	0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61,
+ 	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x18,
+ 	0x0a, 0x07, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+@@ -3588,250 +4388,250 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
+ 	0x6f, 0x52, 0x0e, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
+ 	0x6f, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x18, 0x0c, 0x20, 0x01, 0x28,
+-	0x09, 0x52, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x12, 0x18, 0x0a, 0x07, 0x65, 0x64, 0x69,
+-	0x74, 0x69, 0x6f, 0x6e, 0x18, 0x0d, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74,
+-	0x69, 0x6f, 0x6e, 0x22, 0xb9, 0x06, 0x0a, 0x0f, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
+-	0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
+-	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3b, 0x0a, 0x05, 0x66,
+-	0x69, 0x65, 0x6c, 0x64, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f,
+-	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65,
+-	0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
+-	0x6f, 0x52, 0x05, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x12, 0x43, 0x0a, 0x09, 0x65, 0x78, 0x74, 0x65,
+-	0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69,
+-	0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
+-	0x74, 0x6f, 0x52, 0x09, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a,
+-	0x0b, 0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x03,
+-	0x28, 0x0b, 0x32, 0x20, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+-	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
+-	0x72, 0x6f, 0x74, 0x6f, 0x52, 0x0a, 0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x54, 0x79, 0x70, 0x65,
+-	0x12, 0x41, 0x0a, 0x09, 0x65, 0x6e, 0x75, 0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x04, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
+-	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54,
+-	0x79, 0x70, 0x65, 0x12, 0x58, 0x0a, 0x0f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e,
+-	0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x67,
++	0x09, 0x52, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x12, 0x32, 0x0a, 0x07, 0x65, 0x64, 0x69,
++	0x74, 0x69, 0x6f, 0x6e, 0x18, 0x0e, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69,
++	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0xb9, 0x06,
++	0x0a, 0x0f, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3b, 0x0a, 0x05, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x18, 0x02,
++	0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63,
++	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05, 0x66, 0x69, 0x65,
++	0x6c, 0x64, 0x12, 0x43, 0x0a, 0x09, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18,
++	0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73,
++	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x09, 0x65, 0x78,
++	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a, 0x0b, 0x6e, 0x65, 0x73, 0x74, 0x65,
++	0x64, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x20, 0x2e, 0x67,
+ 	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45,
+-	0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0e, 0x65,
+-	0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x44, 0x0a,
+-	0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x64, 0x65, 0x63, 0x6c, 0x18, 0x08, 0x20, 0x03, 0x28,
+-	0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+-	0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x09, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x44,
+-	0x65, 0x63, 0x6c, 0x12, 0x39, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x07,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x55,
+-	0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65,
+-	0x18, 0x09, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x0a,
++	0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x54, 0x79, 0x70, 0x65, 0x12, 0x41, 0x0a, 0x09, 0x65, 0x6e,
++	0x75, 0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72,
++	0x6f, 0x74, 0x6f, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54, 0x79, 0x70, 0x65, 0x12, 0x58, 0x0a,
++	0x0f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65,
++	0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+ 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
++	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69,
++	0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0e, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69,
++	0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x44, 0x0a, 0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66,
++	0x5f, 0x64, 0x65, 0x63, 0x6c, 0x18, 0x08, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e,
++	0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
++	0x74, 0x6f, 0x52, 0x09, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x63, 0x6c, 0x12, 0x39, 0x0a,
++	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52,
++	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x55, 0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65,
++	0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x09, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
++	0x74, 0x6f, 0x2e, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65,
++	0x52, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12,
++	0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65,
++	0x18, 0x0a, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64,
++	0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x7a, 0x0a, 0x0e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
++	0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18,
++	0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03,
++	0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x12, 0x40,
++	0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
++	0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x1a, 0x37, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67,
++	0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05,
++	0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02,
++	0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0xcc, 0x04, 0x0a, 0x15, 0x45, 0x78,
++	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
++	0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03,
++	0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x59, 0x0a,
++	0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x03,
++	0x28, 0x0b, 0x32, 0x32, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61,
++	0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x44, 0x65, 0x63, 0x6c, 0x61,
++	0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x03, 0x88, 0x01, 0x02, 0x52, 0x0b, 0x64, 0x65, 0x63,
++	0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x73, 0x18, 0x32, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x12, 0x6d, 0x0a, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f,
++	0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x38, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73,
++	0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
++	0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74,
++	0x65, 0x3a, 0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x42, 0x03, 0x88,
++	0x01, 0x02, 0x52, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x1a, 0x94, 0x01, 0x0a, 0x0b, 0x44, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05,
++	0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x1b, 0x0a, 0x09, 0x66, 0x75, 0x6c, 0x6c,
++	0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x66, 0x75, 0x6c,
++	0x6c, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20,
++	0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73,
++	0x65, 0x72, 0x76, 0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x73,
++	0x65, 0x72, 0x76, 0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65,
++	0x64, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65,
++	0x64, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x22, 0x34, 0x0a, 0x11, 0x56, 0x65, 0x72, 0x69, 0x66,
++	0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x0f, 0x0a, 0x0b,
++	0x44, 0x45, 0x43, 0x4c, 0x41, 0x52, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x10, 0x00, 0x12, 0x0e, 0x0a,
++	0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x01, 0x2a, 0x09, 0x08,
++	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0xc1, 0x06, 0x0a, 0x14, 0x46, 0x69, 0x65,
++	0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18,
++	0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x41, 0x0a,
++	0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
++	0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72,
++	0x6f, 0x74, 0x6f, 0x2e, 0x4c, 0x61, 0x62, 0x65, 0x6c, 0x52, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c,
++	0x12, 0x3e, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2a,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72,
++	0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x54, 0x79, 0x70, 0x65, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65,
++	0x12, 0x1b, 0x0a, 0x09, 0x74, 0x79, 0x70, 0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x06, 0x20,
++	0x01, 0x28, 0x09, 0x52, 0x08, 0x74, 0x79, 0x70, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1a, 0x0a,
++	0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x64, 0x65, 0x66,
++	0x61, 0x75, 0x6c, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09,
++	0x52, 0x0c, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x1f,
++	0x0a, 0x0b, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x69, 0x6e, 0x64, 0x65, 0x78, 0x18, 0x09, 0x20,
++	0x01, 0x28, 0x05, 0x52, 0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12,
++	0x1b, 0x0a, 0x09, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x08, 0x6a, 0x73, 0x6f, 0x6e, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x27, 0x0a, 0x0f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x18, 0x11, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x22, 0xb6,
++	0x02, 0x0a, 0x04, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x44, 0x4f, 0x55, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x46, 0x4c, 0x4f, 0x41, 0x54, 0x10, 0x02, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x03, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x55, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x04, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x05, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34, 0x10, 0x06, 0x12, 0x10, 0x0a, 0x0c, 0x54,
++	0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32, 0x10, 0x07, 0x12, 0x0d, 0x0a,
++	0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x4f, 0x4f, 0x4c, 0x10, 0x08, 0x12, 0x0f, 0x0a, 0x0b,
++	0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x09, 0x12, 0x0e, 0x0a,
++	0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x47, 0x52, 0x4f, 0x55, 0x50, 0x10, 0x0a, 0x12, 0x10, 0x0a,
++	0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x10, 0x0b, 0x12,
++	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x59, 0x54, 0x45, 0x53, 0x10, 0x0c, 0x12,
++	0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x0d,
++	0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x10, 0x0e, 0x12,
++	0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32,
++	0x10, 0x0f, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45,
++	0x44, 0x36, 0x34, 0x10, 0x10, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49,
++	0x4e, 0x54, 0x33, 0x32, 0x10, 0x11, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53,
++	0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x12, 0x22, 0x43, 0x0a, 0x05, 0x4c, 0x61, 0x62, 0x65, 0x6c,
++	0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x4f, 0x50, 0x54, 0x49, 0x4f, 0x4e,
++	0x41, 0x4c, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45,
++	0x50, 0x45, 0x41, 0x54, 0x45, 0x44, 0x10, 0x03, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45,
++	0x4c, 0x5f, 0x52, 0x45, 0x51, 0x55, 0x49, 0x52, 0x45, 0x44, 0x10, 0x02, 0x22, 0x63, 0x0a, 0x14,
++	0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
++	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f,
++	0x66, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x73, 0x22, 0xe3, 0x02, 0x0a, 0x13, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
++	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d,
++	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3f, 0x0a,
++	0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x29, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45,
++	0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
++	0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x36,
++	0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
++	0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x5d, 0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
++	0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x36,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+ 	0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64,
+ 	0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65,
+-	0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x7a, 0x0a, 0x0e, 0x45, 0x78,
+-	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05,
+-	0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61,
+-	0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52,
+-	0x03, 0x65, 0x6e, 0x64, 0x12, 0x40, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18,
+-	0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
+-	0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x1a, 0x37, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a,
+-	0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22,
+-	0xad, 0x04, 0x0a, 0x15, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e,
+-	0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+-	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x12, 0x59, 0x0a, 0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69,
+-	0x6f, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x32, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e,
+-	0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+-	0x2e, 0x44, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x03, 0x88, 0x01,
+-	0x02, 0x52, 0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x68,
+-	0x0a, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x0e, 0x32, 0x38, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e,
+-	0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x56, 0x65, 0x72,
+-	0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x3a, 0x0a,
+-	0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x52, 0x0c, 0x76, 0x65, 0x72, 0x69,
+-	0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xb3, 0x01, 0x0a, 0x0b, 0x44, 0x65, 0x63,
+-	0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62,
+-	0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72,
+-	0x12, 0x1b, 0x0a, 0x09, 0x66, 0x75, 0x6c, 0x6c, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20,
+-	0x01, 0x28, 0x09, 0x52, 0x08, 0x66, 0x75, 0x6c, 0x6c, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x12, 0x0a,
+-	0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70,
+-	0x65, 0x12, 0x23, 0x0a, 0x0b, 0x69, 0x73, 0x5f, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64,
+-	0x18, 0x04, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x0a, 0x69, 0x73, 0x52, 0x65,
+-	0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x18, 0x06,
+-	0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x22, 0x34,
+-	0x0a, 0x11, 0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74,
+-	0x61, 0x74, 0x65, 0x12, 0x0f, 0x0a, 0x0b, 0x44, 0x45, 0x43, 0x4c, 0x41, 0x52, 0x41, 0x54, 0x49,
+-	0x4f, 0x4e, 0x10, 0x00, 0x12, 0x0e, 0x0a, 0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49,
+-	0x45, 0x44, 0x10, 0x01, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22,
+-	0xc1, 0x06, 0x0a, 0x14, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06,
+-	0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75,
+-	0x6d, 0x62, 0x65, 0x72, 0x12, 0x41, 0x0a, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x18, 0x04, 0x20,
+-	0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72,
+-	0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x4c, 0x61, 0x62, 0x65, 0x6c,
+-	0x52, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x12, 0x3e, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18,
+-	0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73,
+-	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x54, 0x79, 0x70,
+-	0x65, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1b, 0x0a, 0x09, 0x74, 0x79, 0x70, 0x65, 0x5f,
+-	0x6e, 0x61, 0x6d, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x74, 0x79, 0x70, 0x65,
+-	0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65,
+-	0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65,
+-	0x12, 0x23, 0x0a, 0x0d, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75,
+-	0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0c, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74,
+-	0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x69,
+-	0x6e, 0x64, 0x65, 0x78, 0x18, 0x09, 0x20, 0x01, 0x28, 0x05, 0x52, 0x0a, 0x6f, 0x6e, 0x65, 0x6f,
+-	0x66, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12, 0x1b, 0x0a, 0x09, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x6a, 0x73, 0x6f, 0x6e, 0x4e,
+-	0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x08,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69,
+-	0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x27, 0x0a, 0x0f,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x18,
+-	0x11, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x22, 0xb6, 0x02, 0x0a, 0x04, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0f,
+-	0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x44, 0x4f, 0x55, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12,
+-	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x4c, 0x4f, 0x41, 0x54, 0x10, 0x02, 0x12,
+-	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x03, 0x12,
+-	0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x04,
+-	0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x05,
+-	0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34,
+-	0x10, 0x06, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44,
+-	0x33, 0x32, 0x10, 0x07, 0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x4f, 0x4f,
+-	0x4c, 0x10, 0x08, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x54, 0x52, 0x49,
+-	0x4e, 0x47, 0x10, 0x09, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x47, 0x52, 0x4f,
+-	0x55, 0x50, 0x10, 0x0a, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53,
+-	0x53, 0x41, 0x47, 0x45, 0x10, 0x0b, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42,
+-	0x59, 0x54, 0x45, 0x53, 0x10, 0x0c, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55,
+-	0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x0d, 0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f,
+-	0x45, 0x4e, 0x55, 0x4d, 0x10, 0x0e, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53,
+-	0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32, 0x10, 0x0f, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34, 0x10, 0x10, 0x12, 0x0f, 0x0a, 0x0b,
+-	0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x11, 0x12, 0x0f, 0x0a,
+-	0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x12, 0x22, 0x43,
+-	0x0a, 0x05, 0x4c, 0x61, 0x62, 0x65, 0x6c, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c,
+-	0x5f, 0x4f, 0x50, 0x54, 0x49, 0x4f, 0x4e, 0x41, 0x4c, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c,
+-	0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45, 0x51, 0x55, 0x49, 0x52, 0x45, 0x44, 0x10, 0x02, 0x12,
+-	0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45, 0x50, 0x45, 0x41, 0x54, 0x45,
+-	0x44, 0x10, 0x03, 0x22, 0x63, 0x0a, 0x14, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b,
+-	0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
+-	0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52,
+-	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0xe3, 0x02, 0x0a, 0x13, 0x45, 0x6e, 0x75,
+-	0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f,
+-	0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04,
+-	0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3f, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05,
+-	0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x36, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+-	0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x5d, 0x0a,
+-	0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18,
+-	0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x36, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x6e, 0x75, 0x6d,
+-	0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0d, 0x72,
+-	0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d,
+-	0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x05, 0x20,
+-	0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d,
+-	0x65, 0x1a, 0x3b, 0x0a, 0x11, 0x45, 0x6e, 0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18,
+-	0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03,
+-	0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0x83,
+-	0x01, 0x0a, 0x18, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52,
+-	0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x3b, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56,
+-	0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x22, 0xa7, 0x01, 0x0a, 0x16, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+-	0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12,
+-	0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x12, 0x3e, 0x0a, 0x06, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x18, 0x02, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x06, 0x6d, 0x65, 0x74,
+-	0x68, 0x6f, 0x64, 0x12, 0x39, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0x89,
+-	0x02, 0x0a, 0x15, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
++	0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x05, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65,
++	0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x3b, 0x0a, 0x11, 0x45, 0x6e,
++	0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12,
++	0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05,
++	0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01,
++	0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0x83, 0x01, 0x0a, 0x18, 0x45, 0x6e, 0x75, 0x6d,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62,
++	0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72,
++	0x12, 0x3b, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28,
++	0x0b, 0x32, 0x21, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74,
++	0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0xa7, 0x01,
++	0x0a, 0x16, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+ 	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1d, 0x0a, 0x0a,
+-	0x69, 0x6e, 0x70, 0x75, 0x74, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x09, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f,
+-	0x75, 0x74, 0x70, 0x75, 0x74, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x0a, 0x6f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x38, 0x0a, 0x07,
+-	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e,
++	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3e, 0x0a, 0x06,
++	0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d,
++	0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x52, 0x06, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x12, 0x39, 0x0a, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e,
+ 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+-	0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x30, 0x0a, 0x10, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74,
+-	0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08,
+-	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0f, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x53,
+-	0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x12, 0x30, 0x0a, 0x10, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x72, 0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x06, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0f, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x72, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x22, 0x91, 0x09, 0x0a, 0x0b, 0x46,
+-	0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x21, 0x0a, 0x0c, 0x6a, 0x61,
+-	0x76, 0x61, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x0b, 0x6a, 0x61, 0x76, 0x61, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x30, 0x0a,
+-	0x14, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6f, 0x75, 0x74, 0x65, 0x72, 0x5f, 0x63, 0x6c, 0x61, 0x73,
+-	0x73, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x6a, 0x61, 0x76,
+-	0x61, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x43, 0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x35, 0x0a, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65,
+-	0x5f, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x11, 0x6a, 0x61, 0x76, 0x61, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c,
+-	0x65, 0x46, 0x69, 0x6c, 0x65, 0x73, 0x12, 0x44, 0x0a, 0x1d, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67,
+-	0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x5f, 0x61,
+-	0x6e, 0x64, 0x5f, 0x68, 0x61, 0x73, 0x68, 0x18, 0x14, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18,
+-	0x01, 0x52, 0x19, 0x6a, 0x61, 0x76, 0x61, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x45,
+-	0x71, 0x75, 0x61, 0x6c, 0x73, 0x41, 0x6e, 0x64, 0x48, 0x61, 0x73, 0x68, 0x12, 0x3a, 0x0a, 0x16,
+-	0x6a, 0x61, 0x76, 0x61, 0x5f, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x68, 0x65, 0x63,
+-	0x6b, 0x5f, 0x75, 0x74, 0x66, 0x38, 0x18, 0x1b, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43,
+-	0x68, 0x65, 0x63, 0x6b, 0x55, 0x74, 0x66, 0x38, 0x12, 0x53, 0x0a, 0x0c, 0x6f, 0x70, 0x74, 0x69,
+-	0x6d, 0x69, 0x7a, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x29,
+-	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+-	0x2e, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74,
+-	0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64, 0x65, 0x3a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44,
+-	0x52, 0x0b, 0x6f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x46, 0x6f, 0x72, 0x12, 0x1d, 0x0a,
+-	0x0a, 0x67, 0x6f, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x0b, 0x20, 0x01, 0x28,
+-	0x09, 0x52, 0x09, 0x67, 0x6f, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x35, 0x0a, 0x13,
+-	0x63, 0x63, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69,
+-	0x63, 0x65, 0x73, 0x18, 0x10, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
+-	0x52, 0x11, 0x63, 0x63, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69,
+-	0x63, 0x65, 0x73, 0x12, 0x39, 0x0a, 0x15, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65,
+-	0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x11, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x47,
+-	0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x35,
+-	0x0a, 0x13, 0x70, 0x79, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72,
+-	0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x12, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
+-	0x73, 0x65, 0x52, 0x11, 0x70, 0x79, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72,
+-	0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x37, 0x0a, 0x14, 0x70, 0x68, 0x70, 0x5f, 0x67, 0x65, 0x6e,
+-	0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x2a, 0x20,
+-	0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x12, 0x70, 0x68, 0x70, 0x47,
++	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0x89, 0x02, 0x0a, 0x15, 0x4d, 0x65, 0x74, 0x68,
++	0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1d, 0x0a, 0x0a, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x5f, 0x74,
++	0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x69, 0x6e, 0x70, 0x75, 0x74,
++	0x54, 0x79, 0x70, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x5f, 0x74,
++	0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x6f, 0x75, 0x74, 0x70, 0x75,
++	0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x38, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12,
++	0x30, 0x0a, 0x10, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d,
++	0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x0f, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e,
++	0x67, 0x12, 0x30, 0x0a, 0x10, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x5f, 0x73, 0x74, 0x72, 0x65,
++	0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x0f, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d,
++	0x69, 0x6e, 0x67, 0x22, 0x97, 0x09, 0x0a, 0x0b, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x21, 0x0a, 0x0c, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x70, 0x61, 0x63, 0x6b,
++	0x61, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x6a, 0x61, 0x76, 0x61, 0x50,
++	0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x30, 0x0a, 0x14, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6f,
++	0x75, 0x74, 0x65, 0x72, 0x5f, 0x63, 0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x08,
++	0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x6a, 0x61, 0x76, 0x61, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x43,
++	0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x35, 0x0a, 0x13, 0x6a, 0x61, 0x76, 0x61,
++	0x5f, 0x6d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x5f, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x18,
++	0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x6a, 0x61,
++	0x76, 0x61, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x73, 0x12,
++	0x44, 0x0a, 0x1d, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
++	0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x5f, 0x61, 0x6e, 0x64, 0x5f, 0x68, 0x61, 0x73, 0x68,
++	0x18, 0x14, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x19, 0x6a, 0x61, 0x76, 0x61,
++	0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x45, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x41, 0x6e,
++	0x64, 0x48, 0x61, 0x73, 0x68, 0x12, 0x3a, 0x0a, 0x16, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x73, 0x74,
++	0x72, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x5f, 0x75, 0x74, 0x66, 0x38, 0x18,
++	0x1b, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61,
++	0x76, 0x61, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x55, 0x74, 0x66,
++	0x38, 0x12, 0x53, 0x0a, 0x0c, 0x6f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x5f, 0x66, 0x6f,
++	0x72, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f,
++	0x64, 0x65, 0x3a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44, 0x52, 0x0b, 0x6f, 0x70, 0x74, 0x69, 0x6d,
++	0x69, 0x7a, 0x65, 0x46, 0x6f, 0x72, 0x12, 0x1d, 0x0a, 0x0a, 0x67, 0x6f, 0x5f, 0x70, 0x61, 0x63,
++	0x6b, 0x61, 0x67, 0x65, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x67, 0x6f, 0x50, 0x61,
++	0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x35, 0x0a, 0x13, 0x63, 0x63, 0x5f, 0x67, 0x65, 0x6e, 0x65,
++	0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x10, 0x20, 0x01,
++	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x63, 0x63, 0x47, 0x65, 0x6e,
++	0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x39, 0x0a, 0x15,
++	0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72,
++	0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x11, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53,
++	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x35, 0x0a, 0x13, 0x70, 0x79, 0x5f, 0x67, 0x65,
++	0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x12,
++	0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x70, 0x79, 0x47,
+ 	0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x25,
+ 	0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x17, 0x20, 0x01,
+ 	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65,
+@@ -3856,259 +4656,419 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x70, 0x68, 0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x4e, 0x61, 0x6d, 0x65, 0x73,
+ 	0x70, 0x61, 0x63, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x72, 0x75, 0x62, 0x79, 0x5f, 0x70, 0x61, 0x63,
+ 	0x6b, 0x61, 0x67, 0x65, 0x18, 0x2d, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x72, 0x75, 0x62, 0x79,
+-	0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18,
+-	0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72,
+-	0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e,
+-	0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x22, 0x3a, 0x0a, 0x0c, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64,
+-	0x65, 0x12, 0x09, 0x0a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09,
+-	0x43, 0x4f, 0x44, 0x45, 0x5f, 0x53, 0x49, 0x5a, 0x45, 0x10, 0x02, 0x12, 0x10, 0x0a, 0x0c, 0x4c,
+-	0x49, 0x54, 0x45, 0x5f, 0x52, 0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x03, 0x2a, 0x09, 0x08,
+-	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x26, 0x10, 0x27, 0x22, 0xbb,
+-	0x03, 0x0a, 0x0e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x73, 0x12, 0x3c, 0x0a, 0x17, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x65, 0x74,
+-	0x5f, 0x77, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x01, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x14, 0x6d, 0x65, 0x73, 0x73, 0x61,
+-	0x67, 0x65, 0x53, 0x65, 0x74, 0x57, 0x69, 0x72, 0x65, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12,
+-	0x4c, 0x0a, 0x1f, 0x6e, 0x6f, 0x5f, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x5f, 0x64,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73,
+-	0x6f, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
+-	0x1c, 0x6e, 0x6f, 0x53, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72,
+-	0x69, 0x70, 0x74, 0x6f, 0x72, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f, 0x72, 0x12, 0x25, 0x0a,
+-	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28,
+-	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63,
+-	0x61, 0x74, 0x65, 0x64, 0x12, 0x1b, 0x0a, 0x09, 0x6d, 0x61, 0x70, 0x5f, 0x65, 0x6e, 0x74, 0x72,
+-	0x79, 0x18, 0x07, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x6d, 0x61, 0x70, 0x45, 0x6e, 0x74, 0x72,
+-	0x79, 0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f,
+-	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c,
+-	0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28,
+-	0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+-	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x04, 0x10, 0x05, 0x4a, 0x04, 0x08, 0x05, 0x10, 0x06, 0x4a, 0x04, 0x08, 0x06, 0x10, 0x07,
+-	0x4a, 0x04, 0x08, 0x08, 0x10, 0x09, 0x4a, 0x04, 0x08, 0x09, 0x10, 0x0a, 0x22, 0x85, 0x09, 0x0a,
+-	0x0c, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x41, 0x0a,
+-	0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x23, 0x2e, 0x67,
+-	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
+-	0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x43, 0x54, 0x79, 0x70,
+-	0x65, 0x3a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x52, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65,
+-	0x12, 0x16, 0x0a, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08,
+-	0x52, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x12, 0x47, 0x0a, 0x06, 0x6a, 0x73, 0x74, 0x79,
+-	0x70, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x09,
+-	0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x52, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70,
+-	0x65, 0x12, 0x19, 0x0a, 0x04, 0x6c, 0x61, 0x7a, 0x79, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a,
+-	0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04, 0x6c, 0x61, 0x7a, 0x79, 0x12, 0x2e, 0x0a, 0x0f,
+-	0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64, 0x5f, 0x6c, 0x61, 0x7a, 0x79, 0x18,
+-	0x0f, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0e, 0x75, 0x6e,
+-	0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64, 0x4c, 0x61, 0x7a, 0x79, 0x12, 0x25, 0x0a, 0x0a,
++	0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75,
++	0x72, 0x65, 0x73, 0x18, 0x32, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
++	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73,
++	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
++	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
++	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
++	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x3a, 0x0a, 0x0c, 0x4f, 0x70,
++	0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64, 0x65, 0x12, 0x09, 0x0a, 0x05, 0x53, 0x50,
++	0x45, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x43, 0x4f, 0x44, 0x45, 0x5f, 0x53, 0x49,
++	0x5a, 0x45, 0x10, 0x02, 0x12, 0x10, 0x0a, 0x0c, 0x4c, 0x49, 0x54, 0x45, 0x5f, 0x52, 0x55, 0x4e,
++	0x54, 0x49, 0x4d, 0x45, 0x10, 0x03, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80,
++	0x02, 0x4a, 0x04, 0x08, 0x2a, 0x10, 0x2b, 0x4a, 0x04, 0x08, 0x26, 0x10, 0x27, 0x22, 0xf4, 0x03,
++	0x0a, 0x0e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x12, 0x3c, 0x0a, 0x17, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x65, 0x74, 0x5f,
++	0x77, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28,
++	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x14, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67,
++	0x65, 0x53, 0x65, 0x74, 0x57, 0x69, 0x72, 0x65, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12, 0x4c,
++	0x0a, 0x1f, 0x6e, 0x6f, 0x5f, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x5f, 0x64, 0x65,
++	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f,
++	0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x1c,
++	0x6e, 0x6f, 0x53, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
++	0x70, 0x74, 0x6f, 0x72, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f, 0x72, 0x12, 0x25, 0x0a, 0x0a,
+ 	0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08,
+ 	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
+-	0x74, 0x65, 0x64, 0x12, 0x19, 0x0a, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x18, 0x0a, 0x20, 0x01, 0x28,
+-	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x12, 0x28,
+-	0x0a, 0x0c, 0x64, 0x65, 0x62, 0x75, 0x67, 0x5f, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x10,
+-	0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62,
+-	0x75, 0x67, 0x52, 0x65, 0x64, 0x61, 0x63, 0x74, 0x12, 0x4b, 0x0a, 0x09, 0x72, 0x65, 0x74, 0x65,
+-	0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x11, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2d, 0x2e, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69,
+-	0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x09, 0x72, 0x65, 0x74, 0x65,
+-	0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x4a, 0x0a, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x18,
+-	0x12, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65,
+-	0x74, 0x54, 0x79, 0x70, 0x65, 0x42, 0x02, 0x18, 0x01, 0x52, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65,
+-	0x74, 0x12, 0x48, 0x0a, 0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x18, 0x13, 0x20, 0x03,
+-	0x28, 0x0e, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+-	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79,
+-	0x70, 0x65, 0x52, 0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75,
+-	0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f,
+-	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x2f, 0x0a, 0x05, 0x43, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0a,
+-	0x0a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x43, 0x4f,
+-	0x52, 0x44, 0x10, 0x01, 0x12, 0x10, 0x0a, 0x0c, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x5f, 0x50,
+-	0x49, 0x45, 0x43, 0x45, 0x10, 0x02, 0x22, 0x35, 0x0a, 0x06, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65,
+-	0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x10, 0x00, 0x12,
+-	0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x01, 0x12, 0x0d,
+-	0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x55, 0x4d, 0x42, 0x45, 0x52, 0x10, 0x02, 0x22, 0x55, 0x0a,
+-	0x0f, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e,
+-	0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e,
+-	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e,
+-	0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x52, 0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x01, 0x12, 0x14,
+-	0x0a, 0x10, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x4f, 0x55, 0x52,
+-	0x43, 0x45, 0x10, 0x02, 0x22, 0x8c, 0x02, 0x0a, 0x10, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54,
+-	0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e,
+-	0x10, 0x00, 0x12, 0x14, 0x0a, 0x10, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x46, 0x49, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x1f, 0x0a, 0x1b, 0x54, 0x41, 0x52, 0x47,
+-	0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f,
+-	0x4e, 0x5f, 0x52, 0x41, 0x4e, 0x47, 0x45, 0x10, 0x02, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45,
+-	0x10, 0x03, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x46, 0x49, 0x45, 0x4c, 0x44, 0x10, 0x04, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4f, 0x4e, 0x45, 0x4f, 0x46, 0x10, 0x05,
+-	0x12, 0x14, 0x0a, 0x10, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
+-	0x45, 0x4e, 0x55, 0x4d, 0x10, 0x06, 0x12, 0x1a, 0x0a, 0x16, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54,
+-	0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x45, 0x4e, 0x54, 0x52, 0x59,
+-	0x10, 0x07, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x53, 0x45, 0x52, 0x56, 0x49, 0x43, 0x45, 0x10, 0x08, 0x12, 0x16, 0x0a, 0x12, 0x54,
+-	0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x54, 0x48, 0x4f,
+-	0x44, 0x10, 0x09, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x04, 0x10, 0x05, 0x22, 0x73, 0x0a, 0x0c, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
+-	0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65,
+-	0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09,
+-	0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x98, 0x02, 0x0a, 0x0b, 0x45, 0x6e,
+-	0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x6c, 0x6c,
+-	0x6f, 0x77, 0x5f, 0x61, 0x6c, 0x69, 0x61, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0a,
+-	0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x41, 0x6c, 0x69, 0x61, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65,
+-	0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05,
+-	0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f,
+-	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c,
+-	0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28,
+-	0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
++	0x74, 0x65, 0x64, 0x12, 0x1b, 0x0a, 0x09, 0x6d, 0x61, 0x70, 0x5f, 0x65, 0x6e, 0x74, 0x72, 0x79,
++	0x18, 0x07, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x6d, 0x61, 0x70, 0x45, 0x6e, 0x74, 0x72, 0x79,
++	0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x6c,
++	0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c, 0x64,
++	0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x08,
++	0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64,
++	0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43,
++	0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x73, 0x18, 0x0c, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07,
++	0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x4a, 0x04, 0x08, 0x05,
++	0x10, 0x06, 0x4a, 0x04, 0x08, 0x06, 0x10, 0x07, 0x4a, 0x04, 0x08, 0x08, 0x10, 0x09, 0x4a, 0x04,
++	0x08, 0x09, 0x10, 0x0a, 0x22, 0xad, 0x0a, 0x0a, 0x0c, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x41, 0x0a, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01,
++	0x20, 0x01, 0x28, 0x0e, 0x32, 0x23, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x2e, 0x43, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e,
++	0x47, 0x52, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x70, 0x61, 0x63, 0x6b,
++	0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64,
++	0x12, 0x47, 0x0a, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e,
++	0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
++	0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41,
++	0x4c, 0x52, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70, 0x65, 0x12, 0x19, 0x0a, 0x04, 0x6c, 0x61, 0x7a,
++	0x79, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04,
++	0x6c, 0x61, 0x7a, 0x79, 0x12, 0x2e, 0x0a, 0x0f, 0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69,
++	0x65, 0x64, 0x5f, 0x6c, 0x61, 0x7a, 0x79, 0x18, 0x0f, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66,
++	0x61, 0x6c, 0x73, 0x65, 0x52, 0x0e, 0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64,
++	0x4c, 0x61, 0x7a, 0x79, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74,
++	0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
++	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x19, 0x0a, 0x04, 0x77,
++	0x65, 0x61, 0x6b, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x12, 0x28, 0x0a, 0x0c, 0x64, 0x65, 0x62, 0x75, 0x67, 0x5f,
++	0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x10, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
++	0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62, 0x75, 0x67, 0x52, 0x65, 0x64, 0x61, 0x63, 0x74,
++	0x12, 0x4b, 0x0a, 0x09, 0x72, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x11, 0x20,
++	0x01, 0x28, 0x0e, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69,
++	0x6f, 0x6e, 0x52, 0x09, 0x72, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x48, 0x0a,
++	0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x18, 0x13, 0x20, 0x03, 0x28, 0x0e, 0x32, 0x2e,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79, 0x70, 0x65, 0x52, 0x07,
++	0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x12, 0x57, 0x0a, 0x10, 0x65, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x5f, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x18, 0x14, 0x20, 0x03, 0x28,
++	0x0b, 0x32, 0x2c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x52,
++	0x0f, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73,
++	0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x15, 0x20, 0x01,
++	0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52,
++	0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+ 	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+ 	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+ 	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+ 	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+ 	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x05, 0x10, 0x06, 0x22, 0x9e, 0x01, 0x0a, 0x10, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c,
+-	0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70,
+-	0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66,
+-	0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64,
+-	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
+-	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
+-	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
+-	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
+-	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10,
+-	0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x9c, 0x01, 0x0a, 0x0e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63,
+-	0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72,
+-	0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12,
+-	0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
+-	0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24,
+-	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+-	0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65,
+-	0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80,
+-	0x80, 0x80, 0x80, 0x02, 0x22, 0xe0, 0x02, 0x0a, 0x0d, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63,
+-	0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73,
+-	0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x71, 0x0a,
+-	0x11, 0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x5f, 0x6c, 0x65, 0x76,
+-	0x65, 0x6c, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f,
+-	0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74,
+-	0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x3a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50,
+-	0x4f, 0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x52, 0x10,
+-	0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c,
+-	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
+-	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
+-	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
+-	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
+-	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x50, 0x0a, 0x10, 0x49, 0x64,
+-	0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12, 0x17,
+-	0x0a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e,
+-	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a, 0x0f, 0x4e, 0x4f, 0x5f, 0x53, 0x49,
+-	0x44, 0x45, 0x5f, 0x45, 0x46, 0x46, 0x45, 0x43, 0x54, 0x53, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a,
+-	0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45, 0x4e, 0x54, 0x10, 0x02, 0x2a, 0x09, 0x08, 0xe8,
+-	0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x9a, 0x03, 0x0a, 0x13, 0x55, 0x6e, 0x69, 0x6e,
+-	0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12,
+-	0x41, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e,
++	0x69, 0x6f, 0x6e, 0x1a, 0x5a, 0x0a, 0x0e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65,
++	0x66, 0x61, 0x75, 0x6c, 0x74, 0x12, 0x32, 0x0a, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e,
++	0x18, 0x03, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e,
++	0x52, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c,
++	0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x22,
++	0x2f, 0x0a, 0x05, 0x43, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x54, 0x52, 0x49,
++	0x4e, 0x47, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x43, 0x4f, 0x52, 0x44, 0x10, 0x01, 0x12, 0x10,
++	0x0a, 0x0c, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x5f, 0x50, 0x49, 0x45, 0x43, 0x45, 0x10, 0x02,
++	0x22, 0x35, 0x0a, 0x06, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53,
++	0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x10, 0x00, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f,
++	0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e,
++	0x55, 0x4d, 0x42, 0x45, 0x52, 0x10, 0x02, 0x22, 0x55, 0x0a, 0x0f, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45,
++	0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10,
++	0x00, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x52,
++	0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x01, 0x12, 0x14, 0x0a, 0x10, 0x52, 0x45, 0x54, 0x45,
++	0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x4f, 0x55, 0x52, 0x43, 0x45, 0x10, 0x02, 0x22, 0x8c,
++	0x02, 0x0a, 0x10, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54,
++	0x79, 0x70, 0x65, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x14, 0x0a, 0x10,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x4c, 0x45,
++	0x10, 0x01, 0x12, 0x1f, 0x0a, 0x1b, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x45, 0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f, 0x4e, 0x5f, 0x52, 0x41, 0x4e, 0x47,
++	0x45, 0x10, 0x02, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x10, 0x03, 0x12, 0x15, 0x0a, 0x11,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x45, 0x4c,
++	0x44, 0x10, 0x04, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x4f, 0x4e, 0x45, 0x4f, 0x46, 0x10, 0x05, 0x12, 0x14, 0x0a, 0x10, 0x54, 0x41,
++	0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x10, 0x06,
++	0x12, 0x1a, 0x0a, 0x16, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x45, 0x4e, 0x54, 0x52, 0x59, 0x10, 0x07, 0x12, 0x17, 0x0a, 0x13,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x45, 0x52, 0x56,
++	0x49, 0x43, 0x45, 0x10, 0x08, 0x12, 0x16, 0x0a, 0x12, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f,
++	0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x54, 0x48, 0x4f, 0x44, 0x10, 0x09, 0x2a, 0x09, 0x08,
++	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x4a, 0x04,
++	0x08, 0x12, 0x10, 0x13, 0x22, 0xac, 0x01, 0x0a, 0x0c, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72,
++	0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58,
++	0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
+ 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+ 	0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x52, 0x04, 0x6e, 0x61,
+-	0x6d, 0x65, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72,
+-	0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x69, 0x64,
+-	0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a,
+-	0x12, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76, 0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61,
+-	0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04, 0x52, 0x10, 0x70, 0x6f, 0x73, 0x69, 0x74,
+-	0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x6e,
+-	0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75,
+-	0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52, 0x10, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76,
+-	0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x64, 0x6f, 0x75,
+-	0x62, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x52,
+-	0x0b, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c,
+-	0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01,
+-	0x28, 0x0c, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12,
+-	0x27, 0x0a, 0x0f, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x5f, 0x76, 0x61, 0x6c,
+-	0x75, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67,
+-	0x61, 0x74, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x1a, 0x4a, 0x0a, 0x08, 0x4e, 0x61, 0x6d, 0x65,
+-	0x50, 0x61, 0x72, 0x74, 0x12, 0x1b, 0x0a, 0x09, 0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x70, 0x61, 0x72,
+-	0x74, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09, 0x52, 0x08, 0x6e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72,
+-	0x74, 0x12, 0x21, 0x0a, 0x0c, 0x69, 0x73, 0x5f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
+-	0x6e, 0x18, 0x02, 0x20, 0x02, 0x28, 0x08, 0x52, 0x0b, 0x69, 0x73, 0x45, 0x78, 0x74, 0x65, 0x6e,
+-	0x73, 0x69, 0x6f, 0x6e, 0x22, 0xa7, 0x02, 0x0a, 0x0e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43,
+-	0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x44, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x28, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
+-	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72,
+-	0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x4c, 0x6f, 0x63, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x52, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xce, 0x01,
+-	0x0a, 0x08, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61,
+-	0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61,
+-	0x74, 0x68, 0x12, 0x16, 0x0a, 0x04, 0x73, 0x70, 0x61, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x05,
+-	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x73, 0x70, 0x61, 0x6e, 0x12, 0x29, 0x0a, 0x10, 0x6c, 0x65,
+-	0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d,
+-	0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x2b, 0x0a, 0x11, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e,
+-	0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x10, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e,
+-	0x74, 0x73, 0x12, 0x3a, 0x0a, 0x19, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x65,
+-	0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18,
+-	0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x17, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x44, 0x65,
+-	0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22, 0xd0,
+-	0x02, 0x0a, 0x11, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65,
+-	0x49, 0x6e, 0x66, 0x6f, 0x12, 0x4d, 0x0a, 0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69,
+-	0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72,
+-	0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e,
+-	0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x1a, 0xeb, 0x01, 0x0a, 0x0a, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69,
++	0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80,
++	0x80, 0x80, 0x02, 0x22, 0xd1, 0x02, 0x0a, 0x0b, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x5f, 0x61, 0x6c, 0x69,
++	0x61, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0a, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x41,
++	0x6c, 0x69, 0x61, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74,
++	0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
++	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x56, 0x0a, 0x26, 0x64,
++	0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79,
++	0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66,
++	0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52,
++	0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x4c, 0x65, 0x67, 0x61, 0x63,
++	0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69,
++	0x63, 0x74, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14,
++	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e,
++	0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80,
++	0x02, 0x4a, 0x04, 0x08, 0x05, 0x10, 0x06, 0x22, 0x81, 0x02, 0x0a, 0x10, 0x45, 0x6e, 0x75, 0x6d,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a,
++	0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08,
++	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
++	0x74, 0x65, 0x64, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x28, 0x0a, 0x0c,
++	0x64, 0x65, 0x62, 0x75, 0x67, 0x5f, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x03, 0x20, 0x01,
++	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62, 0x75, 0x67,
++	0x52, 0x65, 0x64, 0x61, 0x63, 0x74, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7,
++	0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69,
++	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0xd5, 0x01, 0x0a, 0x0e,
++	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x37,
++	0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0b,
++	0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66,
++	0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65,
++	0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x58,
++	0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
++	0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80,
++	0x80, 0x80, 0x02, 0x22, 0x99, 0x03, 0x0a, 0x0d, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
++	0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x71, 0x0a, 0x11,
++	0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x5f, 0x6c, 0x65, 0x76, 0x65,
++	0x6c, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65,
++	0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x3a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f,
++	0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x52, 0x10, 0x69,
++	0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12,
++	0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x23, 0x20, 0x01, 0x28,
++	0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08,
++	0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e,
++	0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75,
++	0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x22, 0x50, 0x0a, 0x10, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63,
++	0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12, 0x17, 0x0a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f,
++	0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12,
++	0x13, 0x0a, 0x0f, 0x4e, 0x4f, 0x5f, 0x53, 0x49, 0x44, 0x45, 0x5f, 0x45, 0x46, 0x46, 0x45, 0x43,
++	0x54, 0x53, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45,
++	0x4e, 0x54, 0x10, 0x02, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22,
++	0x9a, 0x03, 0x0a, 0x13, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
++	0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
++	0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65,
++	0x50, 0x61, 0x72, 0x74, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x64,
++	0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03,
++	0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76,
++	0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28,
++	0x04, 0x52, 0x10, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61,
++	0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x5f,
++	0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52,
++	0x10, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75,
++	0x65, 0x12, 0x21, 0x0a, 0x0c, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75,
++	0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x52, 0x0b, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x56,
++	0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76,
++	0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69,
++	0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x27, 0x0a, 0x0f, 0x61, 0x67, 0x67, 0x72, 0x65,
++	0x67, 0x61, 0x74, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09,
++	0x52, 0x0e, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65,
++	0x1a, 0x4a, 0x0a, 0x08, 0x4e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x12, 0x1b, 0x0a, 0x09,
++	0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x70, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09, 0x52,
++	0x08, 0x6e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x12, 0x21, 0x0a, 0x0c, 0x69, 0x73, 0x5f,
++	0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x02, 0x28, 0x08, 0x52,
++	0x0b, 0x69, 0x73, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x8c, 0x0a, 0x0a,
++	0x0a, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x12, 0x8b, 0x01, 0x0a, 0x0e,
++	0x66, 0x69, 0x65, 0x6c, 0x64, 0x5f, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x18, 0x01,
++	0x20, 0x01, 0x28, 0x0e, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x42,
++	0x39, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45,
++	0x58, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x49,
++	0x4d, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe7, 0x07, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45,
++	0x58, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe8, 0x07, 0x52, 0x0d, 0x66, 0x69, 0x65, 0x6c,
++	0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x66, 0x0a, 0x09, 0x65, 0x6e, 0x75,
++	0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x24, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
++	0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x54, 0x79,
++	0x70, 0x65, 0x42, 0x23, 0x88, 0x01, 0x01, 0x98, 0x01, 0x06, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x0b,
++	0x12, 0x06, 0x43, 0x4c, 0x4f, 0x53, 0x45, 0x44, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x09, 0x12, 0x04,
++	0x4f, 0x50, 0x45, 0x4e, 0x18, 0xe7, 0x07, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54, 0x79, 0x70,
++	0x65, 0x12, 0x92, 0x01, 0x0a, 0x17, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x66,
++	0x69, 0x65, 0x6c, 0x64, 0x5f, 0x65, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x18, 0x03, 0x20,
++	0x01, 0x28, 0x0e, 0x32, 0x31, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74,
++	0x2e, 0x52, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x45, 0x6e,
++	0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x42, 0x27, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98, 0x01,
++	0x01, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45, 0x58, 0x50, 0x41, 0x4e, 0x44, 0x45, 0x44, 0x18, 0xe6,
++	0x07, 0xa2, 0x01, 0x0b, 0x12, 0x06, 0x50, 0x41, 0x43, 0x4b, 0x45, 0x44, 0x18, 0xe7, 0x07, 0x52,
++	0x15, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x45, 0x6e,
++	0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x78, 0x0a, 0x0f, 0x75, 0x74, 0x66, 0x38, 0x5f, 0x76,
++	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0e, 0x32,
++	0x2a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x55, 0x74, 0x66,
++	0x38, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x23, 0x88, 0x01, 0x01,
++	0x98, 0x01, 0x04, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x09, 0x12, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x18,
++	0xe6, 0x07, 0xa2, 0x01, 0x0b, 0x12, 0x06, 0x56, 0x45, 0x52, 0x49, 0x46, 0x59, 0x18, 0xe7, 0x07,
++	0x52, 0x0e, 0x75, 0x74, 0x66, 0x38, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x12, 0x78, 0x0a, 0x10, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x65, 0x6e, 0x63, 0x6f,
++	0x64, 0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x45,
++	0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x42, 0x20, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98,
++	0x01, 0x01, 0xa2, 0x01, 0x14, 0x12, 0x0f, 0x4c, 0x45, 0x4e, 0x47, 0x54, 0x48, 0x5f, 0x50, 0x52,
++	0x45, 0x46, 0x49, 0x58, 0x45, 0x44, 0x18, 0xe6, 0x07, 0x52, 0x0f, 0x6d, 0x65, 0x73, 0x73, 0x61,
++	0x67, 0x65, 0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x7c, 0x0a, 0x0b, 0x6a, 0x73,
++	0x6f, 0x6e, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e, 0x32,
++	0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x4a, 0x73, 0x6f,
++	0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x42, 0x33, 0x88, 0x01, 0x01, 0x98, 0x01, 0x03, 0x98,
++	0x01, 0x06, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x17, 0x12, 0x12, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59,
++	0x5f, 0x42, 0x45, 0x53, 0x54, 0x5f, 0x45, 0x46, 0x46, 0x4f, 0x52, 0x54, 0x18, 0xe6, 0x07, 0xa2,
++	0x01, 0x0a, 0x12, 0x05, 0x41, 0x4c, 0x4c, 0x4f, 0x57, 0x18, 0xe7, 0x07, 0x52, 0x0a, 0x6a, 0x73,
++	0x6f, 0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x22, 0x5c, 0x0a, 0x0d, 0x46, 0x69, 0x65, 0x6c,
++	0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x1a, 0x0a, 0x16, 0x46, 0x49, 0x45,
++	0x4c, 0x44, 0x5f, 0x50, 0x52, 0x45, 0x53, 0x45, 0x4e, 0x43, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e,
++	0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0c, 0x0a, 0x08, 0x45, 0x58, 0x50, 0x4c, 0x49, 0x43, 0x49,
++	0x54, 0x10, 0x01, 0x12, 0x0c, 0x0a, 0x08, 0x49, 0x4d, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x10,
++	0x02, 0x12, 0x13, 0x0a, 0x0f, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59, 0x5f, 0x52, 0x45, 0x51, 0x55,
++	0x49, 0x52, 0x45, 0x44, 0x10, 0x03, 0x22, 0x37, 0x0a, 0x08, 0x45, 0x6e, 0x75, 0x6d, 0x54, 0x79,
++	0x70, 0x65, 0x12, 0x15, 0x0a, 0x11, 0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x4f, 0x50, 0x45,
++	0x4e, 0x10, 0x01, 0x12, 0x0a, 0x0a, 0x06, 0x43, 0x4c, 0x4f, 0x53, 0x45, 0x44, 0x10, 0x02, 0x22,
++	0x56, 0x0a, 0x15, 0x52, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64,
++	0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x23, 0x0a, 0x1f, 0x52, 0x45, 0x50, 0x45,
++	0x41, 0x54, 0x45, 0x44, 0x5f, 0x46, 0x49, 0x45, 0x4c, 0x44, 0x5f, 0x45, 0x4e, 0x43, 0x4f, 0x44,
++	0x49, 0x4e, 0x47, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a,
++	0x06, 0x50, 0x41, 0x43, 0x4b, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0c, 0x0a, 0x08, 0x45, 0x58, 0x50,
++	0x41, 0x4e, 0x44, 0x45, 0x44, 0x10, 0x02, 0x22, 0x43, 0x0a, 0x0e, 0x55, 0x74, 0x66, 0x38, 0x56,
++	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x1b, 0x0a, 0x17, 0x55, 0x54, 0x46,
++	0x38, 0x5f, 0x56, 0x41, 0x4c, 0x49, 0x44, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e, 0x4b,
++	0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x56, 0x45, 0x52, 0x49, 0x46, 0x59,
++	0x10, 0x02, 0x12, 0x08, 0x0a, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x03, 0x22, 0x53, 0x0a, 0x0f,
++	0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12,
++	0x1c, 0x0a, 0x18, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x5f, 0x45, 0x4e, 0x43, 0x4f, 0x44,
++	0x49, 0x4e, 0x47, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a,
++	0x0f, 0x4c, 0x45, 0x4e, 0x47, 0x54, 0x48, 0x5f, 0x50, 0x52, 0x45, 0x46, 0x49, 0x58, 0x45, 0x44,
++	0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x44, 0x45, 0x4c, 0x49, 0x4d, 0x49, 0x54, 0x45, 0x44, 0x10,
++	0x02, 0x22, 0x48, 0x0a, 0x0a, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12,
++	0x17, 0x0a, 0x13, 0x4a, 0x53, 0x4f, 0x4e, 0x5f, 0x46, 0x4f, 0x52, 0x4d, 0x41, 0x54, 0x5f, 0x55,
++	0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x4c, 0x4c, 0x4f,
++	0x57, 0x10, 0x01, 0x12, 0x16, 0x0a, 0x12, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59, 0x5f, 0x42, 0x45,
++	0x53, 0x54, 0x5f, 0x45, 0x46, 0x46, 0x4f, 0x52, 0x54, 0x10, 0x02, 0x2a, 0x06, 0x08, 0xe8, 0x07,
++	0x10, 0xe9, 0x07, 0x2a, 0x06, 0x08, 0xe9, 0x07, 0x10, 0xea, 0x07, 0x2a, 0x06, 0x08, 0xea, 0x07,
++	0x10, 0xeb, 0x07, 0x2a, 0x06, 0x08, 0x8b, 0x4e, 0x10, 0x90, 0x4e, 0x2a, 0x06, 0x08, 0x90, 0x4e,
++	0x10, 0x91, 0x4e, 0x4a, 0x06, 0x08, 0xe7, 0x07, 0x10, 0xe8, 0x07, 0x22, 0xfe, 0x02, 0x0a, 0x12,
++	0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c,
++	0x74, 0x73, 0x12, 0x58, 0x0a, 0x08, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x18, 0x01,
++	0x20, 0x03, 0x28, 0x0b, 0x32, 0x3c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72,
++	0x65, 0x53, 0x65, 0x74, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75,
++	0x6c, 0x74, 0x52, 0x08, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x12, 0x41, 0x0a, 0x0f,
++	0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x5f, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x18,
++	0x04, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x52,
++	0x0e, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12,
++	0x41, 0x0a, 0x0f, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x5f, 0x65, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
++	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x52, 0x0e, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x45, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x1a, 0x87, 0x01, 0x0a, 0x18, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x12,
++	0x32, 0x0a, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0e,
++	0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74,
++	0x69, 0x6f, 0x6e, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x22, 0xa7, 0x02, 0x0a,
++	0x0e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12,
++	0x44, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28,
++	0x0b, 0x32, 0x28, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e,
++	0x66, 0x6f, 0x2e, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x08, 0x6c, 0x6f, 0x63,
++	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xce, 0x01, 0x0a, 0x08, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69,
+ 	0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61, 0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05,
+-	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x12, 0x1f, 0x0a, 0x0b, 0x73, 0x6f,
+-	0x75, 0x72, 0x63, 0x65, 0x5f, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+-	0x0a, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x62,
+-	0x65, 0x67, 0x69, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x62, 0x65, 0x67, 0x69,
+-	0x6e, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03,
+-	0x65, 0x6e, 0x64, 0x12, 0x52, 0x0a, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18,
+-	0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x36, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
+-	0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61,
+-	0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x52, 0x08, 0x73,
+-	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x22, 0x28, 0x0a, 0x08, 0x53, 0x65, 0x6d, 0x61, 0x6e,
+-	0x74, 0x69, 0x63, 0x12, 0x08, 0x0a, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x07, 0x0a,
+-	0x03, 0x53, 0x45, 0x54, 0x10, 0x01, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x4c, 0x49, 0x41, 0x53, 0x10,
+-	0x02, 0x42, 0x7e, 0x0a, 0x13, 0x63, 0x6f, 0x6d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x42, 0x10, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
+-	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x73, 0x48, 0x01, 0x5a, 0x2d, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2f, 0x64,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x70, 0x62, 0xf8, 0x01, 0x01, 0xa2, 0x02,
+-	0x03, 0x47, 0x50, 0x42, 0xaa, 0x02, 0x1a, 0x47, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x50, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x52, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f,
+-	0x6e,
++	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x12, 0x16, 0x0a, 0x04, 0x73, 0x70,
++	0x61, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x73, 0x70,
++	0x61, 0x6e, 0x12, 0x29, 0x0a, 0x10, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f,
++	0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6c, 0x65,
++	0x61, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x2b, 0x0a,
++	0x11, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e,
++	0x74, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69,
++	0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x3a, 0x0a, 0x19, 0x6c, 0x65,
++	0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x65, 0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x5f, 0x63,
++	0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x17, 0x6c,
++	0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x44, 0x65, 0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x43, 0x6f,
++	0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22, 0xd0, 0x02, 0x0a, 0x11, 0x47, 0x65, 0x6e, 0x65, 0x72,
++	0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x4d, 0x0a, 0x0a,
++	0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65,
++	0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52,
++	0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xeb, 0x01, 0x0a, 0x0a,
++	0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61,
++	0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61,
++	0x74, 0x68, 0x12, 0x1f, 0x0a, 0x0b, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x66, 0x69, 0x6c,
++	0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x46,
++	0x69, 0x6c, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x62, 0x65, 0x67, 0x69, 0x6e, 0x18, 0x03, 0x20, 0x01,
++	0x28, 0x05, 0x52, 0x05, 0x62, 0x65, 0x67, 0x69, 0x6e, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64,
++	0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x12, 0x52, 0x0a, 0x08, 0x73,
++	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x36, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
++	0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x53, 0x65, 0x6d,
++	0x61, 0x6e, 0x74, 0x69, 0x63, 0x52, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x22,
++	0x28, 0x0a, 0x08, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x12, 0x08, 0x0a, 0x04, 0x4e,
++	0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x07, 0x0a, 0x03, 0x53, 0x45, 0x54, 0x10, 0x01, 0x12, 0x09,
++	0x0a, 0x05, 0x41, 0x4c, 0x49, 0x41, 0x53, 0x10, 0x02, 0x2a, 0x92, 0x02, 0x0a, 0x07, 0x45, 0x64,
++	0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x13, 0x0a, 0x0f, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e,
++	0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a, 0x0e, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x50, 0x52, 0x4f, 0x54, 0x4f, 0x32, 0x10, 0xe6, 0x07, 0x12,
++	0x13, 0x0a, 0x0e, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x50, 0x52, 0x4f, 0x54, 0x4f,
++	0x33, 0x10, 0xe7, 0x07, 0x12, 0x11, 0x0a, 0x0c, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f,
++	0x32, 0x30, 0x32, 0x33, 0x10, 0xe8, 0x07, 0x12, 0x11, 0x0a, 0x0c, 0x45, 0x44, 0x49, 0x54, 0x49,
++	0x4f, 0x4e, 0x5f, 0x32, 0x30, 0x32, 0x34, 0x10, 0xe9, 0x07, 0x12, 0x17, 0x0a, 0x13, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x31, 0x5f, 0x54, 0x45, 0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c,
++	0x59, 0x10, 0x01, 0x12, 0x17, 0x0a, 0x13, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x32,
++	0x5f, 0x54, 0x45, 0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x02, 0x12, 0x1d, 0x0a, 0x17,
++	0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x37, 0x5f, 0x54, 0x45,
++	0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9d, 0x8d, 0x06, 0x12, 0x1d, 0x0a, 0x17, 0x45,
++	0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x38, 0x5f, 0x54, 0x45, 0x53,
++	0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9e, 0x8d, 0x06, 0x12, 0x1d, 0x0a, 0x17, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x39, 0x5f, 0x54, 0x45, 0x53, 0x54,
++	0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9f, 0x8d, 0x06, 0x12, 0x13, 0x0a, 0x0b, 0x45, 0x44, 0x49,
++	0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x4d, 0x41, 0x58, 0x10, 0xff, 0xff, 0xff, 0xff, 0x07, 0x42, 0x7e,
++	0x0a, 0x13, 0x63, 0x6f, 0x6d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x42, 0x10, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f,
++	0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x73, 0x48, 0x01, 0x5a, 0x2d, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
++	0x65, 0x2e, 0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2f, 0x64, 0x65, 0x73, 0x63,
++	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x70, 0x62, 0xf8, 0x01, 0x01, 0xa2, 0x02, 0x03, 0x47, 0x50,
++	0x42, 0xaa, 0x02, 0x1a, 0x47, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x50, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x52, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e,
+ }
+ 
+ var (
+@@ -4123,103 +5083,136 @@ func file_google_protobuf_descriptor_proto_rawDescGZIP() []byte {
+ 	return file_google_protobuf_descriptor_proto_rawDescData
+ }
+ 
+-var file_google_protobuf_descriptor_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+-var file_google_protobuf_descriptor_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
++var file_google_protobuf_descriptor_proto_enumTypes = make([]protoimpl.EnumInfo, 17)
++var file_google_protobuf_descriptor_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+ var file_google_protobuf_descriptor_proto_goTypes = []interface{}{
+-	(ExtensionRangeOptions_VerificationState)(0),  // 0: google.protobuf.ExtensionRangeOptions.VerificationState
+-	(FieldDescriptorProto_Type)(0),                // 1: google.protobuf.FieldDescriptorProto.Type
+-	(FieldDescriptorProto_Label)(0),               // 2: google.protobuf.FieldDescriptorProto.Label
+-	(FileOptions_OptimizeMode)(0),                 // 3: google.protobuf.FileOptions.OptimizeMode
+-	(FieldOptions_CType)(0),                       // 4: google.protobuf.FieldOptions.CType
+-	(FieldOptions_JSType)(0),                      // 5: google.protobuf.FieldOptions.JSType
+-	(FieldOptions_OptionRetention)(0),             // 6: google.protobuf.FieldOptions.OptionRetention
+-	(FieldOptions_OptionTargetType)(0),            // 7: google.protobuf.FieldOptions.OptionTargetType
+-	(MethodOptions_IdempotencyLevel)(0),           // 8: google.protobuf.MethodOptions.IdempotencyLevel
+-	(GeneratedCodeInfo_Annotation_Semantic)(0),    // 9: google.protobuf.GeneratedCodeInfo.Annotation.Semantic
+-	(*FileDescriptorSet)(nil),                     // 10: google.protobuf.FileDescriptorSet
+-	(*FileDescriptorProto)(nil),                   // 11: google.protobuf.FileDescriptorProto
+-	(*DescriptorProto)(nil),                       // 12: google.protobuf.DescriptorProto
+-	(*ExtensionRangeOptions)(nil),                 // 13: google.protobuf.ExtensionRangeOptions
+-	(*FieldDescriptorProto)(nil),                  // 14: google.protobuf.FieldDescriptorProto
+-	(*OneofDescriptorProto)(nil),                  // 15: google.protobuf.OneofDescriptorProto
+-	(*EnumDescriptorProto)(nil),                   // 16: google.protobuf.EnumDescriptorProto
+-	(*EnumValueDescriptorProto)(nil),              // 17: google.protobuf.EnumValueDescriptorProto
+-	(*ServiceDescriptorProto)(nil),                // 18: google.protobuf.ServiceDescriptorProto
+-	(*MethodDescriptorProto)(nil),                 // 19: google.protobuf.MethodDescriptorProto
+-	(*FileOptions)(nil),                           // 20: google.protobuf.FileOptions
+-	(*MessageOptions)(nil),                        // 21: google.protobuf.MessageOptions
+-	(*FieldOptions)(nil),                          // 22: google.protobuf.FieldOptions
+-	(*OneofOptions)(nil),                          // 23: google.protobuf.OneofOptions
+-	(*EnumOptions)(nil),                           // 24: google.protobuf.EnumOptions
+-	(*EnumValueOptions)(nil),                      // 25: google.protobuf.EnumValueOptions
+-	(*ServiceOptions)(nil),                        // 26: google.protobuf.ServiceOptions
+-	(*MethodOptions)(nil),                         // 27: google.protobuf.MethodOptions
+-	(*UninterpretedOption)(nil),                   // 28: google.protobuf.UninterpretedOption
+-	(*SourceCodeInfo)(nil),                        // 29: google.protobuf.SourceCodeInfo
+-	(*GeneratedCodeInfo)(nil),                     // 30: google.protobuf.GeneratedCodeInfo
+-	(*DescriptorProto_ExtensionRange)(nil),        // 31: google.protobuf.DescriptorProto.ExtensionRange
+-	(*DescriptorProto_ReservedRange)(nil),         // 32: google.protobuf.DescriptorProto.ReservedRange
+-	(*ExtensionRangeOptions_Declaration)(nil),     // 33: google.protobuf.ExtensionRangeOptions.Declaration
+-	(*EnumDescriptorProto_EnumReservedRange)(nil), // 34: google.protobuf.EnumDescriptorProto.EnumReservedRange
+-	(*UninterpretedOption_NamePart)(nil),          // 35: google.protobuf.UninterpretedOption.NamePart
+-	(*SourceCodeInfo_Location)(nil),               // 36: google.protobuf.SourceCodeInfo.Location
+-	(*GeneratedCodeInfo_Annotation)(nil),          // 37: google.protobuf.GeneratedCodeInfo.Annotation
++	(Edition)(0), // 0: google.protobuf.Edition
++	(ExtensionRangeOptions_VerificationState)(0),        // 1: google.protobuf.ExtensionRangeOptions.VerificationState
++	(FieldDescriptorProto_Type)(0),                      // 2: google.protobuf.FieldDescriptorProto.Type
++	(FieldDescriptorProto_Label)(0),                     // 3: google.protobuf.FieldDescriptorProto.Label
++	(FileOptions_OptimizeMode)(0),                       // 4: google.protobuf.FileOptions.OptimizeMode
++	(FieldOptions_CType)(0),                             // 5: google.protobuf.FieldOptions.CType
++	(FieldOptions_JSType)(0),                            // 6: google.protobuf.FieldOptions.JSType
++	(FieldOptions_OptionRetention)(0),                   // 7: google.protobuf.FieldOptions.OptionRetention
++	(FieldOptions_OptionTargetType)(0),                  // 8: google.protobuf.FieldOptions.OptionTargetType
++	(MethodOptions_IdempotencyLevel)(0),                 // 9: google.protobuf.MethodOptions.IdempotencyLevel
++	(FeatureSet_FieldPresence)(0),                       // 10: google.protobuf.FeatureSet.FieldPresence
++	(FeatureSet_EnumType)(0),                            // 11: google.protobuf.FeatureSet.EnumType
++	(FeatureSet_RepeatedFieldEncoding)(0),               // 12: google.protobuf.FeatureSet.RepeatedFieldEncoding
++	(FeatureSet_Utf8Validation)(0),                      // 13: google.protobuf.FeatureSet.Utf8Validation
++	(FeatureSet_MessageEncoding)(0),                     // 14: google.protobuf.FeatureSet.MessageEncoding
++	(FeatureSet_JsonFormat)(0),                          // 15: google.protobuf.FeatureSet.JsonFormat
++	(GeneratedCodeInfo_Annotation_Semantic)(0),          // 16: google.protobuf.GeneratedCodeInfo.Annotation.Semantic
++	(*FileDescriptorSet)(nil),                           // 17: google.protobuf.FileDescriptorSet
++	(*FileDescriptorProto)(nil),                         // 18: google.protobuf.FileDescriptorProto
++	(*DescriptorProto)(nil),                             // 19: google.protobuf.DescriptorProto
++	(*ExtensionRangeOptions)(nil),                       // 20: google.protobuf.ExtensionRangeOptions
++	(*FieldDescriptorProto)(nil),                        // 21: google.protobuf.FieldDescriptorProto
++	(*OneofDescriptorProto)(nil),                        // 22: google.protobuf.OneofDescriptorProto
++	(*EnumDescriptorProto)(nil),                         // 23: google.protobuf.EnumDescriptorProto
++	(*EnumValueDescriptorProto)(nil),                    // 24: google.protobuf.EnumValueDescriptorProto
++	(*ServiceDescriptorProto)(nil),                      // 25: google.protobuf.ServiceDescriptorProto
++	(*MethodDescriptorProto)(nil),                       // 26: google.protobuf.MethodDescriptorProto
++	(*FileOptions)(nil),                                 // 27: google.protobuf.FileOptions
++	(*MessageOptions)(nil),                              // 28: google.protobuf.MessageOptions
++	(*FieldOptions)(nil),                                // 29: google.protobuf.FieldOptions
++	(*OneofOptions)(nil),                                // 30: google.protobuf.OneofOptions
++	(*EnumOptions)(nil),                                 // 31: google.protobuf.EnumOptions
++	(*EnumValueOptions)(nil),                            // 32: google.protobuf.EnumValueOptions
++	(*ServiceOptions)(nil),                              // 33: google.protobuf.ServiceOptions
++	(*MethodOptions)(nil),                               // 34: google.protobuf.MethodOptions
++	(*UninterpretedOption)(nil),                         // 35: google.protobuf.UninterpretedOption
++	(*FeatureSet)(nil),                                  // 36: google.protobuf.FeatureSet
++	(*FeatureSetDefaults)(nil),                          // 37: google.protobuf.FeatureSetDefaults
++	(*SourceCodeInfo)(nil),                              // 38: google.protobuf.SourceCodeInfo
++	(*GeneratedCodeInfo)(nil),                           // 39: google.protobuf.GeneratedCodeInfo
++	(*DescriptorProto_ExtensionRange)(nil),              // 40: google.protobuf.DescriptorProto.ExtensionRange
++	(*DescriptorProto_ReservedRange)(nil),               // 41: google.protobuf.DescriptorProto.ReservedRange
++	(*ExtensionRangeOptions_Declaration)(nil),           // 42: google.protobuf.ExtensionRangeOptions.Declaration
++	(*EnumDescriptorProto_EnumReservedRange)(nil),       // 43: google.protobuf.EnumDescriptorProto.EnumReservedRange
++	(*FieldOptions_EditionDefault)(nil),                 // 44: google.protobuf.FieldOptions.EditionDefault
++	(*UninterpretedOption_NamePart)(nil),                // 45: google.protobuf.UninterpretedOption.NamePart
++	(*FeatureSetDefaults_FeatureSetEditionDefault)(nil), // 46: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
++	(*SourceCodeInfo_Location)(nil),                     // 47: google.protobuf.SourceCodeInfo.Location
++	(*GeneratedCodeInfo_Annotation)(nil),                // 48: google.protobuf.GeneratedCodeInfo.Annotation
+ }
+ var file_google_protobuf_descriptor_proto_depIdxs = []int32{
+-	11, // 0: google.protobuf.FileDescriptorSet.file:type_name -> google.protobuf.FileDescriptorProto
+-	12, // 1: google.protobuf.FileDescriptorProto.message_type:type_name -> google.protobuf.DescriptorProto
+-	16, // 2: google.protobuf.FileDescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
+-	18, // 3: google.protobuf.FileDescriptorProto.service:type_name -> google.protobuf.ServiceDescriptorProto
+-	14, // 4: google.protobuf.FileDescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
+-	20, // 5: google.protobuf.FileDescriptorProto.options:type_name -> google.protobuf.FileOptions
+-	29, // 6: google.protobuf.FileDescriptorProto.source_code_info:type_name -> google.protobuf.SourceCodeInfo
+-	14, // 7: google.protobuf.DescriptorProto.field:type_name -> google.protobuf.FieldDescriptorProto
+-	14, // 8: google.protobuf.DescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
+-	12, // 9: google.protobuf.DescriptorProto.nested_type:type_name -> google.protobuf.DescriptorProto
+-	16, // 10: google.protobuf.DescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
+-	31, // 11: google.protobuf.DescriptorProto.extension_range:type_name -> google.protobuf.DescriptorProto.ExtensionRange
+-	15, // 12: google.protobuf.DescriptorProto.oneof_decl:type_name -> google.protobuf.OneofDescriptorProto
+-	21, // 13: google.protobuf.DescriptorProto.options:type_name -> google.protobuf.MessageOptions
+-	32, // 14: google.protobuf.DescriptorProto.reserved_range:type_name -> google.protobuf.DescriptorProto.ReservedRange
+-	28, // 15: google.protobuf.ExtensionRangeOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	33, // 16: google.protobuf.ExtensionRangeOptions.declaration:type_name -> google.protobuf.ExtensionRangeOptions.Declaration
+-	0,  // 17: google.protobuf.ExtensionRangeOptions.verification:type_name -> google.protobuf.ExtensionRangeOptions.VerificationState
+-	2,  // 18: google.protobuf.FieldDescriptorProto.label:type_name -> google.protobuf.FieldDescriptorProto.Label
+-	1,  // 19: google.protobuf.FieldDescriptorProto.type:type_name -> google.protobuf.FieldDescriptorProto.Type
+-	22, // 20: google.protobuf.FieldDescriptorProto.options:type_name -> google.protobuf.FieldOptions
+-	23, // 21: google.protobuf.OneofDescriptorProto.options:type_name -> google.protobuf.OneofOptions
+-	17, // 22: google.protobuf.EnumDescriptorProto.value:type_name -> google.protobuf.EnumValueDescriptorProto
+-	24, // 23: google.protobuf.EnumDescriptorProto.options:type_name -> google.protobuf.EnumOptions
+-	34, // 24: google.protobuf.EnumDescriptorProto.reserved_range:type_name -> google.protobuf.EnumDescriptorProto.EnumReservedRange
+-	25, // 25: google.protobuf.EnumValueDescriptorProto.options:type_name -> google.protobuf.EnumValueOptions
+-	19, // 26: google.protobuf.ServiceDescriptorProto.method:type_name -> google.protobuf.MethodDescriptorProto
+-	26, // 27: google.protobuf.ServiceDescriptorProto.options:type_name -> google.protobuf.ServiceOptions
+-	27, // 28: google.protobuf.MethodDescriptorProto.options:type_name -> google.protobuf.MethodOptions
+-	3,  // 29: google.protobuf.FileOptions.optimize_for:type_name -> google.protobuf.FileOptions.OptimizeMode
+-	28, // 30: google.protobuf.FileOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 31: google.protobuf.MessageOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	4,  // 32: google.protobuf.FieldOptions.ctype:type_name -> google.protobuf.FieldOptions.CType
+-	5,  // 33: google.protobuf.FieldOptions.jstype:type_name -> google.protobuf.FieldOptions.JSType
+-	6,  // 34: google.protobuf.FieldOptions.retention:type_name -> google.protobuf.FieldOptions.OptionRetention
+-	7,  // 35: google.protobuf.FieldOptions.target:type_name -> google.protobuf.FieldOptions.OptionTargetType
+-	7,  // 36: google.protobuf.FieldOptions.targets:type_name -> google.protobuf.FieldOptions.OptionTargetType
+-	28, // 37: google.protobuf.FieldOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 38: google.protobuf.OneofOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 39: google.protobuf.EnumOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 40: google.protobuf.EnumValueOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 41: google.protobuf.ServiceOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	8,  // 42: google.protobuf.MethodOptions.idempotency_level:type_name -> google.protobuf.MethodOptions.IdempotencyLevel
+-	28, // 43: google.protobuf.MethodOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	35, // 44: google.protobuf.UninterpretedOption.name:type_name -> google.protobuf.UninterpretedOption.NamePart
+-	36, // 45: google.protobuf.SourceCodeInfo.location:type_name -> google.protobuf.SourceCodeInfo.Location
+-	37, // 46: google.protobuf.GeneratedCodeInfo.annotation:type_name -> google.protobuf.GeneratedCodeInfo.Annotation
+-	13, // 47: google.protobuf.DescriptorProto.ExtensionRange.options:type_name -> google.protobuf.ExtensionRangeOptions
+-	9,  // 48: google.protobuf.GeneratedCodeInfo.Annotation.semantic:type_name -> google.protobuf.GeneratedCodeInfo.Annotation.Semantic
+-	49, // [49:49] is the sub-list for method output_type
+-	49, // [49:49] is the sub-list for method input_type
+-	49, // [49:49] is the sub-list for extension type_name
+-	49, // [49:49] is the sub-list for extension extendee
+-	0,  // [0:49] is the sub-list for field type_name
++	18, // 0: google.protobuf.FileDescriptorSet.file:type_name -> google.protobuf.FileDescriptorProto
++	19, // 1: google.protobuf.FileDescriptorProto.message_type:type_name -> google.protobuf.DescriptorProto
++	23, // 2: google.protobuf.FileDescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
++	25, // 3: google.protobuf.FileDescriptorProto.service:type_name -> google.protobuf.ServiceDescriptorProto
++	21, // 4: google.protobuf.FileDescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
++	27, // 5: google.protobuf.FileDescriptorProto.options:type_name -> google.protobuf.FileOptions
++	38, // 6: google.protobuf.FileDescriptorProto.source_code_info:type_name -> google.protobuf.SourceCodeInfo
++	0,  // 7: google.protobuf.FileDescriptorProto.edition:type_name -> google.protobuf.Edition
++	21, // 8: google.protobuf.DescriptorProto.field:type_name -> google.protobuf.FieldDescriptorProto
++	21, // 9: google.protobuf.DescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
++	19, // 10: google.protobuf.DescriptorProto.nested_type:type_name -> google.protobuf.DescriptorProto
++	23, // 11: google.protobuf.DescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
++	40, // 12: google.protobuf.DescriptorProto.extension_range:type_name -> google.protobuf.DescriptorProto.ExtensionRange
++	22, // 13: google.protobuf.DescriptorProto.oneof_decl:type_name -> google.protobuf.OneofDescriptorProto
++	28, // 14: google.protobuf.DescriptorProto.options:type_name -> google.protobuf.MessageOptions
++	41, // 15: google.protobuf.DescriptorProto.reserved_range:type_name -> google.protobuf.DescriptorProto.ReservedRange
++	35, // 16: google.protobuf.ExtensionRangeOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	42, // 17: google.protobuf.ExtensionRangeOptions.declaration:type_name -> google.protobuf.ExtensionRangeOptions.Declaration
++	36, // 18: google.protobuf.ExtensionRangeOptions.features:type_name -> google.protobuf.FeatureSet
++	1,  // 19: google.protobuf.ExtensionRangeOptions.verification:type_name -> google.protobuf.ExtensionRangeOptions.VerificationState
++	3,  // 20: google.protobuf.FieldDescriptorProto.label:type_name -> google.protobuf.FieldDescriptorProto.Label
++	2,  // 21: google.protobuf.FieldDescriptorProto.type:type_name -> google.protobuf.FieldDescriptorProto.Type
++	29, // 22: google.protobuf.FieldDescriptorProto.options:type_name -> google.protobuf.FieldOptions
++	30, // 23: google.protobuf.OneofDescriptorProto.options:type_name -> google.protobuf.OneofOptions
++	24, // 24: google.protobuf.EnumDescriptorProto.value:type_name -> google.protobuf.EnumValueDescriptorProto
++	31, // 25: google.protobuf.EnumDescriptorProto.options:type_name -> google.protobuf.EnumOptions
++	43, // 26: google.protobuf.EnumDescriptorProto.reserved_range:type_name -> google.protobuf.EnumDescriptorProto.EnumReservedRange
++	32, // 27: google.protobuf.EnumValueDescriptorProto.options:type_name -> google.protobuf.EnumValueOptions
++	26, // 28: google.protobuf.ServiceDescriptorProto.method:type_name -> google.protobuf.MethodDescriptorProto
++	33, // 29: google.protobuf.ServiceDescriptorProto.options:type_name -> google.protobuf.ServiceOptions
++	34, // 30: google.protobuf.MethodDescriptorProto.options:type_name -> google.protobuf.MethodOptions
++	4,  // 31: google.protobuf.FileOptions.optimize_for:type_name -> google.protobuf.FileOptions.OptimizeMode
++	36, // 32: google.protobuf.FileOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 33: google.protobuf.FileOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 34: google.protobuf.MessageOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 35: google.protobuf.MessageOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	5,  // 36: google.protobuf.FieldOptions.ctype:type_name -> google.protobuf.FieldOptions.CType
++	6,  // 37: google.protobuf.FieldOptions.jstype:type_name -> google.protobuf.FieldOptions.JSType
++	7,  // 38: google.protobuf.FieldOptions.retention:type_name -> google.protobuf.FieldOptions.OptionRetention
++	8,  // 39: google.protobuf.FieldOptions.targets:type_name -> google.protobuf.FieldOptions.OptionTargetType
++	44, // 40: google.protobuf.FieldOptions.edition_defaults:type_name -> google.protobuf.FieldOptions.EditionDefault
++	36, // 41: google.protobuf.FieldOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 42: google.protobuf.FieldOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 43: google.protobuf.OneofOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 44: google.protobuf.OneofOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 45: google.protobuf.EnumOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 46: google.protobuf.EnumOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 47: google.protobuf.EnumValueOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 48: google.protobuf.EnumValueOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 49: google.protobuf.ServiceOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 50: google.protobuf.ServiceOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	9,  // 51: google.protobuf.MethodOptions.idempotency_level:type_name -> google.protobuf.MethodOptions.IdempotencyLevel
++	36, // 52: google.protobuf.MethodOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 53: google.protobuf.MethodOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	45, // 54: google.protobuf.UninterpretedOption.name:type_name -> google.protobuf.UninterpretedOption.NamePart
++	10, // 55: google.protobuf.FeatureSet.field_presence:type_name -> google.protobuf.FeatureSet.FieldPresence
++	11, // 56: google.protobuf.FeatureSet.enum_type:type_name -> google.protobuf.FeatureSet.EnumType
++	12, // 57: google.protobuf.FeatureSet.repeated_field_encoding:type_name -> google.protobuf.FeatureSet.RepeatedFieldEncoding
++	13, // 58: google.protobuf.FeatureSet.utf8_validation:type_name -> google.protobuf.FeatureSet.Utf8Validation
++	14, // 59: google.protobuf.FeatureSet.message_encoding:type_name -> google.protobuf.FeatureSet.MessageEncoding
++	15, // 60: google.protobuf.FeatureSet.json_format:type_name -> google.protobuf.FeatureSet.JsonFormat
++	46, // 61: google.protobuf.FeatureSetDefaults.defaults:type_name -> google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
++	0,  // 62: google.protobuf.FeatureSetDefaults.minimum_edition:type_name -> google.protobuf.Edition
++	0,  // 63: google.protobuf.FeatureSetDefaults.maximum_edition:type_name -> google.protobuf.Edition
++	47, // 64: google.protobuf.SourceCodeInfo.location:type_name -> google.protobuf.SourceCodeInfo.Location
++	48, // 65: google.protobuf.GeneratedCodeInfo.annotation:type_name -> google.protobuf.GeneratedCodeInfo.Annotation
++	20, // 66: google.protobuf.DescriptorProto.ExtensionRange.options:type_name -> google.protobuf.ExtensionRangeOptions
++	0,  // 67: google.protobuf.FieldOptions.EditionDefault.edition:type_name -> google.protobuf.Edition
++	0,  // 68: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.edition:type_name -> google.protobuf.Edition
++	36, // 69: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.features:type_name -> google.protobuf.FeatureSet
++	16, // 70: google.protobuf.GeneratedCodeInfo.Annotation.semantic:type_name -> google.protobuf.GeneratedCodeInfo.Annotation.Semantic
++	71, // [71:71] is the sub-list for method output_type
++	71, // [71:71] is the sub-list for method input_type
++	71, // [71:71] is the sub-list for extension type_name
++	71, // [71:71] is the sub-list for extension extendee
++	0,  // [0:71] is the sub-list for field type_name
+ }
+ 
+ func init() { file_google_protobuf_descriptor_proto_init() }
+@@ -4475,19 +5468,21 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*SourceCodeInfo); i {
++			switch v := v.(*FeatureSet); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+ 				return &v.sizeCache
+ 			case 2:
+ 				return &v.unknownFields
++			case 3:
++				return &v.extensionFields
+ 			default:
+ 				return nil
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*GeneratedCodeInfo); i {
++			switch v := v.(*FeatureSetDefaults); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4499,7 +5494,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*DescriptorProto_ExtensionRange); i {
++			switch v := v.(*SourceCodeInfo); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4511,7 +5506,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*DescriptorProto_ReservedRange); i {
++			switch v := v.(*GeneratedCodeInfo); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4523,7 +5518,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*ExtensionRangeOptions_Declaration); i {
++			switch v := v.(*DescriptorProto_ExtensionRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4535,7 +5530,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*EnumDescriptorProto_EnumReservedRange); i {
++			switch v := v.(*DescriptorProto_ReservedRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4547,7 +5542,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*UninterpretedOption_NamePart); i {
++			switch v := v.(*ExtensionRangeOptions_Declaration); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4559,7 +5554,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*SourceCodeInfo_Location); i {
++			switch v := v.(*EnumDescriptorProto_EnumReservedRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4571,6 +5566,54 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*FieldOptions_EditionDefault); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*UninterpretedOption_NamePart); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*FeatureSetDefaults_FeatureSetEditionDefault); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*SourceCodeInfo_Location); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
+ 			switch v := v.(*GeneratedCodeInfo_Annotation); i {
+ 			case 0:
+ 				return &v.state
+@@ -4588,8 +5631,8 @@ func file_google_protobuf_descriptor_proto_init() {
+ 		File: protoimpl.DescBuilder{
+ 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
+ 			RawDescriptor: file_google_protobuf_descriptor_proto_rawDesc,
+-			NumEnums:      10,
+-			NumMessages:   28,
++			NumEnums:      17,
++			NumMessages:   32,
+ 			NumExtensions: 0,
+ 			NumServices:   0,
+ 		},
+diff --git a/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+new file mode 100644
+index 0000000..25de5ae
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+@@ -0,0 +1,177 @@
++// Protocol Buffers - Google's data interchange format
++// Copyright 2023 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++// Code generated by protoc-gen-go. DO NOT EDIT.
++// source: reflect/protodesc/proto/go_features.proto
++
++package proto
++
++import (
++	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
++	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
++	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
++	reflect "reflect"
++	sync "sync"
++)
++
++type GoFeatures struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	// Whether or not to generate the deprecated UnmarshalJSON method for enums.
++	LegacyUnmarshalJsonEnum *bool `protobuf:"varint,1,opt,name=legacy_unmarshal_json_enum,json=legacyUnmarshalJsonEnum" json:"legacy_unmarshal_json_enum,omitempty"`
++}
++
++func (x *GoFeatures) Reset() {
++	*x = GoFeatures{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_reflect_protodesc_proto_go_features_proto_msgTypes[0]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *GoFeatures) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*GoFeatures) ProtoMessage() {}
++
++func (x *GoFeatures) ProtoReflect() protoreflect.Message {
++	mi := &file_reflect_protodesc_proto_go_features_proto_msgTypes[0]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use GoFeatures.ProtoReflect.Descriptor instead.
++func (*GoFeatures) Descriptor() ([]byte, []int) {
++	return file_reflect_protodesc_proto_go_features_proto_rawDescGZIP(), []int{0}
++}
++
++func (x *GoFeatures) GetLegacyUnmarshalJsonEnum() bool {
++	if x != nil && x.LegacyUnmarshalJsonEnum != nil {
++		return *x.LegacyUnmarshalJsonEnum
++	}
++	return false
++}
++
++var file_reflect_protodesc_proto_go_features_proto_extTypes = []protoimpl.ExtensionInfo{
++	{
++		ExtendedType:  (*descriptorpb.FeatureSet)(nil),
++		ExtensionType: (*GoFeatures)(nil),
++		Field:         1002,
++		Name:          "google.protobuf.go",
++		Tag:           "bytes,1002,opt,name=go",
++		Filename:      "reflect/protodesc/proto/go_features.proto",
++	},
++}
++
++// Extension fields to descriptorpb.FeatureSet.
++var (
++	// optional google.protobuf.GoFeatures go = 1002;
++	E_Go = &file_reflect_protodesc_proto_go_features_proto_extTypes[0]
++)
++
++var File_reflect_protodesc_proto_go_features_proto protoreflect.FileDescriptor
++
++var file_reflect_protodesc_proto_go_features_proto_rawDesc = []byte{
++	0x0a, 0x29, 0x72, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x64,
++	0x65, 0x73, 0x63, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x67, 0x6f, 0x5f, 0x66, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x0f, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x1a, 0x20, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x64, 0x65,
++	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x6a,
++	0x0a, 0x0a, 0x47, 0x6f, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x5c, 0x0a, 0x1a,
++	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x75, 0x6e, 0x6d, 0x61, 0x72, 0x73, 0x68, 0x61, 0x6c,
++	0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x65, 0x6e, 0x75, 0x6d, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08,
++	0x42, 0x1f, 0x88, 0x01, 0x01, 0x98, 0x01, 0x06, 0xa2, 0x01, 0x09, 0x12, 0x04, 0x74, 0x72, 0x75,
++	0x65, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x0a, 0x12, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x18, 0xe7,
++	0x07, 0x52, 0x17, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x55, 0x6e, 0x6d, 0x61, 0x72, 0x73, 0x68,
++	0x61, 0x6c, 0x4a, 0x73, 0x6f, 0x6e, 0x45, 0x6e, 0x75, 0x6d, 0x3a, 0x49, 0x0a, 0x02, 0x67, 0x6f,
++	0x12, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x18, 0xea, 0x07,
++	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x6f, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x52, 0x02, 0x67, 0x6f, 0x42, 0x34, 0x5a, 0x32, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2f, 0x72, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x64, 0x65, 0x73, 0x63, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++}
++
++var (
++	file_reflect_protodesc_proto_go_features_proto_rawDescOnce sync.Once
++	file_reflect_protodesc_proto_go_features_proto_rawDescData = file_reflect_protodesc_proto_go_features_proto_rawDesc
++)
++
++func file_reflect_protodesc_proto_go_features_proto_rawDescGZIP() []byte {
++	file_reflect_protodesc_proto_go_features_proto_rawDescOnce.Do(func() {
++		file_reflect_protodesc_proto_go_features_proto_rawDescData = protoimpl.X.CompressGZIP(file_reflect_protodesc_proto_go_features_proto_rawDescData)
++	})
++	return file_reflect_protodesc_proto_go_features_proto_rawDescData
++}
++
++var file_reflect_protodesc_proto_go_features_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
++var file_reflect_protodesc_proto_go_features_proto_goTypes = []interface{}{
++	(*GoFeatures)(nil),              // 0: google.protobuf.GoFeatures
++	(*descriptorpb.FeatureSet)(nil), // 1: google.protobuf.FeatureSet
++}
++var file_reflect_protodesc_proto_go_features_proto_depIdxs = []int32{
++	1, // 0: google.protobuf.go:extendee -> google.protobuf.FeatureSet
++	0, // 1: google.protobuf.go:type_name -> google.protobuf.GoFeatures
++	2, // [2:2] is the sub-list for method output_type
++	2, // [2:2] is the sub-list for method input_type
++	1, // [1:2] is the sub-list for extension type_name
++	0, // [0:1] is the sub-list for extension extendee
++	0, // [0:0] is the sub-list for field type_name
++}
++
++func init() { file_reflect_protodesc_proto_go_features_proto_init() }
++func file_reflect_protodesc_proto_go_features_proto_init() {
++	if File_reflect_protodesc_proto_go_features_proto != nil {
++		return
++	}
++	if !protoimpl.UnsafeEnabled {
++		file_reflect_protodesc_proto_go_features_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*GoFeatures); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++	}
++	type x struct{}
++	out := protoimpl.TypeBuilder{
++		File: protoimpl.DescBuilder{
++			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
++			RawDescriptor: file_reflect_protodesc_proto_go_features_proto_rawDesc,
++			NumEnums:      0,
++			NumMessages:   1,
++			NumExtensions: 1,
++			NumServices:   0,
++		},
++		GoTypes:           file_reflect_protodesc_proto_go_features_proto_goTypes,
++		DependencyIndexes: file_reflect_protodesc_proto_go_features_proto_depIdxs,
++		MessageInfos:      file_reflect_protodesc_proto_go_features_proto_msgTypes,
++		ExtensionInfos:    file_reflect_protodesc_proto_go_features_proto_extTypes,
++	}.Build()
++	File_reflect_protodesc_proto_go_features_proto = out.File
++	file_reflect_protodesc_proto_go_features_proto_rawDesc = nil
++	file_reflect_protodesc_proto_go_features_proto_goTypes = nil
++	file_reflect_protodesc_proto_go_features_proto_depIdxs = nil
++}
+diff --git a/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+new file mode 100644
+index 0000000..d246571
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+@@ -0,0 +1,28 @@
++// Protocol Buffers - Google's data interchange format
++// Copyright 2023 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++syntax = "proto2";
++
++package google.protobuf;
++
++import "google/protobuf/descriptor.proto";
++
++option go_package = "google.golang.org/protobuf/types/gofeaturespb";
++
++extend google.protobuf.FeatureSet {
++  optional GoFeatures go = 1002;
++}
++
++message GoFeatures {
++  // Whether or not to generate the deprecated UnmarshalJSON method for enums.
++  optional bool legacy_unmarshal_json_enum = 1 [
++    retention = RETENTION_RUNTIME,
++    targets = TARGET_TYPE_ENUM,
++    edition_defaults = { edition: EDITION_PROTO2, value: "true" },
++    edition_defaults = { edition: EDITION_PROTO3, value: "false" }
++  ];
++}
+diff --git a/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go b/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
+index 580b232..9de51be 100644
+--- a/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
++++ b/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
+@@ -237,7 +237,8 @@ type Any struct {
+ 	//
+ 	// Note: this functionality is not currently available in the official
+ 	// protobuf release, and it is not used for type URLs beginning with
+-	// type.googleapis.com.
++	// type.googleapis.com. As of May 2023, there are no widely used type server
++	// implementations and no plans to implement one.
+ 	//
+ 	// Schemes other than `http`, `https` (or the empty scheme) might be
+ 	// used with implementation specific semantics.
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index f3db441..e57446f 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -29,8 +29,8 @@ github.com/gogo/protobuf/sortkeys
+ ## explicit; go 1.11
+ github.com/golang/mock/gomock
+ github.com/golang/mock/mockgen/model
+-# github.com/golang/protobuf v1.5.3
+-## explicit; go 1.9
++# github.com/golang/protobuf v1.5.4
++## explicit; go 1.17
+ github.com/golang/protobuf/descriptor
+ github.com/golang/protobuf/jsonpb
+ github.com/golang/protobuf/proto
+@@ -218,14 +218,15 @@ google.golang.org/grpc/serviceconfig
+ google.golang.org/grpc/stats
+ google.golang.org/grpc/status
+ google.golang.org/grpc/tap
+-# google.golang.org/protobuf v1.31.0
+-## explicit; go 1.11
++# google.golang.org/protobuf v1.33.0
++## explicit; go 1.17
+ google.golang.org/protobuf/encoding/protojson
+ google.golang.org/protobuf/encoding/prototext
+ google.golang.org/protobuf/encoding/protowire
+ google.golang.org/protobuf/internal/descfmt
+ google.golang.org/protobuf/internal/descopts
+ google.golang.org/protobuf/internal/detrand
++google.golang.org/protobuf/internal/editiondefaults
+ google.golang.org/protobuf/internal/encoding/defval
+ google.golang.org/protobuf/internal/encoding/json
+ google.golang.org/protobuf/internal/encoding/messageset
+@@ -249,6 +250,7 @@ google.golang.org/protobuf/reflect/protoregistry
+ google.golang.org/protobuf/runtime/protoiface
+ google.golang.org/protobuf/runtime/protoimpl
+ google.golang.org/protobuf/types/descriptorpb
++google.golang.org/protobuf/types/gofeaturespb
+ google.golang.org/protobuf/types/known/anypb
+ google.golang.org/protobuf/types/known/durationpb
+ google.golang.org/protobuf/types/known/timestamppb
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/livenessprobe/1-29/CHECKSUMS
+++ b/projects/kubernetes-csi/livenessprobe/1-29/CHECKSUMS
@@ -1,3 +1,3 @@
-d6969295d34e8eff3c87c9d9ace64f4817b5163a175d8be4384238266757ac28  _output/1-29/bin/livenessprobe/linux-amd64/livenessprobe
-23dd70fa11a9c2e0c83eccd1b4c8eecdf5d7c7ba55f8c50b6a3a88545b2998b6  _output/1-29/bin/livenessprobe/linux-arm64/livenessprobe
-d981c39b4089a15067100c9408f44898dc9d5c332716bd904c29dc44cd019b59  _output/1-29/bin/livenessprobe/windows-amd64/livenessprobe.exe
+f22ddc72b7428124f72945a6a6ffae35f17ecf71ebe35e1cbb356048bf216b20  _output/1-29/bin/livenessprobe/linux-amd64/livenessprobe
+d855e1a5d85f62483f89761693933b4a08cc98aa465248a23b4d98bd0c677885  _output/1-29/bin/livenessprobe/linux-arm64/livenessprobe
+062bdd08c21daf93a62469e7e09a88e4c514082cc9e0baa7de260ff1ee4d09eb  _output/1-29/bin/livenessprobe/windows-amd64/livenessprobe.exe

--- a/projects/kubernetes-csi/livenessprobe/1-29/patches/0001-Bump-protobuf-to-resolve-CVE-2024-24786-for-Liveness.patch
+++ b/projects/kubernetes-csi/livenessprobe/1-29/patches/0001-Bump-protobuf-to-resolve-CVE-2024-24786-for-Liveness.patch
@@ -1,0 +1,8141 @@
+From 787b5e4818b71783774e36f358a57150abad5983 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Mon, 18 Mar 2024 17:37:01 +0000
+Subject: [PATCH] Bump protobuf to resolve CVE-2024-24786 for Liveness-Probe
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |    4 +-
+ go.sum                                        |   12 +-
+ .../golang/protobuf/jsonpb/decode.go          |    1 +
+ .../golang/protobuf/jsonpb/encode.go          |    1 +
+ .../protoc-gen-go/descriptor/descriptor.pb.go |  128 +-
+ .../github.com/golang/protobuf/ptypes/any.go  |    7 +-
+ .../protobuf/encoding/protojson/decode.go     |   38 +-
+ .../protobuf/encoding/protojson/doc.go        |    2 +-
+ .../protobuf/encoding/protojson/encode.go     |   39 +-
+ .../encoding/protojson/well_known_types.go    |   59 +-
+ .../protobuf/encoding/prototext/decode.go     |    8 +-
+ .../protobuf/encoding/prototext/encode.go     |    4 +-
+ .../protobuf/encoding/protowire/wire.go       |   28 +-
+ .../protobuf/internal/descfmt/stringer.go     |  183 +-
+ .../internal/editiondefaults/defaults.go      |   12 +
+ .../editiondefaults/editions_defaults.binpb   |    4 +
+ .../protobuf/internal/encoding/json/decode.go |    2 +-
+ .../protobuf/internal/filedesc/desc.go        |  102 +-
+ .../protobuf/internal/filedesc/desc_init.go   |   52 +
+ .../protobuf/internal/filedesc/desc_lazy.go   |   28 +
+ .../protobuf/internal/filedesc/editions.go    |  142 +
+ .../protobuf/internal/genid/descriptor_gen.go |  364 ++-
+ .../internal/genid/go_features_gen.go         |   31 +
+ .../protobuf/internal/genid/struct_gen.go     |    5 +
+ .../protobuf/internal/genid/type_gen.go       |   38 +
+ .../protobuf/internal/impl/codec_extension.go |   22 +-
+ .../protobuf/internal/impl/codec_gen.go       |  113 +-
+ .../protobuf/internal/impl/codec_tables.go    |    2 +-
+ .../protobuf/internal/impl/legacy_message.go  |   19 +-
+ .../protobuf/internal/impl/message.go         |   17 +-
+ .../internal/impl/message_reflect_field.go    |    2 +-
+ .../protobuf/internal/impl/pointer_reflect.go |   36 +
+ .../protobuf/internal/impl/pointer_unsafe.go  |   40 +
+ .../protobuf/internal/strs/strings.go         |    2 +-
+ ...ings_unsafe.go => strings_unsafe_go120.go} |    4 +-
+ .../internal/strs/strings_unsafe_go121.go     |   74 +
+ .../protobuf/internal/version/version.go      |    2 +-
+ .../protobuf/proto/decode.go                  |    2 +-
+ .../google.golang.org/protobuf/proto/doc.go   |   58 +-
+ .../protobuf/proto/encode.go                  |    2 +-
+ .../protobuf/proto/extension.go               |    2 +-
+ .../google.golang.org/protobuf/proto/merge.go |    2 +-
+ .../google.golang.org/protobuf/proto/proto.go |   18 +-
+ .../protobuf/reflect/protodesc/desc.go        |   29 +-
+ .../protobuf/reflect/protodesc/desc_init.go   |   56 +
+ .../reflect/protodesc/desc_resolve.go         |    4 +-
+ .../reflect/protodesc/desc_validate.go        |    6 +-
+ .../protobuf/reflect/protodesc/editions.go    |  148 +
+ .../protobuf/reflect/protodesc/proto.go       |   18 +-
+ .../protobuf/reflect/protoreflect/proto.go    |   85 +-
+ .../reflect/protoreflect/source_gen.go        |   64 +-
+ .../protobuf/reflect/protoreflect/type.go     |   44 +-
+ .../protobuf/reflect/protoreflect/value.go    |   24 +-
+ .../reflect/protoreflect/value_equal.go       |    8 +-
+ .../reflect/protoreflect/value_union.go       |   44 +-
+ ...{value_unsafe.go => value_unsafe_go120.go} |    4 +-
+ .../protoreflect/value_unsafe_go121.go        |   87 +
+ .../reflect/protoregistry/registry.go         |   24 +-
+ .../types/descriptorpb/descriptor.pb.go       | 2475 ++++++++++++-----
+ .../types/gofeaturespb/go_features.pb.go      |  177 ++
+ .../types/gofeaturespb/go_features.proto      |   28 +
+ .../protobuf/types/known/anypb/any.pb.go      |    3 +-
+ vendor/modules.txt                            |   10 +-
+ 63 files changed, 3921 insertions(+), 1128 deletions(-)
+ create mode 100644 vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+ create mode 100644 vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+ create mode 100644 vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+ create mode 100644 vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+ rename vendor/google.golang.org/protobuf/internal/strs/{strings_unsafe.go => strings_unsafe_go120.go} (96%)
+ create mode 100644 vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+ create mode 100644 vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+ rename vendor/google.golang.org/protobuf/reflect/protoreflect/{value_unsafe.go => value_unsafe_go120.go} (97%)
+ create mode 100644 vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+ create mode 100644 vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+ create mode 100644 vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+
+diff --git a/go.mod b/go.mod
+index 66f1999..1e1128d 100644
+--- a/go.mod
++++ b/go.mod
+@@ -19,7 +19,7 @@ require (
+ 	github.com/go-logr/stdr v1.2.2 // indirect
+ 	github.com/go-logr/zapr v1.2.3 // indirect
+ 	github.com/gogo/protobuf v1.3.2 // indirect
+-	github.com/golang/protobuf v1.5.3 // indirect
++	github.com/golang/protobuf v1.5.4 // indirect
+ 	github.com/google/go-cmp v0.6.0 // indirect
+ 	github.com/google/gofuzz v1.2.0 // indirect
+ 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+@@ -46,7 +46,7 @@ require (
+ 	golang.org/x/text v0.14.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
+ 	google.golang.org/grpc v1.60.1 // indirect
+-	google.golang.org/protobuf v1.31.0 // indirect
++	google.golang.org/protobuf v1.33.0 // indirect
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+ 	gopkg.in/yaml.v2 v2.4.0 // indirect
+ 	k8s.io/apimachinery v0.29.0 // indirect
+diff --git a/go.sum b/go.sum
+index 37e6f06..8d87ecd 100644
+--- a/go.sum
++++ b/go.sum
+@@ -33,10 +33,8 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
+ github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+ github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
++github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
++github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+@@ -169,10 +167,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 h1:
+ google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17/go.mod h1:oQ5rr10WTTMvP4A36n8JpR1OrO1BEiV4f78CneXZxkA=
+ google.golang.org/grpc v1.60.1 h1:26+wFr+cNqSGFcOXcabYC0lUVJVRa2Sb2ortSK7VrEU=
+ google.golang.org/grpc v1.60.1/go.mod h1:OlCHIeLYqSSsLi6i49B5QGdzaMZK9+M7LXN2FKz4eGM=
+-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
++google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
++google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+diff --git a/vendor/github.com/golang/protobuf/jsonpb/decode.go b/vendor/github.com/golang/protobuf/jsonpb/decode.go
+index 6c16c25..c6f66f1 100644
+--- a/vendor/github.com/golang/protobuf/jsonpb/decode.go
++++ b/vendor/github.com/golang/protobuf/jsonpb/decode.go
+@@ -56,6 +56,7 @@ type Unmarshaler struct {
+ // implement JSONPBMarshaler so that the custom format can be produced.
+ //
+ // The JSON unmarshaling must follow the JSON to proto specification:
++//
+ //	https://developers.google.com/protocol-buffers/docs/proto3#json
+ //
+ // Deprecated: Custom types should implement protobuf reflection instead.
+diff --git a/vendor/github.com/golang/protobuf/jsonpb/encode.go b/vendor/github.com/golang/protobuf/jsonpb/encode.go
+index 685c80a..e9438a9 100644
+--- a/vendor/github.com/golang/protobuf/jsonpb/encode.go
++++ b/vendor/github.com/golang/protobuf/jsonpb/encode.go
+@@ -55,6 +55,7 @@ type Marshaler struct {
+ // implement JSONPBUnmarshaler so that the custom format can be parsed.
+ //
+ // The JSON marshaling must follow the proto to JSON specification:
++//
+ //	https://developers.google.com/protocol-buffers/docs/proto3#json
+ //
+ // Deprecated: Custom types should implement protobuf reflection instead.
+diff --git a/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go b/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
+index 63dc057..a5a1386 100644
+--- a/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
++++ b/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
+@@ -12,6 +12,31 @@ import (
+ 
+ // Symbols defined in public import of google/protobuf/descriptor.proto.
+ 
++type Edition = descriptorpb.Edition
++
++const Edition_EDITION_UNKNOWN = descriptorpb.Edition_EDITION_UNKNOWN
++const Edition_EDITION_PROTO2 = descriptorpb.Edition_EDITION_PROTO2
++const Edition_EDITION_PROTO3 = descriptorpb.Edition_EDITION_PROTO3
++const Edition_EDITION_2023 = descriptorpb.Edition_EDITION_2023
++const Edition_EDITION_2024 = descriptorpb.Edition_EDITION_2024
++const Edition_EDITION_1_TEST_ONLY = descriptorpb.Edition_EDITION_1_TEST_ONLY
++const Edition_EDITION_2_TEST_ONLY = descriptorpb.Edition_EDITION_2_TEST_ONLY
++const Edition_EDITION_99997_TEST_ONLY = descriptorpb.Edition_EDITION_99997_TEST_ONLY
++const Edition_EDITION_99998_TEST_ONLY = descriptorpb.Edition_EDITION_99998_TEST_ONLY
++const Edition_EDITION_99999_TEST_ONLY = descriptorpb.Edition_EDITION_99999_TEST_ONLY
++const Edition_EDITION_MAX = descriptorpb.Edition_EDITION_MAX
++
++var Edition_name = descriptorpb.Edition_name
++var Edition_value = descriptorpb.Edition_value
++
++type ExtensionRangeOptions_VerificationState = descriptorpb.ExtensionRangeOptions_VerificationState
++
++const ExtensionRangeOptions_DECLARATION = descriptorpb.ExtensionRangeOptions_DECLARATION
++const ExtensionRangeOptions_UNVERIFIED = descriptorpb.ExtensionRangeOptions_UNVERIFIED
++
++var ExtensionRangeOptions_VerificationState_name = descriptorpb.ExtensionRangeOptions_VerificationState_name
++var ExtensionRangeOptions_VerificationState_value = descriptorpb.ExtensionRangeOptions_VerificationState_value
++
+ type FieldDescriptorProto_Type = descriptorpb.FieldDescriptorProto_Type
+ 
+ const FieldDescriptorProto_TYPE_DOUBLE = descriptorpb.FieldDescriptorProto_TYPE_DOUBLE
+@@ -39,8 +64,8 @@ var FieldDescriptorProto_Type_value = descriptorpb.FieldDescriptorProto_Type_val
+ type FieldDescriptorProto_Label = descriptorpb.FieldDescriptorProto_Label
+ 
+ const FieldDescriptorProto_LABEL_OPTIONAL = descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL
+-const FieldDescriptorProto_LABEL_REQUIRED = descriptorpb.FieldDescriptorProto_LABEL_REQUIRED
+ const FieldDescriptorProto_LABEL_REPEATED = descriptorpb.FieldDescriptorProto_LABEL_REPEATED
++const FieldDescriptorProto_LABEL_REQUIRED = descriptorpb.FieldDescriptorProto_LABEL_REQUIRED
+ 
+ var FieldDescriptorProto_Label_name = descriptorpb.FieldDescriptorProto_Label_name
+ var FieldDescriptorProto_Label_value = descriptorpb.FieldDescriptorProto_Label_value
+@@ -72,6 +97,31 @@ const FieldOptions_JS_NUMBER = descriptorpb.FieldOptions_JS_NUMBER
+ var FieldOptions_JSType_name = descriptorpb.FieldOptions_JSType_name
+ var FieldOptions_JSType_value = descriptorpb.FieldOptions_JSType_value
+ 
++type FieldOptions_OptionRetention = descriptorpb.FieldOptions_OptionRetention
++
++const FieldOptions_RETENTION_UNKNOWN = descriptorpb.FieldOptions_RETENTION_UNKNOWN
++const FieldOptions_RETENTION_RUNTIME = descriptorpb.FieldOptions_RETENTION_RUNTIME
++const FieldOptions_RETENTION_SOURCE = descriptorpb.FieldOptions_RETENTION_SOURCE
++
++var FieldOptions_OptionRetention_name = descriptorpb.FieldOptions_OptionRetention_name
++var FieldOptions_OptionRetention_value = descriptorpb.FieldOptions_OptionRetention_value
++
++type FieldOptions_OptionTargetType = descriptorpb.FieldOptions_OptionTargetType
++
++const FieldOptions_TARGET_TYPE_UNKNOWN = descriptorpb.FieldOptions_TARGET_TYPE_UNKNOWN
++const FieldOptions_TARGET_TYPE_FILE = descriptorpb.FieldOptions_TARGET_TYPE_FILE
++const FieldOptions_TARGET_TYPE_EXTENSION_RANGE = descriptorpb.FieldOptions_TARGET_TYPE_EXTENSION_RANGE
++const FieldOptions_TARGET_TYPE_MESSAGE = descriptorpb.FieldOptions_TARGET_TYPE_MESSAGE
++const FieldOptions_TARGET_TYPE_FIELD = descriptorpb.FieldOptions_TARGET_TYPE_FIELD
++const FieldOptions_TARGET_TYPE_ONEOF = descriptorpb.FieldOptions_TARGET_TYPE_ONEOF
++const FieldOptions_TARGET_TYPE_ENUM = descriptorpb.FieldOptions_TARGET_TYPE_ENUM
++const FieldOptions_TARGET_TYPE_ENUM_ENTRY = descriptorpb.FieldOptions_TARGET_TYPE_ENUM_ENTRY
++const FieldOptions_TARGET_TYPE_SERVICE = descriptorpb.FieldOptions_TARGET_TYPE_SERVICE
++const FieldOptions_TARGET_TYPE_METHOD = descriptorpb.FieldOptions_TARGET_TYPE_METHOD
++
++var FieldOptions_OptionTargetType_name = descriptorpb.FieldOptions_OptionTargetType_name
++var FieldOptions_OptionTargetType_value = descriptorpb.FieldOptions_OptionTargetType_value
++
+ type MethodOptions_IdempotencyLevel = descriptorpb.MethodOptions_IdempotencyLevel
+ 
+ const MethodOptions_IDEMPOTENCY_UNKNOWN = descriptorpb.MethodOptions_IDEMPOTENCY_UNKNOWN
+@@ -81,10 +131,77 @@ const MethodOptions_IDEMPOTENT = descriptorpb.MethodOptions_IDEMPOTENT
+ var MethodOptions_IdempotencyLevel_name = descriptorpb.MethodOptions_IdempotencyLevel_name
+ var MethodOptions_IdempotencyLevel_value = descriptorpb.MethodOptions_IdempotencyLevel_value
+ 
++type FeatureSet_FieldPresence = descriptorpb.FeatureSet_FieldPresence
++
++const FeatureSet_FIELD_PRESENCE_UNKNOWN = descriptorpb.FeatureSet_FIELD_PRESENCE_UNKNOWN
++const FeatureSet_EXPLICIT = descriptorpb.FeatureSet_EXPLICIT
++const FeatureSet_IMPLICIT = descriptorpb.FeatureSet_IMPLICIT
++const FeatureSet_LEGACY_REQUIRED = descriptorpb.FeatureSet_LEGACY_REQUIRED
++
++var FeatureSet_FieldPresence_name = descriptorpb.FeatureSet_FieldPresence_name
++var FeatureSet_FieldPresence_value = descriptorpb.FeatureSet_FieldPresence_value
++
++type FeatureSet_EnumType = descriptorpb.FeatureSet_EnumType
++
++const FeatureSet_ENUM_TYPE_UNKNOWN = descriptorpb.FeatureSet_ENUM_TYPE_UNKNOWN
++const FeatureSet_OPEN = descriptorpb.FeatureSet_OPEN
++const FeatureSet_CLOSED = descriptorpb.FeatureSet_CLOSED
++
++var FeatureSet_EnumType_name = descriptorpb.FeatureSet_EnumType_name
++var FeatureSet_EnumType_value = descriptorpb.FeatureSet_EnumType_value
++
++type FeatureSet_RepeatedFieldEncoding = descriptorpb.FeatureSet_RepeatedFieldEncoding
++
++const FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN = descriptorpb.FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN
++const FeatureSet_PACKED = descriptorpb.FeatureSet_PACKED
++const FeatureSet_EXPANDED = descriptorpb.FeatureSet_EXPANDED
++
++var FeatureSet_RepeatedFieldEncoding_name = descriptorpb.FeatureSet_RepeatedFieldEncoding_name
++var FeatureSet_RepeatedFieldEncoding_value = descriptorpb.FeatureSet_RepeatedFieldEncoding_value
++
++type FeatureSet_Utf8Validation = descriptorpb.FeatureSet_Utf8Validation
++
++const FeatureSet_UTF8_VALIDATION_UNKNOWN = descriptorpb.FeatureSet_UTF8_VALIDATION_UNKNOWN
++const FeatureSet_VERIFY = descriptorpb.FeatureSet_VERIFY
++const FeatureSet_NONE = descriptorpb.FeatureSet_NONE
++
++var FeatureSet_Utf8Validation_name = descriptorpb.FeatureSet_Utf8Validation_name
++var FeatureSet_Utf8Validation_value = descriptorpb.FeatureSet_Utf8Validation_value
++
++type FeatureSet_MessageEncoding = descriptorpb.FeatureSet_MessageEncoding
++
++const FeatureSet_MESSAGE_ENCODING_UNKNOWN = descriptorpb.FeatureSet_MESSAGE_ENCODING_UNKNOWN
++const FeatureSet_LENGTH_PREFIXED = descriptorpb.FeatureSet_LENGTH_PREFIXED
++const FeatureSet_DELIMITED = descriptorpb.FeatureSet_DELIMITED
++
++var FeatureSet_MessageEncoding_name = descriptorpb.FeatureSet_MessageEncoding_name
++var FeatureSet_MessageEncoding_value = descriptorpb.FeatureSet_MessageEncoding_value
++
++type FeatureSet_JsonFormat = descriptorpb.FeatureSet_JsonFormat
++
++const FeatureSet_JSON_FORMAT_UNKNOWN = descriptorpb.FeatureSet_JSON_FORMAT_UNKNOWN
++const FeatureSet_ALLOW = descriptorpb.FeatureSet_ALLOW
++const FeatureSet_LEGACY_BEST_EFFORT = descriptorpb.FeatureSet_LEGACY_BEST_EFFORT
++
++var FeatureSet_JsonFormat_name = descriptorpb.FeatureSet_JsonFormat_name
++var FeatureSet_JsonFormat_value = descriptorpb.FeatureSet_JsonFormat_value
++
++type GeneratedCodeInfo_Annotation_Semantic = descriptorpb.GeneratedCodeInfo_Annotation_Semantic
++
++const GeneratedCodeInfo_Annotation_NONE = descriptorpb.GeneratedCodeInfo_Annotation_NONE
++const GeneratedCodeInfo_Annotation_SET = descriptorpb.GeneratedCodeInfo_Annotation_SET
++const GeneratedCodeInfo_Annotation_ALIAS = descriptorpb.GeneratedCodeInfo_Annotation_ALIAS
++
++var GeneratedCodeInfo_Annotation_Semantic_name = descriptorpb.GeneratedCodeInfo_Annotation_Semantic_name
++var GeneratedCodeInfo_Annotation_Semantic_value = descriptorpb.GeneratedCodeInfo_Annotation_Semantic_value
++
+ type FileDescriptorSet = descriptorpb.FileDescriptorSet
+ type FileDescriptorProto = descriptorpb.FileDescriptorProto
+ type DescriptorProto = descriptorpb.DescriptorProto
+ type ExtensionRangeOptions = descriptorpb.ExtensionRangeOptions
++
++const Default_ExtensionRangeOptions_Verification = descriptorpb.Default_ExtensionRangeOptions_Verification
++
+ type FieldDescriptorProto = descriptorpb.FieldDescriptorProto
+ type OneofDescriptorProto = descriptorpb.OneofDescriptorProto
+ type EnumDescriptorProto = descriptorpb.EnumDescriptorProto
+@@ -103,7 +220,6 @@ const Default_FileOptions_OptimizeFor = descriptorpb.Default_FileOptions_Optimiz
+ const Default_FileOptions_CcGenericServices = descriptorpb.Default_FileOptions_CcGenericServices
+ const Default_FileOptions_JavaGenericServices = descriptorpb.Default_FileOptions_JavaGenericServices
+ const Default_FileOptions_PyGenericServices = descriptorpb.Default_FileOptions_PyGenericServices
+-const Default_FileOptions_PhpGenericServices = descriptorpb.Default_FileOptions_PhpGenericServices
+ const Default_FileOptions_Deprecated = descriptorpb.Default_FileOptions_Deprecated
+ const Default_FileOptions_CcEnableArenas = descriptorpb.Default_FileOptions_CcEnableArenas
+ 
+@@ -118,8 +234,10 @@ type FieldOptions = descriptorpb.FieldOptions
+ const Default_FieldOptions_Ctype = descriptorpb.Default_FieldOptions_Ctype
+ const Default_FieldOptions_Jstype = descriptorpb.Default_FieldOptions_Jstype
+ const Default_FieldOptions_Lazy = descriptorpb.Default_FieldOptions_Lazy
++const Default_FieldOptions_UnverifiedLazy = descriptorpb.Default_FieldOptions_UnverifiedLazy
+ const Default_FieldOptions_Deprecated = descriptorpb.Default_FieldOptions_Deprecated
+ const Default_FieldOptions_Weak = descriptorpb.Default_FieldOptions_Weak
++const Default_FieldOptions_DebugRedact = descriptorpb.Default_FieldOptions_DebugRedact
+ 
+ type OneofOptions = descriptorpb.OneofOptions
+ type EnumOptions = descriptorpb.EnumOptions
+@@ -129,6 +247,7 @@ const Default_EnumOptions_Deprecated = descriptorpb.Default_EnumOptions_Deprecat
+ type EnumValueOptions = descriptorpb.EnumValueOptions
+ 
+ const Default_EnumValueOptions_Deprecated = descriptorpb.Default_EnumValueOptions_Deprecated
++const Default_EnumValueOptions_DebugRedact = descriptorpb.Default_EnumValueOptions_DebugRedact
+ 
+ type ServiceOptions = descriptorpb.ServiceOptions
+ 
+@@ -140,12 +259,17 @@ const Default_MethodOptions_Deprecated = descriptorpb.Default_MethodOptions_Depr
+ const Default_MethodOptions_IdempotencyLevel = descriptorpb.Default_MethodOptions_IdempotencyLevel
+ 
+ type UninterpretedOption = descriptorpb.UninterpretedOption
++type FeatureSet = descriptorpb.FeatureSet
++type FeatureSetDefaults = descriptorpb.FeatureSetDefaults
+ type SourceCodeInfo = descriptorpb.SourceCodeInfo
+ type GeneratedCodeInfo = descriptorpb.GeneratedCodeInfo
+ type DescriptorProto_ExtensionRange = descriptorpb.DescriptorProto_ExtensionRange
+ type DescriptorProto_ReservedRange = descriptorpb.DescriptorProto_ReservedRange
++type ExtensionRangeOptions_Declaration = descriptorpb.ExtensionRangeOptions_Declaration
+ type EnumDescriptorProto_EnumReservedRange = descriptorpb.EnumDescriptorProto_EnumReservedRange
++type FieldOptions_EditionDefault = descriptorpb.FieldOptions_EditionDefault
+ type UninterpretedOption_NamePart = descriptorpb.UninterpretedOption_NamePart
++type FeatureSetDefaults_FeatureSetEditionDefault = descriptorpb.FeatureSetDefaults_FeatureSetEditionDefault
+ type SourceCodeInfo_Location = descriptorpb.SourceCodeInfo_Location
+ type GeneratedCodeInfo_Annotation = descriptorpb.GeneratedCodeInfo_Annotation
+ 
+diff --git a/vendor/github.com/golang/protobuf/ptypes/any.go b/vendor/github.com/golang/protobuf/ptypes/any.go
+index 85f9f57..fdff3fd 100644
+--- a/vendor/github.com/golang/protobuf/ptypes/any.go
++++ b/vendor/github.com/golang/protobuf/ptypes/any.go
+@@ -127,9 +127,10 @@ func Is(any *anypb.Any, m proto.Message) bool {
+ // The allocated message is stored in the embedded proto.Message.
+ //
+ // Example:
+-//   var x ptypes.DynamicAny
+-//   if err := ptypes.UnmarshalAny(a, &x); err != nil { ... }
+-//   fmt.Printf("unmarshaled message: %v", x.Message)
++//
++//	var x ptypes.DynamicAny
++//	if err := ptypes.UnmarshalAny(a, &x); err != nil { ... }
++//	fmt.Printf("unmarshaled message: %v", x.Message)
+ //
+ // Deprecated: Use the any.UnmarshalNew method instead to unmarshal
+ // the any message contents into a new instance of the underlying message.
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/decode.go b/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
+index 5f28148..f479023 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/decode.go
+@@ -11,6 +11,7 @@ import (
+ 	"strconv"
+ 	"strings"
+ 
++	"google.golang.org/protobuf/encoding/protowire"
+ 	"google.golang.org/protobuf/internal/encoding/json"
+ 	"google.golang.org/protobuf/internal/encoding/messageset"
+ 	"google.golang.org/protobuf/internal/errors"
+@@ -23,7 +24,7 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
+-// Unmarshal reads the given []byte into the given proto.Message.
++// Unmarshal reads the given []byte into the given [proto.Message].
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func Unmarshal(b []byte, m proto.Message) error {
+ 	return UnmarshalOptions{}.Unmarshal(b, m)
+@@ -37,7 +38,7 @@ type UnmarshalOptions struct {
+ 	// required fields will not return an error.
+ 	AllowPartial bool
+ 
+-	// If DiscardUnknown is set, unknown fields are ignored.
++	// If DiscardUnknown is set, unknown fields and enum name values are ignored.
+ 	DiscardUnknown bool
+ 
+ 	// Resolver is used for looking up types when unmarshaling
+@@ -47,9 +48,13 @@ type UnmarshalOptions struct {
+ 		protoregistry.MessageTypeResolver
+ 		protoregistry.ExtensionTypeResolver
+ 	}
++
++	// RecursionLimit limits how deeply messages may be nested.
++	// If zero, a default limit is applied.
++	RecursionLimit int
+ }
+ 
+-// Unmarshal reads the given []byte and populates the given proto.Message
++// Unmarshal reads the given []byte and populates the given [proto.Message]
+ // using options in the UnmarshalOptions object.
+ // It will clear the message first before setting the fields.
+ // If it returns an error, the given message may be partially set.
+@@ -67,6 +72,9 @@ func (o UnmarshalOptions) unmarshal(b []byte, m proto.Message) error {
+ 	if o.Resolver == nil {
+ 		o.Resolver = protoregistry.GlobalTypes
+ 	}
++	if o.RecursionLimit == 0 {
++		o.RecursionLimit = protowire.DefaultRecursionLimit
++	}
+ 
+ 	dec := decoder{json.NewDecoder(b), o}
+ 	if err := dec.unmarshalMessage(m.ProtoReflect(), false); err != nil {
+@@ -114,6 +122,10 @@ func (d decoder) syntaxError(pos int, f string, x ...interface{}) error {
+ 
+ // unmarshalMessage unmarshals a message into the given protoreflect.Message.
+ func (d decoder) unmarshalMessage(m protoreflect.Message, skipTypeURL bool) error {
++	d.opts.RecursionLimit--
++	if d.opts.RecursionLimit < 0 {
++		return errors.New("exceeded max recursion depth")
++	}
+ 	if unmarshal := wellKnownTypeUnmarshaler(m.Descriptor().FullName()); unmarshal != nil {
+ 		return unmarshal(d, m)
+ 	}
+@@ -266,7 +278,9 @@ func (d decoder) unmarshalSingular(m protoreflect.Message, fd protoreflect.Field
+ 	if err != nil {
+ 		return err
+ 	}
+-	m.Set(fd, val)
++	if val.IsValid() {
++		m.Set(fd, val)
++	}
+ 	return nil
+ }
+ 
+@@ -329,7 +343,7 @@ func (d decoder) unmarshalScalar(fd protoreflect.FieldDescriptor) (protoreflect.
+ 		}
+ 
+ 	case protoreflect.EnumKind:
+-		if v, ok := unmarshalEnum(tok, fd); ok {
++		if v, ok := unmarshalEnum(tok, fd, d.opts.DiscardUnknown); ok {
+ 			return v, nil
+ 		}
+ 
+@@ -474,7 +488,7 @@ func unmarshalBytes(tok json.Token) (protoreflect.Value, bool) {
+ 	return protoreflect.ValueOfBytes(b), true
+ }
+ 
+-func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor) (protoreflect.Value, bool) {
++func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor, discardUnknown bool) (protoreflect.Value, bool) {
+ 	switch tok.Kind() {
+ 	case json.String:
+ 		// Lookup EnumNumber based on name.
+@@ -482,6 +496,9 @@ func unmarshalEnum(tok json.Token, fd protoreflect.FieldDescriptor) (protoreflec
+ 		if enumVal := fd.Enum().Values().ByName(protoreflect.Name(s)); enumVal != nil {
+ 			return protoreflect.ValueOfEnum(enumVal.Number()), true
+ 		}
++		if discardUnknown {
++			return protoreflect.Value{}, true
++		}
+ 
+ 	case json.Number:
+ 		if n, ok := tok.Int(32); ok {
+@@ -542,7 +559,9 @@ func (d decoder) unmarshalList(list protoreflect.List, fd protoreflect.FieldDesc
+ 			if err != nil {
+ 				return err
+ 			}
+-			list.Append(val)
++			if val.IsValid() {
++				list.Append(val)
++			}
+ 		}
+ 	}
+ 
+@@ -609,8 +628,9 @@ Loop:
+ 		if err != nil {
+ 			return err
+ 		}
+-
+-		mmap.Set(pkey, pval)
++		if pval.IsValid() {
++			mmap.Set(pkey, pval)
++		}
+ 	}
+ 
+ 	return nil
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/doc.go b/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
+index 21d5d2c..ae71007 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/doc.go
+@@ -6,6 +6,6 @@
+ // format. It follows the guide at
+ // https://protobuf.dev/programming-guides/proto3#json.
+ //
+-// This package produces a different output than the standard "encoding/json"
++// This package produces a different output than the standard [encoding/json]
+ // package, which does not operate correctly on protocol buffer messages.
+ package protojson
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/encode.go b/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
+index 66b9587..3f75098 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/encode.go
+@@ -31,7 +31,7 @@ func Format(m proto.Message) string {
+ 	return MarshalOptions{Multiline: true}.Format(m)
+ }
+ 
+-// Marshal writes the given proto.Message in JSON format using default options.
++// Marshal writes the given [proto.Message] in JSON format using default options.
+ // Do not depend on the output being stable. It may change over time across
+ // different versions of the program.
+ func Marshal(m proto.Message) ([]byte, error) {
+@@ -81,6 +81,25 @@ type MarshalOptions struct {
+ 	//  ╚═══════╧════════════════════════════╝
+ 	EmitUnpopulated bool
+ 
++	// EmitDefaultValues specifies whether to emit default-valued primitive fields,
++	// empty lists, and empty maps. The fields affected are as follows:
++	//  ╔═══════╤════════════════════════════════════════╗
++	//  ║ JSON  │ Protobuf field                         ║
++	//  ╠═══════╪════════════════════════════════════════╣
++	//  ║ false │ non-optional scalar boolean fields     ║
++	//  ║ 0     │ non-optional scalar numeric fields     ║
++	//  ║ ""    │ non-optional scalar string/byte fields ║
++	//  ║ []    │ empty repeated fields                  ║
++	//  ║ {}    │ empty map fields                       ║
++	//  ╚═══════╧════════════════════════════════════════╝
++	//
++	// Behaves similarly to EmitUnpopulated, but does not emit "null"-value fields,
++	// i.e. presence-sensing fields that are omitted will remain omitted to preserve
++	// presence-sensing.
++	// EmitUnpopulated takes precedence over EmitDefaultValues since the former generates
++	// a strict superset of the latter.
++	EmitDefaultValues bool
++
+ 	// Resolver is used for looking up types when expanding google.protobuf.Any
+ 	// messages. If nil, this defaults to using protoregistry.GlobalTypes.
+ 	Resolver interface {
+@@ -102,7 +121,7 @@ func (o MarshalOptions) Format(m proto.Message) string {
+ 	return string(b)
+ }
+ 
+-// Marshal marshals the given proto.Message in the JSON format using options in
++// Marshal marshals the given [proto.Message] in the JSON format using options in
+ // MarshalOptions. Do not depend on the output being stable. It may change over
+ // time across different versions of the program.
+ func (o MarshalOptions) Marshal(m proto.Message) ([]byte, error) {
+@@ -178,7 +197,11 @@ func (m typeURLFieldRanger) Range(f func(protoreflect.FieldDescriptor, protorefl
+ 
+ // unpopulatedFieldRanger wraps a protoreflect.Message and modifies its Range
+ // method to additionally iterate over unpopulated fields.
+-type unpopulatedFieldRanger struct{ protoreflect.Message }
++type unpopulatedFieldRanger struct {
++	protoreflect.Message
++
++	skipNull bool
++}
+ 
+ func (m unpopulatedFieldRanger) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+ 	fds := m.Descriptor().Fields()
+@@ -192,6 +215,9 @@ func (m unpopulatedFieldRanger) Range(f func(protoreflect.FieldDescriptor, proto
+ 		isProto2Scalar := fd.Syntax() == protoreflect.Proto2 && fd.Default().IsValid()
+ 		isSingularMessage := fd.Cardinality() != protoreflect.Repeated && fd.Message() != nil
+ 		if isProto2Scalar || isSingularMessage {
++			if m.skipNull {
++				continue
++			}
+ 			v = protoreflect.Value{} // use invalid value to emit null
+ 		}
+ 		if !f(fd, v) {
+@@ -217,8 +243,11 @@ func (e encoder) marshalMessage(m protoreflect.Message, typeURL string) error {
+ 	defer e.EndObject()
+ 
+ 	var fields order.FieldRanger = m
+-	if e.opts.EmitUnpopulated {
+-		fields = unpopulatedFieldRanger{m}
++	switch {
++	case e.opts.EmitUnpopulated:
++		fields = unpopulatedFieldRanger{Message: m, skipNull: false}
++	case e.opts.EmitDefaultValues:
++		fields = unpopulatedFieldRanger{Message: m, skipNull: true}
+ 	}
+ 	if typeURL != "" {
+ 		fields = typeURLFieldRanger{fields, typeURL}
+diff --git a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+index 6c37d41..4b177c8 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
++++ b/vendor/google.golang.org/protobuf/encoding/protojson/well_known_types.go
+@@ -176,7 +176,7 @@ func (d decoder) unmarshalAny(m protoreflect.Message) error {
+ 	// Use another decoder to parse the unread bytes for @type field. This
+ 	// avoids advancing a read from current decoder because the current JSON
+ 	// object may contain the fields of the embedded type.
+-	dec := decoder{d.Clone(), UnmarshalOptions{}}
++	dec := decoder{d.Clone(), UnmarshalOptions{RecursionLimit: d.opts.RecursionLimit}}
+ 	tok, err := findTypeURL(dec)
+ 	switch err {
+ 	case errEmptyObject:
+@@ -308,48 +308,29 @@ Loop:
+ // array) in order to advance the read to the next JSON value. It relies on
+ // the decoder returning an error if the types are not in valid sequence.
+ func (d decoder) skipJSONValue() error {
+-	tok, err := d.Read()
+-	if err != nil {
+-		return err
+-	}
+-	// Only need to continue reading for objects and arrays.
+-	switch tok.Kind() {
+-	case json.ObjectOpen:
+-		for {
+-			tok, err := d.Read()
+-			if err != nil {
+-				return err
+-			}
+-			switch tok.Kind() {
+-			case json.ObjectClose:
+-				return nil
+-			case json.Name:
+-				// Skip object field value.
+-				if err := d.skipJSONValue(); err != nil {
+-					return err
+-				}
+-			}
++	var open int
++	for {
++		tok, err := d.Read()
++		if err != nil {
++			return err
+ 		}
+-
+-	case json.ArrayOpen:
+-		for {
+-			tok, err := d.Peek()
+-			if err != nil {
+-				return err
+-			}
+-			switch tok.Kind() {
+-			case json.ArrayClose:
+-				d.Read()
+-				return nil
+-			default:
+-				// Skip array item.
+-				if err := d.skipJSONValue(); err != nil {
+-					return err
+-				}
++		switch tok.Kind() {
++		case json.ObjectClose, json.ArrayClose:
++			open--
++		case json.ObjectOpen, json.ArrayOpen:
++			open++
++			if open > d.opts.RecursionLimit {
++				return errors.New("exceeded max recursion depth")
+ 			}
++		case json.EOF:
++			// This can only happen if there's a bug in Decoder.Read.
++			// Avoid an infinite loop if this does happen.
++			return errors.New("unexpected EOF")
++		}
++		if open == 0 {
++			return nil
+ 		}
+ 	}
+-	return nil
+ }
+ 
+ // unmarshalAnyValue unmarshals the given custom-type message from the JSON
+diff --git a/vendor/google.golang.org/protobuf/encoding/prototext/decode.go b/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
+index 4921b2d..a45f112 100644
+--- a/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
++++ b/vendor/google.golang.org/protobuf/encoding/prototext/decode.go
+@@ -21,7 +21,7 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
+-// Unmarshal reads the given []byte into the given proto.Message.
++// Unmarshal reads the given []byte into the given [proto.Message].
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func Unmarshal(b []byte, m proto.Message) error {
+ 	return UnmarshalOptions{}.Unmarshal(b, m)
+@@ -51,7 +51,7 @@ type UnmarshalOptions struct {
+ 	}
+ }
+ 
+-// Unmarshal reads the given []byte and populates the given proto.Message
++// Unmarshal reads the given []byte and populates the given [proto.Message]
+ // using options in the UnmarshalOptions object.
+ // The provided message must be mutable (e.g., a non-nil pointer to a message).
+ func (o UnmarshalOptions) Unmarshal(b []byte, m proto.Message) error {
+@@ -739,7 +739,9 @@ func (d decoder) skipValue() error {
+ 			case text.ListClose:
+ 				return nil
+ 			case text.MessageOpen:
+-				return d.skipMessageValue()
++				if err := d.skipMessageValue(); err != nil {
++					return err
++				}
+ 			default:
+ 				// Skip items. This will not validate whether skipped values are
+ 				// of the same type or not, same behavior as C++
+diff --git a/vendor/google.golang.org/protobuf/encoding/prototext/encode.go b/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
+index 722a7b4..95967e8 100644
+--- a/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
++++ b/vendor/google.golang.org/protobuf/encoding/prototext/encode.go
+@@ -33,7 +33,7 @@ func Format(m proto.Message) string {
+ 	return MarshalOptions{Multiline: true}.Format(m)
+ }
+ 
+-// Marshal writes the given proto.Message in textproto format using default
++// Marshal writes the given [proto.Message] in textproto format using default
+ // options. Do not depend on the output being stable. It may change over time
+ // across different versions of the program.
+ func Marshal(m proto.Message) ([]byte, error) {
+@@ -97,7 +97,7 @@ func (o MarshalOptions) Format(m proto.Message) string {
+ 	return string(b)
+ }
+ 
+-// Marshal writes the given proto.Message in textproto format using options in
++// Marshal writes the given [proto.Message] in textproto format using options in
+ // MarshalOptions object. Do not depend on the output being stable. It may
+ // change over time across different versions of the program.
+ func (o MarshalOptions) Marshal(m proto.Message) ([]byte, error) {
+diff --git a/vendor/google.golang.org/protobuf/encoding/protowire/wire.go b/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
+index f4b4686..e942bc9 100644
+--- a/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
++++ b/vendor/google.golang.org/protobuf/encoding/protowire/wire.go
+@@ -6,7 +6,7 @@
+ // See https://protobuf.dev/programming-guides/encoding.
+ //
+ // For marshaling and unmarshaling entire protobuf messages,
+-// use the "google.golang.org/protobuf/proto" package instead.
++// use the [google.golang.org/protobuf/proto] package instead.
+ package protowire
+ 
+ import (
+@@ -87,7 +87,7 @@ func ParseError(n int) error {
+ 
+ // ConsumeField parses an entire field record (both tag and value) and returns
+ // the field number, the wire type, and the total length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ //
+ // The total length includes the tag header and the end group marker (if the
+ // field is a group).
+@@ -104,8 +104,8 @@ func ConsumeField(b []byte) (Number, Type, int) {
+ }
+ 
+ // ConsumeFieldValue parses a field value and returns its length.
+-// This assumes that the field Number and wire Type have already been parsed.
+-// This returns a negative length upon an error (see ParseError).
++// This assumes that the field [Number] and wire [Type] have already been parsed.
++// This returns a negative length upon an error (see [ParseError]).
+ //
+ // When parsing a group, the length includes the end group marker and
+ // the end group is verified to match the starting field number.
+@@ -164,7 +164,7 @@ func AppendTag(b []byte, num Number, typ Type) []byte {
+ }
+ 
+ // ConsumeTag parses b as a varint-encoded tag, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeTag(b []byte) (Number, Type, int) {
+ 	v, n := ConsumeVarint(b)
+ 	if n < 0 {
+@@ -263,7 +263,7 @@ func AppendVarint(b []byte, v uint64) []byte {
+ }
+ 
+ // ConsumeVarint parses b as a varint-encoded uint64, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeVarint(b []byte) (v uint64, n int) {
+ 	var y uint64
+ 	if len(b) <= 0 {
+@@ -384,7 +384,7 @@ func AppendFixed32(b []byte, v uint32) []byte {
+ }
+ 
+ // ConsumeFixed32 parses b as a little-endian uint32, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeFixed32(b []byte) (v uint32, n int) {
+ 	if len(b) < 4 {
+ 		return 0, errCodeTruncated
+@@ -412,7 +412,7 @@ func AppendFixed64(b []byte, v uint64) []byte {
+ }
+ 
+ // ConsumeFixed64 parses b as a little-endian uint64, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeFixed64(b []byte) (v uint64, n int) {
+ 	if len(b) < 8 {
+ 		return 0, errCodeTruncated
+@@ -432,7 +432,7 @@ func AppendBytes(b []byte, v []byte) []byte {
+ }
+ 
+ // ConsumeBytes parses b as a length-prefixed bytes value, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeBytes(b []byte) (v []byte, n int) {
+ 	m, n := ConsumeVarint(b)
+ 	if n < 0 {
+@@ -456,7 +456,7 @@ func AppendString(b []byte, v string) []byte {
+ }
+ 
+ // ConsumeString parses b as a length-prefixed bytes value, reporting its length.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeString(b []byte) (v string, n int) {
+ 	bb, n := ConsumeBytes(b)
+ 	return string(bb), n
+@@ -471,7 +471,7 @@ func AppendGroup(b []byte, num Number, v []byte) []byte {
+ // ConsumeGroup parses b as a group value until the trailing end group marker,
+ // and verifies that the end marker matches the provided num. The value v
+ // does not contain the end marker, while the length does contain the end marker.
+-// This returns a negative length upon an error (see ParseError).
++// This returns a negative length upon an error (see [ParseError]).
+ func ConsumeGroup(num Number, b []byte) (v []byte, n int) {
+ 	n = ConsumeFieldValue(num, StartGroupType, b)
+ 	if n < 0 {
+@@ -495,8 +495,8 @@ func SizeGroup(num Number, n int) int {
+ 	return n + SizeTag(num)
+ }
+ 
+-// DecodeTag decodes the field Number and wire Type from its unified form.
+-// The Number is -1 if the decoded field number overflows int32.
++// DecodeTag decodes the field [Number] and wire [Type] from its unified form.
++// The [Number] is -1 if the decoded field number overflows int32.
+ // Other than overflow, this does not check for field number validity.
+ func DecodeTag(x uint64) (Number, Type) {
+ 	// NOTE: MessageSet allows for larger field numbers than normal.
+@@ -506,7 +506,7 @@ func DecodeTag(x uint64) (Number, Type) {
+ 	return Number(x >> 3), Type(x & 7)
+ }
+ 
+-// EncodeTag encodes the field Number and wire Type into its unified form.
++// EncodeTag encodes the field [Number] and wire [Type] into its unified form.
+ func EncodeTag(num Number, typ Type) uint64 {
+ 	return uint64(num)<<3 | uint64(typ&7)
+ }
+diff --git a/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go b/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
+index db5248e..a45625c 100644
+--- a/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
++++ b/vendor/google.golang.org/protobuf/internal/descfmt/stringer.go
+@@ -83,7 +83,13 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
+ 	case protoreflect.FileImports:
+ 		for i := 0; i < vs.Len(); i++ {
+ 			var rs records
+-			rs.Append(reflect.ValueOf(vs.Get(i)), "Path", "Package", "IsPublic", "IsWeak")
++			rv := reflect.ValueOf(vs.Get(i))
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("IsPublic"), "IsPublic"},
++				{rv.MethodByName("IsWeak"), "IsWeak"},
++			}...)
+ 			ss = append(ss, "{"+rs.Join()+"}")
+ 		}
+ 		return start + joinStrings(ss, allowMulti) + end
+@@ -92,34 +98,26 @@ func formatListOpt(vs list, isRoot, allowMulti bool) string {
+ 		for i := 0; i < vs.Len(); i++ {
+ 			m := reflect.ValueOf(vs).MethodByName("Get")
+ 			v := m.Call([]reflect.Value{reflect.ValueOf(i)})[0].Interface()
+-			ss = append(ss, formatDescOpt(v.(protoreflect.Descriptor), false, allowMulti && !isEnumValue))
++			ss = append(ss, formatDescOpt(v.(protoreflect.Descriptor), false, allowMulti && !isEnumValue, nil))
+ 		}
+ 		return start + joinStrings(ss, allowMulti && isEnumValue) + end
+ 	}
+ }
+ 
+-// descriptorAccessors is a list of accessors to print for each descriptor.
+-//
+-// Do not print all accessors since some contain redundant information,
+-// while others are pointers that we do not want to follow since the descriptor
+-// is actually a cyclic graph.
+-//
+-// Using a list allows us to print the accessors in a sensible order.
+-var descriptorAccessors = map[reflect.Type][]string{
+-	reflect.TypeOf((*protoreflect.FileDescriptor)(nil)).Elem():      {"Path", "Package", "Imports", "Messages", "Enums", "Extensions", "Services"},
+-	reflect.TypeOf((*protoreflect.MessageDescriptor)(nil)).Elem():   {"IsMapEntry", "Fields", "Oneofs", "ReservedNames", "ReservedRanges", "RequiredNumbers", "ExtensionRanges", "Messages", "Enums", "Extensions"},
+-	reflect.TypeOf((*protoreflect.FieldDescriptor)(nil)).Elem():     {"Number", "Cardinality", "Kind", "HasJSONName", "JSONName", "HasPresence", "IsExtension", "IsPacked", "IsWeak", "IsList", "IsMap", "MapKey", "MapValue", "HasDefault", "Default", "ContainingOneof", "ContainingMessage", "Message", "Enum"},
+-	reflect.TypeOf((*protoreflect.OneofDescriptor)(nil)).Elem():     {"Fields"}, // not directly used; must keep in sync with formatDescOpt
+-	reflect.TypeOf((*protoreflect.EnumDescriptor)(nil)).Elem():      {"Values", "ReservedNames", "ReservedRanges"},
+-	reflect.TypeOf((*protoreflect.EnumValueDescriptor)(nil)).Elem(): {"Number"},
+-	reflect.TypeOf((*protoreflect.ServiceDescriptor)(nil)).Elem():   {"Methods"},
+-	reflect.TypeOf((*protoreflect.MethodDescriptor)(nil)).Elem():    {"Input", "Output", "IsStreamingClient", "IsStreamingServer"},
++type methodAndName struct {
++	method reflect.Value
++	name   string
+ }
+ 
+ func FormatDesc(s fmt.State, r rune, t protoreflect.Descriptor) {
+-	io.WriteString(s, formatDescOpt(t, true, r == 'v' && (s.Flag('+') || s.Flag('#'))))
++	io.WriteString(s, formatDescOpt(t, true, r == 'v' && (s.Flag('+') || s.Flag('#')), nil))
+ }
+-func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
++
++func InternalFormatDescOptForTesting(t protoreflect.Descriptor, isRoot, allowMulti bool, record func(string)) string {
++	return formatDescOpt(t, isRoot, allowMulti, record)
++}
++
++func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool, record func(string)) string {
+ 	rv := reflect.ValueOf(t)
+ 	rt := rv.MethodByName("ProtoType").Type().In(0)
+ 
+@@ -129,26 +127,60 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 	}
+ 
+ 	_, isFile := t.(protoreflect.FileDescriptor)
+-	rs := records{allowMulti: allowMulti}
++	rs := records{
++		allowMulti: allowMulti,
++		record:     record,
++	}
+ 	if t.IsPlaceholder() {
+ 		if isFile {
+-			rs.Append(rv, "Path", "Package", "IsPlaceholder")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
++			}...)
+ 		} else {
+-			rs.Append(rv, "FullName", "IsPlaceholder")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("FullName"), "FullName"},
++				{rv.MethodByName("IsPlaceholder"), "IsPlaceholder"},
++			}...)
+ 		}
+ 	} else {
+ 		switch {
+ 		case isFile:
+-			rs.Append(rv, "Syntax")
++			rs.Append(rv, methodAndName{rv.MethodByName("Syntax"), "Syntax"})
+ 		case isRoot:
+-			rs.Append(rv, "Syntax", "FullName")
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Syntax"), "Syntax"},
++				{rv.MethodByName("FullName"), "FullName"},
++			}...)
+ 		default:
+-			rs.Append(rv, "Name")
++			rs.Append(rv, methodAndName{rv.MethodByName("Name"), "Name"})
+ 		}
+ 		switch t := t.(type) {
+ 		case protoreflect.FieldDescriptor:
+-			for _, s := range descriptorAccessors[rt] {
+-				switch s {
++			accessors := []methodAndName{
++				{rv.MethodByName("Number"), "Number"},
++				{rv.MethodByName("Cardinality"), "Cardinality"},
++				{rv.MethodByName("Kind"), "Kind"},
++				{rv.MethodByName("HasJSONName"), "HasJSONName"},
++				{rv.MethodByName("JSONName"), "JSONName"},
++				{rv.MethodByName("HasPresence"), "HasPresence"},
++				{rv.MethodByName("IsExtension"), "IsExtension"},
++				{rv.MethodByName("IsPacked"), "IsPacked"},
++				{rv.MethodByName("IsWeak"), "IsWeak"},
++				{rv.MethodByName("IsList"), "IsList"},
++				{rv.MethodByName("IsMap"), "IsMap"},
++				{rv.MethodByName("MapKey"), "MapKey"},
++				{rv.MethodByName("MapValue"), "MapValue"},
++				{rv.MethodByName("HasDefault"), "HasDefault"},
++				{rv.MethodByName("Default"), "Default"},
++				{rv.MethodByName("ContainingOneof"), "ContainingOneof"},
++				{rv.MethodByName("ContainingMessage"), "ContainingMessage"},
++				{rv.MethodByName("Message"), "Message"},
++				{rv.MethodByName("Enum"), "Enum"},
++			}
++			for _, s := range accessors {
++				switch s.name {
+ 				case "MapKey":
+ 					if k := t.MapKey(); k != nil {
+ 						rs.recs = append(rs.recs, [2]string{"MapKey", k.Kind().String()})
+@@ -157,20 +189,20 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 					if v := t.MapValue(); v != nil {
+ 						switch v.Kind() {
+ 						case protoreflect.EnumKind:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", string(v.Enum().FullName())})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", string(v.Enum().FullName())})
+ 						case protoreflect.MessageKind, protoreflect.GroupKind:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", string(v.Message().FullName())})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", string(v.Message().FullName())})
+ 						default:
+-							rs.recs = append(rs.recs, [2]string{"MapValue", v.Kind().String()})
++							rs.AppendRecs("MapValue", [2]string{"MapValue", v.Kind().String()})
+ 						}
+ 					}
+ 				case "ContainingOneof":
+ 					if od := t.ContainingOneof(); od != nil {
+-						rs.recs = append(rs.recs, [2]string{"Oneof", string(od.Name())})
++						rs.AppendRecs("ContainingOneof", [2]string{"Oneof", string(od.Name())})
+ 					}
+ 				case "ContainingMessage":
+ 					if t.IsExtension() {
+-						rs.recs = append(rs.recs, [2]string{"Extendee", string(t.ContainingMessage().FullName())})
++						rs.AppendRecs("ContainingMessage", [2]string{"Extendee", string(t.ContainingMessage().FullName())})
+ 					}
+ 				case "Message":
+ 					if !t.IsMap() {
+@@ -187,13 +219,61 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ 				ss = append(ss, string(fs.Get(i).Name()))
+ 			}
+ 			if len(ss) > 0 {
+-				rs.recs = append(rs.recs, [2]string{"Fields", "[" + joinStrings(ss, false) + "]"})
++				rs.AppendRecs("Fields", [2]string{"Fields", "[" + joinStrings(ss, false) + "]"})
+ 			}
+-		default:
+-			rs.Append(rv, descriptorAccessors[rt]...)
++
++		case protoreflect.FileDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Path"), "Path"},
++				{rv.MethodByName("Package"), "Package"},
++				{rv.MethodByName("Imports"), "Imports"},
++				{rv.MethodByName("Messages"), "Messages"},
++				{rv.MethodByName("Enums"), "Enums"},
++				{rv.MethodByName("Extensions"), "Extensions"},
++				{rv.MethodByName("Services"), "Services"},
++			}...)
++
++		case protoreflect.MessageDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("IsMapEntry"), "IsMapEntry"},
++				{rv.MethodByName("Fields"), "Fields"},
++				{rv.MethodByName("Oneofs"), "Oneofs"},
++				{rv.MethodByName("ReservedNames"), "ReservedNames"},
++				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
++				{rv.MethodByName("RequiredNumbers"), "RequiredNumbers"},
++				{rv.MethodByName("ExtensionRanges"), "ExtensionRanges"},
++				{rv.MethodByName("Messages"), "Messages"},
++				{rv.MethodByName("Enums"), "Enums"},
++				{rv.MethodByName("Extensions"), "Extensions"},
++			}...)
++
++		case protoreflect.EnumDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Values"), "Values"},
++				{rv.MethodByName("ReservedNames"), "ReservedNames"},
++				{rv.MethodByName("ReservedRanges"), "ReservedRanges"},
++			}...)
++
++		case protoreflect.EnumValueDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Number"), "Number"},
++			}...)
++
++		case protoreflect.ServiceDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Methods"), "Methods"},
++			}...)
++
++		case protoreflect.MethodDescriptor:
++			rs.Append(rv, []methodAndName{
++				{rv.MethodByName("Input"), "Input"},
++				{rv.MethodByName("Output"), "Output"},
++				{rv.MethodByName("IsStreamingClient"), "IsStreamingClient"},
++				{rv.MethodByName("IsStreamingServer"), "IsStreamingServer"},
++			}...)
+ 		}
+-		if rv.MethodByName("GoType").IsValid() {
+-			rs.Append(rv, "GoType")
++		if m := rv.MethodByName("GoType"); m.IsValid() {
++			rs.Append(rv, methodAndName{m, "GoType"})
+ 		}
+ 	}
+ 	return start + rs.Join() + end
+@@ -202,19 +282,34 @@ func formatDescOpt(t protoreflect.Descriptor, isRoot, allowMulti bool) string {
+ type records struct {
+ 	recs       [][2]string
+ 	allowMulti bool
++
++	// record is a function that will be called for every Append() or
++	// AppendRecs() call, to be used for testing with the
++	// InternalFormatDescOptForTesting function.
++	record func(string)
+ }
+ 
+-func (rs *records) Append(v reflect.Value, accessors ...string) {
++func (rs *records) AppendRecs(fieldName string, newRecs [2]string) {
++	if rs.record != nil {
++		rs.record(fieldName)
++	}
++	rs.recs = append(rs.recs, newRecs)
++}
++
++func (rs *records) Append(v reflect.Value, accessors ...methodAndName) {
+ 	for _, a := range accessors {
++		if rs.record != nil {
++			rs.record(a.name)
++		}
+ 		var rv reflect.Value
+-		if m := v.MethodByName(a); m.IsValid() {
+-			rv = m.Call(nil)[0]
++		if a.method.IsValid() {
++			rv = a.method.Call(nil)[0]
+ 		}
+ 		if v.Kind() == reflect.Struct && !rv.IsValid() {
+-			rv = v.FieldByName(a)
++			rv = v.FieldByName(a.name)
+ 		}
+ 		if !rv.IsValid() {
+-			panic(fmt.Sprintf("unknown accessor: %v.%s", v.Type(), a))
++			panic(fmt.Sprintf("unknown accessor: %v.%s", v.Type(), a.name))
+ 		}
+ 		if _, ok := rv.Interface().(protoreflect.Value); ok {
+ 			rv = rv.MethodByName("Interface").Call(nil)[0]
+@@ -261,7 +356,7 @@ func (rs *records) Append(v reflect.Value, accessors ...string) {
+ 		default:
+ 			s = fmt.Sprint(v)
+ 		}
+-		rs.recs = append(rs.recs, [2]string{a, s})
++		rs.recs = append(rs.recs, [2]string{a.name, s})
+ 	}
+ }
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go b/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+new file mode 100644
+index 0000000..14656b6
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/editiondefaults/defaults.go
+@@ -0,0 +1,12 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Package editiondefaults contains the binary representation of the editions
++// defaults.
++package editiondefaults
++
++import _ "embed"
++
++//go:embed editions_defaults.binpb
++var Defaults []byte
+diff --git a/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb b/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+new file mode 100644
+index 0000000..18f0756
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/editiondefaults/editions_defaults.binpb
+@@ -0,0 +1,4 @@
++
++ (0�
++ (0�
++ (0� �(�
+\ No newline at end of file
+diff --git a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+index d043a6e..d2b3ac0 100644
+--- a/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
++++ b/vendor/google.golang.org/protobuf/internal/encoding/json/decode.go
+@@ -121,7 +121,7 @@ func (d *Decoder) Read() (Token, error) {
+ 
+ 	case ObjectClose:
+ 		if len(d.openStack) == 0 ||
+-			d.lastToken.kind == comma ||
++			d.lastToken.kind&(Name|comma) != 0 ||
+ 			d.openStack[len(d.openStack)-1] != ObjectOpen {
+ 			return Token{}, d.newSyntaxError(tok.pos, unexpectedFmt, tok.RawString())
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+index 7c3689b..8826bcf 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+@@ -21,11 +21,26 @@ import (
+ 	"google.golang.org/protobuf/reflect/protoregistry"
+ )
+ 
++// Edition is an Enum for proto2.Edition
++type Edition int32
++
++// These values align with the value of Enum in descriptor.proto which allows
++// direct conversion between the proto enum and this enum.
++const (
++	EditionUnknown     Edition = 0
++	EditionProto2      Edition = 998
++	EditionProto3      Edition = 999
++	Edition2023        Edition = 1000
++	EditionUnsupported Edition = 100000
++)
++
+ // The types in this file may have a suffix:
+ //	• L0: Contains fields common to all descriptors (except File) and
+ //	must be initialized up front.
+ //	• L1: Contains fields specific to a descriptor and
+-//	must be initialized up front.
++//	must be initialized up front. If the associated proto uses Editions, the
++//  Editions features must always be resolved. If not explicitly set, the
++//  appropriate default must be resolved and set.
+ //	• L2: Contains fields that are lazily initialized when constructing
+ //	from the raw file descriptor. When constructing as a literal, the L2
+ //	fields must be initialized up front.
+@@ -44,6 +59,7 @@ type (
+ 	}
+ 	FileL1 struct {
+ 		Syntax  protoreflect.Syntax
++		Edition Edition // Only used if Syntax == Editions
+ 		Path    string
+ 		Package protoreflect.FullName
+ 
+@@ -51,12 +67,41 @@ type (
+ 		Messages   Messages
+ 		Extensions Extensions
+ 		Services   Services
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	FileL2 struct {
+ 		Options   func() protoreflect.ProtoMessage
+ 		Imports   FileImports
+ 		Locations SourceLocations
+ 	}
++
++	EditionFeatures struct {
++		// IsFieldPresence is true if field_presence is EXPLICIT
++		// https://protobuf.dev/editions/features/#field_presence
++		IsFieldPresence bool
++		// IsFieldPresence is true if field_presence is LEGACY_REQUIRED
++		// https://protobuf.dev/editions/features/#field_presence
++		IsLegacyRequired bool
++		// IsOpenEnum is true if enum_type is OPEN
++		// https://protobuf.dev/editions/features/#enum_type
++		IsOpenEnum bool
++		// IsPacked is true if repeated_field_encoding is PACKED
++		// https://protobuf.dev/editions/features/#repeated_field_encoding
++		IsPacked bool
++		// IsUTF8Validated is true if utf_validation is VERIFY
++		// https://protobuf.dev/editions/features/#utf8_validation
++		IsUTF8Validated bool
++		// IsDelimitedEncoded is true if message_encoding is DELIMITED
++		// https://protobuf.dev/editions/features/#message_encoding
++		IsDelimitedEncoded bool
++		// IsJSONCompliant is true if json_format is ALLOW
++		// https://protobuf.dev/editions/features/#json_format
++		IsJSONCompliant bool
++		// GenerateLegacyUnmarshalJSON determines if the plugin generates the
++		// UnmarshalJSON([]byte) error method for enums.
++		GenerateLegacyUnmarshalJSON bool
++	}
+ )
+ 
+ func (fd *File) ParentFile() protoreflect.FileDescriptor { return fd }
+@@ -117,6 +162,8 @@ type (
+ 	}
+ 	EnumL1 struct {
+ 		eagerValues bool // controls whether EnumL2.Values is already populated
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	EnumL2 struct {
+ 		Options        func() protoreflect.ProtoMessage
+@@ -178,6 +225,8 @@ type (
+ 		Extensions   Extensions
+ 		IsMapEntry   bool // promoted from google.protobuf.MessageOptions
+ 		IsMessageSet bool // promoted from google.protobuf.MessageOptions
++
++		EditionFeatures EditionFeatures
+ 	}
+ 	MessageL2 struct {
+ 		Options               func() protoreflect.ProtoMessage
+@@ -210,6 +259,8 @@ type (
+ 		ContainingOneof  protoreflect.OneofDescriptor // must be consistent with Message.Oneofs.Fields
+ 		Enum             protoreflect.EnumDescriptor
+ 		Message          protoreflect.MessageDescriptor
++
++		EditionFeatures EditionFeatures
+ 	}
+ 
+ 	Oneof struct {
+@@ -219,6 +270,8 @@ type (
+ 	OneofL1 struct {
+ 		Options func() protoreflect.ProtoMessage
+ 		Fields  OneofFields // must be consistent with Message.Fields.ContainingOneof
++
++		EditionFeatures EditionFeatures
+ 	}
+ )
+ 
+@@ -268,23 +321,36 @@ func (fd *Field) Options() protoreflect.ProtoMessage {
+ }
+ func (fd *Field) Number() protoreflect.FieldNumber      { return fd.L1.Number }
+ func (fd *Field) Cardinality() protoreflect.Cardinality { return fd.L1.Cardinality }
+-func (fd *Field) Kind() protoreflect.Kind               { return fd.L1.Kind }
+-func (fd *Field) HasJSONName() bool                     { return fd.L1.StringName.hasJSON }
+-func (fd *Field) JSONName() string                      { return fd.L1.StringName.getJSON(fd) }
+-func (fd *Field) TextName() string                      { return fd.L1.StringName.getText(fd) }
++func (fd *Field) Kind() protoreflect.Kind {
++	return fd.L1.Kind
++}
++func (fd *Field) HasJSONName() bool { return fd.L1.StringName.hasJSON }
++func (fd *Field) JSONName() string  { return fd.L1.StringName.getJSON(fd) }
++func (fd *Field) TextName() string  { return fd.L1.StringName.getText(fd) }
+ func (fd *Field) HasPresence() bool {
+-	return fd.L1.Cardinality != protoreflect.Repeated && (fd.L0.ParentFile.L1.Syntax == protoreflect.Proto2 || fd.L1.Message != nil || fd.L1.ContainingOneof != nil)
++	if fd.L1.Cardinality == protoreflect.Repeated {
++		return false
++	}
++	explicitFieldPresence := fd.Syntax() == protoreflect.Editions && fd.L1.EditionFeatures.IsFieldPresence
++	return fd.Syntax() == protoreflect.Proto2 || explicitFieldPresence || fd.L1.Message != nil || fd.L1.ContainingOneof != nil
+ }
+ func (fd *Field) HasOptionalKeyword() bool {
+ 	return (fd.L0.ParentFile.L1.Syntax == protoreflect.Proto2 && fd.L1.Cardinality == protoreflect.Optional && fd.L1.ContainingOneof == nil) || fd.L1.IsProto3Optional
+ }
+ func (fd *Field) IsPacked() bool {
+-	if !fd.L1.HasPacked && fd.L0.ParentFile.L1.Syntax != protoreflect.Proto2 && fd.L1.Cardinality == protoreflect.Repeated {
+-		switch fd.L1.Kind {
+-		case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
+-		default:
+-			return true
+-		}
++	if fd.L1.Cardinality != protoreflect.Repeated {
++		return false
++	}
++	switch fd.L1.Kind {
++	case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
++		return false
++	}
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Editions {
++		return fd.L1.EditionFeatures.IsPacked
++	}
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Proto3 {
++		// proto3 repeated fields are packed by default.
++		return !fd.L1.HasPacked || fd.L1.IsPacked
+ 	}
+ 	return fd.L1.IsPacked
+ }
+@@ -333,6 +399,9 @@ func (fd *Field) ProtoType(protoreflect.FieldDescriptor) {}
+ // WARNING: This method is exempt from the compatibility promise and may be
+ // removed in the future without warning.
+ func (fd *Field) EnforceUTF8() bool {
++	if fd.L0.ParentFile.L1.Syntax == protoreflect.Editions {
++		return fd.L1.EditionFeatures.IsUTF8Validated
++	}
+ 	if fd.L1.HasEnforceUTF8 {
+ 		return fd.L1.EnforceUTF8
+ 	}
+@@ -359,10 +428,11 @@ type (
+ 		L2 *ExtensionL2 // protected by fileDesc.once
+ 	}
+ 	ExtensionL1 struct {
+-		Number      protoreflect.FieldNumber
+-		Extendee    protoreflect.MessageDescriptor
+-		Cardinality protoreflect.Cardinality
+-		Kind        protoreflect.Kind
++		Number          protoreflect.FieldNumber
++		Extendee        protoreflect.MessageDescriptor
++		Cardinality     protoreflect.Cardinality
++		Kind            protoreflect.Kind
++		EditionFeatures EditionFeatures
+ 	}
+ 	ExtensionL2 struct {
+ 		Options          func() protoreflect.ProtoMessage
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
+index 4a1584c..237e64f 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_init.go
+@@ -5,6 +5,7 @@
+ package filedesc
+ 
+ import (
++	"fmt"
+ 	"sync"
+ 
+ 	"google.golang.org/protobuf/encoding/protowire"
+@@ -98,6 +99,7 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 	var prevField protoreflect.FieldNumber
+ 	var numEnums, numMessages, numExtensions, numServices int
+ 	var posEnums, posMessages, posExtensions, posServices int
++	var options []byte
+ 	b0 := b
+ 	for len(b) > 0 {
+ 		num, typ, n := protowire.ConsumeTag(b)
+@@ -113,6 +115,8 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 					fd.L1.Syntax = protoreflect.Proto2
+ 				case "proto3":
+ 					fd.L1.Syntax = protoreflect.Proto3
++				case "editions":
++					fd.L1.Syntax = protoreflect.Editions
+ 				default:
+ 					panic("invalid syntax")
+ 				}
+@@ -120,6 +124,8 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 				fd.L1.Path = sb.MakeString(v)
+ 			case genid.FileDescriptorProto_Package_field_number:
+ 				fd.L1.Package = protoreflect.FullName(sb.MakeString(v))
++			case genid.FileDescriptorProto_Options_field_number:
++				options = v
+ 			case genid.FileDescriptorProto_EnumType_field_number:
+ 				if prevField != genid.FileDescriptorProto_EnumType_field_number {
+ 					if numEnums > 0 {
+@@ -154,6 +160,13 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 				numServices++
+ 			}
+ 			prevField = num
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FileDescriptorProto_Edition_field_number:
++				fd.L1.Edition = Edition(v)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+@@ -166,6 +179,15 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 		fd.L1.Syntax = protoreflect.Proto2
+ 	}
+ 
++	if fd.L1.Syntax == protoreflect.Editions {
++		fd.L1.EditionFeatures = getFeaturesFor(fd.L1.Edition)
++	}
++
++	// Parse editions features from options if any
++	if options != nil {
++		fd.unmarshalSeedOptions(options)
++	}
++
+ 	// Must allocate all declarations before parsing each descriptor type
+ 	// to ensure we handled all descriptors in "flattened ordering".
+ 	if numEnums > 0 {
+@@ -219,6 +241,28 @@ func (fd *File) unmarshalSeed(b []byte) {
+ 	}
+ }
+ 
++func (fd *File) unmarshalSeedOptions(b []byte) {
++	for b := b; len(b) > 0; {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FileOptions_Features_field_number:
++				if fd.Syntax() != protoreflect.Editions {
++					panic(fmt.Sprintf("invalid descriptor: using edition features in a proto with syntax %s", fd.Syntax()))
++				}
++				fd.L1.EditionFeatures = unmarshalFeatureSet(v, fd.L1.EditionFeatures)
++			}
++		default:
++			m := protowire.ConsumeFieldValue(num, typ, b)
++			b = b[m:]
++		}
++	}
++}
++
+ func (ed *Enum) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protoreflect.Descriptor, i int) {
+ 	ed.L0.ParentFile = pf
+ 	ed.L0.Parent = pd
+@@ -275,6 +319,7 @@ func (md *Message) unmarshalSeed(b []byte, sb *strs.Builder, pf *File, pd protor
+ 	md.L0.ParentFile = pf
+ 	md.L0.Parent = pd
+ 	md.L0.Index = i
++	md.L1.EditionFeatures = featuresFromParentDesc(md.Parent())
+ 
+ 	var prevField protoreflect.FieldNumber
+ 	var numEnums, numMessages, numExtensions int
+@@ -380,6 +425,13 @@ func (md *Message) unmarshalSeedOptions(b []byte) {
+ 			case genid.MessageOptions_MessageSetWireFormat_field_number:
+ 				md.L1.IsMessageSet = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.MessageOptions_Features_field_number:
++				md.L1.EditionFeatures = unmarshalFeatureSet(v, md.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+index 736a19a..482a61c 100644
+--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+@@ -414,6 +414,7 @@ func (fd *Field) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ 	fd.L0.ParentFile = pf
+ 	fd.L0.Parent = pd
+ 	fd.L0.Index = i
++	fd.L1.EditionFeatures = featuresFromParentDesc(fd.Parent())
+ 
+ 	var rawTypeName []byte
+ 	var rawOptions []byte
+@@ -465,6 +466,12 @@ func (fd *Field) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ 			b = b[m:]
+ 		}
+ 	}
++	if fd.Syntax() == protoreflect.Editions && fd.L1.Kind == protoreflect.MessageKind && fd.L1.EditionFeatures.IsDelimitedEncoded {
++		fd.L1.Kind = protoreflect.GroupKind
++	}
++	if fd.Syntax() == protoreflect.Editions && fd.L1.EditionFeatures.IsLegacyRequired {
++		fd.L1.Cardinality = protoreflect.Required
++	}
+ 	if rawTypeName != nil {
+ 		name := makeFullName(sb, rawTypeName)
+ 		switch fd.L1.Kind {
+@@ -497,6 +504,13 @@ func (fd *Field) unmarshalOptions(b []byte) {
+ 				fd.L1.HasEnforceUTF8 = true
+ 				fd.L1.EnforceUTF8 = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FieldOptions_Features_field_number:
++				fd.L1.EditionFeatures = unmarshalFeatureSet(v, fd.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+@@ -534,6 +548,7 @@ func (od *Oneof) unmarshalFull(b []byte, sb *strs.Builder, pf *File, pd protoref
+ func (xd *Extension) unmarshalFull(b []byte, sb *strs.Builder) {
+ 	var rawTypeName []byte
+ 	var rawOptions []byte
++	xd.L1.EditionFeatures = featuresFromParentDesc(xd.L1.Extendee)
+ 	xd.L2 = new(ExtensionL2)
+ 	for len(b) > 0 {
+ 		num, typ, n := protowire.ConsumeTag(b)
+@@ -565,6 +580,12 @@ func (xd *Extension) unmarshalFull(b []byte, sb *strs.Builder) {
+ 			b = b[m:]
+ 		}
+ 	}
++	if xd.Syntax() == protoreflect.Editions && xd.L1.Kind == protoreflect.MessageKind && xd.L1.EditionFeatures.IsDelimitedEncoded {
++		xd.L1.Kind = protoreflect.GroupKind
++	}
++	if xd.Syntax() == protoreflect.Editions && xd.L1.EditionFeatures.IsLegacyRequired {
++		xd.L1.Cardinality = protoreflect.Required
++	}
+ 	if rawTypeName != nil {
+ 		name := makeFullName(sb, rawTypeName)
+ 		switch xd.L1.Kind {
+@@ -589,6 +610,13 @@ func (xd *Extension) unmarshalOptions(b []byte) {
+ 			case genid.FieldOptions_Packed_field_number:
+ 				xd.L2.IsPacked = protowire.DecodeBool(v)
+ 			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FieldOptions_Features_field_number:
++				xd.L1.EditionFeatures = unmarshalFeatureSet(v, xd.L1.EditionFeatures)
++			}
+ 		default:
+ 			m := protowire.ConsumeFieldValue(num, typ, b)
+ 			b = b[m:]
+diff --git a/vendor/google.golang.org/protobuf/internal/filedesc/editions.go b/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+new file mode 100644
+index 0000000..0375a49
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/filedesc/editions.go
+@@ -0,0 +1,142 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package filedesc
++
++import (
++	"fmt"
++
++	"google.golang.org/protobuf/encoding/protowire"
++	"google.golang.org/protobuf/internal/editiondefaults"
++	"google.golang.org/protobuf/internal/genid"
++	"google.golang.org/protobuf/reflect/protoreflect"
++)
++
++var defaultsCache = make(map[Edition]EditionFeatures)
++
++func init() {
++	unmarshalEditionDefaults(editiondefaults.Defaults)
++}
++
++func unmarshalGoFeature(b []byte, parent EditionFeatures) EditionFeatures {
++	for len(b) > 0 {
++		num, _, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch num {
++		case genid.GoFeatures_LegacyUnmarshalJsonEnum_field_number:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			parent.GenerateLegacyUnmarshalJSON = protowire.DecodeBool(v)
++		default:
++			panic(fmt.Sprintf("unkown field number %d while unmarshalling GoFeatures", num))
++		}
++	}
++	return parent
++}
++
++func unmarshalFeatureSet(b []byte, parent EditionFeatures) EditionFeatures {
++	for len(b) > 0 {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSet_FieldPresence_field_number:
++				parent.IsFieldPresence = v == genid.FeatureSet_EXPLICIT_enum_value || v == genid.FeatureSet_LEGACY_REQUIRED_enum_value
++				parent.IsLegacyRequired = v == genid.FeatureSet_LEGACY_REQUIRED_enum_value
++			case genid.FeatureSet_EnumType_field_number:
++				parent.IsOpenEnum = v == genid.FeatureSet_OPEN_enum_value
++			case genid.FeatureSet_RepeatedFieldEncoding_field_number:
++				parent.IsPacked = v == genid.FeatureSet_PACKED_enum_value
++			case genid.FeatureSet_Utf8Validation_field_number:
++				parent.IsUTF8Validated = v == genid.FeatureSet_VERIFY_enum_value
++			case genid.FeatureSet_MessageEncoding_field_number:
++				parent.IsDelimitedEncoded = v == genid.FeatureSet_DELIMITED_enum_value
++			case genid.FeatureSet_JsonFormat_field_number:
++				parent.IsJSONCompliant = v == genid.FeatureSet_ALLOW_enum_value
++			default:
++				panic(fmt.Sprintf("unkown field number %d while unmarshalling FeatureSet", num))
++			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.GoFeatures_LegacyUnmarshalJsonEnum_field_number:
++				parent = unmarshalGoFeature(v, parent)
++			}
++		}
++	}
++
++	return parent
++}
++
++func featuresFromParentDesc(parentDesc protoreflect.Descriptor) EditionFeatures {
++	var parentFS EditionFeatures
++	switch p := parentDesc.(type) {
++	case *File:
++		parentFS = p.L1.EditionFeatures
++	case *Message:
++		parentFS = p.L1.EditionFeatures
++	default:
++		panic(fmt.Sprintf("unknown parent type %T", parentDesc))
++	}
++	return parentFS
++}
++
++func unmarshalEditionDefault(b []byte) {
++	var ed Edition
++	var fs EditionFeatures
++	for len(b) > 0 {
++		num, typ, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch typ {
++		case protowire.VarintType:
++			v, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_number:
++				ed = Edition(v)
++			}
++		case protowire.BytesType:
++			v, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			switch num {
++			case genid.FeatureSetDefaults_FeatureSetEditionDefault_Features_field_number:
++				fs = unmarshalFeatureSet(v, fs)
++			}
++		}
++	}
++	defaultsCache[ed] = fs
++}
++
++func unmarshalEditionDefaults(b []byte) {
++	for len(b) > 0 {
++		num, _, n := protowire.ConsumeTag(b)
++		b = b[n:]
++		switch num {
++		case genid.FeatureSetDefaults_Defaults_field_number:
++			def, m := protowire.ConsumeBytes(b)
++			b = b[m:]
++			unmarshalEditionDefault(def)
++		case genid.FeatureSetDefaults_MinimumEdition_field_number,
++			genid.FeatureSetDefaults_MaximumEdition_field_number:
++			// We don't care about the minimum and maximum editions. If the
++			// edition we are looking for later on is not in the cache we know
++			// it is outside of the range between minimum and maximum edition.
++			_, m := protowire.ConsumeVarint(b)
++			b = b[m:]
++		default:
++			panic(fmt.Sprintf("unkown field number %d while unmarshalling EditionDefault", num))
++		}
++	}
++}
++
++func getFeaturesFor(ed Edition) EditionFeatures {
++	if def, ok := defaultsCache[ed]; ok {
++		return def
++	}
++	panic(fmt.Sprintf("unsupported edition: %v", ed))
++}
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+index 136f1b2..40272c8 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+@@ -12,6 +12,27 @@ import (
+ 
+ const File_google_protobuf_descriptor_proto = "google/protobuf/descriptor.proto"
+ 
++// Full and short names for google.protobuf.Edition.
++const (
++	Edition_enum_fullname = "google.protobuf.Edition"
++	Edition_enum_name     = "Edition"
++)
++
++// Enum values for google.protobuf.Edition.
++const (
++	Edition_EDITION_UNKNOWN_enum_value         = 0
++	Edition_EDITION_PROTO2_enum_value          = 998
++	Edition_EDITION_PROTO3_enum_value          = 999
++	Edition_EDITION_2023_enum_value            = 1000
++	Edition_EDITION_2024_enum_value            = 1001
++	Edition_EDITION_1_TEST_ONLY_enum_value     = 1
++	Edition_EDITION_2_TEST_ONLY_enum_value     = 2
++	Edition_EDITION_99997_TEST_ONLY_enum_value = 99997
++	Edition_EDITION_99998_TEST_ONLY_enum_value = 99998
++	Edition_EDITION_99999_TEST_ONLY_enum_value = 99999
++	Edition_EDITION_MAX_enum_value             = 2147483647
++)
++
+ // Names for google.protobuf.FileDescriptorSet.
+ const (
+ 	FileDescriptorSet_message_name     protoreflect.Name     = "FileDescriptorSet"
+@@ -81,7 +102,7 @@ const (
+ 	FileDescriptorProto_Options_field_number          protoreflect.FieldNumber = 8
+ 	FileDescriptorProto_SourceCodeInfo_field_number   protoreflect.FieldNumber = 9
+ 	FileDescriptorProto_Syntax_field_number           protoreflect.FieldNumber = 12
+-	FileDescriptorProto_Edition_field_number          protoreflect.FieldNumber = 13
++	FileDescriptorProto_Edition_field_number          protoreflect.FieldNumber = 14
+ )
+ 
+ // Names for google.protobuf.DescriptorProto.
+@@ -184,10 +205,12 @@ const (
+ const (
+ 	ExtensionRangeOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 	ExtensionRangeOptions_Declaration_field_name         protoreflect.Name = "declaration"
++	ExtensionRangeOptions_Features_field_name            protoreflect.Name = "features"
+ 	ExtensionRangeOptions_Verification_field_name        protoreflect.Name = "verification"
+ 
+ 	ExtensionRangeOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.uninterpreted_option"
+ 	ExtensionRangeOptions_Declaration_field_fullname         protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.declaration"
++	ExtensionRangeOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.features"
+ 	ExtensionRangeOptions_Verification_field_fullname        protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.verification"
+ )
+ 
+@@ -195,6 +218,7 @@ const (
+ const (
+ 	ExtensionRangeOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ 	ExtensionRangeOptions_Declaration_field_number         protoreflect.FieldNumber = 2
++	ExtensionRangeOptions_Features_field_number            protoreflect.FieldNumber = 50
+ 	ExtensionRangeOptions_Verification_field_number        protoreflect.FieldNumber = 3
+ )
+ 
+@@ -204,6 +228,12 @@ const (
+ 	ExtensionRangeOptions_VerificationState_enum_name     = "VerificationState"
+ )
+ 
++// Enum values for google.protobuf.ExtensionRangeOptions.VerificationState.
++const (
++	ExtensionRangeOptions_DECLARATION_enum_value = 0
++	ExtensionRangeOptions_UNVERIFIED_enum_value  = 1
++)
++
+ // Names for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+ 	ExtensionRangeOptions_Declaration_message_name     protoreflect.Name     = "Declaration"
+@@ -212,29 +242,26 @@ const (
+ 
+ // Field names for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+-	ExtensionRangeOptions_Declaration_Number_field_name     protoreflect.Name = "number"
+-	ExtensionRangeOptions_Declaration_FullName_field_name   protoreflect.Name = "full_name"
+-	ExtensionRangeOptions_Declaration_Type_field_name       protoreflect.Name = "type"
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_name protoreflect.Name = "is_repeated"
+-	ExtensionRangeOptions_Declaration_Reserved_field_name   protoreflect.Name = "reserved"
+-	ExtensionRangeOptions_Declaration_Repeated_field_name   protoreflect.Name = "repeated"
++	ExtensionRangeOptions_Declaration_Number_field_name   protoreflect.Name = "number"
++	ExtensionRangeOptions_Declaration_FullName_field_name protoreflect.Name = "full_name"
++	ExtensionRangeOptions_Declaration_Type_field_name     protoreflect.Name = "type"
++	ExtensionRangeOptions_Declaration_Reserved_field_name protoreflect.Name = "reserved"
++	ExtensionRangeOptions_Declaration_Repeated_field_name protoreflect.Name = "repeated"
+ 
+-	ExtensionRangeOptions_Declaration_Number_field_fullname     protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.number"
+-	ExtensionRangeOptions_Declaration_FullName_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.full_name"
+-	ExtensionRangeOptions_Declaration_Type_field_fullname       protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.type"
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.is_repeated"
+-	ExtensionRangeOptions_Declaration_Reserved_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.reserved"
+-	ExtensionRangeOptions_Declaration_Repeated_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.repeated"
++	ExtensionRangeOptions_Declaration_Number_field_fullname   protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.number"
++	ExtensionRangeOptions_Declaration_FullName_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.full_name"
++	ExtensionRangeOptions_Declaration_Type_field_fullname     protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.type"
++	ExtensionRangeOptions_Declaration_Reserved_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.reserved"
++	ExtensionRangeOptions_Declaration_Repeated_field_fullname protoreflect.FullName = "google.protobuf.ExtensionRangeOptions.Declaration.repeated"
+ )
+ 
+ // Field numbers for google.protobuf.ExtensionRangeOptions.Declaration.
+ const (
+-	ExtensionRangeOptions_Declaration_Number_field_number     protoreflect.FieldNumber = 1
+-	ExtensionRangeOptions_Declaration_FullName_field_number   protoreflect.FieldNumber = 2
+-	ExtensionRangeOptions_Declaration_Type_field_number       protoreflect.FieldNumber = 3
+-	ExtensionRangeOptions_Declaration_IsRepeated_field_number protoreflect.FieldNumber = 4
+-	ExtensionRangeOptions_Declaration_Reserved_field_number   protoreflect.FieldNumber = 5
+-	ExtensionRangeOptions_Declaration_Repeated_field_number   protoreflect.FieldNumber = 6
++	ExtensionRangeOptions_Declaration_Number_field_number   protoreflect.FieldNumber = 1
++	ExtensionRangeOptions_Declaration_FullName_field_number protoreflect.FieldNumber = 2
++	ExtensionRangeOptions_Declaration_Type_field_number     protoreflect.FieldNumber = 3
++	ExtensionRangeOptions_Declaration_Reserved_field_number protoreflect.FieldNumber = 5
++	ExtensionRangeOptions_Declaration_Repeated_field_number protoreflect.FieldNumber = 6
+ )
+ 
+ // Names for google.protobuf.FieldDescriptorProto.
+@@ -291,12 +318,41 @@ const (
+ 	FieldDescriptorProto_Type_enum_name     = "Type"
+ )
+ 
++// Enum values for google.protobuf.FieldDescriptorProto.Type.
++const (
++	FieldDescriptorProto_TYPE_DOUBLE_enum_value   = 1
++	FieldDescriptorProto_TYPE_FLOAT_enum_value    = 2
++	FieldDescriptorProto_TYPE_INT64_enum_value    = 3
++	FieldDescriptorProto_TYPE_UINT64_enum_value   = 4
++	FieldDescriptorProto_TYPE_INT32_enum_value    = 5
++	FieldDescriptorProto_TYPE_FIXED64_enum_value  = 6
++	FieldDescriptorProto_TYPE_FIXED32_enum_value  = 7
++	FieldDescriptorProto_TYPE_BOOL_enum_value     = 8
++	FieldDescriptorProto_TYPE_STRING_enum_value   = 9
++	FieldDescriptorProto_TYPE_GROUP_enum_value    = 10
++	FieldDescriptorProto_TYPE_MESSAGE_enum_value  = 11
++	FieldDescriptorProto_TYPE_BYTES_enum_value    = 12
++	FieldDescriptorProto_TYPE_UINT32_enum_value   = 13
++	FieldDescriptorProto_TYPE_ENUM_enum_value     = 14
++	FieldDescriptorProto_TYPE_SFIXED32_enum_value = 15
++	FieldDescriptorProto_TYPE_SFIXED64_enum_value = 16
++	FieldDescriptorProto_TYPE_SINT32_enum_value   = 17
++	FieldDescriptorProto_TYPE_SINT64_enum_value   = 18
++)
++
+ // Full and short names for google.protobuf.FieldDescriptorProto.Label.
+ const (
+ 	FieldDescriptorProto_Label_enum_fullname = "google.protobuf.FieldDescriptorProto.Label"
+ 	FieldDescriptorProto_Label_enum_name     = "Label"
+ )
+ 
++// Enum values for google.protobuf.FieldDescriptorProto.Label.
++const (
++	FieldDescriptorProto_LABEL_OPTIONAL_enum_value = 1
++	FieldDescriptorProto_LABEL_REPEATED_enum_value = 3
++	FieldDescriptorProto_LABEL_REQUIRED_enum_value = 2
++)
++
+ // Names for google.protobuf.OneofDescriptorProto.
+ const (
+ 	OneofDescriptorProto_message_name     protoreflect.Name     = "OneofDescriptorProto"
+@@ -468,7 +524,6 @@ const (
+ 	FileOptions_CcGenericServices_field_name         protoreflect.Name = "cc_generic_services"
+ 	FileOptions_JavaGenericServices_field_name       protoreflect.Name = "java_generic_services"
+ 	FileOptions_PyGenericServices_field_name         protoreflect.Name = "py_generic_services"
+-	FileOptions_PhpGenericServices_field_name        protoreflect.Name = "php_generic_services"
+ 	FileOptions_Deprecated_field_name                protoreflect.Name = "deprecated"
+ 	FileOptions_CcEnableArenas_field_name            protoreflect.Name = "cc_enable_arenas"
+ 	FileOptions_ObjcClassPrefix_field_name           protoreflect.Name = "objc_class_prefix"
+@@ -478,6 +533,7 @@ const (
+ 	FileOptions_PhpNamespace_field_name              protoreflect.Name = "php_namespace"
+ 	FileOptions_PhpMetadataNamespace_field_name      protoreflect.Name = "php_metadata_namespace"
+ 	FileOptions_RubyPackage_field_name               protoreflect.Name = "ruby_package"
++	FileOptions_Features_field_name                  protoreflect.Name = "features"
+ 	FileOptions_UninterpretedOption_field_name       protoreflect.Name = "uninterpreted_option"
+ 
+ 	FileOptions_JavaPackage_field_fullname               protoreflect.FullName = "google.protobuf.FileOptions.java_package"
+@@ -490,7 +546,6 @@ const (
+ 	FileOptions_CcGenericServices_field_fullname         protoreflect.FullName = "google.protobuf.FileOptions.cc_generic_services"
+ 	FileOptions_JavaGenericServices_field_fullname       protoreflect.FullName = "google.protobuf.FileOptions.java_generic_services"
+ 	FileOptions_PyGenericServices_field_fullname         protoreflect.FullName = "google.protobuf.FileOptions.py_generic_services"
+-	FileOptions_PhpGenericServices_field_fullname        protoreflect.FullName = "google.protobuf.FileOptions.php_generic_services"
+ 	FileOptions_Deprecated_field_fullname                protoreflect.FullName = "google.protobuf.FileOptions.deprecated"
+ 	FileOptions_CcEnableArenas_field_fullname            protoreflect.FullName = "google.protobuf.FileOptions.cc_enable_arenas"
+ 	FileOptions_ObjcClassPrefix_field_fullname           protoreflect.FullName = "google.protobuf.FileOptions.objc_class_prefix"
+@@ -500,6 +555,7 @@ const (
+ 	FileOptions_PhpNamespace_field_fullname              protoreflect.FullName = "google.protobuf.FileOptions.php_namespace"
+ 	FileOptions_PhpMetadataNamespace_field_fullname      protoreflect.FullName = "google.protobuf.FileOptions.php_metadata_namespace"
+ 	FileOptions_RubyPackage_field_fullname               protoreflect.FullName = "google.protobuf.FileOptions.ruby_package"
++	FileOptions_Features_field_fullname                  protoreflect.FullName = "google.protobuf.FileOptions.features"
+ 	FileOptions_UninterpretedOption_field_fullname       protoreflect.FullName = "google.protobuf.FileOptions.uninterpreted_option"
+ )
+ 
+@@ -515,7 +571,6 @@ const (
+ 	FileOptions_CcGenericServices_field_number         protoreflect.FieldNumber = 16
+ 	FileOptions_JavaGenericServices_field_number       protoreflect.FieldNumber = 17
+ 	FileOptions_PyGenericServices_field_number         protoreflect.FieldNumber = 18
+-	FileOptions_PhpGenericServices_field_number        protoreflect.FieldNumber = 42
+ 	FileOptions_Deprecated_field_number                protoreflect.FieldNumber = 23
+ 	FileOptions_CcEnableArenas_field_number            protoreflect.FieldNumber = 31
+ 	FileOptions_ObjcClassPrefix_field_number           protoreflect.FieldNumber = 36
+@@ -525,6 +580,7 @@ const (
+ 	FileOptions_PhpNamespace_field_number              protoreflect.FieldNumber = 41
+ 	FileOptions_PhpMetadataNamespace_field_number      protoreflect.FieldNumber = 44
+ 	FileOptions_RubyPackage_field_number               protoreflect.FieldNumber = 45
++	FileOptions_Features_field_number                  protoreflect.FieldNumber = 50
+ 	FileOptions_UninterpretedOption_field_number       protoreflect.FieldNumber = 999
+ )
+ 
+@@ -534,6 +590,13 @@ const (
+ 	FileOptions_OptimizeMode_enum_name     = "OptimizeMode"
+ )
+ 
++// Enum values for google.protobuf.FileOptions.OptimizeMode.
++const (
++	FileOptions_SPEED_enum_value        = 1
++	FileOptions_CODE_SIZE_enum_value    = 2
++	FileOptions_LITE_RUNTIME_enum_value = 3
++)
++
+ // Names for google.protobuf.MessageOptions.
+ const (
+ 	MessageOptions_message_name     protoreflect.Name     = "MessageOptions"
+@@ -547,6 +610,7 @@ const (
+ 	MessageOptions_Deprecated_field_name                         protoreflect.Name = "deprecated"
+ 	MessageOptions_MapEntry_field_name                           protoreflect.Name = "map_entry"
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_name protoreflect.Name = "deprecated_legacy_json_field_conflicts"
++	MessageOptions_Features_field_name                           protoreflect.Name = "features"
+ 	MessageOptions_UninterpretedOption_field_name                protoreflect.Name = "uninterpreted_option"
+ 
+ 	MessageOptions_MessageSetWireFormat_field_fullname               protoreflect.FullName = "google.protobuf.MessageOptions.message_set_wire_format"
+@@ -554,6 +618,7 @@ const (
+ 	MessageOptions_Deprecated_field_fullname                         protoreflect.FullName = "google.protobuf.MessageOptions.deprecated"
+ 	MessageOptions_MapEntry_field_fullname                           protoreflect.FullName = "google.protobuf.MessageOptions.map_entry"
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_fullname protoreflect.FullName = "google.protobuf.MessageOptions.deprecated_legacy_json_field_conflicts"
++	MessageOptions_Features_field_fullname                           protoreflect.FullName = "google.protobuf.MessageOptions.features"
+ 	MessageOptions_UninterpretedOption_field_fullname                protoreflect.FullName = "google.protobuf.MessageOptions.uninterpreted_option"
+ )
+ 
+@@ -564,6 +629,7 @@ const (
+ 	MessageOptions_Deprecated_field_number                         protoreflect.FieldNumber = 3
+ 	MessageOptions_MapEntry_field_number                           protoreflect.FieldNumber = 7
+ 	MessageOptions_DeprecatedLegacyJsonFieldConflicts_field_number protoreflect.FieldNumber = 11
++	MessageOptions_Features_field_number                           protoreflect.FieldNumber = 12
+ 	MessageOptions_UninterpretedOption_field_number                protoreflect.FieldNumber = 999
+ )
+ 
+@@ -584,8 +650,9 @@ const (
+ 	FieldOptions_Weak_field_name                protoreflect.Name = "weak"
+ 	FieldOptions_DebugRedact_field_name         protoreflect.Name = "debug_redact"
+ 	FieldOptions_Retention_field_name           protoreflect.Name = "retention"
+-	FieldOptions_Target_field_name              protoreflect.Name = "target"
+ 	FieldOptions_Targets_field_name             protoreflect.Name = "targets"
++	FieldOptions_EditionDefaults_field_name     protoreflect.Name = "edition_defaults"
++	FieldOptions_Features_field_name            protoreflect.Name = "features"
+ 	FieldOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	FieldOptions_Ctype_field_fullname               protoreflect.FullName = "google.protobuf.FieldOptions.ctype"
+@@ -597,8 +664,9 @@ const (
+ 	FieldOptions_Weak_field_fullname                protoreflect.FullName = "google.protobuf.FieldOptions.weak"
+ 	FieldOptions_DebugRedact_field_fullname         protoreflect.FullName = "google.protobuf.FieldOptions.debug_redact"
+ 	FieldOptions_Retention_field_fullname           protoreflect.FullName = "google.protobuf.FieldOptions.retention"
+-	FieldOptions_Target_field_fullname              protoreflect.FullName = "google.protobuf.FieldOptions.target"
+ 	FieldOptions_Targets_field_fullname             protoreflect.FullName = "google.protobuf.FieldOptions.targets"
++	FieldOptions_EditionDefaults_field_fullname     protoreflect.FullName = "google.protobuf.FieldOptions.edition_defaults"
++	FieldOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.FieldOptions.features"
+ 	FieldOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.FieldOptions.uninterpreted_option"
+ )
+ 
+@@ -613,8 +681,9 @@ const (
+ 	FieldOptions_Weak_field_number                protoreflect.FieldNumber = 10
+ 	FieldOptions_DebugRedact_field_number         protoreflect.FieldNumber = 16
+ 	FieldOptions_Retention_field_number           protoreflect.FieldNumber = 17
+-	FieldOptions_Target_field_number              protoreflect.FieldNumber = 18
+ 	FieldOptions_Targets_field_number             protoreflect.FieldNumber = 19
++	FieldOptions_EditionDefaults_field_number     protoreflect.FieldNumber = 20
++	FieldOptions_Features_field_number            protoreflect.FieldNumber = 21
+ 	FieldOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -624,24 +693,80 @@ const (
+ 	FieldOptions_CType_enum_name     = "CType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.CType.
++const (
++	FieldOptions_STRING_enum_value       = 0
++	FieldOptions_CORD_enum_value         = 1
++	FieldOptions_STRING_PIECE_enum_value = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.JSType.
+ const (
+ 	FieldOptions_JSType_enum_fullname = "google.protobuf.FieldOptions.JSType"
+ 	FieldOptions_JSType_enum_name     = "JSType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.JSType.
++const (
++	FieldOptions_JS_NORMAL_enum_value = 0
++	FieldOptions_JS_STRING_enum_value = 1
++	FieldOptions_JS_NUMBER_enum_value = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.OptionRetention.
+ const (
+ 	FieldOptions_OptionRetention_enum_fullname = "google.protobuf.FieldOptions.OptionRetention"
+ 	FieldOptions_OptionRetention_enum_name     = "OptionRetention"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.OptionRetention.
++const (
++	FieldOptions_RETENTION_UNKNOWN_enum_value = 0
++	FieldOptions_RETENTION_RUNTIME_enum_value = 1
++	FieldOptions_RETENTION_SOURCE_enum_value  = 2
++)
++
+ // Full and short names for google.protobuf.FieldOptions.OptionTargetType.
+ const (
+ 	FieldOptions_OptionTargetType_enum_fullname = "google.protobuf.FieldOptions.OptionTargetType"
+ 	FieldOptions_OptionTargetType_enum_name     = "OptionTargetType"
+ )
+ 
++// Enum values for google.protobuf.FieldOptions.OptionTargetType.
++const (
++	FieldOptions_TARGET_TYPE_UNKNOWN_enum_value         = 0
++	FieldOptions_TARGET_TYPE_FILE_enum_value            = 1
++	FieldOptions_TARGET_TYPE_EXTENSION_RANGE_enum_value = 2
++	FieldOptions_TARGET_TYPE_MESSAGE_enum_value         = 3
++	FieldOptions_TARGET_TYPE_FIELD_enum_value           = 4
++	FieldOptions_TARGET_TYPE_ONEOF_enum_value           = 5
++	FieldOptions_TARGET_TYPE_ENUM_enum_value            = 6
++	FieldOptions_TARGET_TYPE_ENUM_ENTRY_enum_value      = 7
++	FieldOptions_TARGET_TYPE_SERVICE_enum_value         = 8
++	FieldOptions_TARGET_TYPE_METHOD_enum_value          = 9
++)
++
++// Names for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_message_name     protoreflect.Name     = "EditionDefault"
++	FieldOptions_EditionDefault_message_fullname protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault"
++)
++
++// Field names for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_Edition_field_name protoreflect.Name = "edition"
++	FieldOptions_EditionDefault_Value_field_name   protoreflect.Name = "value"
++
++	FieldOptions_EditionDefault_Edition_field_fullname protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault.edition"
++	FieldOptions_EditionDefault_Value_field_fullname   protoreflect.FullName = "google.protobuf.FieldOptions.EditionDefault.value"
++)
++
++// Field numbers for google.protobuf.FieldOptions.EditionDefault.
++const (
++	FieldOptions_EditionDefault_Edition_field_number protoreflect.FieldNumber = 3
++	FieldOptions_EditionDefault_Value_field_number   protoreflect.FieldNumber = 2
++)
++
+ // Names for google.protobuf.OneofOptions.
+ const (
+ 	OneofOptions_message_name     protoreflect.Name     = "OneofOptions"
+@@ -650,13 +775,16 @@ const (
+ 
+ // Field names for google.protobuf.OneofOptions.
+ const (
++	OneofOptions_Features_field_name            protoreflect.Name = "features"
+ 	OneofOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
++	OneofOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.OneofOptions.features"
+ 	OneofOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.OneofOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.OneofOptions.
+ const (
++	OneofOptions_Features_field_number            protoreflect.FieldNumber = 1
+ 	OneofOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -671,11 +799,13 @@ const (
+ 	EnumOptions_AllowAlias_field_name                         protoreflect.Name = "allow_alias"
+ 	EnumOptions_Deprecated_field_name                         protoreflect.Name = "deprecated"
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_name protoreflect.Name = "deprecated_legacy_json_field_conflicts"
++	EnumOptions_Features_field_name                           protoreflect.Name = "features"
+ 	EnumOptions_UninterpretedOption_field_name                protoreflect.Name = "uninterpreted_option"
+ 
+ 	EnumOptions_AllowAlias_field_fullname                         protoreflect.FullName = "google.protobuf.EnumOptions.allow_alias"
+ 	EnumOptions_Deprecated_field_fullname                         protoreflect.FullName = "google.protobuf.EnumOptions.deprecated"
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_fullname protoreflect.FullName = "google.protobuf.EnumOptions.deprecated_legacy_json_field_conflicts"
++	EnumOptions_Features_field_fullname                           protoreflect.FullName = "google.protobuf.EnumOptions.features"
+ 	EnumOptions_UninterpretedOption_field_fullname                protoreflect.FullName = "google.protobuf.EnumOptions.uninterpreted_option"
+ )
+ 
+@@ -684,6 +814,7 @@ const (
+ 	EnumOptions_AllowAlias_field_number                         protoreflect.FieldNumber = 2
+ 	EnumOptions_Deprecated_field_number                         protoreflect.FieldNumber = 3
+ 	EnumOptions_DeprecatedLegacyJsonFieldConflicts_field_number protoreflect.FieldNumber = 6
++	EnumOptions_Features_field_number                           protoreflect.FieldNumber = 7
+ 	EnumOptions_UninterpretedOption_field_number                protoreflect.FieldNumber = 999
+ )
+ 
+@@ -696,15 +827,21 @@ const (
+ // Field names for google.protobuf.EnumValueOptions.
+ const (
+ 	EnumValueOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
++	EnumValueOptions_Features_field_name            protoreflect.Name = "features"
++	EnumValueOptions_DebugRedact_field_name         protoreflect.Name = "debug_redact"
+ 	EnumValueOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	EnumValueOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.EnumValueOptions.deprecated"
++	EnumValueOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.EnumValueOptions.features"
++	EnumValueOptions_DebugRedact_field_fullname         protoreflect.FullName = "google.protobuf.EnumValueOptions.debug_redact"
+ 	EnumValueOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.EnumValueOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.EnumValueOptions.
+ const (
+ 	EnumValueOptions_Deprecated_field_number          protoreflect.FieldNumber = 1
++	EnumValueOptions_Features_field_number            protoreflect.FieldNumber = 2
++	EnumValueOptions_DebugRedact_field_number         protoreflect.FieldNumber = 3
+ 	EnumValueOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -716,15 +853,18 @@ const (
+ 
+ // Field names for google.protobuf.ServiceOptions.
+ const (
++	ServiceOptions_Features_field_name            protoreflect.Name = "features"
+ 	ServiceOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
+ 	ServiceOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
++	ServiceOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.ServiceOptions.features"
+ 	ServiceOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.ServiceOptions.deprecated"
+ 	ServiceOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.ServiceOptions.uninterpreted_option"
+ )
+ 
+ // Field numbers for google.protobuf.ServiceOptions.
+ const (
++	ServiceOptions_Features_field_number            protoreflect.FieldNumber = 34
+ 	ServiceOptions_Deprecated_field_number          protoreflect.FieldNumber = 33
+ 	ServiceOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+@@ -739,10 +879,12 @@ const (
+ const (
+ 	MethodOptions_Deprecated_field_name          protoreflect.Name = "deprecated"
+ 	MethodOptions_IdempotencyLevel_field_name    protoreflect.Name = "idempotency_level"
++	MethodOptions_Features_field_name            protoreflect.Name = "features"
+ 	MethodOptions_UninterpretedOption_field_name protoreflect.Name = "uninterpreted_option"
+ 
+ 	MethodOptions_Deprecated_field_fullname          protoreflect.FullName = "google.protobuf.MethodOptions.deprecated"
+ 	MethodOptions_IdempotencyLevel_field_fullname    protoreflect.FullName = "google.protobuf.MethodOptions.idempotency_level"
++	MethodOptions_Features_field_fullname            protoreflect.FullName = "google.protobuf.MethodOptions.features"
+ 	MethodOptions_UninterpretedOption_field_fullname protoreflect.FullName = "google.protobuf.MethodOptions.uninterpreted_option"
+ )
+ 
+@@ -750,6 +892,7 @@ const (
+ const (
+ 	MethodOptions_Deprecated_field_number          protoreflect.FieldNumber = 33
+ 	MethodOptions_IdempotencyLevel_field_number    protoreflect.FieldNumber = 34
++	MethodOptions_Features_field_number            protoreflect.FieldNumber = 35
+ 	MethodOptions_UninterpretedOption_field_number protoreflect.FieldNumber = 999
+ )
+ 
+@@ -759,6 +902,13 @@ const (
+ 	MethodOptions_IdempotencyLevel_enum_name     = "IdempotencyLevel"
+ )
+ 
++// Enum values for google.protobuf.MethodOptions.IdempotencyLevel.
++const (
++	MethodOptions_IDEMPOTENCY_UNKNOWN_enum_value = 0
++	MethodOptions_NO_SIDE_EFFECTS_enum_value     = 1
++	MethodOptions_IDEMPOTENT_enum_value          = 2
++)
++
+ // Names for google.protobuf.UninterpretedOption.
+ const (
+ 	UninterpretedOption_message_name     protoreflect.Name     = "UninterpretedOption"
+@@ -816,6 +966,163 @@ const (
+ 	UninterpretedOption_NamePart_IsExtension_field_number protoreflect.FieldNumber = 2
+ )
+ 
++// Names for google.protobuf.FeatureSet.
++const (
++	FeatureSet_message_name     protoreflect.Name     = "FeatureSet"
++	FeatureSet_message_fullname protoreflect.FullName = "google.protobuf.FeatureSet"
++)
++
++// Field names for google.protobuf.FeatureSet.
++const (
++	FeatureSet_FieldPresence_field_name         protoreflect.Name = "field_presence"
++	FeatureSet_EnumType_field_name              protoreflect.Name = "enum_type"
++	FeatureSet_RepeatedFieldEncoding_field_name protoreflect.Name = "repeated_field_encoding"
++	FeatureSet_Utf8Validation_field_name        protoreflect.Name = "utf8_validation"
++	FeatureSet_MessageEncoding_field_name       protoreflect.Name = "message_encoding"
++	FeatureSet_JsonFormat_field_name            protoreflect.Name = "json_format"
++
++	FeatureSet_FieldPresence_field_fullname         protoreflect.FullName = "google.protobuf.FeatureSet.field_presence"
++	FeatureSet_EnumType_field_fullname              protoreflect.FullName = "google.protobuf.FeatureSet.enum_type"
++	FeatureSet_RepeatedFieldEncoding_field_fullname protoreflect.FullName = "google.protobuf.FeatureSet.repeated_field_encoding"
++	FeatureSet_Utf8Validation_field_fullname        protoreflect.FullName = "google.protobuf.FeatureSet.utf8_validation"
++	FeatureSet_MessageEncoding_field_fullname       protoreflect.FullName = "google.protobuf.FeatureSet.message_encoding"
++	FeatureSet_JsonFormat_field_fullname            protoreflect.FullName = "google.protobuf.FeatureSet.json_format"
++)
++
++// Field numbers for google.protobuf.FeatureSet.
++const (
++	FeatureSet_FieldPresence_field_number         protoreflect.FieldNumber = 1
++	FeatureSet_EnumType_field_number              protoreflect.FieldNumber = 2
++	FeatureSet_RepeatedFieldEncoding_field_number protoreflect.FieldNumber = 3
++	FeatureSet_Utf8Validation_field_number        protoreflect.FieldNumber = 4
++	FeatureSet_MessageEncoding_field_number       protoreflect.FieldNumber = 5
++	FeatureSet_JsonFormat_field_number            protoreflect.FieldNumber = 6
++)
++
++// Full and short names for google.protobuf.FeatureSet.FieldPresence.
++const (
++	FeatureSet_FieldPresence_enum_fullname = "google.protobuf.FeatureSet.FieldPresence"
++	FeatureSet_FieldPresence_enum_name     = "FieldPresence"
++)
++
++// Enum values for google.protobuf.FeatureSet.FieldPresence.
++const (
++	FeatureSet_FIELD_PRESENCE_UNKNOWN_enum_value = 0
++	FeatureSet_EXPLICIT_enum_value               = 1
++	FeatureSet_IMPLICIT_enum_value               = 2
++	FeatureSet_LEGACY_REQUIRED_enum_value        = 3
++)
++
++// Full and short names for google.protobuf.FeatureSet.EnumType.
++const (
++	FeatureSet_EnumType_enum_fullname = "google.protobuf.FeatureSet.EnumType"
++	FeatureSet_EnumType_enum_name     = "EnumType"
++)
++
++// Enum values for google.protobuf.FeatureSet.EnumType.
++const (
++	FeatureSet_ENUM_TYPE_UNKNOWN_enum_value = 0
++	FeatureSet_OPEN_enum_value              = 1
++	FeatureSet_CLOSED_enum_value            = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.RepeatedFieldEncoding.
++const (
++	FeatureSet_RepeatedFieldEncoding_enum_fullname = "google.protobuf.FeatureSet.RepeatedFieldEncoding"
++	FeatureSet_RepeatedFieldEncoding_enum_name     = "RepeatedFieldEncoding"
++)
++
++// Enum values for google.protobuf.FeatureSet.RepeatedFieldEncoding.
++const (
++	FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN_enum_value = 0
++	FeatureSet_PACKED_enum_value                          = 1
++	FeatureSet_EXPANDED_enum_value                        = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.Utf8Validation.
++const (
++	FeatureSet_Utf8Validation_enum_fullname = "google.protobuf.FeatureSet.Utf8Validation"
++	FeatureSet_Utf8Validation_enum_name     = "Utf8Validation"
++)
++
++// Enum values for google.protobuf.FeatureSet.Utf8Validation.
++const (
++	FeatureSet_UTF8_VALIDATION_UNKNOWN_enum_value = 0
++	FeatureSet_VERIFY_enum_value                  = 2
++	FeatureSet_NONE_enum_value                    = 3
++)
++
++// Full and short names for google.protobuf.FeatureSet.MessageEncoding.
++const (
++	FeatureSet_MessageEncoding_enum_fullname = "google.protobuf.FeatureSet.MessageEncoding"
++	FeatureSet_MessageEncoding_enum_name     = "MessageEncoding"
++)
++
++// Enum values for google.protobuf.FeatureSet.MessageEncoding.
++const (
++	FeatureSet_MESSAGE_ENCODING_UNKNOWN_enum_value = 0
++	FeatureSet_LENGTH_PREFIXED_enum_value          = 1
++	FeatureSet_DELIMITED_enum_value                = 2
++)
++
++// Full and short names for google.protobuf.FeatureSet.JsonFormat.
++const (
++	FeatureSet_JsonFormat_enum_fullname = "google.protobuf.FeatureSet.JsonFormat"
++	FeatureSet_JsonFormat_enum_name     = "JsonFormat"
++)
++
++// Enum values for google.protobuf.FeatureSet.JsonFormat.
++const (
++	FeatureSet_JSON_FORMAT_UNKNOWN_enum_value = 0
++	FeatureSet_ALLOW_enum_value               = 1
++	FeatureSet_LEGACY_BEST_EFFORT_enum_value  = 2
++)
++
++// Names for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_message_name     protoreflect.Name     = "FeatureSetDefaults"
++	FeatureSetDefaults_message_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults"
++)
++
++// Field names for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_Defaults_field_name       protoreflect.Name = "defaults"
++	FeatureSetDefaults_MinimumEdition_field_name protoreflect.Name = "minimum_edition"
++	FeatureSetDefaults_MaximumEdition_field_name protoreflect.Name = "maximum_edition"
++
++	FeatureSetDefaults_Defaults_field_fullname       protoreflect.FullName = "google.protobuf.FeatureSetDefaults.defaults"
++	FeatureSetDefaults_MinimumEdition_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.minimum_edition"
++	FeatureSetDefaults_MaximumEdition_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.maximum_edition"
++)
++
++// Field numbers for google.protobuf.FeatureSetDefaults.
++const (
++	FeatureSetDefaults_Defaults_field_number       protoreflect.FieldNumber = 1
++	FeatureSetDefaults_MinimumEdition_field_number protoreflect.FieldNumber = 4
++	FeatureSetDefaults_MaximumEdition_field_number protoreflect.FieldNumber = 5
++)
++
++// Names for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_message_name     protoreflect.Name     = "FeatureSetEditionDefault"
++	FeatureSetDefaults_FeatureSetEditionDefault_message_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault"
++)
++
++// Field names for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_name  protoreflect.Name = "edition"
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_name protoreflect.Name = "features"
++
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_fullname  protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.edition"
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_fullname protoreflect.FullName = "google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.features"
++)
++
++// Field numbers for google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.
++const (
++	FeatureSetDefaults_FeatureSetEditionDefault_Edition_field_number  protoreflect.FieldNumber = 3
++	FeatureSetDefaults_FeatureSetEditionDefault_Features_field_number protoreflect.FieldNumber = 2
++)
++
+ // Names for google.protobuf.SourceCodeInfo.
+ const (
+ 	SourceCodeInfo_message_name     protoreflect.Name     = "SourceCodeInfo"
+@@ -917,3 +1224,10 @@ const (
+ 	GeneratedCodeInfo_Annotation_Semantic_enum_fullname = "google.protobuf.GeneratedCodeInfo.Annotation.Semantic"
+ 	GeneratedCodeInfo_Annotation_Semantic_enum_name     = "Semantic"
+ )
++
++// Enum values for google.protobuf.GeneratedCodeInfo.Annotation.Semantic.
++const (
++	GeneratedCodeInfo_Annotation_NONE_enum_value  = 0
++	GeneratedCodeInfo_Annotation_SET_enum_value   = 1
++	GeneratedCodeInfo_Annotation_ALIAS_enum_value = 2
++)
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go b/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+new file mode 100644
+index 0000000..fd9015e
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/genid/go_features_gen.go
+@@ -0,0 +1,31 @@
++// Copyright 2019 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Code generated by generate-protos. DO NOT EDIT.
++
++package genid
++
++import (
++	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
++)
++
++const File_reflect_protodesc_proto_go_features_proto = "reflect/protodesc/proto/go_features.proto"
++
++// Names for google.protobuf.GoFeatures.
++const (
++	GoFeatures_message_name     protoreflect.Name     = "GoFeatures"
++	GoFeatures_message_fullname protoreflect.FullName = "google.protobuf.GoFeatures"
++)
++
++// Field names for google.protobuf.GoFeatures.
++const (
++	GoFeatures_LegacyUnmarshalJsonEnum_field_name protoreflect.Name = "legacy_unmarshal_json_enum"
++
++	GoFeatures_LegacyUnmarshalJsonEnum_field_fullname protoreflect.FullName = "google.protobuf.GoFeatures.legacy_unmarshal_json_enum"
++)
++
++// Field numbers for google.protobuf.GoFeatures.
++const (
++	GoFeatures_LegacyUnmarshalJsonEnum_field_number protoreflect.FieldNumber = 1
++)
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go b/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
+index 1a38944..ad6f80c 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/struct_gen.go
+@@ -18,6 +18,11 @@ const (
+ 	NullValue_enum_name     = "NullValue"
+ )
+ 
++// Enum values for google.protobuf.NullValue.
++const (
++	NullValue_NULL_VALUE_enum_value = 0
++)
++
+ // Names for google.protobuf.Struct.
+ const (
+ 	Struct_message_name     protoreflect.Name     = "Struct"
+diff --git a/vendor/google.golang.org/protobuf/internal/genid/type_gen.go b/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
+index e0f75fe..49bc73e 100644
+--- a/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/genid/type_gen.go
+@@ -18,6 +18,13 @@ const (
+ 	Syntax_enum_name     = "Syntax"
+ )
+ 
++// Enum values for google.protobuf.Syntax.
++const (
++	Syntax_SYNTAX_PROTO2_enum_value   = 0
++	Syntax_SYNTAX_PROTO3_enum_value   = 1
++	Syntax_SYNTAX_EDITIONS_enum_value = 2
++)
++
+ // Names for google.protobuf.Type.
+ const (
+ 	Type_message_name     protoreflect.Name     = "Type"
+@@ -105,12 +112,43 @@ const (
+ 	Field_Kind_enum_name     = "Kind"
+ )
+ 
++// Enum values for google.protobuf.Field.Kind.
++const (
++	Field_TYPE_UNKNOWN_enum_value  = 0
++	Field_TYPE_DOUBLE_enum_value   = 1
++	Field_TYPE_FLOAT_enum_value    = 2
++	Field_TYPE_INT64_enum_value    = 3
++	Field_TYPE_UINT64_enum_value   = 4
++	Field_TYPE_INT32_enum_value    = 5
++	Field_TYPE_FIXED64_enum_value  = 6
++	Field_TYPE_FIXED32_enum_value  = 7
++	Field_TYPE_BOOL_enum_value     = 8
++	Field_TYPE_STRING_enum_value   = 9
++	Field_TYPE_GROUP_enum_value    = 10
++	Field_TYPE_MESSAGE_enum_value  = 11
++	Field_TYPE_BYTES_enum_value    = 12
++	Field_TYPE_UINT32_enum_value   = 13
++	Field_TYPE_ENUM_enum_value     = 14
++	Field_TYPE_SFIXED32_enum_value = 15
++	Field_TYPE_SFIXED64_enum_value = 16
++	Field_TYPE_SINT32_enum_value   = 17
++	Field_TYPE_SINT64_enum_value   = 18
++)
++
+ // Full and short names for google.protobuf.Field.Cardinality.
+ const (
+ 	Field_Cardinality_enum_fullname = "google.protobuf.Field.Cardinality"
+ 	Field_Cardinality_enum_name     = "Cardinality"
+ )
+ 
++// Enum values for google.protobuf.Field.Cardinality.
++const (
++	Field_CARDINALITY_UNKNOWN_enum_value  = 0
++	Field_CARDINALITY_OPTIONAL_enum_value = 1
++	Field_CARDINALITY_REQUIRED_enum_value = 2
++	Field_CARDINALITY_REPEATED_enum_value = 3
++)
++
+ // Names for google.protobuf.Enum.
+ const (
+ 	Enum_message_name     protoreflect.Name     = "Enum"
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go b/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
+index e74cefd..2b8f122 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_extension.go
+@@ -21,26 +21,18 @@ type extensionFieldInfo struct {
+ 	validation          validationInfo
+ }
+ 
+-var legacyExtensionFieldInfoCache sync.Map // map[protoreflect.ExtensionType]*extensionFieldInfo
+-
+ func getExtensionFieldInfo(xt protoreflect.ExtensionType) *extensionFieldInfo {
+ 	if xi, ok := xt.(*ExtensionInfo); ok {
+ 		xi.lazyInit()
+ 		return xi.info
+ 	}
+-	return legacyLoadExtensionFieldInfo(xt)
+-}
+-
+-// legacyLoadExtensionFieldInfo dynamically loads a *ExtensionInfo for xt.
+-func legacyLoadExtensionFieldInfo(xt protoreflect.ExtensionType) *extensionFieldInfo {
+-	if xi, ok := legacyExtensionFieldInfoCache.Load(xt); ok {
+-		return xi.(*extensionFieldInfo)
+-	}
+-	e := makeExtensionFieldInfo(xt.TypeDescriptor())
+-	if e, ok := legacyMessageTypeCache.LoadOrStore(xt, e); ok {
+-		return e.(*extensionFieldInfo)
+-	}
+-	return e
++	// Ideally we'd cache the resulting *extensionFieldInfo so we don't have to
++	// recompute this metadata repeatedly. But without support for something like
++	// weak references, such a cache would pin temporary values (like dynamic
++	// extension types, constructed for the duration of a user request) to the
++	// heap forever, causing memory usage of the cache to grow unbounded.
++	// See discussion in https://github.com/golang/protobuf/issues/1521.
++	return makeExtensionFieldInfo(xt.TypeDescriptor())
+ }
+ 
+ func makeExtensionFieldInfo(xd protoreflect.ExtensionDescriptor) *extensionFieldInfo {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go b/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
+index 1a509b6..f55dc01 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_gen.go
+@@ -162,11 +162,20 @@ func appendBoolSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptions
+ func consumeBoolSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.BoolSlice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growBoolSlice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -732,11 +741,20 @@ func appendInt32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeInt32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1138,11 +1156,20 @@ func appendSint32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeSint32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1544,11 +1571,20 @@ func appendUint32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeUint32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growUint32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -1950,11 +1986,20 @@ func appendInt64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeInt64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -2356,11 +2401,20 @@ func appendSint64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeSint64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -2762,11 +2816,20 @@ func appendUint64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeUint64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := 0
++		for _, v := range b {
++			if v < 0x80 {
++				count++
++			}
++		}
++		if count > 0 {
++			p.growUint64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			var v uint64
+ 			var n int
+@@ -3145,11 +3208,15 @@ func appendSfixed32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpt
+ func consumeSfixed32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growInt32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -3461,11 +3528,15 @@ func appendFixed32Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpti
+ func consumeFixed32Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growUint32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -3777,11 +3848,15 @@ func appendFloatSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOption
+ func consumeFloatSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Float32Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed32()
++		if count > 0 {
++			p.growFloat32Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed32(b)
+ 			if n < 0 {
+@@ -4093,11 +4168,15 @@ func appendSfixed64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpt
+ func consumeSfixed64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Int64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growInt64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+@@ -4409,11 +4488,15 @@ func appendFixed64Slice(b []byte, p pointer, f *coderFieldInfo, opts marshalOpti
+ func consumeFixed64Slice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Uint64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growUint64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+@@ -4725,11 +4808,15 @@ func appendDoubleSlice(b []byte, p pointer, f *coderFieldInfo, opts marshalOptio
+ func consumeDoubleSlice(b []byte, p pointer, wtyp protowire.Type, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+ 	sp := p.Float64Slice()
+ 	if wtyp == protowire.BytesType {
+-		s := *sp
+ 		b, n := protowire.ConsumeBytes(b)
+ 		if n < 0 {
+ 			return out, errDecode
+ 		}
++		count := len(b) / protowire.SizeFixed64()
++		if count > 0 {
++			p.growFloat64Slice(count)
++		}
++		s := *sp
+ 		for len(b) > 0 {
+ 			v, n := protowire.ConsumeFixed64(b)
+ 			if n < 0 {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go b/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
+index 576dcf3..1307775 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/codec_tables.go
+@@ -197,7 +197,7 @@ func fieldCoder(fd protoreflect.FieldDescriptor, ft reflect.Type) (*MessageInfo,
+ 		return getMessageInfo(ft), makeMessageFieldCoder(fd, ft)
+ 	case fd.Kind() == protoreflect.GroupKind:
+ 		return getMessageInfo(ft), makeGroupFieldCoder(fd, ft)
+-	case fd.Syntax() == protoreflect.Proto3 && fd.ContainingOneof() == nil:
++	case !fd.HasPresence() && fd.ContainingOneof() == nil:
+ 		// Populated oneof fields always encode even if set to the zero value,
+ 		// which normally are not encoded in proto3.
+ 		switch fd.Kind() {
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go b/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
+index 61c483f..2ab2c62 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/legacy_message.go
+@@ -206,13 +206,18 @@ func aberrantLoadMessageDescReentrant(t reflect.Type, name protoreflect.FullName
+ 
+ 	// Obtain a list of oneof wrapper types.
+ 	var oneofWrappers []reflect.Type
+-	for _, method := range []string{"XXX_OneofFuncs", "XXX_OneofWrappers"} {
+-		if fn, ok := t.MethodByName(method); ok {
+-			for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
+-				if vs, ok := v.Interface().([]interface{}); ok {
+-					for _, v := range vs {
+-						oneofWrappers = append(oneofWrappers, reflect.TypeOf(v))
+-					}
++	methods := make([]reflect.Method, 0, 2)
++	if m, ok := t.MethodByName("XXX_OneofFuncs"); ok {
++		methods = append(methods, m)
++	}
++	if m, ok := t.MethodByName("XXX_OneofWrappers"); ok {
++		methods = append(methods, m)
++	}
++	for _, fn := range methods {
++		for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
++			if vs, ok := v.Interface().([]interface{}); ok {
++				for _, v := range vs {
++					oneofWrappers = append(oneofWrappers, reflect.TypeOf(v))
+ 				}
+ 			}
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/message.go b/vendor/google.golang.org/protobuf/internal/impl/message.go
+index 4f5fb67..629bacd 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/message.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/message.go
+@@ -192,12 +192,17 @@ fieldLoop:
+ 
+ 	// Derive a mapping of oneof wrappers to fields.
+ 	oneofWrappers := mi.OneofWrappers
+-	for _, method := range []string{"XXX_OneofFuncs", "XXX_OneofWrappers"} {
+-		if fn, ok := reflect.PtrTo(t).MethodByName(method); ok {
+-			for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
+-				if vs, ok := v.Interface().([]interface{}); ok {
+-					oneofWrappers = vs
+-				}
++	methods := make([]reflect.Method, 0, 2)
++	if m, ok := reflect.PtrTo(t).MethodByName("XXX_OneofFuncs"); ok {
++		methods = append(methods, m)
++	}
++	if m, ok := reflect.PtrTo(t).MethodByName("XXX_OneofWrappers"); ok {
++		methods = append(methods, m)
++	}
++	for _, fn := range methods {
++		for _, v := range fn.Func.Call([]reflect.Value{reflect.Zero(fn.Type.In(0))}) {
++			if vs, ok := v.Interface().([]interface{}); ok {
++				oneofWrappers = vs
+ 			}
+ 		}
+ 	}
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go b/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
+index 5e736c6..986322b 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/message_reflect_field.go
+@@ -538,6 +538,6 @@ func isZero(v reflect.Value) bool {
+ 		}
+ 		return true
+ 	default:
+-		panic(&reflect.ValueError{"reflect.Value.IsZero", v.Kind()})
++		panic(&reflect.ValueError{Method: "reflect.Value.IsZero", Kind: v.Kind()})
+ 	}
+ }
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go b/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
+index 4c491bd..517e944 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
+@@ -159,6 +159,42 @@ func (p pointer) SetPointer(v pointer) {
+ 	p.v.Elem().Set(v.v)
+ }
+ 
++func growSlice(p pointer, addCap int) {
++	// TODO: Once we only support Go 1.20 and newer, use reflect.Grow.
++	in := p.v.Elem()
++	out := reflect.MakeSlice(in.Type(), in.Len(), in.Len()+addCap)
++	reflect.Copy(out, in)
++	p.v.Elem().Set(out)
++}
++
++func (p pointer) growBoolSlice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growInt32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growUint32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growInt64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growUint64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growFloat64Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
++func (p pointer) growFloat32Slice(addCap int) {
++	growSlice(p, addCap)
++}
++
+ func (Export) MessageStateOf(p Pointer) *messageState     { panic("not supported") }
+ func (ms *messageState) pointer() pointer                 { panic("not supported") }
+ func (ms *messageState) messageInfo() *MessageInfo        { panic("not supported") }
+diff --git a/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go b/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
+index ee0e057..4b020e3 100644
+--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
++++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
+@@ -138,6 +138,46 @@ func (p pointer) SetPointer(v pointer) {
+ 	*(*unsafe.Pointer)(p.p) = (unsafe.Pointer)(v.p)
+ }
+ 
++func (p pointer) growBoolSlice(addCap int) {
++	sp := p.BoolSlice()
++	s := make([]bool, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growInt32Slice(addCap int) {
++	sp := p.Int32Slice()
++	s := make([]int32, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growUint32Slice(addCap int) {
++	p.growInt32Slice(addCap)
++}
++
++func (p pointer) growFloat32Slice(addCap int) {
++	p.growInt32Slice(addCap)
++}
++
++func (p pointer) growInt64Slice(addCap int) {
++	sp := p.Int64Slice()
++	s := make([]int64, 0, addCap+len(*sp))
++	s = s[:len(*sp)]
++	copy(s, *sp)
++	*sp = s
++}
++
++func (p pointer) growUint64Slice(addCap int) {
++	p.growInt64Slice(addCap)
++}
++
++func (p pointer) growFloat64Slice(addCap int) {
++	p.growInt64Slice(addCap)
++}
++
+ // Static check that MessageState does not exceed the size of a pointer.
+ const _ = uint(unsafe.Sizeof(unsafe.Pointer(nil)) - unsafe.Sizeof(MessageState{}))
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings.go b/vendor/google.golang.org/protobuf/internal/strs/strings.go
+index 0b74e76..a6e7df2 100644
+--- a/vendor/google.golang.org/protobuf/internal/strs/strings.go
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings.go
+@@ -17,7 +17,7 @@ import (
+ 
+ // EnforceUTF8 reports whether to enforce strict UTF-8 validation.
+ func EnforceUTF8(fd protoreflect.FieldDescriptor) bool {
+-	if flags.ProtoLegacy {
++	if flags.ProtoLegacy || fd.Syntax() == protoreflect.Editions {
+ 		if fd, ok := fd.(interface{ EnforceUTF8() bool }); ok {
+ 			return fd.EnforceUTF8()
+ 		}
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+similarity index 96%
+rename from vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
+rename to vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+index 61a84d3..a008acd 100644
+--- a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go120.go
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !purego && !appengine
+-// +build !purego,!appengine
++//go:build !purego && !appengine && !go1.21
++// +build !purego,!appengine,!go1.21
+ 
+ package strs
+ 
+diff --git a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+new file mode 100644
+index 0000000..60166f2
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe_go121.go
+@@ -0,0 +1,74 @@
++// Copyright 2018 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !purego && !appengine && go1.21
++// +build !purego,!appengine,go1.21
++
++package strs
++
++import (
++	"unsafe"
++
++	"google.golang.org/protobuf/reflect/protoreflect"
++)
++
++// UnsafeString returns an unsafe string reference of b.
++// The caller must treat the input slice as immutable.
++//
++// WARNING: Use carefully. The returned result must not leak to the end user
++// unless the input slice is provably immutable.
++func UnsafeString(b []byte) string {
++	return unsafe.String(unsafe.SliceData(b), len(b))
++}
++
++// UnsafeBytes returns an unsafe bytes slice reference of s.
++// The caller must treat returned slice as immutable.
++//
++// WARNING: Use carefully. The returned result must not leak to the end user.
++func UnsafeBytes(s string) []byte {
++	return unsafe.Slice(unsafe.StringData(s), len(s))
++}
++
++// Builder builds a set of strings with shared lifetime.
++// This differs from strings.Builder, which is for building a single string.
++type Builder struct {
++	buf []byte
++}
++
++// AppendFullName is equivalent to protoreflect.FullName.Append,
++// but optimized for large batches where each name has a shared lifetime.
++func (sb *Builder) AppendFullName(prefix protoreflect.FullName, name protoreflect.Name) protoreflect.FullName {
++	n := len(prefix) + len(".") + len(name)
++	if len(prefix) == 0 {
++		n -= len(".")
++	}
++	sb.grow(n)
++	sb.buf = append(sb.buf, prefix...)
++	sb.buf = append(sb.buf, '.')
++	sb.buf = append(sb.buf, name...)
++	return protoreflect.FullName(sb.last(n))
++}
++
++// MakeString is equivalent to string(b), but optimized for large batches
++// with a shared lifetime.
++func (sb *Builder) MakeString(b []byte) string {
++	sb.grow(len(b))
++	sb.buf = append(sb.buf, b...)
++	return sb.last(len(b))
++}
++
++func (sb *Builder) grow(n int) {
++	if cap(sb.buf)-len(sb.buf) >= n {
++		return
++	}
++
++	// Unlike strings.Builder, we do not need to copy over the contents
++	// of the old buffer since our builder provides no API for
++	// retrieving previously created strings.
++	sb.buf = make([]byte, 0, 2*(cap(sb.buf)+n))
++}
++
++func (sb *Builder) last(n int) string {
++	return UnsafeString(sb.buf[len(sb.buf)-n:])
++}
+diff --git a/vendor/google.golang.org/protobuf/internal/version/version.go b/vendor/google.golang.org/protobuf/internal/version/version.go
+index 0999f29..a50fcfb 100644
+--- a/vendor/google.golang.org/protobuf/internal/version/version.go
++++ b/vendor/google.golang.org/protobuf/internal/version/version.go
+@@ -51,7 +51,7 @@ import (
+ //  10. Send out the CL for review and submit it.
+ const (
+ 	Major      = 1
+-	Minor      = 31
++	Minor      = 33
+ 	Patch      = 0
+ 	PreRelease = ""
+ )
+diff --git a/vendor/google.golang.org/protobuf/proto/decode.go b/vendor/google.golang.org/protobuf/proto/decode.go
+index 48d4794..e5b03b5 100644
+--- a/vendor/google.golang.org/protobuf/proto/decode.go
++++ b/vendor/google.golang.org/protobuf/proto/decode.go
+@@ -69,7 +69,7 @@ func (o UnmarshalOptions) Unmarshal(b []byte, m Message) error {
+ // UnmarshalState parses a wire-format message and places the result in m.
+ //
+ // This method permits fine-grained control over the unmarshaler.
+-// Most users should use Unmarshal instead.
++// Most users should use [Unmarshal] instead.
+ func (o UnmarshalOptions) UnmarshalState(in protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+ 	if o.RecursionLimit == 0 {
+ 		o.RecursionLimit = protowire.DefaultRecursionLimit
+diff --git a/vendor/google.golang.org/protobuf/proto/doc.go b/vendor/google.golang.org/protobuf/proto/doc.go
+index ec71e71..80ed16a 100644
+--- a/vendor/google.golang.org/protobuf/proto/doc.go
++++ b/vendor/google.golang.org/protobuf/proto/doc.go
+@@ -18,27 +18,27 @@
+ // This package contains functions to convert to and from the wire format,
+ // an efficient binary serialization of protocol buffers.
+ //
+-// • Size reports the size of a message in the wire format.
++//   - [Size] reports the size of a message in the wire format.
+ //
+-// • Marshal converts a message to the wire format.
+-// The MarshalOptions type provides more control over wire marshaling.
++//   - [Marshal] converts a message to the wire format.
++//     The [MarshalOptions] type provides more control over wire marshaling.
+ //
+-// • Unmarshal converts a message from the wire format.
+-// The UnmarshalOptions type provides more control over wire unmarshaling.
++//   - [Unmarshal] converts a message from the wire format.
++//     The [UnmarshalOptions] type provides more control over wire unmarshaling.
+ //
+ // # Basic message operations
+ //
+-// • Clone makes a deep copy of a message.
++//   - [Clone] makes a deep copy of a message.
+ //
+-// • Merge merges the content of a message into another.
++//   - [Merge] merges the content of a message into another.
+ //
+-// • Equal compares two messages. For more control over comparisons
+-// and detailed reporting of differences, see package
+-// "google.golang.org/protobuf/testing/protocmp".
++//   - [Equal] compares two messages. For more control over comparisons
++//     and detailed reporting of differences, see package
++//     [google.golang.org/protobuf/testing/protocmp].
+ //
+-// • Reset clears the content of a message.
++//   - [Reset] clears the content of a message.
+ //
+-// • CheckInitialized reports whether all required fields in a message are set.
++//   - [CheckInitialized] reports whether all required fields in a message are set.
+ //
+ // # Optional scalar constructors
+ //
+@@ -46,9 +46,9 @@
+ // as pointers to a value. For example, an optional string field has the
+ // Go type *string.
+ //
+-// • Bool, Int32, Int64, Uint32, Uint64, Float32, Float64, and String
+-// take a value and return a pointer to a new instance of it,
+-// to simplify construction of optional field values.
++//   - [Bool], [Int32], [Int64], [Uint32], [Uint64], [Float32], [Float64], and [String]
++//     take a value and return a pointer to a new instance of it,
++//     to simplify construction of optional field values.
+ //
+ // Generated enum types usually have an Enum method which performs the
+ // same operation.
+@@ -57,29 +57,29 @@
+ //
+ // # Extension accessors
+ //
+-// • HasExtension, GetExtension, SetExtension, and ClearExtension
+-// access extension field values in a protocol buffer message.
++//   - [HasExtension], [GetExtension], [SetExtension], and [ClearExtension]
++//     access extension field values in a protocol buffer message.
+ //
+ // Extension fields are only supported in proto2.
+ //
+ // # Related packages
+ //
+-// • Package "google.golang.org/protobuf/encoding/protojson" converts messages to
+-// and from JSON.
++//   - Package [google.golang.org/protobuf/encoding/protojson] converts messages to
++//     and from JSON.
+ //
+-// • Package "google.golang.org/protobuf/encoding/prototext" converts messages to
+-// and from the text format.
++//   - Package [google.golang.org/protobuf/encoding/prototext] converts messages to
++//     and from the text format.
+ //
+-// • Package "google.golang.org/protobuf/reflect/protoreflect" provides a
+-// reflection interface for protocol buffer data types.
++//   - Package [google.golang.org/protobuf/reflect/protoreflect] provides a
++//     reflection interface for protocol buffer data types.
+ //
+-// • Package "google.golang.org/protobuf/testing/protocmp" provides features
+-// to compare protocol buffer messages with the "github.com/google/go-cmp/cmp"
+-// package.
++//   - Package [google.golang.org/protobuf/testing/protocmp] provides features
++//     to compare protocol buffer messages with the [github.com/google/go-cmp/cmp]
++//     package.
+ //
+-// • Package "google.golang.org/protobuf/types/dynamicpb" provides a dynamic
+-// message type, suitable for working with messages where the protocol buffer
+-// type is only known at runtime.
++//   - Package [google.golang.org/protobuf/types/dynamicpb] provides a dynamic
++//     message type, suitable for working with messages where the protocol buffer
++//     type is only known at runtime.
+ //
+ // This module contains additional packages for more specialized use cases.
+ // Consult the individual package documentation for details.
+diff --git a/vendor/google.golang.org/protobuf/proto/encode.go b/vendor/google.golang.org/protobuf/proto/encode.go
+index bf7f816..4fed202 100644
+--- a/vendor/google.golang.org/protobuf/proto/encode.go
++++ b/vendor/google.golang.org/protobuf/proto/encode.go
+@@ -129,7 +129,7 @@ func (o MarshalOptions) MarshalAppend(b []byte, m Message) ([]byte, error) {
+ // MarshalState returns the wire-format encoding of a message.
+ //
+ // This method permits fine-grained control over the marshaler.
+-// Most users should use Marshal instead.
++// Most users should use [Marshal] instead.
+ func (o MarshalOptions) MarshalState(in protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+ 	return o.marshal(in.Buf, in.Message)
+ }
+diff --git a/vendor/google.golang.org/protobuf/proto/extension.go b/vendor/google.golang.org/protobuf/proto/extension.go
+index 5f293cd..17899a3 100644
+--- a/vendor/google.golang.org/protobuf/proto/extension.go
++++ b/vendor/google.golang.org/protobuf/proto/extension.go
+@@ -26,7 +26,7 @@ func HasExtension(m Message, xt protoreflect.ExtensionType) bool {
+ }
+ 
+ // ClearExtension clears an extension field such that subsequent
+-// HasExtension calls return false.
++// [HasExtension] calls return false.
+ // It panics if m is invalid or if xt does not extend m.
+ func ClearExtension(m Message, xt protoreflect.ExtensionType) {
+ 	m.ProtoReflect().Clear(xt.TypeDescriptor())
+diff --git a/vendor/google.golang.org/protobuf/proto/merge.go b/vendor/google.golang.org/protobuf/proto/merge.go
+index d761ab3..3c6fe57 100644
+--- a/vendor/google.golang.org/protobuf/proto/merge.go
++++ b/vendor/google.golang.org/protobuf/proto/merge.go
+@@ -21,7 +21,7 @@ import (
+ // The unknown fields of src are appended to the unknown fields of dst.
+ //
+ // It is semantically equivalent to unmarshaling the encoded form of src
+-// into dst with the UnmarshalOptions.Merge option specified.
++// into dst with the [UnmarshalOptions.Merge] option specified.
+ func Merge(dst, src Message) {
+ 	// TODO: Should nil src be treated as semantically equivalent to a
+ 	// untyped, read-only, empty message? What about a nil dst?
+diff --git a/vendor/google.golang.org/protobuf/proto/proto.go b/vendor/google.golang.org/protobuf/proto/proto.go
+index 1f0d183..7543ee6 100644
+--- a/vendor/google.golang.org/protobuf/proto/proto.go
++++ b/vendor/google.golang.org/protobuf/proto/proto.go
+@@ -15,18 +15,20 @@ import (
+ // protobuf module that accept a Message, except where otherwise specified.
+ //
+ // This is the v2 interface definition for protobuf messages.
+-// The v1 interface definition is "github.com/golang/protobuf/proto".Message.
++// The v1 interface definition is [github.com/golang/protobuf/proto.Message].
+ //
+-// To convert a v1 message to a v2 message,
+-// use "github.com/golang/protobuf/proto".MessageV2.
+-// To convert a v2 message to a v1 message,
+-// use "github.com/golang/protobuf/proto".MessageV1.
++//   - To convert a v1 message to a v2 message,
++//     use [google.golang.org/protobuf/protoadapt.MessageV2Of].
++//   - To convert a v2 message to a v1 message,
++//     use [google.golang.org/protobuf/protoadapt.MessageV1Of].
+ type Message = protoreflect.ProtoMessage
+ 
+-// Error matches all errors produced by packages in the protobuf module.
++// Error matches all errors produced by packages in the protobuf module
++// according to [errors.Is].
+ //
+-// That is, errors.Is(err, Error) reports whether an error is produced
+-// by this module.
++// Example usage:
++//
++//	if errors.Is(err, proto.Error) { ... }
+ var Error error
+ 
+ func init() {
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+index e4dfb12..baa0cc6 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+@@ -3,11 +3,11 @@
+ // license that can be found in the LICENSE file.
+ 
+ // Package protodesc provides functionality for converting
+-// FileDescriptorProto messages to/from protoreflect.FileDescriptor values.
++// FileDescriptorProto messages to/from [protoreflect.FileDescriptor] values.
+ //
+ // The google.protobuf.FileDescriptorProto is a protobuf message that describes
+ // the type information for a .proto file in a form that is easily serializable.
+-// The protoreflect.FileDescriptor is a more structured representation of
++// The [protoreflect.FileDescriptor] is a more structured representation of
+ // the FileDescriptorProto message where references and remote dependencies
+ // can be directly followed.
+ package protodesc
+@@ -24,11 +24,11 @@ import (
+ 	"google.golang.org/protobuf/types/descriptorpb"
+ )
+ 
+-// Resolver is the resolver used by NewFile to resolve dependencies.
++// Resolver is the resolver used by [NewFile] to resolve dependencies.
+ // The enums and messages provided must belong to some parent file,
+ // which is also registered.
+ //
+-// It is implemented by protoregistry.Files.
++// It is implemented by [protoregistry.Files].
+ type Resolver interface {
+ 	FindFileByPath(string) (protoreflect.FileDescriptor, error)
+ 	FindDescriptorByName(protoreflect.FullName) (protoreflect.Descriptor, error)
+@@ -61,19 +61,19 @@ type FileOptions struct {
+ 	AllowUnresolvable bool
+ }
+ 
+-// NewFile creates a new protoreflect.FileDescriptor from the provided
+-// file descriptor message. See FileOptions.New for more information.
++// NewFile creates a new [protoreflect.FileDescriptor] from the provided
++// file descriptor message. See [FileOptions.New] for more information.
+ func NewFile(fd *descriptorpb.FileDescriptorProto, r Resolver) (protoreflect.FileDescriptor, error) {
+ 	return FileOptions{}.New(fd, r)
+ }
+ 
+-// NewFiles creates a new protoregistry.Files from the provided
+-// FileDescriptorSet message. See FileOptions.NewFiles for more information.
++// NewFiles creates a new [protoregistry.Files] from the provided
++// FileDescriptorSet message. See [FileOptions.NewFiles] for more information.
+ func NewFiles(fd *descriptorpb.FileDescriptorSet) (*protoregistry.Files, error) {
+ 	return FileOptions{}.NewFiles(fd)
+ }
+ 
+-// New creates a new protoreflect.FileDescriptor from the provided
++// New creates a new [protoreflect.FileDescriptor] from the provided
+ // file descriptor message. The file must represent a valid proto file according
+ // to protobuf semantics. The returned descriptor is a deep copy of the input.
+ //
+@@ -93,9 +93,15 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
+ 		f.L1.Syntax = protoreflect.Proto2
+ 	case "proto3":
+ 		f.L1.Syntax = protoreflect.Proto3
++	case "editions":
++		f.L1.Syntax = protoreflect.Editions
++		f.L1.Edition = fromEditionProto(fd.GetEdition())
+ 	default:
+ 		return nil, errors.New("invalid syntax: %q", fd.GetSyntax())
+ 	}
++	if f.L1.Syntax == protoreflect.Editions && (fd.GetEdition() < SupportedEditionsMinimum || fd.GetEdition() > SupportedEditionsMaximum) {
++		return nil, errors.New("use of edition %v not yet supported by the Go Protobuf runtime", fd.GetEdition())
++	}
+ 	f.L1.Path = fd.GetName()
+ 	if f.L1.Path == "" {
+ 		return nil, errors.New("file path must be populated")
+@@ -108,6 +114,9 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
+ 		opts = proto.Clone(opts).(*descriptorpb.FileOptions)
+ 		f.L2.Options = func() protoreflect.ProtoMessage { return opts }
+ 	}
++	if f.L1.Syntax == protoreflect.Editions {
++		initFileDescFromFeatureSet(f, fd.GetOptions().GetFeatures())
++	}
+ 
+ 	f.L2.Imports = make(filedesc.FileImports, len(fd.GetDependency()))
+ 	for _, i := range fd.GetPublicDependency() {
+@@ -231,7 +240,7 @@ func (is importSet) importPublic(imps protoreflect.FileImports) {
+ 	}
+ }
+ 
+-// NewFiles creates a new protoregistry.Files from the provided
++// NewFiles creates a new [protoregistry.Files] from the provided
+ // FileDescriptorSet message. The descriptor set must include only
+ // valid files according to protobuf semantics. The returned descriptors
+ // are a deep copy of the input.
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
+index 37efda1..b327816 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
+@@ -28,6 +28,7 @@ func (r descsByName) initEnumDeclarations(eds []*descriptorpb.EnumDescriptorProt
+ 			opts = proto.Clone(opts).(*descriptorpb.EnumOptions)
+ 			e.L2.Options = func() protoreflect.ProtoMessage { return opts }
+ 		}
++		e.L1.EditionFeatures = mergeEditionFeatures(parent, ed.GetOptions().GetFeatures())
+ 		for _, s := range ed.GetReservedName() {
+ 			e.L2.ReservedNames.List = append(e.L2.ReservedNames.List, protoreflect.Name(s))
+ 		}
+@@ -68,6 +69,9 @@ func (r descsByName) initMessagesDeclarations(mds []*descriptorpb.DescriptorProt
+ 		if m.L0, err = r.makeBase(m, parent, md.GetName(), i, sb); err != nil {
+ 			return nil, err
+ 		}
++		if m.Base.L0.ParentFile.Syntax() == protoreflect.Editions {
++			m.L1.EditionFeatures = mergeEditionFeatures(parent, md.GetOptions().GetFeatures())
++		}
+ 		if opts := md.GetOptions(); opts != nil {
+ 			opts = proto.Clone(opts).(*descriptorpb.MessageOptions)
+ 			m.L2.Options = func() protoreflect.ProtoMessage { return opts }
+@@ -114,6 +118,27 @@ func (r descsByName) initMessagesDeclarations(mds []*descriptorpb.DescriptorProt
+ 	return ms, nil
+ }
+ 
++// canBePacked returns whether the field can use packed encoding:
++// https://protobuf.dev/programming-guides/encoding/#packed
++func canBePacked(fd *descriptorpb.FieldDescriptorProto) bool {
++	if fd.GetLabel() != descriptorpb.FieldDescriptorProto_LABEL_REPEATED {
++		return false // not a repeated field
++	}
++
++	switch protoreflect.Kind(fd.GetType()) {
++	case protoreflect.MessageKind, protoreflect.GroupKind:
++		return false // not a scalar type field
++
++	case protoreflect.StringKind, protoreflect.BytesKind:
++		// string and bytes can explicitly not be declared as packed,
++		// see https://protobuf.dev/programming-guides/encoding/#packed
++		return false
++
++	default:
++		return true
++	}
++}
++
+ func (r descsByName) initFieldsFromDescriptorProto(fds []*descriptorpb.FieldDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (fs []filedesc.Field, err error) {
+ 	fs = make([]filedesc.Field, len(fds)) // allocate up-front to ensure stable pointers
+ 	for i, fd := range fds {
+@@ -137,6 +162,34 @@ func (r descsByName) initFieldsFromDescriptorProto(fds []*descriptorpb.FieldDesc
+ 		if fd.JsonName != nil {
+ 			f.L1.StringName.InitJSON(fd.GetJsonName())
+ 		}
++
++		if f.Base.L0.ParentFile.Syntax() == protoreflect.Editions {
++			f.L1.EditionFeatures = mergeEditionFeatures(parent, fd.GetOptions().GetFeatures())
++
++			if f.L1.EditionFeatures.IsLegacyRequired {
++				f.L1.Cardinality = protoreflect.Required
++			}
++			// We reuse the existing field because the old option `[packed =
++			// true]` is mutually exclusive with the editions feature.
++			if canBePacked(fd) {
++				f.L1.HasPacked = true
++				f.L1.IsPacked = f.L1.EditionFeatures.IsPacked
++			}
++
++			// We pretend this option is always explicitly set because the only
++			// use of HasEnforceUTF8 is to determine whether to use EnforceUTF8
++			// or to return the appropriate default.
++			// When using editions we either parse the option or resolve the
++			// appropriate default here (instead of later when this option is
++			// requested from the descriptor).
++			// In proto2/proto3 syntax HasEnforceUTF8 might be false.
++			f.L1.HasEnforceUTF8 = true
++			f.L1.EnforceUTF8 = f.L1.EditionFeatures.IsUTF8Validated
++
++			if f.L1.Kind == protoreflect.MessageKind && f.L1.EditionFeatures.IsDelimitedEncoded {
++				f.L1.Kind = protoreflect.GroupKind
++			}
++		}
+ 	}
+ 	return fs, nil
+ }
+@@ -151,6 +204,9 @@ func (r descsByName) initOneofsFromDescriptorProto(ods []*descriptorpb.OneofDesc
+ 		if opts := od.GetOptions(); opts != nil {
+ 			opts = proto.Clone(opts).(*descriptorpb.OneofOptions)
+ 			o.L1.Options = func() protoreflect.ProtoMessage { return opts }
++			if parent.Syntax() == protoreflect.Editions {
++				o.L1.EditionFeatures = mergeEditionFeatures(parent, opts.GetFeatures())
++			}
+ 		}
+ 	}
+ 	return os, nil
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
+index 27d7e35..254ca58 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
+@@ -276,8 +276,8 @@ func unmarshalDefault(s string, fd protoreflect.FieldDescriptor, allowUnresolvab
+ 	} else if err != nil {
+ 		return v, ev, err
+ 	}
+-	if fd.Syntax() == protoreflect.Proto3 {
+-		return v, ev, errors.New("cannot be specified under proto3 semantics")
++	if !fd.HasPresence() {
++		return v, ev, errors.New("cannot be specified with implicit field presence")
+ 	}
+ 	if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind || fd.Cardinality() == protoreflect.Repeated {
+ 		return v, ev, errors.New("cannot be specified on composite types")
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
+index 9af1d56..e4dcaf8 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
+@@ -107,7 +107,7 @@ func validateMessageDeclarations(ms []filedesc.Message, mds []*descriptorpb.Desc
+ 		if isMessageSet && !flags.ProtoLegacy {
+ 			return errors.New("message %q is a MessageSet, which is a legacy proto1 feature that is no longer supported", m.FullName())
+ 		}
+-		if isMessageSet && (m.Syntax() != protoreflect.Proto2 || m.Fields().Len() > 0 || m.ExtensionRanges().Len() == 0) {
++		if isMessageSet && (m.Syntax() == protoreflect.Proto3 || m.Fields().Len() > 0 || m.ExtensionRanges().Len() == 0) {
+ 			return errors.New("message %q is an invalid proto1 MessageSet", m.FullName())
+ 		}
+ 		if m.Syntax() == protoreflect.Proto3 {
+@@ -314,8 +314,8 @@ func checkValidGroup(fd protoreflect.FieldDescriptor) error {
+ 	switch {
+ 	case fd.Kind() != protoreflect.GroupKind:
+ 		return nil
+-	case fd.Syntax() != protoreflect.Proto2:
+-		return errors.New("invalid under proto2 semantics")
++	case fd.Syntax() == protoreflect.Proto3:
++		return errors.New("invalid under proto3 semantics")
+ 	case md == nil || md.IsPlaceholder():
+ 		return errors.New("message must be resolvable")
+ 	case fd.FullName().Parent() != md.FullName().Parent():
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go b/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+new file mode 100644
+index 0000000..2a6b29d
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+@@ -0,0 +1,148 @@
++// Copyright 2019 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package protodesc
++
++import (
++	"fmt"
++	"os"
++	"sync"
++
++	"google.golang.org/protobuf/internal/editiondefaults"
++	"google.golang.org/protobuf/internal/filedesc"
++	"google.golang.org/protobuf/proto"
++	"google.golang.org/protobuf/reflect/protoreflect"
++	"google.golang.org/protobuf/types/descriptorpb"
++	gofeaturespb "google.golang.org/protobuf/types/gofeaturespb"
++)
++
++const (
++	SupportedEditionsMinimum = descriptorpb.Edition_EDITION_PROTO2
++	SupportedEditionsMaximum = descriptorpb.Edition_EDITION_2023
++)
++
++var defaults = &descriptorpb.FeatureSetDefaults{}
++var defaultsCacheMu sync.Mutex
++var defaultsCache = make(map[filedesc.Edition]*descriptorpb.FeatureSet)
++
++func init() {
++	err := proto.Unmarshal(editiondefaults.Defaults, defaults)
++	if err != nil {
++		fmt.Fprintf(os.Stderr, "unmarshal editions defaults: %v\n", err)
++		os.Exit(1)
++	}
++}
++
++func fromEditionProto(epb descriptorpb.Edition) filedesc.Edition {
++	return filedesc.Edition(epb)
++}
++
++func toEditionProto(ed filedesc.Edition) descriptorpb.Edition {
++	switch ed {
++	case filedesc.EditionUnknown:
++		return descriptorpb.Edition_EDITION_UNKNOWN
++	case filedesc.EditionProto2:
++		return descriptorpb.Edition_EDITION_PROTO2
++	case filedesc.EditionProto3:
++		return descriptorpb.Edition_EDITION_PROTO3
++	case filedesc.Edition2023:
++		return descriptorpb.Edition_EDITION_2023
++	default:
++		panic(fmt.Sprintf("unknown value for edition: %v", ed))
++	}
++}
++
++func getFeatureSetFor(ed filedesc.Edition) *descriptorpb.FeatureSet {
++	defaultsCacheMu.Lock()
++	defer defaultsCacheMu.Unlock()
++	if def, ok := defaultsCache[ed]; ok {
++		return def
++	}
++	edpb := toEditionProto(ed)
++	if defaults.GetMinimumEdition() > edpb || defaults.GetMaximumEdition() < edpb {
++		// This should never happen protodesc.(FileOptions).New would fail when
++		// initializing the file descriptor.
++		// This most likely means the embedded defaults were not updated.
++		fmt.Fprintf(os.Stderr, "internal error: unsupported edition %v (did you forget to update the embedded defaults (i.e. the bootstrap descriptor proto)?)\n", edpb)
++		os.Exit(1)
++	}
++	fs := defaults.GetDefaults()[0].GetFeatures()
++	// Using a linear search for now.
++	// Editions are guaranteed to be sorted and thus we could use a binary search.
++	// Given that there are only a handful of editions (with one more per year)
++	// there is not much reason to use a binary search.
++	for _, def := range defaults.GetDefaults() {
++		if def.GetEdition() <= edpb {
++			fs = def.GetFeatures()
++		} else {
++			break
++		}
++	}
++	defaultsCache[ed] = fs
++	return fs
++}
++
++// mergeEditionFeatures merges the parent and child feature sets. This function
++// should be used when initializing Go descriptors from descriptor protos which
++// is why the parent is a filedesc.EditionsFeatures (Go representation) while
++// the child is a descriptorproto.FeatureSet (protoc representation).
++// Any feature set by the child overwrites what is set by the parent.
++func mergeEditionFeatures(parentDesc protoreflect.Descriptor, child *descriptorpb.FeatureSet) filedesc.EditionFeatures {
++	var parentFS filedesc.EditionFeatures
++	switch p := parentDesc.(type) {
++	case *filedesc.File:
++		parentFS = p.L1.EditionFeatures
++	case *filedesc.Message:
++		parentFS = p.L1.EditionFeatures
++	default:
++		panic(fmt.Sprintf("unknown parent type %T", parentDesc))
++	}
++	if child == nil {
++		return parentFS
++	}
++	if fp := child.FieldPresence; fp != nil {
++		parentFS.IsFieldPresence = *fp == descriptorpb.FeatureSet_LEGACY_REQUIRED ||
++			*fp == descriptorpb.FeatureSet_EXPLICIT
++		parentFS.IsLegacyRequired = *fp == descriptorpb.FeatureSet_LEGACY_REQUIRED
++	}
++	if et := child.EnumType; et != nil {
++		parentFS.IsOpenEnum = *et == descriptorpb.FeatureSet_OPEN
++	}
++
++	if rfe := child.RepeatedFieldEncoding; rfe != nil {
++		parentFS.IsPacked = *rfe == descriptorpb.FeatureSet_PACKED
++	}
++
++	if utf8val := child.Utf8Validation; utf8val != nil {
++		parentFS.IsUTF8Validated = *utf8val == descriptorpb.FeatureSet_VERIFY
++	}
++
++	if me := child.MessageEncoding; me != nil {
++		parentFS.IsDelimitedEncoded = *me == descriptorpb.FeatureSet_DELIMITED
++	}
++
++	if jf := child.JsonFormat; jf != nil {
++		parentFS.IsJSONCompliant = *jf == descriptorpb.FeatureSet_ALLOW
++	}
++
++	if goFeatures, ok := proto.GetExtension(child, gofeaturespb.E_Go).(*gofeaturespb.GoFeatures); ok && goFeatures != nil {
++		if luje := goFeatures.LegacyUnmarshalJsonEnum; luje != nil {
++			parentFS.GenerateLegacyUnmarshalJSON = *luje
++		}
++	}
++
++	return parentFS
++}
++
++// initFileDescFromFeatureSet initializes editions related fields in fd based
++// on fs. If fs is nil it is assumed to be an empty featureset and all fields
++// will be initialized with the appropriate default. fd.L1.Edition must be set
++// before calling this function.
++func initFileDescFromFeatureSet(fd *filedesc.File, fs *descriptorpb.FeatureSet) {
++	dfs := getFeatureSetFor(fd.L1.Edition)
++	// initialize the featureset with the defaults
++	fd.L1.EditionFeatures = mergeEditionFeatures(fd, dfs)
++	// overwrite any options explicitly specified
++	fd.L1.EditionFeatures = mergeEditionFeatures(fd, fs)
++}
+diff --git a/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go b/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
+index a7c5cef..9d6e054 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
++++ b/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
+@@ -16,7 +16,7 @@ import (
+ 	"google.golang.org/protobuf/types/descriptorpb"
+ )
+ 
+-// ToFileDescriptorProto copies a protoreflect.FileDescriptor into a
++// ToFileDescriptorProto copies a [protoreflect.FileDescriptor] into a
+ // google.protobuf.FileDescriptorProto message.
+ func ToFileDescriptorProto(file protoreflect.FileDescriptor) *descriptorpb.FileDescriptorProto {
+ 	p := &descriptorpb.FileDescriptorProto{
+@@ -70,13 +70,13 @@ func ToFileDescriptorProto(file protoreflect.FileDescriptor) *descriptorpb.FileD
+ 	for i, exts := 0, file.Extensions(); i < exts.Len(); i++ {
+ 		p.Extension = append(p.Extension, ToFieldDescriptorProto(exts.Get(i)))
+ 	}
+-	if syntax := file.Syntax(); syntax != protoreflect.Proto2 {
++	if syntax := file.Syntax(); syntax != protoreflect.Proto2 && syntax.IsValid() {
+ 		p.Syntax = proto.String(file.Syntax().String())
+ 	}
+ 	return p
+ }
+ 
+-// ToDescriptorProto copies a protoreflect.MessageDescriptor into a
++// ToDescriptorProto copies a [protoreflect.MessageDescriptor] into a
+ // google.protobuf.DescriptorProto message.
+ func ToDescriptorProto(message protoreflect.MessageDescriptor) *descriptorpb.DescriptorProto {
+ 	p := &descriptorpb.DescriptorProto{
+@@ -119,7 +119,7 @@ func ToDescriptorProto(message protoreflect.MessageDescriptor) *descriptorpb.Des
+ 	return p
+ }
+ 
+-// ToFieldDescriptorProto copies a protoreflect.FieldDescriptor into a
++// ToFieldDescriptorProto copies a [protoreflect.FieldDescriptor] into a
+ // google.protobuf.FieldDescriptorProto message.
+ func ToFieldDescriptorProto(field protoreflect.FieldDescriptor) *descriptorpb.FieldDescriptorProto {
+ 	p := &descriptorpb.FieldDescriptorProto{
+@@ -168,7 +168,7 @@ func ToFieldDescriptorProto(field protoreflect.FieldDescriptor) *descriptorpb.Fi
+ 	return p
+ }
+ 
+-// ToOneofDescriptorProto copies a protoreflect.OneofDescriptor into a
++// ToOneofDescriptorProto copies a [protoreflect.OneofDescriptor] into a
+ // google.protobuf.OneofDescriptorProto message.
+ func ToOneofDescriptorProto(oneof protoreflect.OneofDescriptor) *descriptorpb.OneofDescriptorProto {
+ 	return &descriptorpb.OneofDescriptorProto{
+@@ -177,7 +177,7 @@ func ToOneofDescriptorProto(oneof protoreflect.OneofDescriptor) *descriptorpb.On
+ 	}
+ }
+ 
+-// ToEnumDescriptorProto copies a protoreflect.EnumDescriptor into a
++// ToEnumDescriptorProto copies a [protoreflect.EnumDescriptor] into a
+ // google.protobuf.EnumDescriptorProto message.
+ func ToEnumDescriptorProto(enum protoreflect.EnumDescriptor) *descriptorpb.EnumDescriptorProto {
+ 	p := &descriptorpb.EnumDescriptorProto{
+@@ -200,7 +200,7 @@ func ToEnumDescriptorProto(enum protoreflect.EnumDescriptor) *descriptorpb.EnumD
+ 	return p
+ }
+ 
+-// ToEnumValueDescriptorProto copies a protoreflect.EnumValueDescriptor into a
++// ToEnumValueDescriptorProto copies a [protoreflect.EnumValueDescriptor] into a
+ // google.protobuf.EnumValueDescriptorProto message.
+ func ToEnumValueDescriptorProto(value protoreflect.EnumValueDescriptor) *descriptorpb.EnumValueDescriptorProto {
+ 	return &descriptorpb.EnumValueDescriptorProto{
+@@ -210,7 +210,7 @@ func ToEnumValueDescriptorProto(value protoreflect.EnumValueDescriptor) *descrip
+ 	}
+ }
+ 
+-// ToServiceDescriptorProto copies a protoreflect.ServiceDescriptor into a
++// ToServiceDescriptorProto copies a [protoreflect.ServiceDescriptor] into a
+ // google.protobuf.ServiceDescriptorProto message.
+ func ToServiceDescriptorProto(service protoreflect.ServiceDescriptor) *descriptorpb.ServiceDescriptorProto {
+ 	p := &descriptorpb.ServiceDescriptorProto{
+@@ -223,7 +223,7 @@ func ToServiceDescriptorProto(service protoreflect.ServiceDescriptor) *descripto
+ 	return p
+ }
+ 
+-// ToMethodDescriptorProto copies a protoreflect.MethodDescriptor into a
++// ToMethodDescriptorProto copies a [protoreflect.MethodDescriptor] into a
+ // google.protobuf.MethodDescriptorProto message.
+ func ToMethodDescriptorProto(method protoreflect.MethodDescriptor) *descriptorpb.MethodDescriptorProto {
+ 	p := &descriptorpb.MethodDescriptorProto{
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
+index 55aa149..00b01fb 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/proto.go
+@@ -10,46 +10,46 @@
+ //
+ // # Protocol Buffer Descriptors
+ //
+-// Protobuf descriptors (e.g., EnumDescriptor or MessageDescriptor)
++// Protobuf descriptors (e.g., [EnumDescriptor] or [MessageDescriptor])
+ // are immutable objects that represent protobuf type information.
+ // They are wrappers around the messages declared in descriptor.proto.
+ // Protobuf descriptors alone lack any information regarding Go types.
+ //
+-// Enums and messages generated by this module implement Enum and ProtoMessage,
++// Enums and messages generated by this module implement [Enum] and [ProtoMessage],
+ // where the Descriptor and ProtoReflect.Descriptor accessors respectively
+ // return the protobuf descriptor for the values.
+ //
+ // The protobuf descriptor interfaces are not meant to be implemented by
+ // user code since they might need to be extended in the future to support
+ // additions to the protobuf language.
+-// The "google.golang.org/protobuf/reflect/protodesc" package converts between
++// The [google.golang.org/protobuf/reflect/protodesc] package converts between
+ // google.protobuf.DescriptorProto messages and protobuf descriptors.
+ //
+ // # Go Type Descriptors
+ //
+-// A type descriptor (e.g., EnumType or MessageType) is a constructor for
++// A type descriptor (e.g., [EnumType] or [MessageType]) is a constructor for
+ // a concrete Go type that represents the associated protobuf descriptor.
+ // There is commonly a one-to-one relationship between protobuf descriptors and
+ // Go type descriptors, but it can potentially be a one-to-many relationship.
+ //
+-// Enums and messages generated by this module implement Enum and ProtoMessage,
++// Enums and messages generated by this module implement [Enum] and [ProtoMessage],
+ // where the Type and ProtoReflect.Type accessors respectively
+ // return the protobuf descriptor for the values.
+ //
+-// The "google.golang.org/protobuf/types/dynamicpb" package can be used to
++// The [google.golang.org/protobuf/types/dynamicpb] package can be used to
+ // create Go type descriptors from protobuf descriptors.
+ //
+ // # Value Interfaces
+ //
+-// The Enum and Message interfaces provide a reflective view over an
++// The [Enum] and [Message] interfaces provide a reflective view over an
+ // enum or message instance. For enums, it provides the ability to retrieve
+ // the enum value number for any concrete enum type. For messages, it provides
+ // the ability to access or manipulate fields of the message.
+ //
+-// To convert a proto.Message to a protoreflect.Message, use the
++// To convert a [google.golang.org/protobuf/proto.Message] to a [protoreflect.Message], use the
+ // former's ProtoReflect method. Since the ProtoReflect method is new to the
+ // v2 message interface, it may not be present on older message implementations.
+-// The "github.com/golang/protobuf/proto".MessageReflect function can be used
++// The [github.com/golang/protobuf/proto.MessageReflect] function can be used
+ // to obtain a reflective view on older messages.
+ //
+ // # Relationships
+@@ -71,12 +71,12 @@
+ //	      │                                 │
+ //	      └────────────────── Type() ───────┘
+ //
+-// • An EnumType describes a concrete Go enum type.
++// • An [EnumType] describes a concrete Go enum type.
+ // It has an EnumDescriptor and can construct an Enum instance.
+ //
+-// • An EnumDescriptor describes an abstract protobuf enum type.
++// • An [EnumDescriptor] describes an abstract protobuf enum type.
+ //
+-// • An Enum is a concrete enum instance. Generated enums implement Enum.
++// • An [Enum] is a concrete enum instance. Generated enums implement Enum.
+ //
+ //	  ┌──────────────── New() ─────────────────┐
+ //	  │                                        │
+@@ -90,24 +90,26 @@
+ //	       │                                    │
+ //	       └─────────────────── Type() ─────────┘
+ //
+-// • A MessageType describes a concrete Go message type.
+-// It has a MessageDescriptor and can construct a Message instance.
+-// Just as how Go's reflect.Type is a reflective description of a Go type,
+-// a MessageType is a reflective description of a Go type for a protobuf message.
++// • A [MessageType] describes a concrete Go message type.
++// It has a [MessageDescriptor] and can construct a [Message] instance.
++// Just as how Go's [reflect.Type] is a reflective description of a Go type,
++// a [MessageType] is a reflective description of a Go type for a protobuf message.
+ //
+-// • A MessageDescriptor describes an abstract protobuf message type.
+-// It has no understanding of Go types. In order to construct a MessageType
+-// from just a MessageDescriptor, you can consider looking up the message type
+-// in the global registry using protoregistry.GlobalTypes.FindMessageByName
+-// or constructing a dynamic MessageType using dynamicpb.NewMessageType.
++// • A [MessageDescriptor] describes an abstract protobuf message type.
++// It has no understanding of Go types. In order to construct a [MessageType]
++// from just a [MessageDescriptor], you can consider looking up the message type
++// in the global registry using the FindMessageByName method on
++// [google.golang.org/protobuf/reflect/protoregistry.GlobalTypes]
++// or constructing a dynamic [MessageType] using
++// [google.golang.org/protobuf/types/dynamicpb.NewMessageType].
+ //
+-// • A Message is a reflective view over a concrete message instance.
+-// Generated messages implement ProtoMessage, which can convert to a Message.
+-// Just as how Go's reflect.Value is a reflective view over a Go value,
+-// a Message is a reflective view over a concrete protobuf message instance.
+-// Using Go reflection as an analogy, the ProtoReflect method is similar to
+-// calling reflect.ValueOf, and the Message.Interface method is similar to
+-// calling reflect.Value.Interface.
++// • A [Message] is a reflective view over a concrete message instance.
++// Generated messages implement [ProtoMessage], which can convert to a [Message].
++// Just as how Go's [reflect.Value] is a reflective view over a Go value,
++// a [Message] is a reflective view over a concrete protobuf message instance.
++// Using Go reflection as an analogy, the [ProtoMessage.ProtoReflect] method is similar to
++// calling [reflect.ValueOf], and the [Message.Interface] method is similar to
++// calling [reflect.Value.Interface].
+ //
+ //	      ┌── TypeDescriptor() ──┐    ┌───── Descriptor() ─────┐
+ //	      │                      V    │                        V
+@@ -119,15 +121,15 @@
+ //	                                 │                          │
+ //	                                 └────── implements ────────┘
+ //
+-// • An ExtensionType describes a concrete Go implementation of an extension.
+-// It has an ExtensionTypeDescriptor and can convert to/from
+-// abstract Values and Go values.
++// • An [ExtensionType] describes a concrete Go implementation of an extension.
++// It has an [ExtensionTypeDescriptor] and can convert to/from
++// an abstract [Value] and a Go value.
+ //
+-// • An ExtensionTypeDescriptor is an ExtensionDescriptor
+-// which also has an ExtensionType.
++// • An [ExtensionTypeDescriptor] is an [ExtensionDescriptor]
++// which also has an [ExtensionType].
+ //
+-// • An ExtensionDescriptor describes an abstract protobuf extension field and
+-// may not always be an ExtensionTypeDescriptor.
++// • An [ExtensionDescriptor] describes an abstract protobuf extension field and
++// may not always be an [ExtensionTypeDescriptor].
+ package protoreflect
+ 
+ import (
+@@ -142,7 +144,7 @@ type doNotImplement pragma.DoNotImplement
+ 
+ // ProtoMessage is the top-level interface that all proto messages implement.
+ // This is declared in the protoreflect package to avoid a cyclic dependency;
+-// use the proto.Message type instead, which aliases this type.
++// use the [google.golang.org/protobuf/proto.Message] type instead, which aliases this type.
+ type ProtoMessage interface{ ProtoReflect() Message }
+ 
+ // Syntax is the language version of the proto file.
+@@ -151,8 +153,9 @@ type Syntax syntax
+ type syntax int8 // keep exact type opaque as the int type may change
+ 
+ const (
+-	Proto2 Syntax = 2
+-	Proto3 Syntax = 3
++	Proto2   Syntax = 2
++	Proto3   Syntax = 3
++	Editions Syntax = 4
+ )
+ 
+ // IsValid reports whether the syntax is valid.
+@@ -172,6 +175,8 @@ func (s Syntax) String() string {
+ 		return "proto2"
+ 	case Proto3:
+ 		return "proto3"
++	case Editions:
++		return "editions"
+ 	default:
+ 		return fmt.Sprintf("<unknown:%d>", s)
+ 	}
+@@ -436,7 +441,7 @@ type Names interface {
+ // FullName is a qualified name that uniquely identifies a proto declaration.
+ // A qualified name is the concatenation of the proto package along with the
+ // fully-declared name (i.e., name of parent preceding the name of the child),
+-// with a '.' delimiter placed between each Name.
++// with a '.' delimiter placed between each [Name].
+ //
+ // This should not have any leading or trailing dots.
+ type FullName string // e.g., "google.protobuf.Field.Kind"
+@@ -480,7 +485,7 @@ func isLetterDigit(c byte) bool {
+ }
+ 
+ // Name returns the short name, which is the last identifier segment.
+-// A single segment FullName is the Name itself.
++// A single segment FullName is the [Name] itself.
+ func (n FullName) Name() Name {
+ 	if i := strings.LastIndexByte(string(n), '.'); i >= 0 {
+ 		return Name(n[i+1:])
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
+index 717b106..7dcc2ff 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/source_gen.go
+@@ -35,7 +35,7 @@ func (p *SourcePath) appendFileDescriptorProto(b []byte) []byte {
+ 		b = p.appendSingularField(b, "source_code_info", (*SourcePath).appendSourceCodeInfo)
+ 	case 12:
+ 		b = p.appendSingularField(b, "syntax", nil)
+-	case 13:
++	case 14:
+ 		b = p.appendSingularField(b, "edition", nil)
+ 	}
+ 	return b
+@@ -160,8 +160,6 @@ func (p *SourcePath) appendFileOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "java_generic_services", nil)
+ 	case 18:
+ 		b = p.appendSingularField(b, "py_generic_services", nil)
+-	case 42:
+-		b = p.appendSingularField(b, "php_generic_services", nil)
+ 	case 23:
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 31:
+@@ -180,6 +178,8 @@ func (p *SourcePath) appendFileOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "php_metadata_namespace", nil)
+ 	case 45:
+ 		b = p.appendSingularField(b, "ruby_package", nil)
++	case 50:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -240,6 +240,8 @@ func (p *SourcePath) appendMessageOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "map_entry", nil)
+ 	case 11:
+ 		b = p.appendSingularField(b, "deprecated_legacy_json_field_conflicts", nil)
++	case 12:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -285,6 +287,8 @@ func (p *SourcePath) appendEnumOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 6:
+ 		b = p.appendSingularField(b, "deprecated_legacy_json_field_conflicts", nil)
++	case 7:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -330,6 +334,8 @@ func (p *SourcePath) appendServiceOptions(b []byte) []byte {
+ 		return b
+ 	}
+ 	switch (*p)[0] {
++	case 34:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 33:
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 999:
+@@ -361,16 +367,39 @@ func (p *SourcePath) appendFieldOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "debug_redact", nil)
+ 	case 17:
+ 		b = p.appendSingularField(b, "retention", nil)
+-	case 18:
+-		b = p.appendSingularField(b, "target", nil)
+ 	case 19:
+ 		b = p.appendRepeatedField(b, "targets", nil)
++	case 20:
++		b = p.appendRepeatedField(b, "edition_defaults", (*SourcePath).appendFieldOptions_EditionDefault)
++	case 21:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+ 	return b
+ }
+ 
++func (p *SourcePath) appendFeatureSet(b []byte) []byte {
++	if len(*p) == 0 {
++		return b
++	}
++	switch (*p)[0] {
++	case 1:
++		b = p.appendSingularField(b, "field_presence", nil)
++	case 2:
++		b = p.appendSingularField(b, "enum_type", nil)
++	case 3:
++		b = p.appendSingularField(b, "repeated_field_encoding", nil)
++	case 4:
++		b = p.appendSingularField(b, "utf8_validation", nil)
++	case 5:
++		b = p.appendSingularField(b, "message_encoding", nil)
++	case 6:
++		b = p.appendSingularField(b, "json_format", nil)
++	}
++	return b
++}
++
+ func (p *SourcePath) appendUninterpretedOption(b []byte) []byte {
+ 	if len(*p) == 0 {
+ 		return b
+@@ -422,6 +451,8 @@ func (p *SourcePath) appendExtensionRangeOptions(b []byte) []byte {
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	case 2:
+ 		b = p.appendRepeatedField(b, "declaration", (*SourcePath).appendExtensionRangeOptions_Declaration)
++	case 50:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 3:
+ 		b = p.appendSingularField(b, "verification", nil)
+ 	}
+@@ -433,6 +464,8 @@ func (p *SourcePath) appendOneofOptions(b []byte) []byte {
+ 		return b
+ 	}
+ 	switch (*p)[0] {
++	case 1:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -446,6 +479,10 @@ func (p *SourcePath) appendEnumValueOptions(b []byte) []byte {
+ 	switch (*p)[0] {
+ 	case 1:
+ 		b = p.appendSingularField(b, "deprecated", nil)
++	case 2:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
++	case 3:
++		b = p.appendSingularField(b, "debug_redact", nil)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+@@ -461,12 +498,27 @@ func (p *SourcePath) appendMethodOptions(b []byte) []byte {
+ 		b = p.appendSingularField(b, "deprecated", nil)
+ 	case 34:
+ 		b = p.appendSingularField(b, "idempotency_level", nil)
++	case 35:
++		b = p.appendSingularField(b, "features", (*SourcePath).appendFeatureSet)
+ 	case 999:
+ 		b = p.appendRepeatedField(b, "uninterpreted_option", (*SourcePath).appendUninterpretedOption)
+ 	}
+ 	return b
+ }
+ 
++func (p *SourcePath) appendFieldOptions_EditionDefault(b []byte) []byte {
++	if len(*p) == 0 {
++		return b
++	}
++	switch (*p)[0] {
++	case 3:
++		b = p.appendSingularField(b, "edition", nil)
++	case 2:
++		b = p.appendSingularField(b, "value", nil)
++	}
++	return b
++}
++
+ func (p *SourcePath) appendUninterpretedOption_NamePart(b []byte) []byte {
+ 	if len(*p) == 0 {
+ 		return b
+@@ -491,8 +543,6 @@ func (p *SourcePath) appendExtensionRangeOptions_Declaration(b []byte) []byte {
+ 		b = p.appendSingularField(b, "full_name", nil)
+ 	case 3:
+ 		b = p.appendSingularField(b, "type", nil)
+-	case 4:
+-		b = p.appendSingularField(b, "is_repeated", nil)
+ 	case 5:
+ 		b = p.appendSingularField(b, "reserved", nil)
+ 	case 6:
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
+index 3867470..60ff62b 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/type.go
+@@ -12,7 +12,7 @@ package protoreflect
+ // exactly identical. However, it is possible for the same semantically
+ // identical proto type to be represented by multiple type descriptors.
+ //
+-// For example, suppose we have t1 and t2 which are both MessageDescriptors.
++// For example, suppose we have t1 and t2 which are both an [MessageDescriptor].
+ // If t1 == t2, then the types are definitely equal and all accessors return
+ // the same information. However, if t1 != t2, then it is still possible that
+ // they still represent the same proto type (e.g., t1.FullName == t2.FullName).
+@@ -115,7 +115,7 @@ type Descriptor interface {
+ // corresponds with the google.protobuf.FileDescriptorProto message.
+ //
+ // Top-level declarations:
+-// EnumDescriptor, MessageDescriptor, FieldDescriptor, and/or ServiceDescriptor.
++// [EnumDescriptor], [MessageDescriptor], [FieldDescriptor], and/or [ServiceDescriptor].
+ type FileDescriptor interface {
+ 	Descriptor // Descriptor.FullName is identical to Package
+ 
+@@ -180,8 +180,8 @@ type FileImport struct {
+ // corresponds with the google.protobuf.DescriptorProto message.
+ //
+ // Nested declarations:
+-// FieldDescriptor, OneofDescriptor, FieldDescriptor, EnumDescriptor,
+-// and/or MessageDescriptor.
++// [FieldDescriptor], [OneofDescriptor], [FieldDescriptor], [EnumDescriptor],
++// and/or [MessageDescriptor].
+ type MessageDescriptor interface {
+ 	Descriptor
+ 
+@@ -214,7 +214,7 @@ type MessageDescriptor interface {
+ 	ExtensionRanges() FieldRanges
+ 	// ExtensionRangeOptions returns the ith extension range options.
+ 	//
+-	// To avoid a dependency cycle, this method returns a proto.Message value,
++	// To avoid a dependency cycle, this method returns a proto.Message] value,
+ 	// which always contains a google.protobuf.ExtensionRangeOptions message.
+ 	// This method returns a typed nil-pointer if no options are present.
+ 	// The caller must import the descriptorpb package to use this.
+@@ -231,9 +231,9 @@ type MessageDescriptor interface {
+ }
+ type isMessageDescriptor interface{ ProtoType(MessageDescriptor) }
+ 
+-// MessageType encapsulates a MessageDescriptor with a concrete Go implementation.
++// MessageType encapsulates a [MessageDescriptor] with a concrete Go implementation.
+ // It is recommended that implementations of this interface also implement the
+-// MessageFieldTypes interface.
++// [MessageFieldTypes] interface.
+ type MessageType interface {
+ 	// New returns a newly allocated empty message.
+ 	// It may return nil for synthetic messages representing a map entry.
+@@ -249,19 +249,19 @@ type MessageType interface {
+ 	Descriptor() MessageDescriptor
+ }
+ 
+-// MessageFieldTypes extends a MessageType by providing type information
++// MessageFieldTypes extends a [MessageType] by providing type information
+ // regarding enums and messages referenced by the message fields.
+ type MessageFieldTypes interface {
+ 	MessageType
+ 
+-	// Enum returns the EnumType for the ith field in Descriptor.Fields.
++	// Enum returns the EnumType for the ith field in MessageDescriptor.Fields.
+ 	// It returns nil if the ith field is not an enum kind.
+ 	// It panics if out of bounds.
+ 	//
+ 	// Invariant: mt.Enum(i).Descriptor() == mt.Descriptor().Fields(i).Enum()
+ 	Enum(i int) EnumType
+ 
+-	// Message returns the MessageType for the ith field in Descriptor.Fields.
++	// Message returns the MessageType for the ith field in MessageDescriptor.Fields.
+ 	// It returns nil if the ith field is not a message or group kind.
+ 	// It panics if out of bounds.
+ 	//
+@@ -286,8 +286,8 @@ type MessageDescriptors interface {
+ // corresponds with the google.protobuf.FieldDescriptorProto message.
+ //
+ // It is used for both normal fields defined within the parent message
+-// (e.g., MessageDescriptor.Fields) and fields that extend some remote message
+-// (e.g., FileDescriptor.Extensions or MessageDescriptor.Extensions).
++// (e.g., [MessageDescriptor.Fields]) and fields that extend some remote message
++// (e.g., [FileDescriptor.Extensions] or [MessageDescriptor.Extensions]).
+ type FieldDescriptor interface {
+ 	Descriptor
+ 
+@@ -344,7 +344,7 @@ type FieldDescriptor interface {
+ 	// IsMap reports whether this field represents a map,
+ 	// where the value type for the associated field is a Map.
+ 	// It is equivalent to checking whether Cardinality is Repeated,
+-	// that the Kind is MessageKind, and that Message.IsMapEntry reports true.
++	// that the Kind is MessageKind, and that MessageDescriptor.IsMapEntry reports true.
+ 	IsMap() bool
+ 
+ 	// MapKey returns the field descriptor for the key in the map entry.
+@@ -419,7 +419,7 @@ type OneofDescriptor interface {
+ 
+ 	// IsSynthetic reports whether this is a synthetic oneof created to support
+ 	// proto3 optional semantics. If true, Fields contains exactly one field
+-	// with HasOptionalKeyword specified.
++	// with FieldDescriptor.HasOptionalKeyword specified.
+ 	IsSynthetic() bool
+ 
+ 	// Fields is a list of fields belonging to this oneof.
+@@ -442,10 +442,10 @@ type OneofDescriptors interface {
+ 	doNotImplement
+ }
+ 
+-// ExtensionDescriptor is an alias of FieldDescriptor for documentation.
++// ExtensionDescriptor is an alias of [FieldDescriptor] for documentation.
+ type ExtensionDescriptor = FieldDescriptor
+ 
+-// ExtensionTypeDescriptor is an ExtensionDescriptor with an associated ExtensionType.
++// ExtensionTypeDescriptor is an [ExtensionDescriptor] with an associated [ExtensionType].
+ type ExtensionTypeDescriptor interface {
+ 	ExtensionDescriptor
+ 
+@@ -470,12 +470,12 @@ type ExtensionDescriptors interface {
+ 	doNotImplement
+ }
+ 
+-// ExtensionType encapsulates an ExtensionDescriptor with a concrete
++// ExtensionType encapsulates an [ExtensionDescriptor] with a concrete
+ // Go implementation. The nested field descriptor must be for a extension field.
+ //
+ // While a normal field is a member of the parent message that it is declared
+-// within (see Descriptor.Parent), an extension field is a member of some other
+-// target message (see ExtensionDescriptor.Extendee) and may have no
++// within (see [Descriptor.Parent]), an extension field is a member of some other
++// target message (see [FieldDescriptor.ContainingMessage]) and may have no
+ // relationship with the parent. However, the full name of an extension field is
+ // relative to the parent that it is declared within.
+ //
+@@ -532,7 +532,7 @@ type ExtensionType interface {
+ // corresponds with the google.protobuf.EnumDescriptorProto message.
+ //
+ // Nested declarations:
+-// EnumValueDescriptor.
++// [EnumValueDescriptor].
+ type EnumDescriptor interface {
+ 	Descriptor
+ 
+@@ -548,7 +548,7 @@ type EnumDescriptor interface {
+ }
+ type isEnumDescriptor interface{ ProtoType(EnumDescriptor) }
+ 
+-// EnumType encapsulates an EnumDescriptor with a concrete Go implementation.
++// EnumType encapsulates an [EnumDescriptor] with a concrete Go implementation.
+ type EnumType interface {
+ 	// New returns an instance of this enum type with its value set to n.
+ 	New(n EnumNumber) Enum
+@@ -610,7 +610,7 @@ type EnumValueDescriptors interface {
+ // ServiceDescriptor describes a service and
+ // corresponds with the google.protobuf.ServiceDescriptorProto message.
+ //
+-// Nested declarations: MethodDescriptor.
++// Nested declarations: [MethodDescriptor].
+ type ServiceDescriptor interface {
+ 	Descriptor
+ 
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
+index 37601b7..a7b0d06 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value.go
+@@ -27,16 +27,16 @@ type Enum interface {
+ // Message is a reflective interface for a concrete message value,
+ // encapsulating both type and value information for the message.
+ //
+-// Accessor/mutators for individual fields are keyed by FieldDescriptor.
++// Accessor/mutators for individual fields are keyed by [FieldDescriptor].
+ // For non-extension fields, the descriptor must exactly match the
+ // field known by the parent message.
+-// For extension fields, the descriptor must implement ExtensionTypeDescriptor,
+-// extend the parent message (i.e., have the same message FullName), and
++// For extension fields, the descriptor must implement [ExtensionTypeDescriptor],
++// extend the parent message (i.e., have the same message [FullName]), and
+ // be within the parent's extension range.
+ //
+-// Each field Value can be a scalar or a composite type (Message, List, or Map).
+-// See Value for the Go types associated with a FieldDescriptor.
+-// Providing a Value that is invalid or of an incorrect type panics.
++// Each field [Value] can be a scalar or a composite type ([Message], [List], or [Map]).
++// See [Value] for the Go types associated with a [FieldDescriptor].
++// Providing a [Value] that is invalid or of an incorrect type panics.
+ type Message interface {
+ 	// Descriptor returns message descriptor, which contains only the protobuf
+ 	// type information for the message.
+@@ -152,7 +152,7 @@ type Message interface {
+ 	// This method may return nil.
+ 	//
+ 	// The returned methods type is identical to
+-	// "google.golang.org/protobuf/runtime/protoiface".Methods.
++	// google.golang.org/protobuf/runtime/protoiface.Methods.
+ 	// Consult the protoiface package documentation for details.
+ 	ProtoMethods() *methods
+ }
+@@ -175,8 +175,8 @@ func (b RawFields) IsValid() bool {
+ }
+ 
+ // List is a zero-indexed, ordered list.
+-// The element Value type is determined by FieldDescriptor.Kind.
+-// Providing a Value that is invalid or of an incorrect type panics.
++// The element [Value] type is determined by [FieldDescriptor.Kind].
++// Providing a [Value] that is invalid or of an incorrect type panics.
+ type List interface {
+ 	// Len reports the number of entries in the List.
+ 	// Get, Set, and Truncate panic with out of bound indexes.
+@@ -226,9 +226,9 @@ type List interface {
+ }
+ 
+ // Map is an unordered, associative map.
+-// The entry MapKey type is determined by FieldDescriptor.MapKey.Kind.
+-// The entry Value type is determined by FieldDescriptor.MapValue.Kind.
+-// Providing a MapKey or Value that is invalid or of an incorrect type panics.
++// The entry [MapKey] type is determined by [FieldDescriptor.MapKey].Kind.
++// The entry [Value] type is determined by [FieldDescriptor.MapValue].Kind.
++// Providing a [MapKey] or [Value] that is invalid or of an incorrect type panics.
+ type Map interface {
+ 	// Len reports the number of elements in the map.
+ 	Len() int
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
+index 5916525..654599d 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_equal.go
+@@ -24,19 +24,19 @@ import (
+ //     Unlike the == operator, a NaN is equal to another NaN.
+ //
+ //   - Enums are equal if they contain the same number.
+-//     Since Value does not contain an enum descriptor,
++//     Since [Value] does not contain an enum descriptor,
+ //     enum values do not consider the type of the enum.
+ //
+ //   - Other scalar values are equal if they contain the same value.
+ //
+-//   - Message values are equal if they belong to the same message descriptor,
++//   - [Message] values are equal if they belong to the same message descriptor,
+ //     have the same set of populated known and extension field values,
+ //     and the same set of unknown fields values.
+ //
+-//   - Lists are equal if they are the same length and
++//   - [List] values are equal if they are the same length and
+ //     each corresponding element is equal.
+ //
+-//   - Maps are equal if they have the same set of keys and
++//   - [Map] values are equal if they have the same set of keys and
+ //     the corresponding value for each key is equal.
+ func (v1 Value) Equal(v2 Value) bool {
+ 	return equalValue(v1, v2)
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
+index 08e5ef7..1603097 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
+@@ -11,7 +11,7 @@ import (
+ 
+ // Value is a union where only one Go type may be set at a time.
+ // The Value is used to represent all possible values a field may take.
+-// The following shows which Go type is used to represent each proto Kind:
++// The following shows which Go type is used to represent each proto [Kind]:
+ //
+ //	╔════════════╤═════════════════════════════════════╗
+ //	║ Go type    │ Protobuf kind                       ║
+@@ -31,22 +31,22 @@ import (
+ //
+ // Multiple protobuf Kinds may be represented by a single Go type if the type
+ // can losslessly represent the information for the proto kind. For example,
+-// Int64Kind, Sint64Kind, and Sfixed64Kind are all represented by int64,
++// [Int64Kind], [Sint64Kind], and [Sfixed64Kind] are all represented by int64,
+ // but use different integer encoding methods.
+ //
+-// The List or Map types are used if the field cardinality is repeated.
+-// A field is a List if FieldDescriptor.IsList reports true.
+-// A field is a Map if FieldDescriptor.IsMap reports true.
++// The [List] or [Map] types are used if the field cardinality is repeated.
++// A field is a [List] if [FieldDescriptor.IsList] reports true.
++// A field is a [Map] if [FieldDescriptor.IsMap] reports true.
+ //
+ // Converting to/from a Value and a concrete Go value panics on type mismatch.
+-// For example, ValueOf("hello").Int() panics because this attempts to
++// For example, [ValueOf]("hello").Int() panics because this attempts to
+ // retrieve an int64 from a string.
+ //
+-// List, Map, and Message Values are called "composite" values.
++// [List], [Map], and [Message] Values are called "composite" values.
+ //
+ // A composite Value may alias (reference) memory at some location,
+ // such that changes to the Value updates the that location.
+-// A composite value acquired with a Mutable method, such as Message.Mutable,
++// A composite value acquired with a Mutable method, such as [Message.Mutable],
+ // always references the source object.
+ //
+ // For example:
+@@ -65,7 +65,7 @@ import (
+ //	// appending to the List here may or may not modify the message.
+ //	list.Append(protoreflect.ValueOfInt32(0))
+ //
+-// Some operations, such as Message.Get, may return an "empty, read-only"
++// Some operations, such as [Message.Get], may return an "empty, read-only"
+ // composite Value. Modifying an empty, read-only value panics.
+ type Value value
+ 
+@@ -306,7 +306,7 @@ func (v Value) Float() float64 {
+ 	}
+ }
+ 
+-// String returns v as a string. Since this method implements fmt.Stringer,
++// String returns v as a string. Since this method implements [fmt.Stringer],
+ // this returns the formatted string value for any non-string type.
+ func (v Value) String() string {
+ 	switch v.typ {
+@@ -327,7 +327,7 @@ func (v Value) Bytes() []byte {
+ 	}
+ }
+ 
+-// Enum returns v as a EnumNumber and panics if the type is not a EnumNumber.
++// Enum returns v as a [EnumNumber] and panics if the type is not a [EnumNumber].
+ func (v Value) Enum() EnumNumber {
+ 	switch v.typ {
+ 	case enumType:
+@@ -337,7 +337,7 @@ func (v Value) Enum() EnumNumber {
+ 	}
+ }
+ 
+-// Message returns v as a Message and panics if the type is not a Message.
++// Message returns v as a [Message] and panics if the type is not a [Message].
+ func (v Value) Message() Message {
+ 	switch vi := v.getIface().(type) {
+ 	case Message:
+@@ -347,7 +347,7 @@ func (v Value) Message() Message {
+ 	}
+ }
+ 
+-// List returns v as a List and panics if the type is not a List.
++// List returns v as a [List] and panics if the type is not a [List].
+ func (v Value) List() List {
+ 	switch vi := v.getIface().(type) {
+ 	case List:
+@@ -357,7 +357,7 @@ func (v Value) List() List {
+ 	}
+ }
+ 
+-// Map returns v as a Map and panics if the type is not a Map.
++// Map returns v as a [Map] and panics if the type is not a [Map].
+ func (v Value) Map() Map {
+ 	switch vi := v.getIface().(type) {
+ 	case Map:
+@@ -367,7 +367,7 @@ func (v Value) Map() Map {
+ 	}
+ }
+ 
+-// MapKey returns v as a MapKey and panics for invalid MapKey types.
++// MapKey returns v as a [MapKey] and panics for invalid [MapKey] types.
+ func (v Value) MapKey() MapKey {
+ 	switch v.typ {
+ 	case boolType, int32Type, int64Type, uint32Type, uint64Type, stringType:
+@@ -378,8 +378,8 @@ func (v Value) MapKey() MapKey {
+ }
+ 
+ // MapKey is used to index maps, where the Go type of the MapKey must match
+-// the specified key Kind (see MessageDescriptor.IsMapEntry).
+-// The following shows what Go type is used to represent each proto Kind:
++// the specified key [Kind] (see [MessageDescriptor.IsMapEntry]).
++// The following shows what Go type is used to represent each proto [Kind]:
+ //
+ //	╔═════════╤═════════════════════════════════════╗
+ //	║ Go type │ Protobuf kind                       ║
+@@ -392,13 +392,13 @@ func (v Value) MapKey() MapKey {
+ //	║ string  │ StringKind                          ║
+ //	╚═════════╧═════════════════════════════════════╝
+ //
+-// A MapKey is constructed and accessed through a Value:
++// A MapKey is constructed and accessed through a [Value]:
+ //
+ //	k := ValueOf("hash").MapKey() // convert string to MapKey
+ //	s := k.String()               // convert MapKey to string
+ //
+-// The MapKey is a strict subset of valid types used in Value;
+-// converting a Value to a MapKey with an invalid type panics.
++// The MapKey is a strict subset of valid types used in [Value];
++// converting a [Value] to a MapKey with an invalid type panics.
+ type MapKey value
+ 
+ // IsValid reports whether k is populated with a value.
+@@ -426,13 +426,13 @@ func (k MapKey) Uint() uint64 {
+ 	return Value(k).Uint()
+ }
+ 
+-// String returns k as a string. Since this method implements fmt.Stringer,
++// String returns k as a string. Since this method implements [fmt.Stringer],
+ // this returns the formatted string value for any non-string type.
+ func (k MapKey) String() string {
+ 	return Value(k).String()
+ }
+ 
+-// Value returns k as a Value.
++// Value returns k as a [Value].
+ func (k MapKey) Value() Value {
+ 	return Value(k)
+ }
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+similarity index 97%
+rename from vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
+rename to vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+index 702ddf2..b1fdbe3 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go120.go
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !purego && !appengine
+-// +build !purego,!appengine
++//go:build !purego && !appengine && !go1.21
++// +build !purego,!appengine,!go1.21
+ 
+ package protoreflect
+ 
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+new file mode 100644
+index 0000000..4354701
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe_go121.go
+@@ -0,0 +1,87 @@
++// Copyright 2018 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !purego && !appengine && go1.21
++// +build !purego,!appengine,go1.21
++
++package protoreflect
++
++import (
++	"unsafe"
++
++	"google.golang.org/protobuf/internal/pragma"
++)
++
++type (
++	ifaceHeader struct {
++		_    [0]interface{} // if interfaces have greater alignment than unsafe.Pointer, this will enforce it.
++		Type unsafe.Pointer
++		Data unsafe.Pointer
++	}
++)
++
++var (
++	nilType     = typeOf(nil)
++	boolType    = typeOf(*new(bool))
++	int32Type   = typeOf(*new(int32))
++	int64Type   = typeOf(*new(int64))
++	uint32Type  = typeOf(*new(uint32))
++	uint64Type  = typeOf(*new(uint64))
++	float32Type = typeOf(*new(float32))
++	float64Type = typeOf(*new(float64))
++	stringType  = typeOf(*new(string))
++	bytesType   = typeOf(*new([]byte))
++	enumType    = typeOf(*new(EnumNumber))
++)
++
++// typeOf returns a pointer to the Go type information.
++// The pointer is comparable and equal if and only if the types are identical.
++func typeOf(t interface{}) unsafe.Pointer {
++	return (*ifaceHeader)(unsafe.Pointer(&t)).Type
++}
++
++// value is a union where only one type can be represented at a time.
++// The struct is 24B large on 64-bit systems and requires the minimum storage
++// necessary to represent each possible type.
++//
++// The Go GC needs to be able to scan variables containing pointers.
++// As such, pointers and non-pointers cannot be intermixed.
++type value struct {
++	pragma.DoNotCompare // 0B
++
++	// typ stores the type of the value as a pointer to the Go type.
++	typ unsafe.Pointer // 8B
++
++	// ptr stores the data pointer for a String, Bytes, or interface value.
++	ptr unsafe.Pointer // 8B
++
++	// num stores a Bool, Int32, Int64, Uint32, Uint64, Float32, Float64, or
++	// Enum value as a raw uint64.
++	//
++	// It is also used to store the length of a String or Bytes value;
++	// the capacity is ignored.
++	num uint64 // 8B
++}
++
++func valueOfString(v string) Value {
++	return Value{typ: stringType, ptr: unsafe.Pointer(unsafe.StringData(v)), num: uint64(len(v))}
++}
++func valueOfBytes(v []byte) Value {
++	return Value{typ: bytesType, ptr: unsafe.Pointer(unsafe.SliceData(v)), num: uint64(len(v))}
++}
++func valueOfIface(v interface{}) Value {
++	p := (*ifaceHeader)(unsafe.Pointer(&v))
++	return Value{typ: p.Type, ptr: p.Data}
++}
++
++func (v Value) getString() string {
++	return unsafe.String((*byte)(v.ptr), v.num)
++}
++func (v Value) getBytes() []byte {
++	return unsafe.Slice((*byte)(v.ptr), v.num)
++}
++func (v Value) getIface() (x interface{}) {
++	*(*ifaceHeader)(unsafe.Pointer(&x)) = ifaceHeader{Type: v.typ, Data: v.ptr}
++	return x
++}
+diff --git a/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go b/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
+index aeb5597..6267dc5 100644
+--- a/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
++++ b/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
+@@ -5,12 +5,12 @@
+ // Package protoregistry provides data structures to register and lookup
+ // protobuf descriptor types.
+ //
+-// The Files registry contains file descriptors and provides the ability
++// The [Files] registry contains file descriptors and provides the ability
+ // to iterate over the files or lookup a specific descriptor within the files.
+-// Files only contains protobuf descriptors and has no understanding of Go
++// [Files] only contains protobuf descriptors and has no understanding of Go
+ // type information that may be associated with each descriptor.
+ //
+-// The Types registry contains descriptor types for which there is a known
++// The [Types] registry contains descriptor types for which there is a known
+ // Go type associated with that descriptor. It provides the ability to iterate
+ // over the registered types or lookup a type by name.
+ package protoregistry
+@@ -218,7 +218,7 @@ func (r *Files) checkGenProtoConflict(path string) {
+ 
+ // FindDescriptorByName looks up a descriptor by the full name.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Files) FindDescriptorByName(name protoreflect.FullName) (protoreflect.Descriptor, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -310,7 +310,7 @@ func (s *nameSuffix) Pop() (name protoreflect.Name) {
+ 
+ // FindFileByPath looks up a file by the path.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ // This returns an error if multiple files have the same path.
+ func (r *Files) FindFileByPath(path string) (protoreflect.FileDescriptor, error) {
+ 	if r == nil {
+@@ -431,7 +431,7 @@ func rangeTopLevelDescriptors(fd protoreflect.FileDescriptor, f func(protoreflec
+ // A compliant implementation must deterministically return the same type
+ // if no error is encountered.
+ //
+-// The Types type implements this interface.
++// The [Types] type implements this interface.
+ type MessageTypeResolver interface {
+ 	// FindMessageByName looks up a message by its full name.
+ 	// E.g., "google.protobuf.Any"
+@@ -451,7 +451,7 @@ type MessageTypeResolver interface {
+ // A compliant implementation must deterministically return the same type
+ // if no error is encountered.
+ //
+-// The Types type implements this interface.
++// The [Types] type implements this interface.
+ type ExtensionTypeResolver interface {
+ 	// FindExtensionByName looks up a extension field by the field's full name.
+ 	// Note that this is the full name of the field as determined by
+@@ -590,7 +590,7 @@ func (r *Types) register(kind string, desc protoreflect.Descriptor, typ interfac
+ // FindEnumByName looks up an enum by its full name.
+ // E.g., "google.protobuf.Field.Kind".
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -611,7 +611,7 @@ func (r *Types) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumTyp
+ // FindMessageByName looks up a message by its full name,
+ // e.g. "google.protobuf.Any".
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -632,7 +632,7 @@ func (r *Types) FindMessageByName(message protoreflect.FullName) (protoreflect.M
+ // FindMessageByURL looks up a message by a URL identifier.
+ // See documentation on google.protobuf.Any.type_url for the URL format.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+ 	// This function is similar to FindMessageByName but
+ 	// truncates anything before and including '/' in the URL.
+@@ -662,7 +662,7 @@ func (r *Types) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+ // where the extension is declared and is unrelated to the full name of the
+ // message being extended.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+@@ -703,7 +703,7 @@ func (r *Types) FindExtensionByName(field protoreflect.FullName) (protoreflect.E
+ // FindExtensionByNumber looks up a extension field by the field number
+ // within some parent message, identified by full name.
+ //
+-// This returns (nil, NotFound) if not found.
++// This returns (nil, [NotFound]) if not found.
+ func (r *Types) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+ 	if r == nil {
+ 		return nil, NotFound
+diff --git a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+index 04c00f7..78624cf 100644
+--- a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
++++ b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+@@ -48,6 +48,103 @@ import (
+ 	sync "sync"
+ )
+ 
++// The full set of known editions.
++type Edition int32
++
++const (
++	// A placeholder for an unknown edition value.
++	Edition_EDITION_UNKNOWN Edition = 0
++	// Legacy syntax "editions".  These pre-date editions, but behave much like
++	// distinct editions.  These can't be used to specify the edition of proto
++	// files, but feature definitions must supply proto2/proto3 defaults for
++	// backwards compatibility.
++	Edition_EDITION_PROTO2 Edition = 998
++	Edition_EDITION_PROTO3 Edition = 999
++	// Editions that have been released.  The specific values are arbitrary and
++	// should not be depended on, but they will always be time-ordered for easy
++	// comparison.
++	Edition_EDITION_2023 Edition = 1000
++	Edition_EDITION_2024 Edition = 1001
++	// Placeholder editions for testing feature resolution.  These should not be
++	// used or relyed on outside of tests.
++	Edition_EDITION_1_TEST_ONLY     Edition = 1
++	Edition_EDITION_2_TEST_ONLY     Edition = 2
++	Edition_EDITION_99997_TEST_ONLY Edition = 99997
++	Edition_EDITION_99998_TEST_ONLY Edition = 99998
++	Edition_EDITION_99999_TEST_ONLY Edition = 99999
++	// Placeholder for specifying unbounded edition support.  This should only
++	// ever be used by plugins that can expect to never require any changes to
++	// support a new edition.
++	Edition_EDITION_MAX Edition = 2147483647
++)
++
++// Enum value maps for Edition.
++var (
++	Edition_name = map[int32]string{
++		0:          "EDITION_UNKNOWN",
++		998:        "EDITION_PROTO2",
++		999:        "EDITION_PROTO3",
++		1000:       "EDITION_2023",
++		1001:       "EDITION_2024",
++		1:          "EDITION_1_TEST_ONLY",
++		2:          "EDITION_2_TEST_ONLY",
++		99997:      "EDITION_99997_TEST_ONLY",
++		99998:      "EDITION_99998_TEST_ONLY",
++		99999:      "EDITION_99999_TEST_ONLY",
++		2147483647: "EDITION_MAX",
++	}
++	Edition_value = map[string]int32{
++		"EDITION_UNKNOWN":         0,
++		"EDITION_PROTO2":          998,
++		"EDITION_PROTO3":          999,
++		"EDITION_2023":            1000,
++		"EDITION_2024":            1001,
++		"EDITION_1_TEST_ONLY":     1,
++		"EDITION_2_TEST_ONLY":     2,
++		"EDITION_99997_TEST_ONLY": 99997,
++		"EDITION_99998_TEST_ONLY": 99998,
++		"EDITION_99999_TEST_ONLY": 99999,
++		"EDITION_MAX":             2147483647,
++	}
++)
++
++func (x Edition) Enum() *Edition {
++	p := new(Edition)
++	*p = x
++	return p
++}
++
++func (x Edition) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (Edition) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[0].Descriptor()
++}
++
++func (Edition) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[0]
++}
++
++func (x Edition) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *Edition) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = Edition(num)
++	return nil
++}
++
++// Deprecated: Use Edition.Descriptor instead.
++func (Edition) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{0}
++}
++
+ // The verification state of the extension range.
+ type ExtensionRangeOptions_VerificationState int32
+ 
+@@ -80,11 +177,11 @@ func (x ExtensionRangeOptions_VerificationState) String() string {
+ }
+ 
+ func (ExtensionRangeOptions_VerificationState) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[0].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[1].Descriptor()
+ }
+ 
+ func (ExtensionRangeOptions_VerificationState) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[0]
++	return &file_google_protobuf_descriptor_proto_enumTypes[1]
+ }
+ 
+ func (x ExtensionRangeOptions_VerificationState) Number() protoreflect.EnumNumber {
+@@ -125,9 +222,10 @@ const (
+ 	FieldDescriptorProto_TYPE_BOOL    FieldDescriptorProto_Type = 8
+ 	FieldDescriptorProto_TYPE_STRING  FieldDescriptorProto_Type = 9
+ 	// Tag-delimited aggregate.
+-	// Group type is deprecated and not supported in proto3. However, Proto3
++	// Group type is deprecated and not supported after google.protobuf. However, Proto3
+ 	// implementations should still be able to parse the group wire format and
+-	// treat group fields as unknown fields.
++	// treat group fields as unknown fields.  In Editions, the group wire format
++	// can be enabled via the `message_encoding` feature.
+ 	FieldDescriptorProto_TYPE_GROUP   FieldDescriptorProto_Type = 10
+ 	FieldDescriptorProto_TYPE_MESSAGE FieldDescriptorProto_Type = 11 // Length-delimited aggregate.
+ 	// New in version 2.
+@@ -195,11 +293,11 @@ func (x FieldDescriptorProto_Type) String() string {
+ }
+ 
+ func (FieldDescriptorProto_Type) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[1].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[2].Descriptor()
+ }
+ 
+ func (FieldDescriptorProto_Type) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[1]
++	return &file_google_protobuf_descriptor_proto_enumTypes[2]
+ }
+ 
+ func (x FieldDescriptorProto_Type) Number() protoreflect.EnumNumber {
+@@ -226,21 +324,24 @@ type FieldDescriptorProto_Label int32
+ const (
+ 	// 0 is reserved for errors
+ 	FieldDescriptorProto_LABEL_OPTIONAL FieldDescriptorProto_Label = 1
+-	FieldDescriptorProto_LABEL_REQUIRED FieldDescriptorProto_Label = 2
+ 	FieldDescriptorProto_LABEL_REPEATED FieldDescriptorProto_Label = 3
++	// The required label is only allowed in google.protobuf.  In proto3 and Editions
++	// it's explicitly prohibited.  In Editions, the `field_presence` feature
++	// can be used to get this behavior.
++	FieldDescriptorProto_LABEL_REQUIRED FieldDescriptorProto_Label = 2
+ )
+ 
+ // Enum value maps for FieldDescriptorProto_Label.
+ var (
+ 	FieldDescriptorProto_Label_name = map[int32]string{
+ 		1: "LABEL_OPTIONAL",
+-		2: "LABEL_REQUIRED",
+ 		3: "LABEL_REPEATED",
++		2: "LABEL_REQUIRED",
+ 	}
+ 	FieldDescriptorProto_Label_value = map[string]int32{
+ 		"LABEL_OPTIONAL": 1,
+-		"LABEL_REQUIRED": 2,
+ 		"LABEL_REPEATED": 3,
++		"LABEL_REQUIRED": 2,
+ 	}
+ )
+ 
+@@ -255,11 +356,11 @@ func (x FieldDescriptorProto_Label) String() string {
+ }
+ 
+ func (FieldDescriptorProto_Label) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[2].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[3].Descriptor()
+ }
+ 
+ func (FieldDescriptorProto_Label) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[2]
++	return &file_google_protobuf_descriptor_proto_enumTypes[3]
+ }
+ 
+ func (x FieldDescriptorProto_Label) Number() protoreflect.EnumNumber {
+@@ -316,11 +417,11 @@ func (x FileOptions_OptimizeMode) String() string {
+ }
+ 
+ func (FileOptions_OptimizeMode) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[3].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[4].Descriptor()
+ }
+ 
+ func (FileOptions_OptimizeMode) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[3]
++	return &file_google_protobuf_descriptor_proto_enumTypes[4]
+ }
+ 
+ func (x FileOptions_OptimizeMode) Number() protoreflect.EnumNumber {
+@@ -382,11 +483,11 @@ func (x FieldOptions_CType) String() string {
+ }
+ 
+ func (FieldOptions_CType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[4].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[5].Descriptor()
+ }
+ 
+ func (FieldOptions_CType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[4]
++	return &file_google_protobuf_descriptor_proto_enumTypes[5]
+ }
+ 
+ func (x FieldOptions_CType) Number() protoreflect.EnumNumber {
+@@ -444,11 +545,11 @@ func (x FieldOptions_JSType) String() string {
+ }
+ 
+ func (FieldOptions_JSType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[5].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[6].Descriptor()
+ }
+ 
+ func (FieldOptions_JSType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[5]
++	return &file_google_protobuf_descriptor_proto_enumTypes[6]
+ }
+ 
+ func (x FieldOptions_JSType) Number() protoreflect.EnumNumber {
+@@ -506,11 +607,11 @@ func (x FieldOptions_OptionRetention) String() string {
+ }
+ 
+ func (FieldOptions_OptionRetention) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[6].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[7].Descriptor()
+ }
+ 
+ func (FieldOptions_OptionRetention) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[6]
++	return &file_google_protobuf_descriptor_proto_enumTypes[7]
+ }
+ 
+ func (x FieldOptions_OptionRetention) Number() protoreflect.EnumNumber {
+@@ -590,11 +691,11 @@ func (x FieldOptions_OptionTargetType) String() string {
+ }
+ 
+ func (FieldOptions_OptionTargetType) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[7].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[8].Descriptor()
+ }
+ 
+ func (FieldOptions_OptionTargetType) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[7]
++	return &file_google_protobuf_descriptor_proto_enumTypes[8]
+ }
+ 
+ func (x FieldOptions_OptionTargetType) Number() protoreflect.EnumNumber {
+@@ -652,11 +753,11 @@ func (x MethodOptions_IdempotencyLevel) String() string {
+ }
+ 
+ func (MethodOptions_IdempotencyLevel) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[8].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[9].Descriptor()
+ }
+ 
+ func (MethodOptions_IdempotencyLevel) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[8]
++	return &file_google_protobuf_descriptor_proto_enumTypes[9]
+ }
+ 
+ func (x MethodOptions_IdempotencyLevel) Number() protoreflect.EnumNumber {
+@@ -678,6 +779,363 @@ func (MethodOptions_IdempotencyLevel) EnumDescriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{17, 0}
+ }
+ 
++type FeatureSet_FieldPresence int32
++
++const (
++	FeatureSet_FIELD_PRESENCE_UNKNOWN FeatureSet_FieldPresence = 0
++	FeatureSet_EXPLICIT               FeatureSet_FieldPresence = 1
++	FeatureSet_IMPLICIT               FeatureSet_FieldPresence = 2
++	FeatureSet_LEGACY_REQUIRED        FeatureSet_FieldPresence = 3
++)
++
++// Enum value maps for FeatureSet_FieldPresence.
++var (
++	FeatureSet_FieldPresence_name = map[int32]string{
++		0: "FIELD_PRESENCE_UNKNOWN",
++		1: "EXPLICIT",
++		2: "IMPLICIT",
++		3: "LEGACY_REQUIRED",
++	}
++	FeatureSet_FieldPresence_value = map[string]int32{
++		"FIELD_PRESENCE_UNKNOWN": 0,
++		"EXPLICIT":               1,
++		"IMPLICIT":               2,
++		"LEGACY_REQUIRED":        3,
++	}
++)
++
++func (x FeatureSet_FieldPresence) Enum() *FeatureSet_FieldPresence {
++	p := new(FeatureSet_FieldPresence)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_FieldPresence) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_FieldPresence) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[10].Descriptor()
++}
++
++func (FeatureSet_FieldPresence) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[10]
++}
++
++func (x FeatureSet_FieldPresence) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_FieldPresence) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_FieldPresence(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_FieldPresence.Descriptor instead.
++func (FeatureSet_FieldPresence) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 0}
++}
++
++type FeatureSet_EnumType int32
++
++const (
++	FeatureSet_ENUM_TYPE_UNKNOWN FeatureSet_EnumType = 0
++	FeatureSet_OPEN              FeatureSet_EnumType = 1
++	FeatureSet_CLOSED            FeatureSet_EnumType = 2
++)
++
++// Enum value maps for FeatureSet_EnumType.
++var (
++	FeatureSet_EnumType_name = map[int32]string{
++		0: "ENUM_TYPE_UNKNOWN",
++		1: "OPEN",
++		2: "CLOSED",
++	}
++	FeatureSet_EnumType_value = map[string]int32{
++		"ENUM_TYPE_UNKNOWN": 0,
++		"OPEN":              1,
++		"CLOSED":            2,
++	}
++)
++
++func (x FeatureSet_EnumType) Enum() *FeatureSet_EnumType {
++	p := new(FeatureSet_EnumType)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_EnumType) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_EnumType) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[11].Descriptor()
++}
++
++func (FeatureSet_EnumType) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[11]
++}
++
++func (x FeatureSet_EnumType) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_EnumType) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_EnumType(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_EnumType.Descriptor instead.
++func (FeatureSet_EnumType) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 1}
++}
++
++type FeatureSet_RepeatedFieldEncoding int32
++
++const (
++	FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN FeatureSet_RepeatedFieldEncoding = 0
++	FeatureSet_PACKED                          FeatureSet_RepeatedFieldEncoding = 1
++	FeatureSet_EXPANDED                        FeatureSet_RepeatedFieldEncoding = 2
++)
++
++// Enum value maps for FeatureSet_RepeatedFieldEncoding.
++var (
++	FeatureSet_RepeatedFieldEncoding_name = map[int32]string{
++		0: "REPEATED_FIELD_ENCODING_UNKNOWN",
++		1: "PACKED",
++		2: "EXPANDED",
++	}
++	FeatureSet_RepeatedFieldEncoding_value = map[string]int32{
++		"REPEATED_FIELD_ENCODING_UNKNOWN": 0,
++		"PACKED":                          1,
++		"EXPANDED":                        2,
++	}
++)
++
++func (x FeatureSet_RepeatedFieldEncoding) Enum() *FeatureSet_RepeatedFieldEncoding {
++	p := new(FeatureSet_RepeatedFieldEncoding)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_RepeatedFieldEncoding) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_RepeatedFieldEncoding) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[12].Descriptor()
++}
++
++func (FeatureSet_RepeatedFieldEncoding) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[12]
++}
++
++func (x FeatureSet_RepeatedFieldEncoding) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_RepeatedFieldEncoding) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_RepeatedFieldEncoding(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_RepeatedFieldEncoding.Descriptor instead.
++func (FeatureSet_RepeatedFieldEncoding) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 2}
++}
++
++type FeatureSet_Utf8Validation int32
++
++const (
++	FeatureSet_UTF8_VALIDATION_UNKNOWN FeatureSet_Utf8Validation = 0
++	FeatureSet_VERIFY                  FeatureSet_Utf8Validation = 2
++	FeatureSet_NONE                    FeatureSet_Utf8Validation = 3
++)
++
++// Enum value maps for FeatureSet_Utf8Validation.
++var (
++	FeatureSet_Utf8Validation_name = map[int32]string{
++		0: "UTF8_VALIDATION_UNKNOWN",
++		2: "VERIFY",
++		3: "NONE",
++	}
++	FeatureSet_Utf8Validation_value = map[string]int32{
++		"UTF8_VALIDATION_UNKNOWN": 0,
++		"VERIFY":                  2,
++		"NONE":                    3,
++	}
++)
++
++func (x FeatureSet_Utf8Validation) Enum() *FeatureSet_Utf8Validation {
++	p := new(FeatureSet_Utf8Validation)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_Utf8Validation) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_Utf8Validation) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[13].Descriptor()
++}
++
++func (FeatureSet_Utf8Validation) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[13]
++}
++
++func (x FeatureSet_Utf8Validation) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_Utf8Validation) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_Utf8Validation(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_Utf8Validation.Descriptor instead.
++func (FeatureSet_Utf8Validation) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 3}
++}
++
++type FeatureSet_MessageEncoding int32
++
++const (
++	FeatureSet_MESSAGE_ENCODING_UNKNOWN FeatureSet_MessageEncoding = 0
++	FeatureSet_LENGTH_PREFIXED          FeatureSet_MessageEncoding = 1
++	FeatureSet_DELIMITED                FeatureSet_MessageEncoding = 2
++)
++
++// Enum value maps for FeatureSet_MessageEncoding.
++var (
++	FeatureSet_MessageEncoding_name = map[int32]string{
++		0: "MESSAGE_ENCODING_UNKNOWN",
++		1: "LENGTH_PREFIXED",
++		2: "DELIMITED",
++	}
++	FeatureSet_MessageEncoding_value = map[string]int32{
++		"MESSAGE_ENCODING_UNKNOWN": 0,
++		"LENGTH_PREFIXED":          1,
++		"DELIMITED":                2,
++	}
++)
++
++func (x FeatureSet_MessageEncoding) Enum() *FeatureSet_MessageEncoding {
++	p := new(FeatureSet_MessageEncoding)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_MessageEncoding) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_MessageEncoding) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[14].Descriptor()
++}
++
++func (FeatureSet_MessageEncoding) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[14]
++}
++
++func (x FeatureSet_MessageEncoding) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_MessageEncoding) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_MessageEncoding(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_MessageEncoding.Descriptor instead.
++func (FeatureSet_MessageEncoding) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 4}
++}
++
++type FeatureSet_JsonFormat int32
++
++const (
++	FeatureSet_JSON_FORMAT_UNKNOWN FeatureSet_JsonFormat = 0
++	FeatureSet_ALLOW               FeatureSet_JsonFormat = 1
++	FeatureSet_LEGACY_BEST_EFFORT  FeatureSet_JsonFormat = 2
++)
++
++// Enum value maps for FeatureSet_JsonFormat.
++var (
++	FeatureSet_JsonFormat_name = map[int32]string{
++		0: "JSON_FORMAT_UNKNOWN",
++		1: "ALLOW",
++		2: "LEGACY_BEST_EFFORT",
++	}
++	FeatureSet_JsonFormat_value = map[string]int32{
++		"JSON_FORMAT_UNKNOWN": 0,
++		"ALLOW":               1,
++		"LEGACY_BEST_EFFORT":  2,
++	}
++)
++
++func (x FeatureSet_JsonFormat) Enum() *FeatureSet_JsonFormat {
++	p := new(FeatureSet_JsonFormat)
++	*p = x
++	return p
++}
++
++func (x FeatureSet_JsonFormat) String() string {
++	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
++}
++
++func (FeatureSet_JsonFormat) Descriptor() protoreflect.EnumDescriptor {
++	return file_google_protobuf_descriptor_proto_enumTypes[15].Descriptor()
++}
++
++func (FeatureSet_JsonFormat) Type() protoreflect.EnumType {
++	return &file_google_protobuf_descriptor_proto_enumTypes[15]
++}
++
++func (x FeatureSet_JsonFormat) Number() protoreflect.EnumNumber {
++	return protoreflect.EnumNumber(x)
++}
++
++// Deprecated: Do not use.
++func (x *FeatureSet_JsonFormat) UnmarshalJSON(b []byte) error {
++	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
++	if err != nil {
++		return err
++	}
++	*x = FeatureSet_JsonFormat(num)
++	return nil
++}
++
++// Deprecated: Use FeatureSet_JsonFormat.Descriptor instead.
++func (FeatureSet_JsonFormat) EnumDescriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 5}
++}
++
+ // Represents the identified object's effect on the element in the original
+ // .proto file.
+ type GeneratedCodeInfo_Annotation_Semantic int32
+@@ -716,11 +1174,11 @@ func (x GeneratedCodeInfo_Annotation_Semantic) String() string {
+ }
+ 
+ func (GeneratedCodeInfo_Annotation_Semantic) Descriptor() protoreflect.EnumDescriptor {
+-	return file_google_protobuf_descriptor_proto_enumTypes[9].Descriptor()
++	return file_google_protobuf_descriptor_proto_enumTypes[16].Descriptor()
+ }
+ 
+ func (GeneratedCodeInfo_Annotation_Semantic) Type() protoreflect.EnumType {
+-	return &file_google_protobuf_descriptor_proto_enumTypes[9]
++	return &file_google_protobuf_descriptor_proto_enumTypes[16]
+ }
+ 
+ func (x GeneratedCodeInfo_Annotation_Semantic) Number() protoreflect.EnumNumber {
+@@ -739,7 +1197,7 @@ func (x *GeneratedCodeInfo_Annotation_Semantic) UnmarshalJSON(b []byte) error {
+ 
+ // Deprecated: Use GeneratedCodeInfo_Annotation_Semantic.Descriptor instead.
+ func (GeneratedCodeInfo_Annotation_Semantic) EnumDescriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22, 0, 0}
+ }
+ 
+ // The protocol compiler can output a FileDescriptorSet containing the .proto
+@@ -822,8 +1280,8 @@ type FileDescriptorProto struct {
+ 	//
+ 	// If `edition` is present, this value must be "editions".
+ 	Syntax *string `protobuf:"bytes,12,opt,name=syntax" json:"syntax,omitempty"`
+-	// The edition of the proto file, which is an opaque string.
+-	Edition *string `protobuf:"bytes,13,opt,name=edition" json:"edition,omitempty"`
++	// The edition of the proto file.
++	Edition *Edition `protobuf:"varint,14,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
+ }
+ 
+ func (x *FileDescriptorProto) Reset() {
+@@ -942,11 +1400,11 @@ func (x *FileDescriptorProto) GetSyntax() string {
+ 	return ""
+ }
+ 
+-func (x *FileDescriptorProto) GetEdition() string {
++func (x *FileDescriptorProto) GetEdition() Edition {
+ 	if x != nil && x.Edition != nil {
+ 		return *x.Edition
+ 	}
+-	return ""
++	return Edition_EDITION_UNKNOWN
+ }
+ 
+ // Describes a message type.
+@@ -1079,13 +1537,14 @@ type ExtensionRangeOptions struct {
+ 
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+-	// go/protobuf-stripping-extension-declarations
+-	// Like Metadata, but we use a repeated field to hold all extension
+-	// declarations. This should avoid the size increases of transforming a large
+-	// extension range into small ranges in generated binaries.
++	// For external users: DO NOT USE. We are in the process of open sourcing
++	// extension declaration and executing internal cleanups before it can be
++	// used externally.
+ 	Declaration []*ExtensionRangeOptions_Declaration `protobuf:"bytes,2,rep,name=declaration" json:"declaration,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,50,opt,name=features" json:"features,omitempty"`
+ 	// The verification state of the range.
+-	// TODO(b/278783756): flip the default to DECLARATION once all empty ranges
++	// TODO: flip the default to DECLARATION once all empty ranges
+ 	// are marked as UNVERIFIED.
+ 	Verification *ExtensionRangeOptions_VerificationState `protobuf:"varint,3,opt,name=verification,enum=google.protobuf.ExtensionRangeOptions_VerificationState,def=1" json:"verification,omitempty"`
+ }
+@@ -1141,6 +1600,13 @@ func (x *ExtensionRangeOptions) GetDeclaration() []*ExtensionRangeOptions_Declar
+ 	return nil
+ }
+ 
++func (x *ExtensionRangeOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *ExtensionRangeOptions) GetVerification() ExtensionRangeOptions_VerificationState {
+ 	if x != nil && x.Verification != nil {
+ 		return *x.Verification
+@@ -1186,12 +1652,12 @@ type FieldDescriptorProto struct {
+ 	// If true, this is a proto3 "optional". When a proto3 field is optional, it
+ 	// tracks presence regardless of field type.
+ 	//
+-	// When proto3_optional is true, this field must be belong to a oneof to
+-	// signal to old proto3 clients that presence is tracked for this field. This
+-	// oneof is known as a "synthetic" oneof, and this field must be its sole
+-	// member (each proto3 optional field gets its own synthetic oneof). Synthetic
+-	// oneofs exist in the descriptor only, and do not generate any API. Synthetic
+-	// oneofs must be ordered after all "real" oneofs.
++	// When proto3_optional is true, this field must belong to a oneof to signal
++	// to old proto3 clients that presence is tracked for this field. This oneof
++	// is known as a "synthetic" oneof, and this field must be its sole member
++	// (each proto3 optional field gets its own synthetic oneof). Synthetic oneofs
++	// exist in the descriptor only, and do not generate any API. Synthetic oneofs
++	// must be ordered after all "real" oneofs.
+ 	//
+ 	// For message fields, proto3_optional doesn't create any semantic change,
+ 	// since non-repeated message fields always track presence. However it still
+@@ -1738,7 +2204,6 @@ type FileOptions struct {
+ 	CcGenericServices   *bool `protobuf:"varint,16,opt,name=cc_generic_services,json=ccGenericServices,def=0" json:"cc_generic_services,omitempty"`
+ 	JavaGenericServices *bool `protobuf:"varint,17,opt,name=java_generic_services,json=javaGenericServices,def=0" json:"java_generic_services,omitempty"`
+ 	PyGenericServices   *bool `protobuf:"varint,18,opt,name=py_generic_services,json=pyGenericServices,def=0" json:"py_generic_services,omitempty"`
+-	PhpGenericServices  *bool `protobuf:"varint,42,opt,name=php_generic_services,json=phpGenericServices,def=0" json:"php_generic_services,omitempty"`
+ 	// Is this file deprecated?
+ 	// Depending on the target platform, this can emit Deprecated annotations
+ 	// for everything in the file, or it will be completely ignored; in the very
+@@ -1772,6 +2237,8 @@ type FileOptions struct {
+ 	// is empty. When this option is not set, the package name will be used for
+ 	// determining the ruby package.
+ 	RubyPackage *string `protobuf:"bytes,45,opt,name=ruby_package,json=rubyPackage" json:"ruby_package,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,50,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here.
+ 	// See the documentation for the "Options" section above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+@@ -1785,7 +2252,6 @@ const (
+ 	Default_FileOptions_CcGenericServices   = bool(false)
+ 	Default_FileOptions_JavaGenericServices = bool(false)
+ 	Default_FileOptions_PyGenericServices   = bool(false)
+-	Default_FileOptions_PhpGenericServices  = bool(false)
+ 	Default_FileOptions_Deprecated          = bool(false)
+ 	Default_FileOptions_CcEnableArenas      = bool(true)
+ )
+@@ -1893,13 +2359,6 @@ func (x *FileOptions) GetPyGenericServices() bool {
+ 	return Default_FileOptions_PyGenericServices
+ }
+ 
+-func (x *FileOptions) GetPhpGenericServices() bool {
+-	if x != nil && x.PhpGenericServices != nil {
+-		return *x.PhpGenericServices
+-	}
+-	return Default_FileOptions_PhpGenericServices
+-}
+-
+ func (x *FileOptions) GetDeprecated() bool {
+ 	if x != nil && x.Deprecated != nil {
+ 		return *x.Deprecated
+@@ -1963,6 +2422,13 @@ func (x *FileOptions) GetRubyPackage() string {
+ 	return ""
+ }
+ 
++func (x *FileOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *FileOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2006,10 +2472,6 @@ type MessageOptions struct {
+ 	// for the message, or it will be completely ignored; in the very least,
+ 	// this is a formalization for deprecating messages.
+ 	Deprecated *bool `protobuf:"varint,3,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
+-	// NOTE: Do not set the option in .proto files. Always use the maps syntax
+-	// instead. The option should only be implicitly set by the proto compiler
+-	// parser.
+-	//
+ 	// Whether the message is an automatically generated map entry type for the
+ 	// maps field.
+ 	//
+@@ -2030,6 +2492,10 @@ type MessageOptions struct {
+ 	// use a native map in the target language to hold the keys and values.
+ 	// The reflection APIs in such implementations still need to work as
+ 	// if the field is a repeated message field.
++	//
++	// NOTE: Do not set the option in .proto files. Always use the maps syntax
++	// instead. The option should only be implicitly set by the proto compiler
++	// parser.
+ 	MapEntry *bool `protobuf:"varint,7,opt,name=map_entry,json=mapEntry" json:"map_entry,omitempty"`
+ 	// Enable the legacy handling of JSON field name conflicts.  This lowercases
+ 	// and strips underscored from the fields before comparison in proto3 only.
+@@ -2039,11 +2505,13 @@ type MessageOptions struct {
+ 	// This should only be used as a temporary measure against broken builds due
+ 	// to the change in behavior for JSON field name conflicts.
+ 	//
+-	// TODO(b/261750190) This is legacy behavior we plan to remove once downstream
++	// TODO This is legacy behavior we plan to remove once downstream
+ 	// teams have had time to migrate.
+ 	//
+ 	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+ 	DeprecatedLegacyJsonFieldConflicts *bool `protobuf:"varint,11,opt,name=deprecated_legacy_json_field_conflicts,json=deprecatedLegacyJsonFieldConflicts" json:"deprecated_legacy_json_field_conflicts,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,12,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2123,6 +2591,13 @@ func (x *MessageOptions) GetDeprecatedLegacyJsonFieldConflicts() bool {
+ 	return false
+ }
+ 
++func (x *MessageOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *MessageOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2147,7 +2622,9 @@ type FieldOptions struct {
+ 	// a more efficient representation on the wire. Rather than repeatedly
+ 	// writing the tag and type for each element, the entire array is encoded as
+ 	// a single length-delimited blob. In proto3, only explicit setting it to
+-	// false will avoid using packed encoding.
++	// false will avoid using packed encoding.  This option is prohibited in
++	// Editions, but the `repeated_field_encoding` feature can be used to control
++	// the behavior.
+ 	Packed *bool `protobuf:"varint,2,opt,name=packed" json:"packed,omitempty"`
+ 	// The jstype option determines the JavaScript type used for values of the
+ 	// field.  The option is permitted only for 64 bit integral and fixed types
+@@ -2178,19 +2655,11 @@ type FieldOptions struct {
+ 	// call from multiple threads concurrently, while non-const methods continue
+ 	// to require exclusive access.
+ 	//
+-	// Note that implementations may choose not to check required fields within
+-	// a lazy sub-message.  That is, calling IsInitialized() on the outer message
+-	// may return true even if the inner message has missing required fields.
+-	// This is necessary because otherwise the inner message would have to be
+-	// parsed in order to perform the check, defeating the purpose of lazy
+-	// parsing.  An implementation which chooses not to check required fields
+-	// must be consistent about it.  That is, for any particular sub-message, the
+-	// implementation must either *always* check its required fields, or *never*
+-	// check its required fields, regardless of whether or not the message has
+-	// been parsed.
+-	//
+-	// As of May 2022, lazy verifies the contents of the byte stream during
+-	// parsing.  An invalid byte stream will cause the overall parsing to fail.
++	// Note that lazy message fields are still eagerly verified to check
++	// ill-formed wireformat or missing required fields. Calling IsInitialized()
++	// on the outer message would fail if the inner message has missing required
++	// fields. Failed verification would result in parsing failure (except when
++	// uninitialized messages are acceptable).
+ 	Lazy *bool `protobuf:"varint,5,opt,name=lazy,def=0" json:"lazy,omitempty"`
+ 	// unverified_lazy does no correctness checks on the byte stream. This should
+ 	// only be used where lazy with verification is prohibitive for performance
+@@ -2205,11 +2674,12 @@ type FieldOptions struct {
+ 	Weak *bool `protobuf:"varint,10,opt,name=weak,def=0" json:"weak,omitempty"`
+ 	// Indicate that the field value should not be printed out when using debug
+ 	// formats, e.g. when the field contains sensitive credentials.
+-	DebugRedact *bool                         `protobuf:"varint,16,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
+-	Retention   *FieldOptions_OptionRetention `protobuf:"varint,17,opt,name=retention,enum=google.protobuf.FieldOptions_OptionRetention" json:"retention,omitempty"`
+-	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-	Target  *FieldOptions_OptionTargetType  `protobuf:"varint,18,opt,name=target,enum=google.protobuf.FieldOptions_OptionTargetType" json:"target,omitempty"`
+-	Targets []FieldOptions_OptionTargetType `protobuf:"varint,19,rep,name=targets,enum=google.protobuf.FieldOptions_OptionTargetType" json:"targets,omitempty"`
++	DebugRedact     *bool                           `protobuf:"varint,16,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
++	Retention       *FieldOptions_OptionRetention   `protobuf:"varint,17,opt,name=retention,enum=google.protobuf.FieldOptions_OptionRetention" json:"retention,omitempty"`
++	Targets         []FieldOptions_OptionTargetType `protobuf:"varint,19,rep,name=targets,enum=google.protobuf.FieldOptions_OptionTargetType" json:"targets,omitempty"`
++	EditionDefaults []*FieldOptions_EditionDefault  `protobuf:"bytes,20,rep,name=edition_defaults,json=editionDefaults" json:"edition_defaults,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,21,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2320,17 +2790,23 @@ func (x *FieldOptions) GetRetention() FieldOptions_OptionRetention {
+ 	return FieldOptions_RETENTION_UNKNOWN
+ }
+ 
+-// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-func (x *FieldOptions) GetTarget() FieldOptions_OptionTargetType {
+-	if x != nil && x.Target != nil {
+-		return *x.Target
++func (x *FieldOptions) GetTargets() []FieldOptions_OptionTargetType {
++	if x != nil {
++		return x.Targets
+ 	}
+-	return FieldOptions_TARGET_TYPE_UNKNOWN
++	return nil
+ }
+ 
+-func (x *FieldOptions) GetTargets() []FieldOptions_OptionTargetType {
++func (x *FieldOptions) GetEditionDefaults() []*FieldOptions_EditionDefault {
+ 	if x != nil {
+-		return x.Targets
++		return x.EditionDefaults
++	}
++	return nil
++}
++
++func (x *FieldOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
+ 	}
+ 	return nil
+ }
+@@ -2348,6 +2824,8 @@ type OneofOptions struct {
+ 	unknownFields   protoimpl.UnknownFields
+ 	extensionFields protoimpl.ExtensionFields
+ 
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,1,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2384,6 +2862,13 @@ func (*OneofOptions) Descriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{13}
+ }
+ 
++func (x *OneofOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *OneofOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2409,11 +2894,13 @@ type EnumOptions struct {
+ 	// and strips underscored from the fields before comparison in proto3 only.
+ 	// The new behavior takes `json_name` into account and applies to proto2 as
+ 	// well.
+-	// TODO(b/261750190) Remove this legacy behavior once downstream teams have
++	// TODO Remove this legacy behavior once downstream teams have
+ 	// had time to migrate.
+ 	//
+ 	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+ 	DeprecatedLegacyJsonFieldConflicts *bool `protobuf:"varint,6,opt,name=deprecated_legacy_json_field_conflicts,json=deprecatedLegacyJsonFieldConflicts" json:"deprecated_legacy_json_field_conflicts,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,7,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2477,6 +2964,13 @@ func (x *EnumOptions) GetDeprecatedLegacyJsonFieldConflicts() bool {
+ 	return false
+ }
+ 
++func (x *EnumOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *EnumOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2495,13 +2989,20 @@ type EnumValueOptions struct {
+ 	// for the enum value, or it will be completely ignored; in the very least,
+ 	// this is a formalization for deprecating enum values.
+ 	Deprecated *bool `protobuf:"varint,1,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,2,opt,name=features" json:"features,omitempty"`
++	// Indicate that fields annotated with this enum value should not be printed
++	// out when using debug formats, e.g. when the field contains sensitive
++	// credentials.
++	DebugRedact *bool `protobuf:"varint,3,opt,name=debug_redact,json=debugRedact,def=0" json:"debug_redact,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+ 
+ // Default values for EnumValueOptions fields.
+ const (
+-	Default_EnumValueOptions_Deprecated = bool(false)
++	Default_EnumValueOptions_Deprecated  = bool(false)
++	Default_EnumValueOptions_DebugRedact = bool(false)
+ )
+ 
+ func (x *EnumValueOptions) Reset() {
+@@ -2543,6 +3044,20 @@ func (x *EnumValueOptions) GetDeprecated() bool {
+ 	return Default_EnumValueOptions_Deprecated
+ }
+ 
++func (x *EnumValueOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
++func (x *EnumValueOptions) GetDebugRedact() bool {
++	if x != nil && x.DebugRedact != nil {
++		return *x.DebugRedact
++	}
++	return Default_EnumValueOptions_DebugRedact
++}
++
+ func (x *EnumValueOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2556,6 +3071,8 @@ type ServiceOptions struct {
+ 	unknownFields   protoimpl.UnknownFields
+ 	extensionFields protoimpl.ExtensionFields
+ 
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,34,opt,name=features" json:"features,omitempty"`
+ 	// Is this service deprecated?
+ 	// Depending on the target platform, this can emit Deprecated annotations
+ 	// for the service, or it will be completely ignored; in the very least,
+@@ -2602,6 +3119,13 @@ func (*ServiceOptions) Descriptor() ([]byte, []int) {
+ 	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{16}
+ }
+ 
++func (x *ServiceOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *ServiceOptions) GetDeprecated() bool {
+ 	if x != nil && x.Deprecated != nil {
+ 		return *x.Deprecated
+@@ -2628,6 +3152,8 @@ type MethodOptions struct {
+ 	// this is a formalization for deprecating methods.
+ 	Deprecated       *bool                           `protobuf:"varint,33,opt,name=deprecated,def=0" json:"deprecated,omitempty"`
+ 	IdempotencyLevel *MethodOptions_IdempotencyLevel `protobuf:"varint,34,opt,name=idempotency_level,json=idempotencyLevel,enum=google.protobuf.MethodOptions_IdempotencyLevel,def=0" json:"idempotency_level,omitempty"`
++	// Any features defined in the specific edition.
++	Features *FeatureSet `protobuf:"bytes,35,opt,name=features" json:"features,omitempty"`
+ 	// The parser stores options it doesn't recognize here. See above.
+ 	UninterpretedOption []*UninterpretedOption `protobuf:"bytes,999,rep,name=uninterpreted_option,json=uninterpretedOption" json:"uninterpreted_option,omitempty"`
+ }
+@@ -2684,6 +3210,13 @@ func (x *MethodOptions) GetIdempotencyLevel() MethodOptions_IdempotencyLevel {
+ 	return Default_MethodOptions_IdempotencyLevel
+ }
+ 
++func (x *MethodOptions) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ func (x *MethodOptions) GetUninterpretedOption() []*UninterpretedOption {
+ 	if x != nil {
+ 		return x.UninterpretedOption
+@@ -2770,28 +3303,193 @@ func (x *UninterpretedOption) GetNegativeIntValue() int64 {
+ 	if x != nil && x.NegativeIntValue != nil {
+ 		return *x.NegativeIntValue
+ 	}
+-	return 0
++	return 0
++}
++
++func (x *UninterpretedOption) GetDoubleValue() float64 {
++	if x != nil && x.DoubleValue != nil {
++		return *x.DoubleValue
++	}
++	return 0
++}
++
++func (x *UninterpretedOption) GetStringValue() []byte {
++	if x != nil {
++		return x.StringValue
++	}
++	return nil
++}
++
++func (x *UninterpretedOption) GetAggregateValue() string {
++	if x != nil && x.AggregateValue != nil {
++		return *x.AggregateValue
++	}
++	return ""
++}
++
++// TODO Enums in C++ gencode (and potentially other languages) are
++// not well scoped.  This means that each of the feature enums below can clash
++// with each other.  The short names we've chosen maximize call-site
++// readability, but leave us very open to this scenario.  A future feature will
++// be designed and implemented to handle this, hopefully before we ever hit a
++// conflict here.
++type FeatureSet struct {
++	state           protoimpl.MessageState
++	sizeCache       protoimpl.SizeCache
++	unknownFields   protoimpl.UnknownFields
++	extensionFields protoimpl.ExtensionFields
++
++	FieldPresence         *FeatureSet_FieldPresence         `protobuf:"varint,1,opt,name=field_presence,json=fieldPresence,enum=google.protobuf.FeatureSet_FieldPresence" json:"field_presence,omitempty"`
++	EnumType              *FeatureSet_EnumType              `protobuf:"varint,2,opt,name=enum_type,json=enumType,enum=google.protobuf.FeatureSet_EnumType" json:"enum_type,omitempty"`
++	RepeatedFieldEncoding *FeatureSet_RepeatedFieldEncoding `protobuf:"varint,3,opt,name=repeated_field_encoding,json=repeatedFieldEncoding,enum=google.protobuf.FeatureSet_RepeatedFieldEncoding" json:"repeated_field_encoding,omitempty"`
++	Utf8Validation        *FeatureSet_Utf8Validation        `protobuf:"varint,4,opt,name=utf8_validation,json=utf8Validation,enum=google.protobuf.FeatureSet_Utf8Validation" json:"utf8_validation,omitempty"`
++	MessageEncoding       *FeatureSet_MessageEncoding       `protobuf:"varint,5,opt,name=message_encoding,json=messageEncoding,enum=google.protobuf.FeatureSet_MessageEncoding" json:"message_encoding,omitempty"`
++	JsonFormat            *FeatureSet_JsonFormat            `protobuf:"varint,6,opt,name=json_format,json=jsonFormat,enum=google.protobuf.FeatureSet_JsonFormat" json:"json_format,omitempty"`
++}
++
++func (x *FeatureSet) Reset() {
++	*x = FeatureSet{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSet) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSet) ProtoMessage() {}
++
++func (x *FeatureSet) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FeatureSet.ProtoReflect.Descriptor instead.
++func (*FeatureSet) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19}
++}
++
++func (x *FeatureSet) GetFieldPresence() FeatureSet_FieldPresence {
++	if x != nil && x.FieldPresence != nil {
++		return *x.FieldPresence
++	}
++	return FeatureSet_FIELD_PRESENCE_UNKNOWN
++}
++
++func (x *FeatureSet) GetEnumType() FeatureSet_EnumType {
++	if x != nil && x.EnumType != nil {
++		return *x.EnumType
++	}
++	return FeatureSet_ENUM_TYPE_UNKNOWN
++}
++
++func (x *FeatureSet) GetRepeatedFieldEncoding() FeatureSet_RepeatedFieldEncoding {
++	if x != nil && x.RepeatedFieldEncoding != nil {
++		return *x.RepeatedFieldEncoding
++	}
++	return FeatureSet_REPEATED_FIELD_ENCODING_UNKNOWN
++}
++
++func (x *FeatureSet) GetUtf8Validation() FeatureSet_Utf8Validation {
++	if x != nil && x.Utf8Validation != nil {
++		return *x.Utf8Validation
++	}
++	return FeatureSet_UTF8_VALIDATION_UNKNOWN
++}
++
++func (x *FeatureSet) GetMessageEncoding() FeatureSet_MessageEncoding {
++	if x != nil && x.MessageEncoding != nil {
++		return *x.MessageEncoding
++	}
++	return FeatureSet_MESSAGE_ENCODING_UNKNOWN
++}
++
++func (x *FeatureSet) GetJsonFormat() FeatureSet_JsonFormat {
++	if x != nil && x.JsonFormat != nil {
++		return *x.JsonFormat
++	}
++	return FeatureSet_JSON_FORMAT_UNKNOWN
++}
++
++// A compiled specification for the defaults of a set of features.  These
++// messages are generated from FeatureSet extensions and can be used to seed
++// feature resolution. The resolution with this object becomes a simple search
++// for the closest matching edition, followed by proto merges.
++type FeatureSetDefaults struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Defaults []*FeatureSetDefaults_FeatureSetEditionDefault `protobuf:"bytes,1,rep,name=defaults" json:"defaults,omitempty"`
++	// The minimum supported edition (inclusive) when this was constructed.
++	// Editions before this will not have defaults.
++	MinimumEdition *Edition `protobuf:"varint,4,opt,name=minimum_edition,json=minimumEdition,enum=google.protobuf.Edition" json:"minimum_edition,omitempty"`
++	// The maximum known edition (inclusive) when this was constructed. Editions
++	// after this will not have reliable defaults.
++	MaximumEdition *Edition `protobuf:"varint,5,opt,name=maximum_edition,json=maximumEdition,enum=google.protobuf.Edition" json:"maximum_edition,omitempty"`
++}
++
++func (x *FeatureSetDefaults) Reset() {
++	*x = FeatureSetDefaults{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSetDefaults) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSetDefaults) ProtoMessage() {}
++
++func (x *FeatureSetDefaults) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
+ }
+ 
+-func (x *UninterpretedOption) GetDoubleValue() float64 {
+-	if x != nil && x.DoubleValue != nil {
+-		return *x.DoubleValue
+-	}
+-	return 0
++// Deprecated: Use FeatureSetDefaults.ProtoReflect.Descriptor instead.
++func (*FeatureSetDefaults) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20}
+ }
+ 
+-func (x *UninterpretedOption) GetStringValue() []byte {
++func (x *FeatureSetDefaults) GetDefaults() []*FeatureSetDefaults_FeatureSetEditionDefault {
+ 	if x != nil {
+-		return x.StringValue
++		return x.Defaults
+ 	}
+ 	return nil
+ }
+ 
+-func (x *UninterpretedOption) GetAggregateValue() string {
+-	if x != nil && x.AggregateValue != nil {
+-		return *x.AggregateValue
++func (x *FeatureSetDefaults) GetMinimumEdition() Edition {
++	if x != nil && x.MinimumEdition != nil {
++		return *x.MinimumEdition
+ 	}
+-	return ""
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FeatureSetDefaults) GetMaximumEdition() Edition {
++	if x != nil && x.MaximumEdition != nil {
++		return *x.MaximumEdition
++	}
++	return Edition_EDITION_UNKNOWN
+ }
+ 
+ // Encapsulates information about the original source file from which a
+@@ -2855,7 +3553,7 @@ type SourceCodeInfo struct {
+ func (x *SourceCodeInfo) Reset() {
+ 	*x = SourceCodeInfo{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2868,7 +3566,7 @@ func (x *SourceCodeInfo) String() string {
+ func (*SourceCodeInfo) ProtoMessage() {}
+ 
+ func (x *SourceCodeInfo) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[19]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -2881,7 +3579,7 @@ func (x *SourceCodeInfo) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use SourceCodeInfo.ProtoReflect.Descriptor instead.
+ func (*SourceCodeInfo) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{21}
+ }
+ 
+ func (x *SourceCodeInfo) GetLocation() []*SourceCodeInfo_Location {
+@@ -2907,7 +3605,7 @@ type GeneratedCodeInfo struct {
+ func (x *GeneratedCodeInfo) Reset() {
+ 	*x = GeneratedCodeInfo{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2920,7 +3618,7 @@ func (x *GeneratedCodeInfo) String() string {
+ func (*GeneratedCodeInfo) ProtoMessage() {}
+ 
+ func (x *GeneratedCodeInfo) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[20]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -2933,7 +3631,7 @@ func (x *GeneratedCodeInfo) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use GeneratedCodeInfo.ProtoReflect.Descriptor instead.
+ func (*GeneratedCodeInfo) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22}
+ }
+ 
+ func (x *GeneratedCodeInfo) GetAnnotation() []*GeneratedCodeInfo_Annotation {
+@@ -2956,7 +3654,7 @@ type DescriptorProto_ExtensionRange struct {
+ func (x *DescriptorProto_ExtensionRange) Reset() {
+ 	*x = DescriptorProto_ExtensionRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -2969,7 +3667,7 @@ func (x *DescriptorProto_ExtensionRange) String() string {
+ func (*DescriptorProto_ExtensionRange) ProtoMessage() {}
+ 
+ func (x *DescriptorProto_ExtensionRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[21]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3021,7 +3719,7 @@ type DescriptorProto_ReservedRange struct {
+ func (x *DescriptorProto_ReservedRange) Reset() {
+ 	*x = DescriptorProto_ReservedRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3034,7 +3732,7 @@ func (x *DescriptorProto_ReservedRange) String() string {
+ func (*DescriptorProto_ReservedRange) ProtoMessage() {}
+ 
+ func (x *DescriptorProto_ReservedRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[22]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3078,10 +3776,6 @@ type ExtensionRangeOptions_Declaration struct {
+ 	// Metadata.type, Declaration.type must have a leading dot for messages
+ 	// and enums.
+ 	Type *string `protobuf:"bytes,3,opt,name=type" json:"type,omitempty"`
+-	// Deprecated. Please use "repeated".
+-	//
+-	// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-	IsRepeated *bool `protobuf:"varint,4,opt,name=is_repeated,json=isRepeated" json:"is_repeated,omitempty"`
+ 	// If true, indicates that the number is reserved in the extension range,
+ 	// and any extension field with the number will fail to compile. Set this
+ 	// when a declared extension field is deleted.
+@@ -3094,7 +3788,7 @@ type ExtensionRangeOptions_Declaration struct {
+ func (x *ExtensionRangeOptions_Declaration) Reset() {
+ 	*x = ExtensionRangeOptions_Declaration{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3107,7 +3801,7 @@ func (x *ExtensionRangeOptions_Declaration) String() string {
+ func (*ExtensionRangeOptions_Declaration) ProtoMessage() {}
+ 
+ func (x *ExtensionRangeOptions_Declaration) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[23]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3144,14 +3838,6 @@ func (x *ExtensionRangeOptions_Declaration) GetType() string {
+ 	return ""
+ }
+ 
+-// Deprecated: Marked as deprecated in google/protobuf/descriptor.proto.
+-func (x *ExtensionRangeOptions_Declaration) GetIsRepeated() bool {
+-	if x != nil && x.IsRepeated != nil {
+-		return *x.IsRepeated
+-	}
+-	return false
+-}
+-
+ func (x *ExtensionRangeOptions_Declaration) GetReserved() bool {
+ 	if x != nil && x.Reserved != nil {
+ 		return *x.Reserved
+@@ -3184,7 +3870,7 @@ type EnumDescriptorProto_EnumReservedRange struct {
+ func (x *EnumDescriptorProto_EnumReservedRange) Reset() {
+ 	*x = EnumDescriptorProto_EnumReservedRange{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3197,7 +3883,7 @@ func (x *EnumDescriptorProto_EnumReservedRange) String() string {
+ func (*EnumDescriptorProto_EnumReservedRange) ProtoMessage() {}
+ 
+ func (x *EnumDescriptorProto_EnumReservedRange) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[24]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3227,6 +3913,61 @@ func (x *EnumDescriptorProto_EnumReservedRange) GetEnd() int32 {
+ 	return 0
+ }
+ 
++type FieldOptions_EditionDefault struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Edition *Edition `protobuf:"varint,3,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
++	Value   *string  `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"` // Textproto value.
++}
++
++func (x *FieldOptions_EditionDefault) Reset() {
++	*x = FieldOptions_EditionDefault{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FieldOptions_EditionDefault) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FieldOptions_EditionDefault) ProtoMessage() {}
++
++func (x *FieldOptions_EditionDefault) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FieldOptions_EditionDefault.ProtoReflect.Descriptor instead.
++func (*FieldOptions_EditionDefault) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{12, 0}
++}
++
++func (x *FieldOptions_EditionDefault) GetEdition() Edition {
++	if x != nil && x.Edition != nil {
++		return *x.Edition
++	}
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FieldOptions_EditionDefault) GetValue() string {
++	if x != nil && x.Value != nil {
++		return *x.Value
++	}
++	return ""
++}
++
+ // The name of the uninterpreted option.  Each string represents a segment in
+ // a dot-separated name.  is_extension is true iff a segment represents an
+ // extension (denoted with parentheses in options specs in .proto files).
+@@ -3244,7 +3985,7 @@ type UninterpretedOption_NamePart struct {
+ func (x *UninterpretedOption_NamePart) Reset() {
+ 	*x = UninterpretedOption_NamePart{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[28]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3257,7 +3998,7 @@ func (x *UninterpretedOption_NamePart) String() string {
+ func (*UninterpretedOption_NamePart) ProtoMessage() {}
+ 
+ func (x *UninterpretedOption_NamePart) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[25]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[28]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3287,6 +4028,65 @@ func (x *UninterpretedOption_NamePart) GetIsExtension() bool {
+ 	return false
+ }
+ 
++// A map from every known edition with a unique set of defaults to its
++// defaults. Not all editions may be contained here.  For a given edition,
++// the defaults at the closest matching edition ordered at or before it should
++// be used.  This field must be in strict ascending order by edition.
++type FeatureSetDefaults_FeatureSetEditionDefault struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	Edition  *Edition    `protobuf:"varint,3,opt,name=edition,enum=google.protobuf.Edition" json:"edition,omitempty"`
++	Features *FeatureSet `protobuf:"bytes,2,opt,name=features" json:"features,omitempty"`
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) Reset() {
++	*x = FeatureSetDefaults_FeatureSetEditionDefault{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[29]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*FeatureSetDefaults_FeatureSetEditionDefault) ProtoMessage() {}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) ProtoReflect() protoreflect.Message {
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[29]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use FeatureSetDefaults_FeatureSetEditionDefault.ProtoReflect.Descriptor instead.
++func (*FeatureSetDefaults_FeatureSetEditionDefault) Descriptor() ([]byte, []int) {
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0}
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) GetEdition() Edition {
++	if x != nil && x.Edition != nil {
++		return *x.Edition
++	}
++	return Edition_EDITION_UNKNOWN
++}
++
++func (x *FeatureSetDefaults_FeatureSetEditionDefault) GetFeatures() *FeatureSet {
++	if x != nil {
++		return x.Features
++	}
++	return nil
++}
++
+ type SourceCodeInfo_Location struct {
+ 	state         protoimpl.MessageState
+ 	sizeCache     protoimpl.SizeCache
+@@ -3296,7 +4096,7 @@ type SourceCodeInfo_Location struct {
+ 	// location.
+ 	//
+ 	// Each element is a field number or an index.  They form a path from
+-	// the root FileDescriptorProto to the place where the definition occurs.
++	// the root FileDescriptorProto to the place where the definition appears.
+ 	// For example, this path:
+ 	//
+ 	//	[ 4, 3, 2, 7, 1 ]
+@@ -3388,7 +4188,7 @@ type SourceCodeInfo_Location struct {
+ func (x *SourceCodeInfo_Location) Reset() {
+ 	*x = SourceCodeInfo_Location{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[30]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3401,7 +4201,7 @@ func (x *SourceCodeInfo_Location) String() string {
+ func (*SourceCodeInfo_Location) ProtoMessage() {}
+ 
+ func (x *SourceCodeInfo_Location) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[26]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[30]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3414,7 +4214,7 @@ func (x *SourceCodeInfo_Location) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use SourceCodeInfo_Location.ProtoReflect.Descriptor instead.
+ func (*SourceCodeInfo_Location) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{19, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{21, 0}
+ }
+ 
+ func (x *SourceCodeInfo_Location) GetPath() []int32 {
+@@ -3475,7 +4275,7 @@ type GeneratedCodeInfo_Annotation struct {
+ func (x *GeneratedCodeInfo_Annotation) Reset() {
+ 	*x = GeneratedCodeInfo_Annotation{}
+ 	if protoimpl.UnsafeEnabled {
+-		mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++		mi := &file_google_protobuf_descriptor_proto_msgTypes[31]
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		ms.StoreMessageInfo(mi)
+ 	}
+@@ -3488,7 +4288,7 @@ func (x *GeneratedCodeInfo_Annotation) String() string {
+ func (*GeneratedCodeInfo_Annotation) ProtoMessage() {}
+ 
+ func (x *GeneratedCodeInfo_Annotation) ProtoReflect() protoreflect.Message {
+-	mi := &file_google_protobuf_descriptor_proto_msgTypes[27]
++	mi := &file_google_protobuf_descriptor_proto_msgTypes[31]
+ 	if protoimpl.UnsafeEnabled && x != nil {
+ 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+ 		if ms.LoadMessageInfo() == nil {
+@@ -3501,7 +4301,7 @@ func (x *GeneratedCodeInfo_Annotation) ProtoReflect() protoreflect.Message {
+ 
+ // Deprecated: Use GeneratedCodeInfo_Annotation.ProtoReflect.Descriptor instead.
+ func (*GeneratedCodeInfo_Annotation) Descriptor() ([]byte, []int) {
+-	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{20, 0}
++	return file_google_protobuf_descriptor_proto_rawDescGZIP(), []int{22, 0}
+ }
+ 
+ func (x *GeneratedCodeInfo_Annotation) GetPath() []int32 {
+@@ -3550,7 +4350,7 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+ 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73,
+ 	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x04, 0x66, 0x69,
+-	0x6c, 0x65, 0x22, 0xfe, 0x04, 0x0a, 0x13, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72,
++	0x6c, 0x65, 0x22, 0x98, 0x05, 0x0a, 0x13, 0x46, 0x69, 0x6c, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72,
+ 	0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61,
+ 	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x18,
+ 	0x0a, 0x07, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+@@ -3588,250 +4388,250 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
+ 	0x6f, 0x52, 0x0e, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
+ 	0x6f, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x18, 0x0c, 0x20, 0x01, 0x28,
+-	0x09, 0x52, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x12, 0x18, 0x0a, 0x07, 0x65, 0x64, 0x69,
+-	0x74, 0x69, 0x6f, 0x6e, 0x18, 0x0d, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74,
+-	0x69, 0x6f, 0x6e, 0x22, 0xb9, 0x06, 0x0a, 0x0f, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
+-	0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
+-	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3b, 0x0a, 0x05, 0x66,
+-	0x69, 0x65, 0x6c, 0x64, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f,
+-	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65,
+-	0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
+-	0x6f, 0x52, 0x05, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x12, 0x43, 0x0a, 0x09, 0x65, 0x78, 0x74, 0x65,
+-	0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69,
+-	0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
+-	0x74, 0x6f, 0x52, 0x09, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a,
+-	0x0b, 0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x03,
+-	0x28, 0x0b, 0x32, 0x20, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+-	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
+-	0x72, 0x6f, 0x74, 0x6f, 0x52, 0x0a, 0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x54, 0x79, 0x70, 0x65,
+-	0x12, 0x41, 0x0a, 0x09, 0x65, 0x6e, 0x75, 0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x04, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
+-	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54,
+-	0x79, 0x70, 0x65, 0x12, 0x58, 0x0a, 0x0f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e,
+-	0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x67,
++	0x09, 0x52, 0x06, 0x73, 0x79, 0x6e, 0x74, 0x61, 0x78, 0x12, 0x32, 0x0a, 0x07, 0x65, 0x64, 0x69,
++	0x74, 0x69, 0x6f, 0x6e, 0x18, 0x0e, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69,
++	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0xb9, 0x06,
++	0x0a, 0x0f, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3b, 0x0a, 0x05, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x18, 0x02,
++	0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63,
++	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05, 0x66, 0x69, 0x65,
++	0x6c, 0x64, 0x12, 0x43, 0x0a, 0x09, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18,
++	0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73,
++	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x09, 0x65, 0x78,
++	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a, 0x0b, 0x6e, 0x65, 0x73, 0x74, 0x65,
++	0x64, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x20, 0x2e, 0x67,
+ 	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45,
+-	0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0e, 0x65,
+-	0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x44, 0x0a,
+-	0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x64, 0x65, 0x63, 0x6c, 0x18, 0x08, 0x20, 0x03, 0x28,
+-	0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+-	0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x09, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x44,
+-	0x65, 0x63, 0x6c, 0x12, 0x39, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x07,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x55,
+-	0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65,
+-	0x18, 0x09, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x0a,
++	0x6e, 0x65, 0x73, 0x74, 0x65, 0x64, 0x54, 0x79, 0x70, 0x65, 0x12, 0x41, 0x0a, 0x09, 0x65, 0x6e,
++	0x75, 0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72,
++	0x6f, 0x74, 0x6f, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54, 0x79, 0x70, 0x65, 0x12, 0x58, 0x0a,
++	0x0f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65,
++	0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+ 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
++	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69,
++	0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0e, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69,
++	0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x44, 0x0a, 0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66,
++	0x5f, 0x64, 0x65, 0x63, 0x6c, 0x18, 0x08, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e,
++	0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
++	0x74, 0x6f, 0x52, 0x09, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x63, 0x6c, 0x12, 0x39, 0x0a,
++	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52,
++	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x55, 0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65,
++	0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x09, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f,
++	0x74, 0x6f, 0x2e, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65,
++	0x52, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12,
++	0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65,
++	0x18, 0x0a, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64,
++	0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x7a, 0x0a, 0x0e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
++	0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18,
++	0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03,
++	0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x12, 0x40,
++	0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
++	0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x1a, 0x37, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67,
++	0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05,
++	0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02,
++	0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0xcc, 0x04, 0x0a, 0x15, 0x45, 0x78,
++	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
++	0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03,
++	0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x59, 0x0a,
++	0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x03,
++	0x28, 0x0b, 0x32, 0x32, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61,
++	0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x44, 0x65, 0x63, 0x6c, 0x61,
++	0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x03, 0x88, 0x01, 0x02, 0x52, 0x0b, 0x64, 0x65, 0x63,
++	0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x73, 0x18, 0x32, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x12, 0x6d, 0x0a, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f,
++	0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x38, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73,
++	0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
++	0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74,
++	0x65, 0x3a, 0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x42, 0x03, 0x88,
++	0x01, 0x02, 0x52, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x1a, 0x94, 0x01, 0x0a, 0x0b, 0x44, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05,
++	0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x1b, 0x0a, 0x09, 0x66, 0x75, 0x6c, 0x6c,
++	0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x66, 0x75, 0x6c,
++	0x6c, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20,
++	0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73,
++	0x65, 0x72, 0x76, 0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x73,
++	0x65, 0x72, 0x76, 0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65,
++	0x64, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65,
++	0x64, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x22, 0x34, 0x0a, 0x11, 0x56, 0x65, 0x72, 0x69, 0x66,
++	0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x0f, 0x0a, 0x0b,
++	0x44, 0x45, 0x43, 0x4c, 0x41, 0x52, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x10, 0x00, 0x12, 0x0e, 0x0a,
++	0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x01, 0x2a, 0x09, 0x08,
++	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0xc1, 0x06, 0x0a, 0x14, 0x46, 0x69, 0x65,
++	0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18,
++	0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x41, 0x0a,
++	0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
++	0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72,
++	0x6f, 0x74, 0x6f, 0x2e, 0x4c, 0x61, 0x62, 0x65, 0x6c, 0x52, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c,
++	0x12, 0x3e, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2a,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72,
++	0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x54, 0x79, 0x70, 0x65, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65,
++	0x12, 0x1b, 0x0a, 0x09, 0x74, 0x79, 0x70, 0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x06, 0x20,
++	0x01, 0x28, 0x09, 0x52, 0x08, 0x74, 0x79, 0x70, 0x65, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1a, 0x0a,
++	0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x64, 0x65, 0x66,
++	0x61, 0x75, 0x6c, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09,
++	0x52, 0x0c, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x1f,
++	0x0a, 0x0b, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x69, 0x6e, 0x64, 0x65, 0x78, 0x18, 0x09, 0x20,
++	0x01, 0x28, 0x05, 0x52, 0x0a, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12,
++	0x1b, 0x0a, 0x09, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x08, 0x6a, 0x73, 0x6f, 0x6e, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x27, 0x0a, 0x0f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x18, 0x11, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x22, 0xb6,
++	0x02, 0x0a, 0x04, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x44, 0x4f, 0x55, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x46, 0x4c, 0x4f, 0x41, 0x54, 0x10, 0x02, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x03, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45,
++	0x5f, 0x55, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x04, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x05, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34, 0x10, 0x06, 0x12, 0x10, 0x0a, 0x0c, 0x54,
++	0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32, 0x10, 0x07, 0x12, 0x0d, 0x0a,
++	0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x4f, 0x4f, 0x4c, 0x10, 0x08, 0x12, 0x0f, 0x0a, 0x0b,
++	0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x09, 0x12, 0x0e, 0x0a,
++	0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x47, 0x52, 0x4f, 0x55, 0x50, 0x10, 0x0a, 0x12, 0x10, 0x0a,
++	0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x10, 0x0b, 0x12,
++	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x59, 0x54, 0x45, 0x53, 0x10, 0x0c, 0x12,
++	0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x0d,
++	0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x10, 0x0e, 0x12,
++	0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32,
++	0x10, 0x0f, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45,
++	0x44, 0x36, 0x34, 0x10, 0x10, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49,
++	0x4e, 0x54, 0x33, 0x32, 0x10, 0x11, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53,
++	0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x12, 0x22, 0x43, 0x0a, 0x05, 0x4c, 0x61, 0x62, 0x65, 0x6c,
++	0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x4f, 0x50, 0x54, 0x49, 0x4f, 0x4e,
++	0x41, 0x4c, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45,
++	0x50, 0x45, 0x41, 0x54, 0x45, 0x44, 0x10, 0x03, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45,
++	0x4c, 0x5f, 0x52, 0x45, 0x51, 0x55, 0x49, 0x52, 0x45, 0x44, 0x10, 0x02, 0x22, 0x63, 0x0a, 0x14,
++	0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
++	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f,
++	0x66, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x73, 0x22, 0xe3, 0x02, 0x0a, 0x13, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
++	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d,
++	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3f, 0x0a,
++	0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x29, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45,
++	0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
++	0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x36,
++	0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
++	0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x5d, 0x0a, 0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
++	0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x36,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+ 	0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64,
+ 	0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65,
+-	0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x7a, 0x0a, 0x0e, 0x45, 0x78,
+-	0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05,
+-	0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61,
+-	0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52,
+-	0x03, 0x65, 0x6e, 0x64, 0x12, 0x40, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18,
+-	0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
+-	0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x1a, 0x37, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a,
+-	0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22,
+-	0xad, 0x04, 0x0a, 0x15, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e,
+-	0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+-	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x12, 0x59, 0x0a, 0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69,
+-	0x6f, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x32, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e,
+-	0x73, 0x69, 0x6f, 0x6e, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+-	0x2e, 0x44, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x03, 0x88, 0x01,
+-	0x02, 0x52, 0x0b, 0x64, 0x65, 0x63, 0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x68,
+-	0x0a, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x0e, 0x32, 0x38, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e,
+-	0x52, 0x61, 0x6e, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x56, 0x65, 0x72,
+-	0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x3a, 0x0a,
+-	0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49, 0x45, 0x44, 0x52, 0x0c, 0x76, 0x65, 0x72, 0x69,
+-	0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xb3, 0x01, 0x0a, 0x0b, 0x44, 0x65, 0x63,
+-	0x6c, 0x61, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62,
+-	0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72,
+-	0x12, 0x1b, 0x0a, 0x09, 0x66, 0x75, 0x6c, 0x6c, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20,
+-	0x01, 0x28, 0x09, 0x52, 0x08, 0x66, 0x75, 0x6c, 0x6c, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x12, 0x0a,
+-	0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70,
+-	0x65, 0x12, 0x23, 0x0a, 0x0b, 0x69, 0x73, 0x5f, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64,
+-	0x18, 0x04, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x0a, 0x69, 0x73, 0x52, 0x65,
+-	0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x18, 0x06,
+-	0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x22, 0x34,
+-	0x0a, 0x11, 0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74,
+-	0x61, 0x74, 0x65, 0x12, 0x0f, 0x0a, 0x0b, 0x44, 0x45, 0x43, 0x4c, 0x41, 0x52, 0x41, 0x54, 0x49,
+-	0x4f, 0x4e, 0x10, 0x00, 0x12, 0x0e, 0x0a, 0x0a, 0x55, 0x4e, 0x56, 0x45, 0x52, 0x49, 0x46, 0x49,
+-	0x45, 0x44, 0x10, 0x01, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22,
+-	0xc1, 0x06, 0x0a, 0x14, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+-	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06,
+-	0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75,
+-	0x6d, 0x62, 0x65, 0x72, 0x12, 0x41, 0x0a, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x18, 0x04, 0x20,
+-	0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72,
+-	0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x4c, 0x61, 0x62, 0x65, 0x6c,
+-	0x52, 0x05, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x12, 0x3e, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18,
+-	0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x65, 0x73,
+-	0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x54, 0x79, 0x70,
+-	0x65, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1b, 0x0a, 0x09, 0x74, 0x79, 0x70, 0x65, 0x5f,
+-	0x6e, 0x61, 0x6d, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x74, 0x79, 0x70, 0x65,
+-	0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65,
+-	0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x65,
+-	0x12, 0x23, 0x0a, 0x0d, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75,
+-	0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0c, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74,
+-	0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f, 0x6e, 0x65, 0x6f, 0x66, 0x5f, 0x69,
+-	0x6e, 0x64, 0x65, 0x78, 0x18, 0x09, 0x20, 0x01, 0x28, 0x05, 0x52, 0x0a, 0x6f, 0x6e, 0x65, 0x6f,
+-	0x66, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12, 0x1b, 0x0a, 0x09, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x6a, 0x73, 0x6f, 0x6e, 0x4e,
+-	0x61, 0x6d, 0x65, 0x12, 0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x08,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69,
+-	0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x27, 0x0a, 0x0f,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x18,
+-	0x11, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x22, 0xb6, 0x02, 0x0a, 0x04, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0f,
+-	0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x44, 0x4f, 0x55, 0x42, 0x4c, 0x45, 0x10, 0x01, 0x12,
+-	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x4c, 0x4f, 0x41, 0x54, 0x10, 0x02, 0x12,
+-	0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x03, 0x12,
+-	0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x04,
+-	0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x05,
+-	0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34,
+-	0x10, 0x06, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x58, 0x45, 0x44,
+-	0x33, 0x32, 0x10, 0x07, 0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42, 0x4f, 0x4f,
+-	0x4c, 0x10, 0x08, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x54, 0x52, 0x49,
+-	0x4e, 0x47, 0x10, 0x09, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x47, 0x52, 0x4f,
+-	0x55, 0x50, 0x10, 0x0a, 0x12, 0x10, 0x0a, 0x0c, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53,
+-	0x53, 0x41, 0x47, 0x45, 0x10, 0x0b, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x42,
+-	0x59, 0x54, 0x45, 0x53, 0x10, 0x0c, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55,
+-	0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x0d, 0x12, 0x0d, 0x0a, 0x09, 0x54, 0x59, 0x50, 0x45, 0x5f,
+-	0x45, 0x4e, 0x55, 0x4d, 0x10, 0x0e, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53,
+-	0x46, 0x49, 0x58, 0x45, 0x44, 0x33, 0x32, 0x10, 0x0f, 0x12, 0x11, 0x0a, 0x0d, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x53, 0x46, 0x49, 0x58, 0x45, 0x44, 0x36, 0x34, 0x10, 0x10, 0x12, 0x0f, 0x0a, 0x0b,
+-	0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49, 0x4e, 0x54, 0x33, 0x32, 0x10, 0x11, 0x12, 0x0f, 0x0a,
+-	0x0b, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x49, 0x4e, 0x54, 0x36, 0x34, 0x10, 0x12, 0x22, 0x43,
+-	0x0a, 0x05, 0x4c, 0x61, 0x62, 0x65, 0x6c, 0x12, 0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c,
+-	0x5f, 0x4f, 0x50, 0x54, 0x49, 0x4f, 0x4e, 0x41, 0x4c, 0x10, 0x01, 0x12, 0x12, 0x0a, 0x0e, 0x4c,
+-	0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45, 0x51, 0x55, 0x49, 0x52, 0x45, 0x44, 0x10, 0x02, 0x12,
+-	0x12, 0x0a, 0x0e, 0x4c, 0x41, 0x42, 0x45, 0x4c, 0x5f, 0x52, 0x45, 0x50, 0x45, 0x41, 0x54, 0x45,
+-	0x44, 0x10, 0x03, 0x22, 0x63, 0x0a, 0x14, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x37, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b,
+-	0x32, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
+-	0x75, 0x66, 0x2e, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52,
+-	0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0xe3, 0x02, 0x0a, 0x13, 0x45, 0x6e, 0x75,
+-	0x6d, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f,
+-	0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04,
+-	0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3f, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x05,
+-	0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x36, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+-	0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x5d, 0x0a,
+-	0x0e, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x18,
+-	0x04, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x36, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x45, 0x6e, 0x75, 0x6d,
+-	0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x0d, 0x72,
+-	0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d,
+-	0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x05, 0x20,
+-	0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d,
+-	0x65, 0x1a, 0x3b, 0x0a, 0x11, 0x45, 0x6e, 0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18,
+-	0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03,
+-	0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0x83,
+-	0x01, 0x0a, 0x18, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52,
+-	0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x3b, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56,
+-	0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x22, 0xa7, 0x01, 0x0a, 0x16, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+-	0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12,
+-	0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e,
+-	0x61, 0x6d, 0x65, 0x12, 0x3e, 0x0a, 0x06, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x18, 0x02, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63,
+-	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x52, 0x06, 0x6d, 0x65, 0x74,
+-	0x68, 0x6f, 0x64, 0x12, 0x39, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0x89,
+-	0x02, 0x0a, 0x15, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
++	0x64, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x05, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0c, 0x72, 0x65,
++	0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x4e, 0x61, 0x6d, 0x65, 0x1a, 0x3b, 0x0a, 0x11, 0x45, 0x6e,
++	0x75, 0x6d, 0x52, 0x65, 0x73, 0x65, 0x72, 0x76, 0x65, 0x64, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12,
++	0x14, 0x0a, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05,
++	0x73, 0x74, 0x61, 0x72, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01,
++	0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x22, 0x83, 0x01, 0x0a, 0x18, 0x45, 0x6e, 0x75, 0x6d,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
++	0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62,
++	0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72,
++	0x12, 0x3b, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28,
++	0x0b, 0x32, 0x21, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74,
++	0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0xa7, 0x01,
++	0x0a, 0x16, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70,
+ 	0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
+-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1d, 0x0a, 0x0a,
+-	0x69, 0x6e, 0x70, 0x75, 0x74, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x09, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f,
+-	0x75, 0x74, 0x70, 0x75, 0x74, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x0a, 0x6f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x38, 0x0a, 0x07,
+-	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e,
++	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3e, 0x0a, 0x06,
++	0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x26, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d,
++	0x65, 0x74, 0x68, 0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50,
++	0x72, 0x6f, 0x74, 0x6f, 0x52, 0x06, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x12, 0x39, 0x0a, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e,
+ 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+-	0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x30, 0x0a, 0x10, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74,
+-	0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08,
+-	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0f, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x53,
+-	0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x12, 0x30, 0x0a, 0x10, 0x73, 0x65, 0x72, 0x76,
+-	0x65, 0x72, 0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x06, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0f, 0x73, 0x65, 0x72, 0x76, 0x65,
+-	0x72, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e, 0x67, 0x22, 0x91, 0x09, 0x0a, 0x0b, 0x46,
+-	0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x21, 0x0a, 0x0c, 0x6a, 0x61,
+-	0x76, 0x61, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x0b, 0x6a, 0x61, 0x76, 0x61, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x30, 0x0a,
+-	0x14, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6f, 0x75, 0x74, 0x65, 0x72, 0x5f, 0x63, 0x6c, 0x61, 0x73,
+-	0x73, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x6a, 0x61, 0x76,
+-	0x61, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x43, 0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x12,
+-	0x35, 0x0a, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65,
+-	0x5f, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x11, 0x6a, 0x61, 0x76, 0x61, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c,
+-	0x65, 0x46, 0x69, 0x6c, 0x65, 0x73, 0x12, 0x44, 0x0a, 0x1d, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67,
+-	0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x5f, 0x61,
+-	0x6e, 0x64, 0x5f, 0x68, 0x61, 0x73, 0x68, 0x18, 0x14, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18,
+-	0x01, 0x52, 0x19, 0x6a, 0x61, 0x76, 0x61, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x45,
+-	0x71, 0x75, 0x61, 0x6c, 0x73, 0x41, 0x6e, 0x64, 0x48, 0x61, 0x73, 0x68, 0x12, 0x3a, 0x0a, 0x16,
+-	0x6a, 0x61, 0x76, 0x61, 0x5f, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x68, 0x65, 0x63,
+-	0x6b, 0x5f, 0x75, 0x74, 0x66, 0x38, 0x18, 0x1b, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43,
+-	0x68, 0x65, 0x63, 0x6b, 0x55, 0x74, 0x66, 0x38, 0x12, 0x53, 0x0a, 0x0c, 0x6f, 0x70, 0x74, 0x69,
+-	0x6d, 0x69, 0x7a, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x29,
+-	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+-	0x2e, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74,
+-	0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64, 0x65, 0x3a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44,
+-	0x52, 0x0b, 0x6f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x46, 0x6f, 0x72, 0x12, 0x1d, 0x0a,
+-	0x0a, 0x67, 0x6f, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x18, 0x0b, 0x20, 0x01, 0x28,
+-	0x09, 0x52, 0x09, 0x67, 0x6f, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x35, 0x0a, 0x13,
+-	0x63, 0x63, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69,
+-	0x63, 0x65, 0x73, 0x18, 0x10, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
+-	0x52, 0x11, 0x63, 0x63, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69,
+-	0x63, 0x65, 0x73, 0x12, 0x39, 0x0a, 0x15, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65,
+-	0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x11, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x47,
+-	0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x35,
+-	0x0a, 0x13, 0x70, 0x79, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72,
+-	0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x12, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
+-	0x73, 0x65, 0x52, 0x11, 0x70, 0x79, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72,
+-	0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x37, 0x0a, 0x14, 0x70, 0x68, 0x70, 0x5f, 0x67, 0x65, 0x6e,
+-	0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x2a, 0x20,
+-	0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x12, 0x70, 0x68, 0x70, 0x47,
++	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x22, 0x89, 0x02, 0x0a, 0x15, 0x4d, 0x65, 0x74, 0x68,
++	0x6f, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74,
++	0x6f, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
++	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1d, 0x0a, 0x0a, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x5f, 0x74,
++	0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x69, 0x6e, 0x70, 0x75, 0x74,
++	0x54, 0x79, 0x70, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x6f, 0x75, 0x74, 0x70, 0x75, 0x74, 0x5f, 0x74,
++	0x79, 0x70, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x6f, 0x75, 0x74, 0x70, 0x75,
++	0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x38, 0x0a, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x07, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12,
++	0x30, 0x0a, 0x10, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x5f, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d,
++	0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x0f, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x69, 0x6e,
++	0x67, 0x12, 0x30, 0x0a, 0x10, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x5f, 0x73, 0x74, 0x72, 0x65,
++	0x61, 0x6d, 0x69, 0x6e, 0x67, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x0f, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6d,
++	0x69, 0x6e, 0x67, 0x22, 0x97, 0x09, 0x0a, 0x0b, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x21, 0x0a, 0x0c, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x70, 0x61, 0x63, 0x6b,
++	0x61, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x6a, 0x61, 0x76, 0x61, 0x50,
++	0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x30, 0x0a, 0x14, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x6f,
++	0x75, 0x74, 0x65, 0x72, 0x5f, 0x63, 0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x08,
++	0x20, 0x01, 0x28, 0x09, 0x52, 0x12, 0x6a, 0x61, 0x76, 0x61, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x43,
++	0x6c, 0x61, 0x73, 0x73, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x35, 0x0a, 0x13, 0x6a, 0x61, 0x76, 0x61,
++	0x5f, 0x6d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x5f, 0x66, 0x69, 0x6c, 0x65, 0x73, 0x18,
++	0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x6a, 0x61,
++	0x76, 0x61, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x73, 0x12,
++	0x44, 0x0a, 0x1d, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
++	0x5f, 0x65, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x5f, 0x61, 0x6e, 0x64, 0x5f, 0x68, 0x61, 0x73, 0x68,
++	0x18, 0x14, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x19, 0x6a, 0x61, 0x76, 0x61,
++	0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x45, 0x71, 0x75, 0x61, 0x6c, 0x73, 0x41, 0x6e,
++	0x64, 0x48, 0x61, 0x73, 0x68, 0x12, 0x3a, 0x0a, 0x16, 0x6a, 0x61, 0x76, 0x61, 0x5f, 0x73, 0x74,
++	0x72, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x5f, 0x75, 0x74, 0x66, 0x38, 0x18,
++	0x1b, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x13, 0x6a, 0x61,
++	0x76, 0x61, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x55, 0x74, 0x66,
++	0x38, 0x12, 0x53, 0x0a, 0x0c, 0x6f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x5f, 0x66, 0x6f,
++	0x72, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x6c, 0x65, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f,
++	0x64, 0x65, 0x3a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44, 0x52, 0x0b, 0x6f, 0x70, 0x74, 0x69, 0x6d,
++	0x69, 0x7a, 0x65, 0x46, 0x6f, 0x72, 0x12, 0x1d, 0x0a, 0x0a, 0x67, 0x6f, 0x5f, 0x70, 0x61, 0x63,
++	0x6b, 0x61, 0x67, 0x65, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x67, 0x6f, 0x50, 0x61,
++	0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x35, 0x0a, 0x13, 0x63, 0x63, 0x5f, 0x67, 0x65, 0x6e, 0x65,
++	0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x10, 0x20, 0x01,
++	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x63, 0x63, 0x47, 0x65, 0x6e,
++	0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x39, 0x0a, 0x15,
++	0x6a, 0x61, 0x76, 0x61, 0x5f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72,
++	0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x11, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x13, 0x6a, 0x61, 0x76, 0x61, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53,
++	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x35, 0x0a, 0x13, 0x70, 0x79, 0x5f, 0x67, 0x65,
++	0x6e, 0x65, 0x72, 0x69, 0x63, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18, 0x12,
++	0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x11, 0x70, 0x79, 0x47,
+ 	0x65, 0x6e, 0x65, 0x72, 0x69, 0x63, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x12, 0x25,
+ 	0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x17, 0x20, 0x01,
+ 	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65,
+@@ -3856,259 +4656,419 @@ var file_google_protobuf_descriptor_proto_rawDesc = []byte{
+ 	0x70, 0x68, 0x70, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x4e, 0x61, 0x6d, 0x65, 0x73,
+ 	0x70, 0x61, 0x63, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x72, 0x75, 0x62, 0x79, 0x5f, 0x70, 0x61, 0x63,
+ 	0x6b, 0x61, 0x67, 0x65, 0x18, 0x2d, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x72, 0x75, 0x62, 0x79,
+-	0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18,
+-	0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72,
+-	0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e,
+-	0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x22, 0x3a, 0x0a, 0x0c, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64,
+-	0x65, 0x12, 0x09, 0x0a, 0x05, 0x53, 0x50, 0x45, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09,
+-	0x43, 0x4f, 0x44, 0x45, 0x5f, 0x53, 0x49, 0x5a, 0x45, 0x10, 0x02, 0x12, 0x10, 0x0a, 0x0c, 0x4c,
+-	0x49, 0x54, 0x45, 0x5f, 0x52, 0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x03, 0x2a, 0x09, 0x08,
+-	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x26, 0x10, 0x27, 0x22, 0xbb,
+-	0x03, 0x0a, 0x0e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x73, 0x12, 0x3c, 0x0a, 0x17, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x65, 0x74,
+-	0x5f, 0x77, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x01, 0x20, 0x01,
+-	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x14, 0x6d, 0x65, 0x73, 0x73, 0x61,
+-	0x67, 0x65, 0x53, 0x65, 0x74, 0x57, 0x69, 0x72, 0x65, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12,
+-	0x4c, 0x0a, 0x1f, 0x6e, 0x6f, 0x5f, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x5f, 0x64,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73,
+-	0x6f, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
+-	0x1c, 0x6e, 0x6f, 0x53, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72,
+-	0x69, 0x70, 0x74, 0x6f, 0x72, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f, 0x72, 0x12, 0x25, 0x0a,
+-	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28,
+-	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63,
+-	0x61, 0x74, 0x65, 0x64, 0x12, 0x1b, 0x0a, 0x09, 0x6d, 0x61, 0x70, 0x5f, 0x65, 0x6e, 0x74, 0x72,
+-	0x79, 0x18, 0x07, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x6d, 0x61, 0x70, 0x45, 0x6e, 0x74, 0x72,
+-	0x79, 0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f,
+-	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c,
+-	0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28,
+-	0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+-	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x04, 0x10, 0x05, 0x4a, 0x04, 0x08, 0x05, 0x10, 0x06, 0x4a, 0x04, 0x08, 0x06, 0x10, 0x07,
+-	0x4a, 0x04, 0x08, 0x08, 0x10, 0x09, 0x4a, 0x04, 0x08, 0x09, 0x10, 0x0a, 0x22, 0x85, 0x09, 0x0a,
+-	0x0c, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x41, 0x0a,
+-	0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x23, 0x2e, 0x67,
+-	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
+-	0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x43, 0x54, 0x79, 0x70,
+-	0x65, 0x3a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x52, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65,
+-	0x12, 0x16, 0x0a, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08,
+-	0x52, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x12, 0x47, 0x0a, 0x06, 0x6a, 0x73, 0x74, 0x79,
+-	0x70, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x09,
+-	0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x52, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70,
+-	0x65, 0x12, 0x19, 0x0a, 0x04, 0x6c, 0x61, 0x7a, 0x79, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a,
+-	0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04, 0x6c, 0x61, 0x7a, 0x79, 0x12, 0x2e, 0x0a, 0x0f,
+-	0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64, 0x5f, 0x6c, 0x61, 0x7a, 0x79, 0x18,
+-	0x0f, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0e, 0x75, 0x6e,
+-	0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64, 0x4c, 0x61, 0x7a, 0x79, 0x12, 0x25, 0x0a, 0x0a,
++	0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75,
++	0x72, 0x65, 0x73, 0x18, 0x32, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
++	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73,
++	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
++	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
++	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
++	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
++	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x3a, 0x0a, 0x0c, 0x4f, 0x70,
++	0x74, 0x69, 0x6d, 0x69, 0x7a, 0x65, 0x4d, 0x6f, 0x64, 0x65, 0x12, 0x09, 0x0a, 0x05, 0x53, 0x50,
++	0x45, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x43, 0x4f, 0x44, 0x45, 0x5f, 0x53, 0x49,
++	0x5a, 0x45, 0x10, 0x02, 0x12, 0x10, 0x0a, 0x0c, 0x4c, 0x49, 0x54, 0x45, 0x5f, 0x52, 0x55, 0x4e,
++	0x54, 0x49, 0x4d, 0x45, 0x10, 0x03, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80,
++	0x02, 0x4a, 0x04, 0x08, 0x2a, 0x10, 0x2b, 0x4a, 0x04, 0x08, 0x26, 0x10, 0x27, 0x22, 0xf4, 0x03,
++	0x0a, 0x0e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x12, 0x3c, 0x0a, 0x17, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x73, 0x65, 0x74, 0x5f,
++	0x77, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28,
++	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x14, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67,
++	0x65, 0x53, 0x65, 0x74, 0x57, 0x69, 0x72, 0x65, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12, 0x4c,
++	0x0a, 0x1f, 0x6e, 0x6f, 0x5f, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x5f, 0x64, 0x65,
++	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x5f, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f,
++	0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x1c,
++	0x6e, 0x6f, 0x53, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
++	0x70, 0x74, 0x6f, 0x72, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x6f, 0x72, 0x12, 0x25, 0x0a, 0x0a,
+ 	0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08,
+ 	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
+-	0x74, 0x65, 0x64, 0x12, 0x19, 0x0a, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x18, 0x0a, 0x20, 0x01, 0x28,
+-	0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x12, 0x28,
+-	0x0a, 0x0c, 0x64, 0x65, 0x62, 0x75, 0x67, 0x5f, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x10,
+-	0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62,
+-	0x75, 0x67, 0x52, 0x65, 0x64, 0x61, 0x63, 0x74, 0x12, 0x4b, 0x0a, 0x09, 0x72, 0x65, 0x74, 0x65,
+-	0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x11, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2d, 0x2e, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69,
+-	0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f,
+-	0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x09, 0x72, 0x65, 0x74, 0x65,
+-	0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x4a, 0x0a, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x18,
+-	0x12, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65,
+-	0x74, 0x54, 0x79, 0x70, 0x65, 0x42, 0x02, 0x18, 0x01, 0x52, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65,
+-	0x74, 0x12, 0x48, 0x0a, 0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x18, 0x13, 0x20, 0x03,
+-	0x28, 0x0e, 0x32, 0x2e, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
+-	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79,
+-	0x70, 0x65, 0x52, 0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75,
+-	0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f,
+-	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69,
+-	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+-	0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x2f, 0x0a, 0x05, 0x43, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0a,
+-	0x0a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x43, 0x4f,
+-	0x52, 0x44, 0x10, 0x01, 0x12, 0x10, 0x0a, 0x0c, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x5f, 0x50,
+-	0x49, 0x45, 0x43, 0x45, 0x10, 0x02, 0x22, 0x35, 0x0a, 0x06, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65,
+-	0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x10, 0x00, 0x12,
+-	0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x01, 0x12, 0x0d,
+-	0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x55, 0x4d, 0x42, 0x45, 0x52, 0x10, 0x02, 0x22, 0x55, 0x0a,
+-	0x0f, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e,
+-	0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e,
+-	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e,
+-	0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x52, 0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x01, 0x12, 0x14,
+-	0x0a, 0x10, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x4f, 0x55, 0x52,
+-	0x43, 0x45, 0x10, 0x02, 0x22, 0x8c, 0x02, 0x0a, 0x10, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54,
+-	0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79, 0x70, 0x65, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e,
+-	0x10, 0x00, 0x12, 0x14, 0x0a, 0x10, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x46, 0x49, 0x4c, 0x45, 0x10, 0x01, 0x12, 0x1f, 0x0a, 0x1b, 0x54, 0x41, 0x52, 0x47,
+-	0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f,
+-	0x4e, 0x5f, 0x52, 0x41, 0x4e, 0x47, 0x45, 0x10, 0x02, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45,
+-	0x10, 0x03, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x46, 0x49, 0x45, 0x4c, 0x44, 0x10, 0x04, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52,
+-	0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4f, 0x4e, 0x45, 0x4f, 0x46, 0x10, 0x05,
+-	0x12, 0x14, 0x0a, 0x10, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
+-	0x45, 0x4e, 0x55, 0x4d, 0x10, 0x06, 0x12, 0x1a, 0x0a, 0x16, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54,
+-	0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x45, 0x4e, 0x54, 0x52, 0x59,
+-	0x10, 0x07, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
+-	0x45, 0x5f, 0x53, 0x45, 0x52, 0x56, 0x49, 0x43, 0x45, 0x10, 0x08, 0x12, 0x16, 0x0a, 0x12, 0x54,
+-	0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x54, 0x48, 0x4f,
+-	0x44, 0x10, 0x09, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x04, 0x10, 0x05, 0x22, 0x73, 0x0a, 0x0c, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
+-	0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20,
+-	0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65,
+-	0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74,
+-	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09,
+-	0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x98, 0x02, 0x0a, 0x0b, 0x45, 0x6e,
+-	0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x6c, 0x6c,
+-	0x6f, 0x77, 0x5f, 0x61, 0x6c, 0x69, 0x61, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0a,
+-	0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x41, 0x6c, 0x69, 0x61, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65,
+-	0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05,
+-	0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f,
+-	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c,
+-	0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28,
+-	0x08, 0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65,
+-	0x64, 0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64,
+-	0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
++	0x74, 0x65, 0x64, 0x12, 0x1b, 0x0a, 0x09, 0x6d, 0x61, 0x70, 0x5f, 0x65, 0x6e, 0x74, 0x72, 0x79,
++	0x18, 0x07, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08, 0x6d, 0x61, 0x70, 0x45, 0x6e, 0x74, 0x72, 0x79,
++	0x12, 0x56, 0x0a, 0x26, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x6c,
++	0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c, 0x64,
++	0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x08,
++	0x42, 0x02, 0x18, 0x01, 0x52, 0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64,
++	0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43,
++	0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74,
++	0x75, 0x72, 0x65, 0x73, 0x18, 0x0c, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07,
++	0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x4a, 0x04, 0x08, 0x05,
++	0x10, 0x06, 0x4a, 0x04, 0x08, 0x06, 0x10, 0x07, 0x4a, 0x04, 0x08, 0x08, 0x10, 0x09, 0x4a, 0x04,
++	0x08, 0x09, 0x10, 0x0a, 0x22, 0xad, 0x0a, 0x0a, 0x0c, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x41, 0x0a, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01,
++	0x20, 0x01, 0x28, 0x0e, 0x32, 0x23, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x2e, 0x43, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x4e,
++	0x47, 0x52, 0x05, 0x63, 0x74, 0x79, 0x70, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x70, 0x61, 0x63, 0x6b,
++	0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x06, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x64,
++	0x12, 0x47, 0x0a, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e,
++	0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
++	0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x09, 0x4a, 0x53, 0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41,
++	0x4c, 0x52, 0x06, 0x6a, 0x73, 0x74, 0x79, 0x70, 0x65, 0x12, 0x19, 0x0a, 0x04, 0x6c, 0x61, 0x7a,
++	0x79, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x04,
++	0x6c, 0x61, 0x7a, 0x79, 0x12, 0x2e, 0x0a, 0x0f, 0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69,
++	0x65, 0x64, 0x5f, 0x6c, 0x61, 0x7a, 0x79, 0x18, 0x0f, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66,
++	0x61, 0x6c, 0x73, 0x65, 0x52, 0x0e, 0x75, 0x6e, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x64,
++	0x4c, 0x61, 0x7a, 0x79, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74,
++	0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
++	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x19, 0x0a, 0x04, 0x77,
++	0x65, 0x61, 0x6b, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x04, 0x77, 0x65, 0x61, 0x6b, 0x12, 0x28, 0x0a, 0x0c, 0x64, 0x65, 0x62, 0x75, 0x67, 0x5f,
++	0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x10, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
++	0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62, 0x75, 0x67, 0x52, 0x65, 0x64, 0x61, 0x63, 0x74,
++	0x12, 0x4b, 0x0a, 0x09, 0x72, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x11, 0x20,
++	0x01, 0x28, 0x0e, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x73, 0x2e, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69,
++	0x6f, 0x6e, 0x52, 0x09, 0x72, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x48, 0x0a,
++	0x07, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x18, 0x13, 0x20, 0x03, 0x28, 0x0e, 0x32, 0x2e,
++	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
++	0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54, 0x79, 0x70, 0x65, 0x52, 0x07,
++	0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x73, 0x12, 0x57, 0x0a, 0x10, 0x65, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x5f, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x18, 0x14, 0x20, 0x03, 0x28,
++	0x0b, 0x32, 0x2c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
++	0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x52,
++	0x0f, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73,
++	0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x15, 0x20, 0x01,
++	0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52,
++	0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69,
+ 	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f,
+ 	0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+ 	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74,
+ 	0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13,
+ 	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04,
+-	0x08, 0x05, 0x10, 0x06, 0x22, 0x9e, 0x01, 0x0a, 0x10, 0x45, 0x6e, 0x75, 0x6d, 0x56, 0x61, 0x6c,
+-	0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70,
+-	0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66,
+-	0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64,
+-	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
+-	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
+-	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
+-	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
+-	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10,
+-	0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x9c, 0x01, 0x0a, 0x0e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63,
+-	0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72,
+-	0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61,
+-	0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12,
+-	0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
+-	0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24,
+-	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+-	0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70,
+-	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65,
+-	0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80,
+-	0x80, 0x80, 0x80, 0x02, 0x22, 0xe0, 0x02, 0x0a, 0x0d, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63,
+-	0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73,
+-	0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x71, 0x0a,
+-	0x11, 0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x5f, 0x6c, 0x65, 0x76,
+-	0x65, 0x6c, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f,
+-	0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74,
+-	0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x3a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50,
+-	0x4f, 0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x52, 0x10,
+-	0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c,
+-	0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
+-	0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32,
+-	0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
+-	0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f,
+-	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72,
+-	0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x50, 0x0a, 0x10, 0x49, 0x64,
+-	0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12, 0x17,
+-	0x0a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e,
+-	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a, 0x0f, 0x4e, 0x4f, 0x5f, 0x53, 0x49,
+-	0x44, 0x45, 0x5f, 0x45, 0x46, 0x46, 0x45, 0x43, 0x54, 0x53, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a,
+-	0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45, 0x4e, 0x54, 0x10, 0x02, 0x2a, 0x09, 0x08, 0xe8,
+-	0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0x9a, 0x03, 0x0a, 0x13, 0x55, 0x6e, 0x69, 0x6e,
+-	0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12,
+-	0x41, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e,
++	0x69, 0x6f, 0x6e, 0x1a, 0x5a, 0x0a, 0x0e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65,
++	0x66, 0x61, 0x75, 0x6c, 0x74, 0x12, 0x32, 0x0a, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e,
++	0x18, 0x03, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e,
++	0x52, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c,
++	0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x22,
++	0x2f, 0x0a, 0x05, 0x43, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x54, 0x52, 0x49,
++	0x4e, 0x47, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x43, 0x4f, 0x52, 0x44, 0x10, 0x01, 0x12, 0x10,
++	0x0a, 0x0c, 0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x5f, 0x50, 0x49, 0x45, 0x43, 0x45, 0x10, 0x02,
++	0x22, 0x35, 0x0a, 0x06, 0x4a, 0x53, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53,
++	0x5f, 0x4e, 0x4f, 0x52, 0x4d, 0x41, 0x4c, 0x10, 0x00, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f,
++	0x53, 0x54, 0x52, 0x49, 0x4e, 0x47, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x4a, 0x53, 0x5f, 0x4e,
++	0x55, 0x4d, 0x42, 0x45, 0x52, 0x10, 0x02, 0x22, 0x55, 0x0a, 0x0f, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x52, 0x65, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45,
++	0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10,
++	0x00, 0x12, 0x15, 0x0a, 0x11, 0x52, 0x45, 0x54, 0x45, 0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x52,
++	0x55, 0x4e, 0x54, 0x49, 0x4d, 0x45, 0x10, 0x01, 0x12, 0x14, 0x0a, 0x10, 0x52, 0x45, 0x54, 0x45,
++	0x4e, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x4f, 0x55, 0x52, 0x43, 0x45, 0x10, 0x02, 0x22, 0x8c,
++	0x02, 0x0a, 0x10, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x54,
++	0x79, 0x70, 0x65, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x14, 0x0a, 0x10,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x4c, 0x45,
++	0x10, 0x01, 0x12, 0x1f, 0x0a, 0x1b, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50,
++	0x45, 0x5f, 0x45, 0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f, 0x4e, 0x5f, 0x52, 0x41, 0x4e, 0x47,
++	0x45, 0x10, 0x02, 0x12, 0x17, 0x0a, 0x13, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x10, 0x03, 0x12, 0x15, 0x0a, 0x11,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x46, 0x49, 0x45, 0x4c,
++	0x44, 0x10, 0x04, 0x12, 0x15, 0x0a, 0x11, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59,
++	0x50, 0x45, 0x5f, 0x4f, 0x4e, 0x45, 0x4f, 0x46, 0x10, 0x05, 0x12, 0x14, 0x0a, 0x10, 0x54, 0x41,
++	0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x45, 0x4e, 0x55, 0x4d, 0x10, 0x06,
++	0x12, 0x1a, 0x0a, 0x16, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x45, 0x4e, 0x54, 0x52, 0x59, 0x10, 0x07, 0x12, 0x17, 0x0a, 0x13,
++	0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x53, 0x45, 0x52, 0x56,
++	0x49, 0x43, 0x45, 0x10, 0x08, 0x12, 0x16, 0x0a, 0x12, 0x54, 0x41, 0x52, 0x47, 0x45, 0x54, 0x5f,
++	0x54, 0x59, 0x50, 0x45, 0x5f, 0x4d, 0x45, 0x54, 0x48, 0x4f, 0x44, 0x10, 0x09, 0x2a, 0x09, 0x08,
++	0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x4a, 0x04, 0x08, 0x04, 0x10, 0x05, 0x4a, 0x04,
++	0x08, 0x12, 0x10, 0x13, 0x22, 0xac, 0x01, 0x0a, 0x0c, 0x4f, 0x6e, 0x65, 0x6f, 0x66, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72,
++	0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58,
++	0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
+ 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+ 	0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
+-	0x69, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x52, 0x04, 0x6e, 0x61,
+-	0x6d, 0x65, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72,
+-	0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x69, 0x64,
+-	0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a,
+-	0x12, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76, 0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61,
+-	0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04, 0x52, 0x10, 0x70, 0x6f, 0x73, 0x69, 0x74,
+-	0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x6e,
+-	0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75,
+-	0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52, 0x10, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76,
+-	0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x64, 0x6f, 0x75,
+-	0x62, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x52,
+-	0x0b, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c,
+-	0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01,
+-	0x28, 0x0c, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12,
+-	0x27, 0x0a, 0x0f, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x5f, 0x76, 0x61, 0x6c,
+-	0x75, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67,
+-	0x61, 0x74, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x1a, 0x4a, 0x0a, 0x08, 0x4e, 0x61, 0x6d, 0x65,
+-	0x50, 0x61, 0x72, 0x74, 0x12, 0x1b, 0x0a, 0x09, 0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x70, 0x61, 0x72,
+-	0x74, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09, 0x52, 0x08, 0x6e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72,
+-	0x74, 0x12, 0x21, 0x0a, 0x0c, 0x69, 0x73, 0x5f, 0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
+-	0x6e, 0x18, 0x02, 0x20, 0x02, 0x28, 0x08, 0x52, 0x0b, 0x69, 0x73, 0x45, 0x78, 0x74, 0x65, 0x6e,
+-	0x73, 0x69, 0x6f, 0x6e, 0x22, 0xa7, 0x02, 0x0a, 0x0e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43,
+-	0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x44, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x28, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
+-	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72,
+-	0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x4c, 0x6f, 0x63, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x52, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xce, 0x01,
+-	0x0a, 0x08, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61,
+-	0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61,
+-	0x74, 0x68, 0x12, 0x16, 0x0a, 0x04, 0x73, 0x70, 0x61, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x05,
+-	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x73, 0x70, 0x61, 0x6e, 0x12, 0x29, 0x0a, 0x10, 0x6c, 0x65,
+-	0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x03,
+-	0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d,
+-	0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x2b, 0x0a, 0x11, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e,
+-	0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09,
+-	0x52, 0x10, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e,
+-	0x74, 0x73, 0x12, 0x3a, 0x0a, 0x19, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x65,
+-	0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18,
+-	0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x17, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x44, 0x65,
+-	0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22, 0xd0,
+-	0x02, 0x0a, 0x11, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65,
+-	0x49, 0x6e, 0x66, 0x6f, 0x12, 0x4d, 0x0a, 0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69,
+-	0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+-	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72,
+-	0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e,
+-	0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74,
+-	0x69, 0x6f, 0x6e, 0x1a, 0xeb, 0x01, 0x0a, 0x0a, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69,
++	0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80,
++	0x80, 0x80, 0x02, 0x22, 0xd1, 0x02, 0x0a, 0x0b, 0x45, 0x6e, 0x75, 0x6d, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x73, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x5f, 0x61, 0x6c, 0x69,
++	0x61, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0a, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x41,
++	0x6c, 0x69, 0x61, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74,
++	0x65, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52,
++	0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x56, 0x0a, 0x26, 0x64,
++	0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79,
++	0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x5f, 0x63, 0x6f, 0x6e, 0x66,
++	0x6c, 0x69, 0x63, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28, 0x08, 0x42, 0x02, 0x18, 0x01, 0x52,
++	0x22, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x4c, 0x65, 0x67, 0x61, 0x63,
++	0x79, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43, 0x6f, 0x6e, 0x66, 0x6c, 0x69,
++	0x63, 0x74, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14,
++	0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e,
++	0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f,
++	0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80,
++	0x02, 0x4a, 0x04, 0x08, 0x05, 0x10, 0x06, 0x22, 0x81, 0x02, 0x0a, 0x10, 0x45, 0x6e, 0x75, 0x6d,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a,
++	0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08,
++	0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
++	0x74, 0x65, 0x64, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x28, 0x0a, 0x0c,
++	0x64, 0x65, 0x62, 0x75, 0x67, 0x5f, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x18, 0x03, 0x20, 0x01,
++	0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0b, 0x64, 0x65, 0x62, 0x75, 0x67,
++	0x52, 0x65, 0x64, 0x61, 0x63, 0x74, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7,
++	0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69,
++	0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22, 0xd5, 0x01, 0x0a, 0x0e,
++	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x37,
++	0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0b,
++	0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08, 0x66,
++	0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65,
++	0x63, 0x61, 0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c,
++	0x73, 0x65, 0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x58,
++	0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f,
++	0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74,
++	0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74,
++	0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80,
++	0x80, 0x80, 0x02, 0x22, 0x99, 0x03, 0x0a, 0x0d, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x4f, 0x70,
++	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x25, 0x0a, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61,
++	0x74, 0x65, 0x64, 0x18, 0x21, 0x20, 0x01, 0x28, 0x08, 0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65,
++	0x52, 0x0a, 0x64, 0x65, 0x70, 0x72, 0x65, 0x63, 0x61, 0x74, 0x65, 0x64, 0x12, 0x71, 0x0a, 0x11,
++	0x69, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x5f, 0x6c, 0x65, 0x76, 0x65,
++	0x6c, 0x18, 0x22, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2f, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64,
++	0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65,
++	0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x3a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f,
++	0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x52, 0x10, 0x69,
++	0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12,
++	0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x23, 0x20, 0x01, 0x28,
++	0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x52, 0x08,
++	0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x58, 0x0a, 0x14, 0x75, 0x6e, 0x69, 0x6e,
++	0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x5f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e,
++	0x18, 0xe7, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
++	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65,
++	0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x13, 0x75,
++	0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69,
++	0x6f, 0x6e, 0x22, 0x50, 0x0a, 0x10, 0x49, 0x64, 0x65, 0x6d, 0x70, 0x6f, 0x74, 0x65, 0x6e, 0x63,
++	0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x12, 0x17, 0x0a, 0x13, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f,
++	0x54, 0x45, 0x4e, 0x43, 0x59, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12,
++	0x13, 0x0a, 0x0f, 0x4e, 0x4f, 0x5f, 0x53, 0x49, 0x44, 0x45, 0x5f, 0x45, 0x46, 0x46, 0x45, 0x43,
++	0x54, 0x53, 0x10, 0x01, 0x12, 0x0e, 0x0a, 0x0a, 0x49, 0x44, 0x45, 0x4d, 0x50, 0x4f, 0x54, 0x45,
++	0x4e, 0x54, 0x10, 0x02, 0x2a, 0x09, 0x08, 0xe8, 0x07, 0x10, 0x80, 0x80, 0x80, 0x80, 0x02, 0x22,
++	0x9a, 0x03, 0x0a, 0x13, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x72, 0x65, 0x74, 0x65,
++	0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x41, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
++	0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x6e, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x70,
++	0x72, 0x65, 0x74, 0x65, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65,
++	0x50, 0x61, 0x72, 0x74, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x29, 0x0a, 0x10, 0x69, 0x64,
++	0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03,
++	0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72,
++	0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76,
++	0x65, 0x5f, 0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28,
++	0x04, 0x52, 0x10, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61,
++	0x6c, 0x75, 0x65, 0x12, 0x2c, 0x0a, 0x12, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x5f,
++	0x69, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52,
++	0x10, 0x6e, 0x65, 0x67, 0x61, 0x74, 0x69, 0x76, 0x65, 0x49, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x75,
++	0x65, 0x12, 0x21, 0x0a, 0x0c, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75,
++	0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x52, 0x0b, 0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x56,
++	0x61, 0x6c, 0x75, 0x65, 0x12, 0x21, 0x0a, 0x0c, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76,
++	0x61, 0x6c, 0x75, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69,
++	0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x27, 0x0a, 0x0f, 0x61, 0x67, 0x67, 0x72, 0x65,
++	0x67, 0x61, 0x74, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09,
++	0x52, 0x0e, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65,
++	0x1a, 0x4a, 0x0a, 0x08, 0x4e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x12, 0x1b, 0x0a, 0x09,
++	0x6e, 0x61, 0x6d, 0x65, 0x5f, 0x70, 0x61, 0x72, 0x74, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09, 0x52,
++	0x08, 0x6e, 0x61, 0x6d, 0x65, 0x50, 0x61, 0x72, 0x74, 0x12, 0x21, 0x0a, 0x0c, 0x69, 0x73, 0x5f,
++	0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x02, 0x28, 0x08, 0x52,
++	0x0b, 0x69, 0x73, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x8c, 0x0a, 0x0a,
++	0x0a, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x12, 0x8b, 0x01, 0x0a, 0x0e,
++	0x66, 0x69, 0x65, 0x6c, 0x64, 0x5f, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x18, 0x01,
++	0x20, 0x01, 0x28, 0x0e, 0x32, 0x29, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x42,
++	0x39, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45,
++	0x58, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x49,
++	0x4d, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe7, 0x07, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45,
++	0x58, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x18, 0xe8, 0x07, 0x52, 0x0d, 0x66, 0x69, 0x65, 0x6c,
++	0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x66, 0x0a, 0x09, 0x65, 0x6e, 0x75,
++	0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x24, 0x2e, 0x67,
++	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46,
++	0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x45, 0x6e, 0x75, 0x6d, 0x54, 0x79,
++	0x70, 0x65, 0x42, 0x23, 0x88, 0x01, 0x01, 0x98, 0x01, 0x06, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x0b,
++	0x12, 0x06, 0x43, 0x4c, 0x4f, 0x53, 0x45, 0x44, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x09, 0x12, 0x04,
++	0x4f, 0x50, 0x45, 0x4e, 0x18, 0xe7, 0x07, 0x52, 0x08, 0x65, 0x6e, 0x75, 0x6d, 0x54, 0x79, 0x70,
++	0x65, 0x12, 0x92, 0x01, 0x0a, 0x17, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x66,
++	0x69, 0x65, 0x6c, 0x64, 0x5f, 0x65, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x18, 0x03, 0x20,
++	0x01, 0x28, 0x0e, 0x32, 0x31, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74,
++	0x2e, 0x52, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x45, 0x6e,
++	0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x42, 0x27, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98, 0x01,
++	0x01, 0xa2, 0x01, 0x0d, 0x12, 0x08, 0x45, 0x58, 0x50, 0x41, 0x4e, 0x44, 0x45, 0x44, 0x18, 0xe6,
++	0x07, 0xa2, 0x01, 0x0b, 0x12, 0x06, 0x50, 0x41, 0x43, 0x4b, 0x45, 0x44, 0x18, 0xe7, 0x07, 0x52,
++	0x15, 0x72, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x45, 0x6e,
++	0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x78, 0x0a, 0x0f, 0x75, 0x74, 0x66, 0x38, 0x5f, 0x76,
++	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0e, 0x32,
++	0x2a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x55, 0x74, 0x66,
++	0x38, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x23, 0x88, 0x01, 0x01,
++	0x98, 0x01, 0x04, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x09, 0x12, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x18,
++	0xe6, 0x07, 0xa2, 0x01, 0x0b, 0x12, 0x06, 0x56, 0x45, 0x52, 0x49, 0x46, 0x59, 0x18, 0xe7, 0x07,
++	0x52, 0x0e, 0x75, 0x74, 0x66, 0x38, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
++	0x12, 0x78, 0x0a, 0x10, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x5f, 0x65, 0x6e, 0x63, 0x6f,
++	0x64, 0x69, 0x6e, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x2b, 0x2e, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x45,
++	0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x42, 0x20, 0x88, 0x01, 0x01, 0x98, 0x01, 0x04, 0x98,
++	0x01, 0x01, 0xa2, 0x01, 0x14, 0x12, 0x0f, 0x4c, 0x45, 0x4e, 0x47, 0x54, 0x48, 0x5f, 0x50, 0x52,
++	0x45, 0x46, 0x49, 0x58, 0x45, 0x44, 0x18, 0xe6, 0x07, 0x52, 0x0f, 0x6d, 0x65, 0x73, 0x73, 0x61,
++	0x67, 0x65, 0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x7c, 0x0a, 0x0b, 0x6a, 0x73,
++	0x6f, 0x6e, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e, 0x32,
++	0x26, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
++	0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x2e, 0x4a, 0x73, 0x6f,
++	0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x42, 0x33, 0x88, 0x01, 0x01, 0x98, 0x01, 0x03, 0x98,
++	0x01, 0x06, 0x98, 0x01, 0x01, 0xa2, 0x01, 0x17, 0x12, 0x12, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59,
++	0x5f, 0x42, 0x45, 0x53, 0x54, 0x5f, 0x45, 0x46, 0x46, 0x4f, 0x52, 0x54, 0x18, 0xe6, 0x07, 0xa2,
++	0x01, 0x0a, 0x12, 0x05, 0x41, 0x4c, 0x4c, 0x4f, 0x57, 0x18, 0xe7, 0x07, 0x52, 0x0a, 0x6a, 0x73,
++	0x6f, 0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x22, 0x5c, 0x0a, 0x0d, 0x46, 0x69, 0x65, 0x6c,
++	0x64, 0x50, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x1a, 0x0a, 0x16, 0x46, 0x49, 0x45,
++	0x4c, 0x44, 0x5f, 0x50, 0x52, 0x45, 0x53, 0x45, 0x4e, 0x43, 0x45, 0x5f, 0x55, 0x4e, 0x4b, 0x4e,
++	0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0c, 0x0a, 0x08, 0x45, 0x58, 0x50, 0x4c, 0x49, 0x43, 0x49,
++	0x54, 0x10, 0x01, 0x12, 0x0c, 0x0a, 0x08, 0x49, 0x4d, 0x50, 0x4c, 0x49, 0x43, 0x49, 0x54, 0x10,
++	0x02, 0x12, 0x13, 0x0a, 0x0f, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59, 0x5f, 0x52, 0x45, 0x51, 0x55,
++	0x49, 0x52, 0x45, 0x44, 0x10, 0x03, 0x22, 0x37, 0x0a, 0x08, 0x45, 0x6e, 0x75, 0x6d, 0x54, 0x79,
++	0x70, 0x65, 0x12, 0x15, 0x0a, 0x11, 0x45, 0x4e, 0x55, 0x4d, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f,
++	0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x08, 0x0a, 0x04, 0x4f, 0x50, 0x45,
++	0x4e, 0x10, 0x01, 0x12, 0x0a, 0x0a, 0x06, 0x43, 0x4c, 0x4f, 0x53, 0x45, 0x44, 0x10, 0x02, 0x22,
++	0x56, 0x0a, 0x15, 0x52, 0x65, 0x70, 0x65, 0x61, 0x74, 0x65, 0x64, 0x46, 0x69, 0x65, 0x6c, 0x64,
++	0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x23, 0x0a, 0x1f, 0x52, 0x45, 0x50, 0x45,
++	0x41, 0x54, 0x45, 0x44, 0x5f, 0x46, 0x49, 0x45, 0x4c, 0x44, 0x5f, 0x45, 0x4e, 0x43, 0x4f, 0x44,
++	0x49, 0x4e, 0x47, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a,
++	0x06, 0x50, 0x41, 0x43, 0x4b, 0x45, 0x44, 0x10, 0x01, 0x12, 0x0c, 0x0a, 0x08, 0x45, 0x58, 0x50,
++	0x41, 0x4e, 0x44, 0x45, 0x44, 0x10, 0x02, 0x22, 0x43, 0x0a, 0x0e, 0x55, 0x74, 0x66, 0x38, 0x56,
++	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x1b, 0x0a, 0x17, 0x55, 0x54, 0x46,
++	0x38, 0x5f, 0x56, 0x41, 0x4c, 0x49, 0x44, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e, 0x4b,
++	0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x06, 0x56, 0x45, 0x52, 0x49, 0x46, 0x59,
++	0x10, 0x02, 0x12, 0x08, 0x0a, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x03, 0x22, 0x53, 0x0a, 0x0f,
++	0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x45, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x12,
++	0x1c, 0x0a, 0x18, 0x4d, 0x45, 0x53, 0x53, 0x41, 0x47, 0x45, 0x5f, 0x45, 0x4e, 0x43, 0x4f, 0x44,
++	0x49, 0x4e, 0x47, 0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a,
++	0x0f, 0x4c, 0x45, 0x4e, 0x47, 0x54, 0x48, 0x5f, 0x50, 0x52, 0x45, 0x46, 0x49, 0x58, 0x45, 0x44,
++	0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x44, 0x45, 0x4c, 0x49, 0x4d, 0x49, 0x54, 0x45, 0x44, 0x10,
++	0x02, 0x22, 0x48, 0x0a, 0x0a, 0x4a, 0x73, 0x6f, 0x6e, 0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12,
++	0x17, 0x0a, 0x13, 0x4a, 0x53, 0x4f, 0x4e, 0x5f, 0x46, 0x4f, 0x52, 0x4d, 0x41, 0x54, 0x5f, 0x55,
++	0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x4c, 0x4c, 0x4f,
++	0x57, 0x10, 0x01, 0x12, 0x16, 0x0a, 0x12, 0x4c, 0x45, 0x47, 0x41, 0x43, 0x59, 0x5f, 0x42, 0x45,
++	0x53, 0x54, 0x5f, 0x45, 0x46, 0x46, 0x4f, 0x52, 0x54, 0x10, 0x02, 0x2a, 0x06, 0x08, 0xe8, 0x07,
++	0x10, 0xe9, 0x07, 0x2a, 0x06, 0x08, 0xe9, 0x07, 0x10, 0xea, 0x07, 0x2a, 0x06, 0x08, 0xea, 0x07,
++	0x10, 0xeb, 0x07, 0x2a, 0x06, 0x08, 0x8b, 0x4e, 0x10, 0x90, 0x4e, 0x2a, 0x06, 0x08, 0x90, 0x4e,
++	0x10, 0x91, 0x4e, 0x4a, 0x06, 0x08, 0xe7, 0x07, 0x10, 0xe8, 0x07, 0x22, 0xfe, 0x02, 0x0a, 0x12,
++	0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c,
++	0x74, 0x73, 0x12, 0x58, 0x0a, 0x08, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x18, 0x01,
++	0x20, 0x03, 0x28, 0x0b, 0x32, 0x3c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72,
++	0x65, 0x53, 0x65, 0x74, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75,
++	0x6c, 0x74, 0x52, 0x08, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x73, 0x12, 0x41, 0x0a, 0x0f,
++	0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x5f, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x18,
++	0x04, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x52,
++	0x0e, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12,
++	0x41, 0x0a, 0x0f, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x5f, 0x65, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
++	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x52, 0x0e, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x45, 0x64, 0x69, 0x74, 0x69,
++	0x6f, 0x6e, 0x1a, 0x87, 0x01, 0x0a, 0x18, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65,
++	0x74, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x12,
++	0x32, 0x0a, 0x07, 0x65, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0e,
++	0x32, 0x18, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x45, 0x64, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x07, 0x65, 0x64, 0x69, 0x74,
++	0x69, 0x6f, 0x6e, 0x12, 0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18,
++	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
++	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53,
++	0x65, 0x74, 0x52, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x22, 0xa7, 0x02, 0x0a,
++	0x0e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12,
++	0x44, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28,
++	0x0b, 0x32, 0x28, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e,
++	0x66, 0x6f, 0x2e, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x08, 0x6c, 0x6f, 0x63,
++	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xce, 0x01, 0x0a, 0x08, 0x4c, 0x6f, 0x63, 0x61, 0x74, 0x69,
+ 	0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61, 0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05,
+-	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x12, 0x1f, 0x0a, 0x0b, 0x73, 0x6f,
+-	0x75, 0x72, 0x63, 0x65, 0x5f, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+-	0x0a, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x62,
+-	0x65, 0x67, 0x69, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x62, 0x65, 0x67, 0x69,
+-	0x6e, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64, 0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03,
+-	0x65, 0x6e, 0x64, 0x12, 0x52, 0x0a, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18,
+-	0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x36, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+-	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
+-	0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61,
+-	0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x52, 0x08, 0x73,
+-	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x22, 0x28, 0x0a, 0x08, 0x53, 0x65, 0x6d, 0x61, 0x6e,
+-	0x74, 0x69, 0x63, 0x12, 0x08, 0x0a, 0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x07, 0x0a,
+-	0x03, 0x53, 0x45, 0x54, 0x10, 0x01, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x4c, 0x49, 0x41, 0x53, 0x10,
+-	0x02, 0x42, 0x7e, 0x0a, 0x13, 0x63, 0x6f, 0x6d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x42, 0x10, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69,
+-	0x70, 0x74, 0x6f, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x73, 0x48, 0x01, 0x5a, 0x2d, 0x67, 0x6f,
+-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f,
+-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2f, 0x64,
+-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x70, 0x62, 0xf8, 0x01, 0x01, 0xa2, 0x02,
+-	0x03, 0x47, 0x50, 0x42, 0xaa, 0x02, 0x1a, 0x47, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x50, 0x72,
+-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x52, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f,
+-	0x6e,
++	0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x12, 0x16, 0x0a, 0x04, 0x73, 0x70,
++	0x61, 0x6e, 0x18, 0x02, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x73, 0x70,
++	0x61, 0x6e, 0x12, 0x29, 0x0a, 0x10, 0x6c, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f,
++	0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6c, 0x65,
++	0x61, 0x64, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x2b, 0x0a,
++	0x11, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e,
++	0x74, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x74, 0x72, 0x61, 0x69, 0x6c, 0x69,
++	0x6e, 0x67, 0x43, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x3a, 0x0a, 0x19, 0x6c, 0x65,
++	0x61, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x65, 0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x5f, 0x63,
++	0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x06, 0x20, 0x03, 0x28, 0x09, 0x52, 0x17, 0x6c,
++	0x65, 0x61, 0x64, 0x69, 0x6e, 0x67, 0x44, 0x65, 0x74, 0x61, 0x63, 0x68, 0x65, 0x64, 0x43, 0x6f,
++	0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22, 0xd0, 0x02, 0x0a, 0x11, 0x47, 0x65, 0x6e, 0x65, 0x72,
++	0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x4d, 0x0a, 0x0a,
++	0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b,
++	0x32, 0x2d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65,
++	0x49, 0x6e, 0x66, 0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52,
++	0x0a, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xeb, 0x01, 0x0a, 0x0a,
++	0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x04, 0x70, 0x61,
++	0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x05, 0x42, 0x02, 0x10, 0x01, 0x52, 0x04, 0x70, 0x61,
++	0x74, 0x68, 0x12, 0x1f, 0x0a, 0x0b, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x66, 0x69, 0x6c,
++	0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x46,
++	0x69, 0x6c, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x62, 0x65, 0x67, 0x69, 0x6e, 0x18, 0x03, 0x20, 0x01,
++	0x28, 0x05, 0x52, 0x05, 0x62, 0x65, 0x67, 0x69, 0x6e, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x6e, 0x64,
++	0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x03, 0x65, 0x6e, 0x64, 0x12, 0x52, 0x0a, 0x08, 0x73,
++	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x36, 0x2e,
++	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
++	0x47, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x43, 0x6f, 0x64, 0x65, 0x49, 0x6e, 0x66,
++	0x6f, 0x2e, 0x41, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x53, 0x65, 0x6d,
++	0x61, 0x6e, 0x74, 0x69, 0x63, 0x52, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x22,
++	0x28, 0x0a, 0x08, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x12, 0x08, 0x0a, 0x04, 0x4e,
++	0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x07, 0x0a, 0x03, 0x53, 0x45, 0x54, 0x10, 0x01, 0x12, 0x09,
++	0x0a, 0x05, 0x41, 0x4c, 0x49, 0x41, 0x53, 0x10, 0x02, 0x2a, 0x92, 0x02, 0x0a, 0x07, 0x45, 0x64,
++	0x69, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x13, 0x0a, 0x0f, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e,
++	0x5f, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x13, 0x0a, 0x0e, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x50, 0x52, 0x4f, 0x54, 0x4f, 0x32, 0x10, 0xe6, 0x07, 0x12,
++	0x13, 0x0a, 0x0e, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x50, 0x52, 0x4f, 0x54, 0x4f,
++	0x33, 0x10, 0xe7, 0x07, 0x12, 0x11, 0x0a, 0x0c, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f,
++	0x32, 0x30, 0x32, 0x33, 0x10, 0xe8, 0x07, 0x12, 0x11, 0x0a, 0x0c, 0x45, 0x44, 0x49, 0x54, 0x49,
++	0x4f, 0x4e, 0x5f, 0x32, 0x30, 0x32, 0x34, 0x10, 0xe9, 0x07, 0x12, 0x17, 0x0a, 0x13, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x31, 0x5f, 0x54, 0x45, 0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c,
++	0x59, 0x10, 0x01, 0x12, 0x17, 0x0a, 0x13, 0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x32,
++	0x5f, 0x54, 0x45, 0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x02, 0x12, 0x1d, 0x0a, 0x17,
++	0x45, 0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x37, 0x5f, 0x54, 0x45,
++	0x53, 0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9d, 0x8d, 0x06, 0x12, 0x1d, 0x0a, 0x17, 0x45,
++	0x44, 0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x38, 0x5f, 0x54, 0x45, 0x53,
++	0x54, 0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9e, 0x8d, 0x06, 0x12, 0x1d, 0x0a, 0x17, 0x45, 0x44,
++	0x49, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x39, 0x39, 0x39, 0x39, 0x39, 0x5f, 0x54, 0x45, 0x53, 0x54,
++	0x5f, 0x4f, 0x4e, 0x4c, 0x59, 0x10, 0x9f, 0x8d, 0x06, 0x12, 0x13, 0x0a, 0x0b, 0x45, 0x44, 0x49,
++	0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x4d, 0x41, 0x58, 0x10, 0xff, 0xff, 0xff, 0xff, 0x07, 0x42, 0x7e,
++	0x0a, 0x13, 0x63, 0x6f, 0x6d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x42, 0x10, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f,
++	0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x73, 0x48, 0x01, 0x5a, 0x2d, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
++	0x65, 0x2e, 0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x70, 0x72, 0x6f,
++	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x74, 0x79, 0x70, 0x65, 0x73, 0x2f, 0x64, 0x65, 0x73, 0x63,
++	0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x70, 0x62, 0xf8, 0x01, 0x01, 0xa2, 0x02, 0x03, 0x47, 0x50,
++	0x42, 0xaa, 0x02, 0x1a, 0x47, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x50, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2e, 0x52, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e,
+ }
+ 
+ var (
+@@ -4123,103 +5083,136 @@ func file_google_protobuf_descriptor_proto_rawDescGZIP() []byte {
+ 	return file_google_protobuf_descriptor_proto_rawDescData
+ }
+ 
+-var file_google_protobuf_descriptor_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+-var file_google_protobuf_descriptor_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
++var file_google_protobuf_descriptor_proto_enumTypes = make([]protoimpl.EnumInfo, 17)
++var file_google_protobuf_descriptor_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+ var file_google_protobuf_descriptor_proto_goTypes = []interface{}{
+-	(ExtensionRangeOptions_VerificationState)(0),  // 0: google.protobuf.ExtensionRangeOptions.VerificationState
+-	(FieldDescriptorProto_Type)(0),                // 1: google.protobuf.FieldDescriptorProto.Type
+-	(FieldDescriptorProto_Label)(0),               // 2: google.protobuf.FieldDescriptorProto.Label
+-	(FileOptions_OptimizeMode)(0),                 // 3: google.protobuf.FileOptions.OptimizeMode
+-	(FieldOptions_CType)(0),                       // 4: google.protobuf.FieldOptions.CType
+-	(FieldOptions_JSType)(0),                      // 5: google.protobuf.FieldOptions.JSType
+-	(FieldOptions_OptionRetention)(0),             // 6: google.protobuf.FieldOptions.OptionRetention
+-	(FieldOptions_OptionTargetType)(0),            // 7: google.protobuf.FieldOptions.OptionTargetType
+-	(MethodOptions_IdempotencyLevel)(0),           // 8: google.protobuf.MethodOptions.IdempotencyLevel
+-	(GeneratedCodeInfo_Annotation_Semantic)(0),    // 9: google.protobuf.GeneratedCodeInfo.Annotation.Semantic
+-	(*FileDescriptorSet)(nil),                     // 10: google.protobuf.FileDescriptorSet
+-	(*FileDescriptorProto)(nil),                   // 11: google.protobuf.FileDescriptorProto
+-	(*DescriptorProto)(nil),                       // 12: google.protobuf.DescriptorProto
+-	(*ExtensionRangeOptions)(nil),                 // 13: google.protobuf.ExtensionRangeOptions
+-	(*FieldDescriptorProto)(nil),                  // 14: google.protobuf.FieldDescriptorProto
+-	(*OneofDescriptorProto)(nil),                  // 15: google.protobuf.OneofDescriptorProto
+-	(*EnumDescriptorProto)(nil),                   // 16: google.protobuf.EnumDescriptorProto
+-	(*EnumValueDescriptorProto)(nil),              // 17: google.protobuf.EnumValueDescriptorProto
+-	(*ServiceDescriptorProto)(nil),                // 18: google.protobuf.ServiceDescriptorProto
+-	(*MethodDescriptorProto)(nil),                 // 19: google.protobuf.MethodDescriptorProto
+-	(*FileOptions)(nil),                           // 20: google.protobuf.FileOptions
+-	(*MessageOptions)(nil),                        // 21: google.protobuf.MessageOptions
+-	(*FieldOptions)(nil),                          // 22: google.protobuf.FieldOptions
+-	(*OneofOptions)(nil),                          // 23: google.protobuf.OneofOptions
+-	(*EnumOptions)(nil),                           // 24: google.protobuf.EnumOptions
+-	(*EnumValueOptions)(nil),                      // 25: google.protobuf.EnumValueOptions
+-	(*ServiceOptions)(nil),                        // 26: google.protobuf.ServiceOptions
+-	(*MethodOptions)(nil),                         // 27: google.protobuf.MethodOptions
+-	(*UninterpretedOption)(nil),                   // 28: google.protobuf.UninterpretedOption
+-	(*SourceCodeInfo)(nil),                        // 29: google.protobuf.SourceCodeInfo
+-	(*GeneratedCodeInfo)(nil),                     // 30: google.protobuf.GeneratedCodeInfo
+-	(*DescriptorProto_ExtensionRange)(nil),        // 31: google.protobuf.DescriptorProto.ExtensionRange
+-	(*DescriptorProto_ReservedRange)(nil),         // 32: google.protobuf.DescriptorProto.ReservedRange
+-	(*ExtensionRangeOptions_Declaration)(nil),     // 33: google.protobuf.ExtensionRangeOptions.Declaration
+-	(*EnumDescriptorProto_EnumReservedRange)(nil), // 34: google.protobuf.EnumDescriptorProto.EnumReservedRange
+-	(*UninterpretedOption_NamePart)(nil),          // 35: google.protobuf.UninterpretedOption.NamePart
+-	(*SourceCodeInfo_Location)(nil),               // 36: google.protobuf.SourceCodeInfo.Location
+-	(*GeneratedCodeInfo_Annotation)(nil),          // 37: google.protobuf.GeneratedCodeInfo.Annotation
++	(Edition)(0), // 0: google.protobuf.Edition
++	(ExtensionRangeOptions_VerificationState)(0),        // 1: google.protobuf.ExtensionRangeOptions.VerificationState
++	(FieldDescriptorProto_Type)(0),                      // 2: google.protobuf.FieldDescriptorProto.Type
++	(FieldDescriptorProto_Label)(0),                     // 3: google.protobuf.FieldDescriptorProto.Label
++	(FileOptions_OptimizeMode)(0),                       // 4: google.protobuf.FileOptions.OptimizeMode
++	(FieldOptions_CType)(0),                             // 5: google.protobuf.FieldOptions.CType
++	(FieldOptions_JSType)(0),                            // 6: google.protobuf.FieldOptions.JSType
++	(FieldOptions_OptionRetention)(0),                   // 7: google.protobuf.FieldOptions.OptionRetention
++	(FieldOptions_OptionTargetType)(0),                  // 8: google.protobuf.FieldOptions.OptionTargetType
++	(MethodOptions_IdempotencyLevel)(0),                 // 9: google.protobuf.MethodOptions.IdempotencyLevel
++	(FeatureSet_FieldPresence)(0),                       // 10: google.protobuf.FeatureSet.FieldPresence
++	(FeatureSet_EnumType)(0),                            // 11: google.protobuf.FeatureSet.EnumType
++	(FeatureSet_RepeatedFieldEncoding)(0),               // 12: google.protobuf.FeatureSet.RepeatedFieldEncoding
++	(FeatureSet_Utf8Validation)(0),                      // 13: google.protobuf.FeatureSet.Utf8Validation
++	(FeatureSet_MessageEncoding)(0),                     // 14: google.protobuf.FeatureSet.MessageEncoding
++	(FeatureSet_JsonFormat)(0),                          // 15: google.protobuf.FeatureSet.JsonFormat
++	(GeneratedCodeInfo_Annotation_Semantic)(0),          // 16: google.protobuf.GeneratedCodeInfo.Annotation.Semantic
++	(*FileDescriptorSet)(nil),                           // 17: google.protobuf.FileDescriptorSet
++	(*FileDescriptorProto)(nil),                         // 18: google.protobuf.FileDescriptorProto
++	(*DescriptorProto)(nil),                             // 19: google.protobuf.DescriptorProto
++	(*ExtensionRangeOptions)(nil),                       // 20: google.protobuf.ExtensionRangeOptions
++	(*FieldDescriptorProto)(nil),                        // 21: google.protobuf.FieldDescriptorProto
++	(*OneofDescriptorProto)(nil),                        // 22: google.protobuf.OneofDescriptorProto
++	(*EnumDescriptorProto)(nil),                         // 23: google.protobuf.EnumDescriptorProto
++	(*EnumValueDescriptorProto)(nil),                    // 24: google.protobuf.EnumValueDescriptorProto
++	(*ServiceDescriptorProto)(nil),                      // 25: google.protobuf.ServiceDescriptorProto
++	(*MethodDescriptorProto)(nil),                       // 26: google.protobuf.MethodDescriptorProto
++	(*FileOptions)(nil),                                 // 27: google.protobuf.FileOptions
++	(*MessageOptions)(nil),                              // 28: google.protobuf.MessageOptions
++	(*FieldOptions)(nil),                                // 29: google.protobuf.FieldOptions
++	(*OneofOptions)(nil),                                // 30: google.protobuf.OneofOptions
++	(*EnumOptions)(nil),                                 // 31: google.protobuf.EnumOptions
++	(*EnumValueOptions)(nil),                            // 32: google.protobuf.EnumValueOptions
++	(*ServiceOptions)(nil),                              // 33: google.protobuf.ServiceOptions
++	(*MethodOptions)(nil),                               // 34: google.protobuf.MethodOptions
++	(*UninterpretedOption)(nil),                         // 35: google.protobuf.UninterpretedOption
++	(*FeatureSet)(nil),                                  // 36: google.protobuf.FeatureSet
++	(*FeatureSetDefaults)(nil),                          // 37: google.protobuf.FeatureSetDefaults
++	(*SourceCodeInfo)(nil),                              // 38: google.protobuf.SourceCodeInfo
++	(*GeneratedCodeInfo)(nil),                           // 39: google.protobuf.GeneratedCodeInfo
++	(*DescriptorProto_ExtensionRange)(nil),              // 40: google.protobuf.DescriptorProto.ExtensionRange
++	(*DescriptorProto_ReservedRange)(nil),               // 41: google.protobuf.DescriptorProto.ReservedRange
++	(*ExtensionRangeOptions_Declaration)(nil),           // 42: google.protobuf.ExtensionRangeOptions.Declaration
++	(*EnumDescriptorProto_EnumReservedRange)(nil),       // 43: google.protobuf.EnumDescriptorProto.EnumReservedRange
++	(*FieldOptions_EditionDefault)(nil),                 // 44: google.protobuf.FieldOptions.EditionDefault
++	(*UninterpretedOption_NamePart)(nil),                // 45: google.protobuf.UninterpretedOption.NamePart
++	(*FeatureSetDefaults_FeatureSetEditionDefault)(nil), // 46: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
++	(*SourceCodeInfo_Location)(nil),                     // 47: google.protobuf.SourceCodeInfo.Location
++	(*GeneratedCodeInfo_Annotation)(nil),                // 48: google.protobuf.GeneratedCodeInfo.Annotation
+ }
+ var file_google_protobuf_descriptor_proto_depIdxs = []int32{
+-	11, // 0: google.protobuf.FileDescriptorSet.file:type_name -> google.protobuf.FileDescriptorProto
+-	12, // 1: google.protobuf.FileDescriptorProto.message_type:type_name -> google.protobuf.DescriptorProto
+-	16, // 2: google.protobuf.FileDescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
+-	18, // 3: google.protobuf.FileDescriptorProto.service:type_name -> google.protobuf.ServiceDescriptorProto
+-	14, // 4: google.protobuf.FileDescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
+-	20, // 5: google.protobuf.FileDescriptorProto.options:type_name -> google.protobuf.FileOptions
+-	29, // 6: google.protobuf.FileDescriptorProto.source_code_info:type_name -> google.protobuf.SourceCodeInfo
+-	14, // 7: google.protobuf.DescriptorProto.field:type_name -> google.protobuf.FieldDescriptorProto
+-	14, // 8: google.protobuf.DescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
+-	12, // 9: google.protobuf.DescriptorProto.nested_type:type_name -> google.protobuf.DescriptorProto
+-	16, // 10: google.protobuf.DescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
+-	31, // 11: google.protobuf.DescriptorProto.extension_range:type_name -> google.protobuf.DescriptorProto.ExtensionRange
+-	15, // 12: google.protobuf.DescriptorProto.oneof_decl:type_name -> google.protobuf.OneofDescriptorProto
+-	21, // 13: google.protobuf.DescriptorProto.options:type_name -> google.protobuf.MessageOptions
+-	32, // 14: google.protobuf.DescriptorProto.reserved_range:type_name -> google.protobuf.DescriptorProto.ReservedRange
+-	28, // 15: google.protobuf.ExtensionRangeOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	33, // 16: google.protobuf.ExtensionRangeOptions.declaration:type_name -> google.protobuf.ExtensionRangeOptions.Declaration
+-	0,  // 17: google.protobuf.ExtensionRangeOptions.verification:type_name -> google.protobuf.ExtensionRangeOptions.VerificationState
+-	2,  // 18: google.protobuf.FieldDescriptorProto.label:type_name -> google.protobuf.FieldDescriptorProto.Label
+-	1,  // 19: google.protobuf.FieldDescriptorProto.type:type_name -> google.protobuf.FieldDescriptorProto.Type
+-	22, // 20: google.protobuf.FieldDescriptorProto.options:type_name -> google.protobuf.FieldOptions
+-	23, // 21: google.protobuf.OneofDescriptorProto.options:type_name -> google.protobuf.OneofOptions
+-	17, // 22: google.protobuf.EnumDescriptorProto.value:type_name -> google.protobuf.EnumValueDescriptorProto
+-	24, // 23: google.protobuf.EnumDescriptorProto.options:type_name -> google.protobuf.EnumOptions
+-	34, // 24: google.protobuf.EnumDescriptorProto.reserved_range:type_name -> google.protobuf.EnumDescriptorProto.EnumReservedRange
+-	25, // 25: google.protobuf.EnumValueDescriptorProto.options:type_name -> google.protobuf.EnumValueOptions
+-	19, // 26: google.protobuf.ServiceDescriptorProto.method:type_name -> google.protobuf.MethodDescriptorProto
+-	26, // 27: google.protobuf.ServiceDescriptorProto.options:type_name -> google.protobuf.ServiceOptions
+-	27, // 28: google.protobuf.MethodDescriptorProto.options:type_name -> google.protobuf.MethodOptions
+-	3,  // 29: google.protobuf.FileOptions.optimize_for:type_name -> google.protobuf.FileOptions.OptimizeMode
+-	28, // 30: google.protobuf.FileOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 31: google.protobuf.MessageOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	4,  // 32: google.protobuf.FieldOptions.ctype:type_name -> google.protobuf.FieldOptions.CType
+-	5,  // 33: google.protobuf.FieldOptions.jstype:type_name -> google.protobuf.FieldOptions.JSType
+-	6,  // 34: google.protobuf.FieldOptions.retention:type_name -> google.protobuf.FieldOptions.OptionRetention
+-	7,  // 35: google.protobuf.FieldOptions.target:type_name -> google.protobuf.FieldOptions.OptionTargetType
+-	7,  // 36: google.protobuf.FieldOptions.targets:type_name -> google.protobuf.FieldOptions.OptionTargetType
+-	28, // 37: google.protobuf.FieldOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 38: google.protobuf.OneofOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 39: google.protobuf.EnumOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 40: google.protobuf.EnumValueOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	28, // 41: google.protobuf.ServiceOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	8,  // 42: google.protobuf.MethodOptions.idempotency_level:type_name -> google.protobuf.MethodOptions.IdempotencyLevel
+-	28, // 43: google.protobuf.MethodOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
+-	35, // 44: google.protobuf.UninterpretedOption.name:type_name -> google.protobuf.UninterpretedOption.NamePart
+-	36, // 45: google.protobuf.SourceCodeInfo.location:type_name -> google.protobuf.SourceCodeInfo.Location
+-	37, // 46: google.protobuf.GeneratedCodeInfo.annotation:type_name -> google.protobuf.GeneratedCodeInfo.Annotation
+-	13, // 47: google.protobuf.DescriptorProto.ExtensionRange.options:type_name -> google.protobuf.ExtensionRangeOptions
+-	9,  // 48: google.protobuf.GeneratedCodeInfo.Annotation.semantic:type_name -> google.protobuf.GeneratedCodeInfo.Annotation.Semantic
+-	49, // [49:49] is the sub-list for method output_type
+-	49, // [49:49] is the sub-list for method input_type
+-	49, // [49:49] is the sub-list for extension type_name
+-	49, // [49:49] is the sub-list for extension extendee
+-	0,  // [0:49] is the sub-list for field type_name
++	18, // 0: google.protobuf.FileDescriptorSet.file:type_name -> google.protobuf.FileDescriptorProto
++	19, // 1: google.protobuf.FileDescriptorProto.message_type:type_name -> google.protobuf.DescriptorProto
++	23, // 2: google.protobuf.FileDescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
++	25, // 3: google.protobuf.FileDescriptorProto.service:type_name -> google.protobuf.ServiceDescriptorProto
++	21, // 4: google.protobuf.FileDescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
++	27, // 5: google.protobuf.FileDescriptorProto.options:type_name -> google.protobuf.FileOptions
++	38, // 6: google.protobuf.FileDescriptorProto.source_code_info:type_name -> google.protobuf.SourceCodeInfo
++	0,  // 7: google.protobuf.FileDescriptorProto.edition:type_name -> google.protobuf.Edition
++	21, // 8: google.protobuf.DescriptorProto.field:type_name -> google.protobuf.FieldDescriptorProto
++	21, // 9: google.protobuf.DescriptorProto.extension:type_name -> google.protobuf.FieldDescriptorProto
++	19, // 10: google.protobuf.DescriptorProto.nested_type:type_name -> google.protobuf.DescriptorProto
++	23, // 11: google.protobuf.DescriptorProto.enum_type:type_name -> google.protobuf.EnumDescriptorProto
++	40, // 12: google.protobuf.DescriptorProto.extension_range:type_name -> google.protobuf.DescriptorProto.ExtensionRange
++	22, // 13: google.protobuf.DescriptorProto.oneof_decl:type_name -> google.protobuf.OneofDescriptorProto
++	28, // 14: google.protobuf.DescriptorProto.options:type_name -> google.protobuf.MessageOptions
++	41, // 15: google.protobuf.DescriptorProto.reserved_range:type_name -> google.protobuf.DescriptorProto.ReservedRange
++	35, // 16: google.protobuf.ExtensionRangeOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	42, // 17: google.protobuf.ExtensionRangeOptions.declaration:type_name -> google.protobuf.ExtensionRangeOptions.Declaration
++	36, // 18: google.protobuf.ExtensionRangeOptions.features:type_name -> google.protobuf.FeatureSet
++	1,  // 19: google.protobuf.ExtensionRangeOptions.verification:type_name -> google.protobuf.ExtensionRangeOptions.VerificationState
++	3,  // 20: google.protobuf.FieldDescriptorProto.label:type_name -> google.protobuf.FieldDescriptorProto.Label
++	2,  // 21: google.protobuf.FieldDescriptorProto.type:type_name -> google.protobuf.FieldDescriptorProto.Type
++	29, // 22: google.protobuf.FieldDescriptorProto.options:type_name -> google.protobuf.FieldOptions
++	30, // 23: google.protobuf.OneofDescriptorProto.options:type_name -> google.protobuf.OneofOptions
++	24, // 24: google.protobuf.EnumDescriptorProto.value:type_name -> google.protobuf.EnumValueDescriptorProto
++	31, // 25: google.protobuf.EnumDescriptorProto.options:type_name -> google.protobuf.EnumOptions
++	43, // 26: google.protobuf.EnumDescriptorProto.reserved_range:type_name -> google.protobuf.EnumDescriptorProto.EnumReservedRange
++	32, // 27: google.protobuf.EnumValueDescriptorProto.options:type_name -> google.protobuf.EnumValueOptions
++	26, // 28: google.protobuf.ServiceDescriptorProto.method:type_name -> google.protobuf.MethodDescriptorProto
++	33, // 29: google.protobuf.ServiceDescriptorProto.options:type_name -> google.protobuf.ServiceOptions
++	34, // 30: google.protobuf.MethodDescriptorProto.options:type_name -> google.protobuf.MethodOptions
++	4,  // 31: google.protobuf.FileOptions.optimize_for:type_name -> google.protobuf.FileOptions.OptimizeMode
++	36, // 32: google.protobuf.FileOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 33: google.protobuf.FileOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 34: google.protobuf.MessageOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 35: google.protobuf.MessageOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	5,  // 36: google.protobuf.FieldOptions.ctype:type_name -> google.protobuf.FieldOptions.CType
++	6,  // 37: google.protobuf.FieldOptions.jstype:type_name -> google.protobuf.FieldOptions.JSType
++	7,  // 38: google.protobuf.FieldOptions.retention:type_name -> google.protobuf.FieldOptions.OptionRetention
++	8,  // 39: google.protobuf.FieldOptions.targets:type_name -> google.protobuf.FieldOptions.OptionTargetType
++	44, // 40: google.protobuf.FieldOptions.edition_defaults:type_name -> google.protobuf.FieldOptions.EditionDefault
++	36, // 41: google.protobuf.FieldOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 42: google.protobuf.FieldOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 43: google.protobuf.OneofOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 44: google.protobuf.OneofOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 45: google.protobuf.EnumOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 46: google.protobuf.EnumOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 47: google.protobuf.EnumValueOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 48: google.protobuf.EnumValueOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	36, // 49: google.protobuf.ServiceOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 50: google.protobuf.ServiceOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	9,  // 51: google.protobuf.MethodOptions.idempotency_level:type_name -> google.protobuf.MethodOptions.IdempotencyLevel
++	36, // 52: google.protobuf.MethodOptions.features:type_name -> google.protobuf.FeatureSet
++	35, // 53: google.protobuf.MethodOptions.uninterpreted_option:type_name -> google.protobuf.UninterpretedOption
++	45, // 54: google.protobuf.UninterpretedOption.name:type_name -> google.protobuf.UninterpretedOption.NamePart
++	10, // 55: google.protobuf.FeatureSet.field_presence:type_name -> google.protobuf.FeatureSet.FieldPresence
++	11, // 56: google.protobuf.FeatureSet.enum_type:type_name -> google.protobuf.FeatureSet.EnumType
++	12, // 57: google.protobuf.FeatureSet.repeated_field_encoding:type_name -> google.protobuf.FeatureSet.RepeatedFieldEncoding
++	13, // 58: google.protobuf.FeatureSet.utf8_validation:type_name -> google.protobuf.FeatureSet.Utf8Validation
++	14, // 59: google.protobuf.FeatureSet.message_encoding:type_name -> google.protobuf.FeatureSet.MessageEncoding
++	15, // 60: google.protobuf.FeatureSet.json_format:type_name -> google.protobuf.FeatureSet.JsonFormat
++	46, // 61: google.protobuf.FeatureSetDefaults.defaults:type_name -> google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
++	0,  // 62: google.protobuf.FeatureSetDefaults.minimum_edition:type_name -> google.protobuf.Edition
++	0,  // 63: google.protobuf.FeatureSetDefaults.maximum_edition:type_name -> google.protobuf.Edition
++	47, // 64: google.protobuf.SourceCodeInfo.location:type_name -> google.protobuf.SourceCodeInfo.Location
++	48, // 65: google.protobuf.GeneratedCodeInfo.annotation:type_name -> google.protobuf.GeneratedCodeInfo.Annotation
++	20, // 66: google.protobuf.DescriptorProto.ExtensionRange.options:type_name -> google.protobuf.ExtensionRangeOptions
++	0,  // 67: google.protobuf.FieldOptions.EditionDefault.edition:type_name -> google.protobuf.Edition
++	0,  // 68: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.edition:type_name -> google.protobuf.Edition
++	36, // 69: google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.features:type_name -> google.protobuf.FeatureSet
++	16, // 70: google.protobuf.GeneratedCodeInfo.Annotation.semantic:type_name -> google.protobuf.GeneratedCodeInfo.Annotation.Semantic
++	71, // [71:71] is the sub-list for method output_type
++	71, // [71:71] is the sub-list for method input_type
++	71, // [71:71] is the sub-list for extension type_name
++	71, // [71:71] is the sub-list for extension extendee
++	0,  // [0:71] is the sub-list for field type_name
+ }
+ 
+ func init() { file_google_protobuf_descriptor_proto_init() }
+@@ -4475,19 +5468,21 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*SourceCodeInfo); i {
++			switch v := v.(*FeatureSet); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+ 				return &v.sizeCache
+ 			case 2:
+ 				return &v.unknownFields
++			case 3:
++				return &v.extensionFields
+ 			default:
+ 				return nil
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*GeneratedCodeInfo); i {
++			switch v := v.(*FeatureSetDefaults); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4499,7 +5494,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*DescriptorProto_ExtensionRange); i {
++			switch v := v.(*SourceCodeInfo); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4511,7 +5506,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*DescriptorProto_ReservedRange); i {
++			switch v := v.(*GeneratedCodeInfo); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4523,7 +5518,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*ExtensionRangeOptions_Declaration); i {
++			switch v := v.(*DescriptorProto_ExtensionRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4535,7 +5530,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*EnumDescriptorProto_EnumReservedRange); i {
++			switch v := v.(*DescriptorProto_ReservedRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4547,7 +5542,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*UninterpretedOption_NamePart); i {
++			switch v := v.(*ExtensionRangeOptions_Declaration); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4559,7 +5554,7 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
+-			switch v := v.(*SourceCodeInfo_Location); i {
++			switch v := v.(*EnumDescriptorProto_EnumReservedRange); i {
+ 			case 0:
+ 				return &v.state
+ 			case 1:
+@@ -4571,6 +5566,54 @@ func file_google_protobuf_descriptor_proto_init() {
+ 			}
+ 		}
+ 		file_google_protobuf_descriptor_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*FieldOptions_EditionDefault); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*UninterpretedOption_NamePart); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*FeatureSetDefaults_FeatureSetEditionDefault); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*SourceCodeInfo_Location); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++		file_google_protobuf_descriptor_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
+ 			switch v := v.(*GeneratedCodeInfo_Annotation); i {
+ 			case 0:
+ 				return &v.state
+@@ -4588,8 +5631,8 @@ func file_google_protobuf_descriptor_proto_init() {
+ 		File: protoimpl.DescBuilder{
+ 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
+ 			RawDescriptor: file_google_protobuf_descriptor_proto_rawDesc,
+-			NumEnums:      10,
+-			NumMessages:   28,
++			NumEnums:      17,
++			NumMessages:   32,
+ 			NumExtensions: 0,
+ 			NumServices:   0,
+ 		},
+diff --git a/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+new file mode 100644
+index 0000000..25de5ae
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.pb.go
+@@ -0,0 +1,177 @@
++// Protocol Buffers - Google's data interchange format
++// Copyright 2023 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++// Code generated by protoc-gen-go. DO NOT EDIT.
++// source: reflect/protodesc/proto/go_features.proto
++
++package proto
++
++import (
++	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
++	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
++	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
++	reflect "reflect"
++	sync "sync"
++)
++
++type GoFeatures struct {
++	state         protoimpl.MessageState
++	sizeCache     protoimpl.SizeCache
++	unknownFields protoimpl.UnknownFields
++
++	// Whether or not to generate the deprecated UnmarshalJSON method for enums.
++	LegacyUnmarshalJsonEnum *bool `protobuf:"varint,1,opt,name=legacy_unmarshal_json_enum,json=legacyUnmarshalJsonEnum" json:"legacy_unmarshal_json_enum,omitempty"`
++}
++
++func (x *GoFeatures) Reset() {
++	*x = GoFeatures{}
++	if protoimpl.UnsafeEnabled {
++		mi := &file_reflect_protodesc_proto_go_features_proto_msgTypes[0]
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		ms.StoreMessageInfo(mi)
++	}
++}
++
++func (x *GoFeatures) String() string {
++	return protoimpl.X.MessageStringOf(x)
++}
++
++func (*GoFeatures) ProtoMessage() {}
++
++func (x *GoFeatures) ProtoReflect() protoreflect.Message {
++	mi := &file_reflect_protodesc_proto_go_features_proto_msgTypes[0]
++	if protoimpl.UnsafeEnabled && x != nil {
++		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
++		if ms.LoadMessageInfo() == nil {
++			ms.StoreMessageInfo(mi)
++		}
++		return ms
++	}
++	return mi.MessageOf(x)
++}
++
++// Deprecated: Use GoFeatures.ProtoReflect.Descriptor instead.
++func (*GoFeatures) Descriptor() ([]byte, []int) {
++	return file_reflect_protodesc_proto_go_features_proto_rawDescGZIP(), []int{0}
++}
++
++func (x *GoFeatures) GetLegacyUnmarshalJsonEnum() bool {
++	if x != nil && x.LegacyUnmarshalJsonEnum != nil {
++		return *x.LegacyUnmarshalJsonEnum
++	}
++	return false
++}
++
++var file_reflect_protodesc_proto_go_features_proto_extTypes = []protoimpl.ExtensionInfo{
++	{
++		ExtendedType:  (*descriptorpb.FeatureSet)(nil),
++		ExtensionType: (*GoFeatures)(nil),
++		Field:         1002,
++		Name:          "google.protobuf.go",
++		Tag:           "bytes,1002,opt,name=go",
++		Filename:      "reflect/protodesc/proto/go_features.proto",
++	},
++}
++
++// Extension fields to descriptorpb.FeatureSet.
++var (
++	// optional google.protobuf.GoFeatures go = 1002;
++	E_Go = &file_reflect_protodesc_proto_go_features_proto_extTypes[0]
++)
++
++var File_reflect_protodesc_proto_go_features_proto protoreflect.FileDescriptor
++
++var file_reflect_protodesc_proto_go_features_proto_rawDesc = []byte{
++	0x0a, 0x29, 0x72, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x64,
++	0x65, 0x73, 0x63, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x67, 0x6f, 0x5f, 0x66, 0x65, 0x61,
++	0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x0f, 0x67, 0x6f, 0x6f,
++	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x1a, 0x20, 0x67, 0x6f,
++	0x6f, 0x67, 0x6c, 0x65, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x64, 0x65,
++	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x6f, 0x72, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x6a,
++	0x0a, 0x0a, 0x47, 0x6f, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x5c, 0x0a, 0x1a,
++	0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x5f, 0x75, 0x6e, 0x6d, 0x61, 0x72, 0x73, 0x68, 0x61, 0x6c,
++	0x5f, 0x6a, 0x73, 0x6f, 0x6e, 0x5f, 0x65, 0x6e, 0x75, 0x6d, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08,
++	0x42, 0x1f, 0x88, 0x01, 0x01, 0x98, 0x01, 0x06, 0xa2, 0x01, 0x09, 0x12, 0x04, 0x74, 0x72, 0x75,
++	0x65, 0x18, 0xe6, 0x07, 0xa2, 0x01, 0x0a, 0x12, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x18, 0xe7,
++	0x07, 0x52, 0x17, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x55, 0x6e, 0x6d, 0x61, 0x72, 0x73, 0x68,
++	0x61, 0x6c, 0x4a, 0x73, 0x6f, 0x6e, 0x45, 0x6e, 0x75, 0x6d, 0x3a, 0x49, 0x0a, 0x02, 0x67, 0x6f,
++	0x12, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
++	0x75, 0x66, 0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x53, 0x65, 0x74, 0x18, 0xea, 0x07,
++	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72,
++	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x47, 0x6f, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65,
++	0x73, 0x52, 0x02, 0x67, 0x6f, 0x42, 0x34, 0x5a, 0x32, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
++	0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++	0x62, 0x75, 0x66, 0x2f, 0x72, 0x65, 0x66, 0x6c, 0x65, 0x63, 0x74, 0x2f, 0x70, 0x72, 0x6f, 0x74,
++	0x6f, 0x64, 0x65, 0x73, 0x63, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
++}
++
++var (
++	file_reflect_protodesc_proto_go_features_proto_rawDescOnce sync.Once
++	file_reflect_protodesc_proto_go_features_proto_rawDescData = file_reflect_protodesc_proto_go_features_proto_rawDesc
++)
++
++func file_reflect_protodesc_proto_go_features_proto_rawDescGZIP() []byte {
++	file_reflect_protodesc_proto_go_features_proto_rawDescOnce.Do(func() {
++		file_reflect_protodesc_proto_go_features_proto_rawDescData = protoimpl.X.CompressGZIP(file_reflect_protodesc_proto_go_features_proto_rawDescData)
++	})
++	return file_reflect_protodesc_proto_go_features_proto_rawDescData
++}
++
++var file_reflect_protodesc_proto_go_features_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
++var file_reflect_protodesc_proto_go_features_proto_goTypes = []interface{}{
++	(*GoFeatures)(nil),              // 0: google.protobuf.GoFeatures
++	(*descriptorpb.FeatureSet)(nil), // 1: google.protobuf.FeatureSet
++}
++var file_reflect_protodesc_proto_go_features_proto_depIdxs = []int32{
++	1, // 0: google.protobuf.go:extendee -> google.protobuf.FeatureSet
++	0, // 1: google.protobuf.go:type_name -> google.protobuf.GoFeatures
++	2, // [2:2] is the sub-list for method output_type
++	2, // [2:2] is the sub-list for method input_type
++	1, // [1:2] is the sub-list for extension type_name
++	0, // [0:1] is the sub-list for extension extendee
++	0, // [0:0] is the sub-list for field type_name
++}
++
++func init() { file_reflect_protodesc_proto_go_features_proto_init() }
++func file_reflect_protodesc_proto_go_features_proto_init() {
++	if File_reflect_protodesc_proto_go_features_proto != nil {
++		return
++	}
++	if !protoimpl.UnsafeEnabled {
++		file_reflect_protodesc_proto_go_features_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
++			switch v := v.(*GoFeatures); i {
++			case 0:
++				return &v.state
++			case 1:
++				return &v.sizeCache
++			case 2:
++				return &v.unknownFields
++			default:
++				return nil
++			}
++		}
++	}
++	type x struct{}
++	out := protoimpl.TypeBuilder{
++		File: protoimpl.DescBuilder{
++			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
++			RawDescriptor: file_reflect_protodesc_proto_go_features_proto_rawDesc,
++			NumEnums:      0,
++			NumMessages:   1,
++			NumExtensions: 1,
++			NumServices:   0,
++		},
++		GoTypes:           file_reflect_protodesc_proto_go_features_proto_goTypes,
++		DependencyIndexes: file_reflect_protodesc_proto_go_features_proto_depIdxs,
++		MessageInfos:      file_reflect_protodesc_proto_go_features_proto_msgTypes,
++		ExtensionInfos:    file_reflect_protodesc_proto_go_features_proto_extTypes,
++	}.Build()
++	File_reflect_protodesc_proto_go_features_proto = out.File
++	file_reflect_protodesc_proto_go_features_proto_rawDesc = nil
++	file_reflect_protodesc_proto_go_features_proto_goTypes = nil
++	file_reflect_protodesc_proto_go_features_proto_depIdxs = nil
++}
+diff --git a/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+new file mode 100644
+index 0000000..d246571
+--- /dev/null
++++ b/vendor/google.golang.org/protobuf/types/gofeaturespb/go_features.proto
+@@ -0,0 +1,28 @@
++// Protocol Buffers - Google's data interchange format
++// Copyright 2023 Google Inc.  All rights reserved.
++//
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file or at
++// https://developers.google.com/open-source/licenses/bsd
++
++syntax = "proto2";
++
++package google.protobuf;
++
++import "google/protobuf/descriptor.proto";
++
++option go_package = "google.golang.org/protobuf/types/gofeaturespb";
++
++extend google.protobuf.FeatureSet {
++  optional GoFeatures go = 1002;
++}
++
++message GoFeatures {
++  // Whether or not to generate the deprecated UnmarshalJSON method for enums.
++  optional bool legacy_unmarshal_json_enum = 1 [
++    retention = RETENTION_RUNTIME,
++    targets = TARGET_TYPE_ENUM,
++    edition_defaults = { edition: EDITION_PROTO2, value: "true" },
++    edition_defaults = { edition: EDITION_PROTO3, value: "false" }
++  ];
++}
+diff --git a/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go b/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
+index 580b232..9de51be 100644
+--- a/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
++++ b/vendor/google.golang.org/protobuf/types/known/anypb/any.pb.go
+@@ -237,7 +237,8 @@ type Any struct {
+ 	//
+ 	// Note: this functionality is not currently available in the official
+ 	// protobuf release, and it is not used for type URLs beginning with
+-	// type.googleapis.com.
++	// type.googleapis.com. As of May 2023, there are no widely used type server
++	// implementations and no plans to implement one.
+ 	//
+ 	// Schemes other than `http`, `https` (or the empty scheme) might be
+ 	// used with implementation specific semantics.
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index f3db441..e57446f 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -29,8 +29,8 @@ github.com/gogo/protobuf/sortkeys
+ ## explicit; go 1.11
+ github.com/golang/mock/gomock
+ github.com/golang/mock/mockgen/model
+-# github.com/golang/protobuf v1.5.3
+-## explicit; go 1.9
++# github.com/golang/protobuf v1.5.4
++## explicit; go 1.17
+ github.com/golang/protobuf/descriptor
+ github.com/golang/protobuf/jsonpb
+ github.com/golang/protobuf/proto
+@@ -218,14 +218,15 @@ google.golang.org/grpc/serviceconfig
+ google.golang.org/grpc/stats
+ google.golang.org/grpc/status
+ google.golang.org/grpc/tap
+-# google.golang.org/protobuf v1.31.0
+-## explicit; go 1.11
++# google.golang.org/protobuf v1.33.0
++## explicit; go 1.17
+ google.golang.org/protobuf/encoding/protojson
+ google.golang.org/protobuf/encoding/prototext
+ google.golang.org/protobuf/encoding/protowire
+ google.golang.org/protobuf/internal/descfmt
+ google.golang.org/protobuf/internal/descopts
+ google.golang.org/protobuf/internal/detrand
++google.golang.org/protobuf/internal/editiondefaults
+ google.golang.org/protobuf/internal/encoding/defval
+ google.golang.org/protobuf/internal/encoding/json
+ google.golang.org/protobuf/internal/encoding/messageset
+@@ -249,6 +250,7 @@ google.golang.org/protobuf/reflect/protoregistry
+ google.golang.org/protobuf/runtime/protoiface
+ google.golang.org/protobuf/runtime/protoimpl
+ google.golang.org/protobuf/types/descriptorpb
++google.golang.org/protobuf/types/gofeaturespb
+ google.golang.org/protobuf/types/known/anypb
+ google.golang.org/protobuf/types/known/durationpb
+ google.golang.org/protobuf/types/known/timestamppb
+-- 
+2.40.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
resolve CVE-2024-24786 for Liveness-Probe

Had to also bump [github.com/golang/protobuf](http://github.com/golang/protobuf) to 1.5.4 due to [v1.33.0 of google.golang.org/protobuf Fails to Compile · Issue #16163 · protocolbuffers/protobuf](https://github.com/protocolbuffers/protobuf/issues/16163)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
