### PR TITLE
Add script to auto tag releases when release docs job run

### DIFF
--- a/release/github_tag_doc_release.sh
+++ b/release/github_tag_doc_release.sh
@@ -25,6 +25,8 @@ while read ANNOUNCEMENT; do
     echo "Must be run in a Prowjob for access to PULL_BASE_SHA"
     exit 1
   fi
-  echo "git tag -a ${RELEASE_TAG} ${BASE_PULL_SHA} -m ${RELEASE_TAG}"
-  echo "git push upstream ${RELEASE_TAG}"
+  git remote -v # TODO: Remove once we confirm the git repo has the correct remotes.
+  git tag -a ${RELEASE_TAG} ${BASE_PULL_SHA} -m ${RELEASE_TAG}
+  git push upstream ${RELEASE_TAG}
+
 done <$(git -C . diff --name-only HEAD^ HEAD | grep '^docs/contents/releases' | grep release-announcement.txt)

--- a/release/github_tag_doc_release.sh
+++ b/release/github_tag_doc_release.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BASE_DIRECTORY=$(git rev-parse --show-toplevel)
+cd ${BASE_DIRECTORY}
+
+while read ANNOUNCEMENT; do
+  RELEASE_TAG=$(echo "${ANNOUNCEMENT}" | grep -o -E "[[:digit:]]{1}\-[[:digit:]]{2}-eks-[[:digit:]]{1,2}") # e.g. 1-25-eks-36
+  if [ -z "$RELEASE_TAG" ]; then
+    echo "Failed to publish release notification: Unable to generate release number for notification subject"
+    exit 1
+  elif [ -z "${PULL_BASE_SHA}" ]; then
+    echo "Must be run in a Prowjob for access to PULL_BASE_SHA"
+    exit 1
+  fi
+  echo "git tag -a ${RELEASE_TAG} ${BASE_PULL_SHA} -m ${RELEASE_TAG}"
+  echo "git push upstream ${RELEASE_TAG}"
+done <$(git -C . diff --name-only HEAD^ HEAD | grep '^docs/contents/releases' | grep release-announcement.txt)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Using the last release job yamls [1.29](https://prow.eks.amazonaws.com/prowjob?prowjob=bc9c736e-f913-11ee-a988-ea5cbbb20fdb) & [1.27](https://prow.eks.amazonaws.com/prowjob?prowjob=b82c49f4-f913-11ee-a592-3aab9e666086) as a references `base sha` or `PULL_BASE_SHA` environment variable for the prowjobs are the unique sha for the merged doc release commit, which is the commit used when tagging a release. This script will be called by the prowjobs tag the commit for the release.

Just merging this does nothing. Must merge https://github.com/aws/eks-distro-prow-jobs/pull/603 as well to have the job call the script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
