### PR TITLE
Bump kops all versions

### DIFF
--- a/development/kops/create_cluster.sh
+++ b/development/kops/create_cluster.sh
@@ -19,9 +19,13 @@ BASEDIR=$(dirname "$0")
 source ${BASEDIR}/set_environment.sh
 $PREFLIGHT_CHECK_PASSED || exit 1
 
+if [[ ${RELEASE_BRANCH#*-} > ${KOPS_VERSION#*.} ]]; then
+  export KOPS_RUN_TOO_NEW_VERSION=1
+fi
+
 ADDITIONAL_ARGS=""
 if [ -n "$NODE_INSTANCE_PROFILE" ]; then
-    ADDITIONAL_ARGS="--lifecycle-overrides IAMRole=ExistsAndWarnIfChanges,IAMRolePolicy=ExistsAndWarnIfChanges,IAMInstanceProfileRole=ExistsAndWarnIfChanges"
+  ADDITIONAL_ARGS="--lifecycle-overrides IAMRole=ExistsAndWarnIfChanges,IAMRolePolicy=ExistsAndWarnIfChanges,IAMInstanceProfileRole=ExistsAndWarnIfChanges"
 fi
 
 ${KOPS} update cluster --admin --name ${KOPS_CLUSTER_NAME} --yes $ADDITIONAL_ARGS

--- a/development/kops/set_environment.sh
+++ b/development/kops/set_environment.sh
@@ -24,57 +24,54 @@ export NODE_INSTANCE_TYPE=${NODE_INSTANCE_TYPE:-t3.medium}
 export NODE_ARCHITECTURE=${NODE_ARCHITECTURE:-amd64}
 export UBUNTU_RELEASE=${UBUNTU_RELEASE:-focal-20.04}
 export IPV6=${IPV6:-false}
-if [[ ! "$RELEASE_BRANCH" < "1-29" ]]; then
-	export KOPS_VERSION="1.29.0-beta.1"
-else
-	export KOPS_VERSION="1.28.4"
-fi
+
+export KOPS_VERSION="1.29.0-beta.1"
 
 if [ -n "$ARTIFACT_BUCKET" ]; then
-	export ARTIFACT_BASE_URL="https://$ARTIFACT_BUCKET.s3.amazonaws.com"
+  export ARTIFACT_BASE_URL="https://$ARTIFACT_BUCKET.s3.amazonaws.com"
 fi
 
 if [ "${PREFLIGHT_CHECK_PASSED:-false}" != "true" ]; then
-	PREFLIGHT_CHECK_PASSED=true
-	GOOD="\xE2\x9C\x94"
-	BAD="\xE2\x9D\x8C"
-	export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-${AWS_REGION}}
-	export AWS_REGION="${AWS_DEFAULT_REGION}"
-	if [ -z "$AWS_DEFAULT_REGION" ]; then
-		PREFLIGHT_CHECK_PASSED=false
-		echo -e "${BAD} AWS_REGION must be set and exported"
-	else
-		echo -e "${GOOD} AWS_REGION=${AWS_REGION}"
-	fi
+  PREFLIGHT_CHECK_PASSED=true
+  GOOD="\xE2\x9C\x94"
+  BAD="\xE2\x9D\x8C"
+  export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-${AWS_REGION}}
+  export AWS_REGION="${AWS_DEFAULT_REGION}"
+  if [ -z "$AWS_DEFAULT_REGION" ]; then
+    PREFLIGHT_CHECK_PASSED=false
+    echo -e "${BAD} AWS_REGION must be set and exported"
+  else
+    echo -e "${GOOD} AWS_REGION=${AWS_REGION}"
+  fi
 
-	if ! aws sts get-caller-identity --query Account --output text >/dev/null 2>/dev/null; then
-		PREFLIGHT_CHECK_PASSED=false
-		echo -e "${BAD} AWS CLI failed to authenticate"
-	else
-		echo -e "${GOOD} AWS CLI authenticated"
-	fi
+  if ! aws sts get-caller-identity --query Account --output text >/dev/null 2>/dev/null; then
+    PREFLIGHT_CHECK_PASSED=false
+    echo -e "${BAD} AWS CLI failed to authenticate"
+  else
+    echo -e "${GOOD} AWS CLI authenticated"
+  fi
 
-	if [ -z "$KOPS_STATE_STORE" ]; then
-		PREFLIGHT_CHECK_PASSED=false
-		echo -e "${BAD} KOPS_STATE_STORE must be set and exported"
-	else
-		echo -e "${GOOD} KOPS_STATE_STORE=${KOPS_STATE_STORE}"
-	fi
-	if [[ "${KOPS_STATE_STORE}" != s3://* ]]; then
-		export KOPS_STATE_STORE="s3://${KOPS_STATE_STORE}"
-	fi
-	export BUCKET_NAME=${KOPS_STATE_STORE#"s3://"}
+  if [ -z "$KOPS_STATE_STORE" ]; then
+    PREFLIGHT_CHECK_PASSED=false
+    echo -e "${BAD} KOPS_STATE_STORE must be set and exported"
+  else
+    echo -e "${GOOD} KOPS_STATE_STORE=${KOPS_STATE_STORE}"
+  fi
+  if [[ "${KOPS_STATE_STORE}" != s3://* ]]; then
+    export KOPS_STATE_STORE="s3://${KOPS_STATE_STORE}"
+  fi
+  export BUCKET_NAME=${KOPS_STATE_STORE#"s3://"}
 
-	if [ -z "$KOPS_CLUSTER_NAME" ]; then
-		PREFLIGHT_CHECK_PASSED=false
-		echo -e "${BAD} KOPS_CLUSTER_NAME must be set and exported"
-	else
-		echo -e "${GOOD} KOPS_CLUSTER_NAME=${KOPS_CLUSTER_NAME}"
-	fi
+  if [ -z "$KOPS_CLUSTER_NAME" ]; then
+    PREFLIGHT_CHECK_PASSED=false
+    echo -e "${BAD} KOPS_CLUSTER_NAME must be set and exported"
+  else
+    echo -e "${GOOD} KOPS_CLUSTER_NAME=${KOPS_CLUSTER_NAME}"
+  fi
 
-	if [ "${JOB_TYPE:-}" == "presubmit" ]; then
-		PREFLIGHT_CHECK_PASSED=true
-	fi
+  if [ "${JOB_TYPE:-}" == "presubmit" ]; then
+    PREFLIGHT_CHECK_PASSED=true
+  fi
 fi
 export PREFLIGHT_CHECK_PASSED
 
@@ -91,16 +88,16 @@ export PATH=$(pwd)/bin:${PATH}
 
 # Set OS and ARCH env vars
 if [ "$(uname)" == "Darwin" ]; then
-	export OS="darwin"
-	export ARCH="amd64"
+  export OS="darwin"
+  export ARCH="amd64"
 else
-	export OS="linux"
-	export ARCH="amd64"
+  export OS="linux"
+  export ARCH="amd64"
 fi
 
 # Set customer user-agent for curl to ensure we can track requests against the CloudFront distribution
 UA_SYSTEM_INFO="${OS}/${ARCH};"
 if [[ -n "${PROW_JOB_ID}" ]]; then
-	UA_SYSTEM_INFO+=" prowJobId:${PROW_JOB_ID};"
+  UA_SYSTEM_INFO+=" prowJobId:${PROW_JOB_ID};"
 fi
 export USERAGENT="EksDistro-${BASENAME}/${RELEASE_BRANCH} ($UA_SYSTEM_INFO)"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**>1-29**
Trying 1.29.0-beta.1 for all versions because the way we get kops artifacts.

**1-30**
Kops is returning error because upstream hasn't released a 1.30 kops, so to begin testing we need to use the latest 1.29 kops. 
```
*********************************************************************************

This version of kubernetes is not yet supported; upgrading kops is required
(you can bypass this check by exporting KOPS_RUN_TOO_NEW_VERSION)

*********************************************************************************
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
