### PR TITLE
Patch external-resizer CVE-2023-45288 by bumping /x/net to 0.23.0

### DIFF
--- a/projects/kubernetes-csi/external-resizer/1-25/CHECKSUMS
+++ b/projects/kubernetes-csi/external-resizer/1-25/CHECKSUMS
@@ -1,2 +1,2 @@
-cb05f08b5873e5fce1048b88bd97dd848544328464768b64a9d5f790361cd725  _output/1-25/bin/external-resizer/linux-amd64/csi-resizer
-4be58b892ed0dec5bd6ad0ae28ceabfc9183d92b3d1ca6ed8126de969d25b413  _output/1-25/bin/external-resizer/linux-arm64/csi-resizer
+a73c82508caf8a3c9eef44001c5f909efe535ac08d913522d93c141c167368e3  _output/1-25/bin/external-resizer/linux-amd64/csi-resizer
+2fb169baa87202c1e4c64658b87758cb12aa9818bb6b52cd595767a864541752  _output/1-25/bin/external-resizer/linux-arm64/csi-resizer

--- a/projects/kubernetes-csi/external-resizer/1-25/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
+++ b/projects/kubernetes-csi/external-resizer/1-25/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
@@ -1,0 +1,3278 @@
+From 6f30bd8a770c0000df2176d1feccf54db95c72f3 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:21:40 +0000
+Subject: [PATCH] Fix CVE CVE-2023-45288 by bumping /x/net to 0.23.0
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |   6 +-
+ go.sum                                        |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/fcntl.go         |   2 +-
+ vendor/golang.org/x/sys/unix/ioctl_linux.go   |   5 +
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  42 ++-
+ vendor/golang.org/x/sys/unix/syscall_bsd.go   |   2 +-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go | 127 ++++++-
+ .../golang.org/x/sys/unix/syscall_openbsd.go  |  14 +
+ .../golang.org/x/sys/unix/syscall_solaris.go  |   2 +-
+ .../x/sys/unix/syscall_zos_s390x.go           |   2 +-
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  92 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  25 ++
+ .../x/sys/unix/zsyscall_openbsd_386.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_386.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_amd64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_mips64.s      |   5 +
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_ppc64.s       |   6 +
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_riscv64.s     |   5 +
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 217 ++++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   6 +-
+ .../x/sys/windows/zsyscall_windows.go         |  28 ++
+ vendor/modules.txt                            |   6 +-
+ 69 files changed, 1451 insertions(+), 210 deletions(-)
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index 408a4aa5..08785a0f 100644
+--- a/go.mod
++++ b/go.mod
+@@ -9,7 +9,7 @@ require (
+ 	github.com/imdario/mergo v0.3.12 // indirect
+ 	github.com/kubernetes-csi/csi-lib-utils v0.17.0
+ 	golang.org/x/oauth2 v0.13.0 // indirect
+-	golang.org/x/term v0.14.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	google.golang.org/appengine v1.6.8 // indirect
+ 	google.golang.org/grpc v1.60.1
+ 	k8s.io/api v0.29.0
+@@ -62,8 +62,8 @@ require (
+ 	go.uber.org/goleak v1.3.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.19.0 // indirect
+-	golang.org/x/net v0.18.0 // indirect
+-	golang.org/x/sys v0.14.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.3.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
+diff --git a/go.sum b/go.sum
+index 0b5edd30..f747ed99 100644
+--- a/go.sum
++++ b/go.sum
+@@ -165,8 +165,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
+-golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.13.0 h1:jDDenyj+WgFtmV3zYVoi8aE2BwtXFLWOA67ZfNWftiY=
+ golang.org/x/oauth2 v0.13.0/go.mod h1:/JMhi4ZRXAf4HG9LiNmxvk+45+96RUlVThiH8FzNBn0=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -181,12 +181,12 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.14.0 h1:LGK9IlZ8T9jvdy6cTdfKUCltatMFOehAQo9SRC46UQ8=
+-golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90d..43557ab7 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984f..3b9f06b9 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c640..ce2e8b40 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 00000000..61075bd1
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86..ce375c8c 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4b..b0e41985 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/fcntl.go b/vendor/golang.org/x/sys/unix/fcntl.go
+index 58c6bfc7..6200876f 100644
+--- a/vendor/golang.org/x/sys/unix/fcntl.go
++++ b/vendor/golang.org/x/sys/unix/fcntl.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build dragonfly || freebsd || linux || netbsd || openbsd
++//go:build dragonfly || freebsd || linux || netbsd
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/ioctl_linux.go b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+index 0d12c085..dbe680ea 100644
+--- a/vendor/golang.org/x/sys/unix/ioctl_linux.go
++++ b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+@@ -231,3 +231,8 @@ func IoctlLoopGetStatus64(fd int) (*LoopInfo64, error) {
+ func IoctlLoopSetStatus64(fd int, value *LoopInfo64) error {
+ 	return ioctlPtr(fd, LOOP_SET_STATUS64, unsafe.Pointer(value))
+ }
++
++// IoctlLoopConfigure configures all loop device parameters in a single step
++func IoctlLoopConfigure(fd int, value *LoopConfig) error {
++	return ioctlPtr(fd, LOOP_CONFIGURE, unsafe.Pointer(value))
++}
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index cbe24150..fdcaa974 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -519,6 +521,7 @@ ccflags="$@"
+ 		$2 ~ /^LOCK_(SH|EX|NB|UN)$/ ||
+ 		$2 ~ /^LO_(KEY|NAME)_SIZE$/ ||
+ 		$2 ~ /^LOOP_(CLR|CTL|GET|SET)_/ ||
++		$2 == "LOOP_CONFIGURE" ||
+ 		$2 ~ /^(AF|SOCK|SO|SOL|IPPROTO|IP|IPV6|TCP|MCAST|EVFILT|NOTE|SHUT|PROT|MAP|MREMAP|MFD|T?PACKET|MSG|SCM|MCL|DT|MADV|PR|LOCAL|TCPOPT|UDP)_/ ||
+ 		$2 ~ /^NFC_(GENL|PROTO|COMM|RF|SE|DIRECTION|LLCP|SOCKPROTO)_/ ||
+ 		$2 ~ /^NFC_.*_(MAX)?SIZE$/ ||
+@@ -560,7 +563,7 @@ ccflags="$@"
+ 		$2 ~ /^RLIMIT_(AS|CORE|CPU|DATA|FSIZE|LOCKS|MEMLOCK|MSGQUEUE|NICE|NOFILE|NPROC|RSS|RTPRIO|RTTIME|SIGPENDING|STACK)|RLIM_INFINITY/ ||
+ 		$2 ~ /^PRIO_(PROCESS|PGRP|USER)/ ||
+ 		$2 ~ /^CLONE_[A-Z_]+/ ||
+-		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+)$/ &&
++		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+|BPF_F_LINK)$/ &&
+ 		$2 ~ /^(BPF|DLT)_/ ||
+ 		$2 ~ /^AUDIT_/ ||
+ 		$2 ~ /^(CLOCK|TIMER)_/ ||
+@@ -581,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -602,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_bsd.go b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+index 6f328e3a..a00c3e54 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_bsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+@@ -316,7 +316,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ //sys	recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Socklen) (n int, err error)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc6993..2f0fa76e 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4d..2b57e0f7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index a5e1c10e..5682e262 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -61,15 +61,23 @@ func FanotifyMark(fd int, flags uint, mask uint64, dirFd int, pathname string) (
+ }
+ 
+ //sys	fchmodat(dirfd int, path string, mode uint32) (err error)
+-
+-func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+-	// Linux fchmodat doesn't support the flags parameter. Mimick glibc's behavior
+-	// and check the flags. Otherwise the mode would be applied to the symlink
+-	// destination which is not what the user expects.
+-	if flags&^AT_SYMLINK_NOFOLLOW != 0 {
+-		return EINVAL
+-	} else if flags&AT_SYMLINK_NOFOLLOW != 0 {
+-		return EOPNOTSUPP
++//sys	fchmodat2(dirfd int, path string, mode uint32, flags int) (err error)
++
++func Fchmodat(dirfd int, path string, mode uint32, flags int) error {
++	// Linux fchmodat doesn't support the flags parameter, but fchmodat2 does.
++	// Try fchmodat2 if flags are specified.
++	if flags != 0 {
++		err := fchmodat2(dirfd, path, mode, flags)
++		if err == ENOSYS {
++			// fchmodat2 isn't available. If the flags are known to be valid,
++			// return EOPNOTSUPP to indicate that fchmodat doesn't support them.
++			if flags&^(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EINVAL
++			} else if flags&(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EOPNOTSUPP
++			}
++		}
++		return err
+ 	}
+ 	return fchmodat(dirfd, path, mode)
+ }
+@@ -1302,7 +1310,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 			return "", err
+ 		}
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func GetsockoptTpacketStats(fd, level, opt int) (*TpacketStats, error) {
+@@ -1841,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_openbsd.go b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+index d2882ee0..b25343c7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_openbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+@@ -166,6 +166,20 @@ func Getresgid() (rgid, egid, sgid int) {
+ 
+ //sys	sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) = SYS___SYSCTL
+ 
++//sys	fcntl(fd int, cmd int, arg int) (n int, err error)
++//sys	fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) = SYS_FCNTL
++
++// FcntlInt performs a fcntl syscall on fd with the provided command and argument.
++func FcntlInt(fd uintptr, cmd, arg int) (int, error) {
++	return fcntl(int(fd), cmd, arg)
++}
++
++// FcntlFlock performs a fcntl syscall for the F_GETLK, F_SETLK or F_SETLKW command.
++func FcntlFlock(fd uintptr, cmd int, lk *Flock_t) error {
++	_, err := fcntlPtr(int(fd), cmd, unsafe.Pointer(lk))
++	return err
++}
++
+ //sys	ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error)
+ 
+ func Ppoll(fds []PollFd, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_solaris.go b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+index 60c8142d..21974af0 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
++++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+@@ -158,7 +158,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ const ImplementsGetwd = true
+diff --git a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+index d99d05f1..b473038c 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+@@ -1104,7 +1104,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 		return "", err
+ 	}
+ 
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func Recvmsg(fd int, p, oob []byte, flags int) (n, oobn int, recvflags int, from Sockaddr, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index 9c00cbf5..36bf8399 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -486,7 +486,6 @@ const (
+ 	BPF_F_ANY_ALIGNMENT                         = 0x2
+ 	BPF_F_BEFORE                                = 0x8
+ 	BPF_F_ID                                    = 0x20
+-	BPF_F_LINK                                  = 0x2000
+ 	BPF_F_NETFILTER_IP_DEFRAG                   = 0x1
+ 	BPF_F_QUERY_EFFECTIVE                       = 0x1
+ 	BPF_F_REPLACE                               = 0x4
+@@ -1786,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -1802,6 +1803,7 @@ const (
+ 	LOCK_SH                                     = 0x1
+ 	LOCK_UN                                     = 0x8
+ 	LOOP_CLR_FD                                 = 0x4c01
++	LOOP_CONFIGURE                              = 0x4c0a
+ 	LOOP_CTL_ADD                                = 0x4c80
+ 	LOOP_CTL_GET_FREE                           = 0x4c82
+ 	LOOP_CTL_REMOVE                             = 0x4c81
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821c..42ff8c3c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e411..dca43600 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c6398556..5cca668a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e2..d8cae6d1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09..28e39afd 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642..cd66e92c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d7..c1595eba 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0..ee9456b0 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84..8cfca81e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d..60b0deb3 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc7..f90aa728 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e..ba9e0150 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813e..07cdfd6e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4e..2f1dd214 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994d..f40519d9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index faca7a55..87d8612a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -37,6 +37,21 @@ func fchmodat(dirfd int, path string, mode uint32) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fchmodat2(dirfd int, path string, mode uint32, flags int) (err error) {
++	var _p0 *byte
++	_p0, err = BytePtrFromString(path)
++	if err != nil {
++		return
++	}
++	_, _, e1 := Syscall6(SYS_FCHMODAT2, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	_, _, e1 := Syscall(SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -891,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index 88bfc288..9dc42410 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+index 4cbeff17..41b56173 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index b8a67b99..0d3a0751 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+index 1123f275..4019a656 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index af50a65c..c39f7776 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+index 82badae3..ac4af24f 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 8fb4ff36..57571d07 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+index 24d7eecb..f77d5321 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index f469a83e..e62963e6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+index 9a498a06..fae140b6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index c26ca2e1..00831354 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+index 1f224aa4..9d1e0ff0 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+@@ -213,6 +213,12 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	CALL	libc_fcntl(SB)
++	RET
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	CALL	libc_ppoll(SB)
+ 	RET
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index bcc920dd..79029ed5 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+index 87a79c70..da115f9a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbd..0cc3ce49 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc250..856d92d6 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf246..8d467094 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e..edc17324 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77..445eba20 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362e..adba01bc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4f..014c4e9c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca8..ccc97d74 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d3..ec2b64a9 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e374..21a839e3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c..c11121ec 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e59..909b631f 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195..e49bed16 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943b..66017d2d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc5..47bab18d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index 997bcd55..eff6bcde 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -2671,6 +2735,7 @@ const (
+ 	BPF_PROG_TYPE_LSM                          = 0x1d
+ 	BPF_PROG_TYPE_SK_LOOKUP                    = 0x1e
+ 	BPF_PROG_TYPE_SYSCALL                      = 0x1f
++	BPF_PROG_TYPE_NETFILTER                    = 0x20
+ 	BPF_CGROUP_INET_INGRESS                    = 0x0
+ 	BPF_CGROUP_INET_EGRESS                     = 0x1
+ 	BPF_CGROUP_INET_SOCK_CREATE                = 0x2
+@@ -2715,6 +2780,11 @@ const (
+ 	BPF_PERF_EVENT                             = 0x29
+ 	BPF_TRACE_KPROBE_MULTI                     = 0x2a
+ 	BPF_LSM_CGROUP                             = 0x2b
++	BPF_STRUCT_OPS                             = 0x2c
++	BPF_NETFILTER                              = 0x2d
++	BPF_TCX_INGRESS                            = 0x2e
++	BPF_TCX_EGRESS                             = 0x2f
++	BPF_TRACE_UPROBE_MULTI                     = 0x30
+ 	BPF_LINK_TYPE_UNSPEC                       = 0x0
+ 	BPF_LINK_TYPE_RAW_TRACEPOINT               = 0x1
+ 	BPF_LINK_TYPE_TRACING                      = 0x2
+@@ -2725,6 +2795,18 @@ const (
+ 	BPF_LINK_TYPE_PERF_EVENT                   = 0x7
+ 	BPF_LINK_TYPE_KPROBE_MULTI                 = 0x8
+ 	BPF_LINK_TYPE_STRUCT_OPS                   = 0x9
++	BPF_LINK_TYPE_NETFILTER                    = 0xa
++	BPF_LINK_TYPE_TCX                          = 0xb
++	BPF_LINK_TYPE_UPROBE_MULTI                 = 0xc
++	BPF_PERF_EVENT_UNSPEC                      = 0x0
++	BPF_PERF_EVENT_UPROBE                      = 0x1
++	BPF_PERF_EVENT_URETPROBE                   = 0x2
++	BPF_PERF_EVENT_KPROBE                      = 0x3
++	BPF_PERF_EVENT_KRETPROBE                   = 0x4
++	BPF_PERF_EVENT_TRACEPOINT                  = 0x5
++	BPF_PERF_EVENT_EVENT                       = 0x6
++	BPF_F_KPROBE_MULTI_RETURN                  = 0x1
++	BPF_F_UPROBE_MULTI_RETURN                  = 0x1
+ 	BPF_ANY                                    = 0x0
+ 	BPF_NOEXIST                                = 0x1
+ 	BPF_EXIST                                  = 0x2
+@@ -2742,6 +2824,8 @@ const (
+ 	BPF_F_MMAPABLE                             = 0x400
+ 	BPF_F_PRESERVE_ELEMS                       = 0x800
+ 	BPF_F_INNER_MAP                            = 0x1000
++	BPF_F_LINK                                 = 0x2000
++	BPF_F_PATH_FD                              = 0x4000
+ 	BPF_STATS_RUN_TIME                         = 0x0
+ 	BPF_STACK_BUILD_ID_EMPTY                   = 0x0
+ 	BPF_STACK_BUILD_ID_VALID                   = 0x1
+@@ -2762,6 +2846,7 @@ const (
+ 	BPF_F_ZERO_CSUM_TX                         = 0x2
+ 	BPF_F_DONT_FRAGMENT                        = 0x4
+ 	BPF_F_SEQ_NUMBER                           = 0x8
++	BPF_F_NO_TUNNEL_KEY                        = 0x10
+ 	BPF_F_TUNINFO_FLAGS                        = 0x10
+ 	BPF_F_INDEX_MASK                           = 0xffffffff
+ 	BPF_F_CURRENT_CPU                          = 0xffffffff
+@@ -2778,6 +2863,8 @@ const (
+ 	BPF_F_ADJ_ROOM_ENCAP_L4_UDP                = 0x10
+ 	BPF_F_ADJ_ROOM_NO_CSUM_RESET               = 0x20
+ 	BPF_F_ADJ_ROOM_ENCAP_L2_ETH                = 0x40
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV4               = 0x80
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV6               = 0x100
+ 	BPF_ADJ_ROOM_ENCAP_L2_MASK                 = 0xff
+ 	BPF_ADJ_ROOM_ENCAP_L2_SHIFT                = 0x38
+ 	BPF_F_SYSCTL_BASE_NAME                     = 0x1
+@@ -2866,6 +2953,8 @@ const (
+ 	BPF_DEVCG_DEV_CHAR                         = 0x2
+ 	BPF_FIB_LOOKUP_DIRECT                      = 0x1
+ 	BPF_FIB_LOOKUP_OUTPUT                      = 0x2
++	BPF_FIB_LOOKUP_SKIP_NEIGH                  = 0x4
++	BPF_FIB_LOOKUP_TBID                        = 0x8
+ 	BPF_FIB_LKUP_RET_SUCCESS                   = 0x0
+ 	BPF_FIB_LKUP_RET_BLACKHOLE                 = 0x1
+ 	BPF_FIB_LKUP_RET_UNREACHABLE               = 0x2
+@@ -2901,6 +2990,7 @@ const (
+ 	BPF_CORE_ENUMVAL_EXISTS                    = 0xa
+ 	BPF_CORE_ENUMVAL_VALUE                     = 0xb
+ 	BPF_CORE_TYPE_MATCHES                      = 0xc
++	BPF_F_TIMER_ABS                            = 0x1
+ )
+ 
+ const (
+@@ -2979,6 +3069,12 @@ type LoopInfo64 struct {
+ 	Encrypt_key      [32]uint8
+ 	Init             [2]uint64
+ }
++type LoopConfig struct {
++	Fd   uint32
++	Size uint32
++	Info LoopInfo64
++	_    [8]uint64
++}
+ 
+ type TIPCSocketAddr struct {
+ 	Ref  uint32
+@@ -3367,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4151,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5102,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5515,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad1925..d4577a42 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index fb6cfd04..6395a031 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -155,6 +154,8 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetModuleFileName(module Handle, filename *uint16, size uint32) (n uint32, err error) = kernel32.GetModuleFileNameW
+ //sys	GetModuleHandleEx(flags uint32, moduleName *uint16, module *Handle) (err error) = kernel32.GetModuleHandleExW
+ //sys	SetDefaultDllDirectories(directoryFlags uint32) (err error)
++//sys	AddDllDirectory(path *uint16) (cookie uintptr, err error) = kernel32.AddDllDirectory
++//sys	RemoveDllDirectory(cookie uintptr) (err error) = kernel32.RemoveDllDirectory
+ //sys	SetDllDirectory(path string) (err error) = kernel32.SetDllDirectoryW
+ //sys	GetVersion() (ver uint32, err error)
+ //sys	FormatMessage(flags uint32, msgsrc uintptr, msgid uint32, langid uint32, buf []uint16, args *byte) (n uint32, err error) = FormatMessageW
+@@ -192,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index db6282e0..e8791c82 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -184,6 +184,7 @@ var (
+ 	procGetAdaptersInfo                                      = modiphlpapi.NewProc("GetAdaptersInfo")
+ 	procGetBestInterfaceEx                                   = modiphlpapi.NewProc("GetBestInterfaceEx")
+ 	procGetIfEntry                                           = modiphlpapi.NewProc("GetIfEntry")
++	procAddDllDirectory                                      = modkernel32.NewProc("AddDllDirectory")
+ 	procAssignProcessToJobObject                             = modkernel32.NewProc("AssignProcessToJobObject")
+ 	procCancelIo                                             = modkernel32.NewProc("CancelIo")
+ 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
+@@ -330,6 +331,7 @@ var (
+ 	procReadProcessMemory                                    = modkernel32.NewProc("ReadProcessMemory")
+ 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
+ 	procRemoveDirectoryW                                     = modkernel32.NewProc("RemoveDirectoryW")
++	procRemoveDllDirectory                                   = modkernel32.NewProc("RemoveDllDirectory")
+ 	procResetEvent                                           = modkernel32.NewProc("ResetEvent")
+ 	procResizePseudoConsole                                  = modkernel32.NewProc("ResizePseudoConsole")
+ 	procResumeThread                                         = modkernel32.NewProc("ResumeThread")
+@@ -340,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -1605,6 +1608,15 @@ func GetIfEntry(pIfRow *MibIfRow) (errcode error) {
+ 	return
+ }
+ 
++func AddDllDirectory(path *uint16) (cookie uintptr, err error) {
++	r0, _, e1 := syscall.Syscall(procAddDllDirectory.Addr(), 1, uintptr(unsafe.Pointer(path)), 0, 0)
++	cookie = uintptr(r0)
++	if cookie == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func AssignProcessToJobObject(job Handle, process Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procAssignProcessToJobObject.Addr(), 2, uintptr(job), uintptr(process), 0)
+ 	if r1 == 0 {
+@@ -2879,6 +2891,14 @@ func RemoveDirectory(path *uint16) (err error) {
+ 	return
+ }
+ 
++func RemoveDllDirectory(cookie uintptr) (err error) {
++	r1, _, e1 := syscall.Syscall(procRemoveDllDirectory.Addr(), 1, uintptr(cookie), 0, 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func ResetEvent(event Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procResetEvent.Addr(), 1, uintptr(event), 0, 0)
+ 	if r1 == 0 {
+@@ -2969,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index f56ffc95..a6f82bb3 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -185,7 +185,7 @@ go.uber.org/zap/internal/bufferpool
+ go.uber.org/zap/internal/color
+ go.uber.org/zap/internal/exit
+ go.uber.org/zap/zapcore
+-# golang.org/x/net v0.18.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -197,12 +197,12 @@ golang.org/x/net/trace
+ ## explicit; go 1.18
+ golang.org/x/oauth2
+ golang.org/x/oauth2/internal
+-# golang.org/x/sys v0.14.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-# golang.org/x/term v0.14.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/external-resizer/1-26/CHECKSUMS
+++ b/projects/kubernetes-csi/external-resizer/1-26/CHECKSUMS
@@ -1,2 +1,2 @@
-cb05f08b5873e5fce1048b88bd97dd848544328464768b64a9d5f790361cd725  _output/1-26/bin/external-resizer/linux-amd64/csi-resizer
-4be58b892ed0dec5bd6ad0ae28ceabfc9183d92b3d1ca6ed8126de969d25b413  _output/1-26/bin/external-resizer/linux-arm64/csi-resizer
+a73c82508caf8a3c9eef44001c5f909efe535ac08d913522d93c141c167368e3  _output/1-26/bin/external-resizer/linux-amd64/csi-resizer
+2fb169baa87202c1e4c64658b87758cb12aa9818bb6b52cd595767a864541752  _output/1-26/bin/external-resizer/linux-arm64/csi-resizer

--- a/projects/kubernetes-csi/external-resizer/1-26/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
+++ b/projects/kubernetes-csi/external-resizer/1-26/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
@@ -1,0 +1,3278 @@
+From 6f30bd8a770c0000df2176d1feccf54db95c72f3 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:21:40 +0000
+Subject: [PATCH] Fix CVE CVE-2023-45288 by bumping /x/net to 0.23.0
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |   6 +-
+ go.sum                                        |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/fcntl.go         |   2 +-
+ vendor/golang.org/x/sys/unix/ioctl_linux.go   |   5 +
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  42 ++-
+ vendor/golang.org/x/sys/unix/syscall_bsd.go   |   2 +-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go | 127 ++++++-
+ .../golang.org/x/sys/unix/syscall_openbsd.go  |  14 +
+ .../golang.org/x/sys/unix/syscall_solaris.go  |   2 +-
+ .../x/sys/unix/syscall_zos_s390x.go           |   2 +-
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  92 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  25 ++
+ .../x/sys/unix/zsyscall_openbsd_386.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_386.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_amd64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_mips64.s      |   5 +
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_ppc64.s       |   6 +
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_riscv64.s     |   5 +
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 217 ++++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   6 +-
+ .../x/sys/windows/zsyscall_windows.go         |  28 ++
+ vendor/modules.txt                            |   6 +-
+ 69 files changed, 1451 insertions(+), 210 deletions(-)
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index 408a4aa5..08785a0f 100644
+--- a/go.mod
++++ b/go.mod
+@@ -9,7 +9,7 @@ require (
+ 	github.com/imdario/mergo v0.3.12 // indirect
+ 	github.com/kubernetes-csi/csi-lib-utils v0.17.0
+ 	golang.org/x/oauth2 v0.13.0 // indirect
+-	golang.org/x/term v0.14.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	google.golang.org/appengine v1.6.8 // indirect
+ 	google.golang.org/grpc v1.60.1
+ 	k8s.io/api v0.29.0
+@@ -62,8 +62,8 @@ require (
+ 	go.uber.org/goleak v1.3.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.19.0 // indirect
+-	golang.org/x/net v0.18.0 // indirect
+-	golang.org/x/sys v0.14.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.3.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
+diff --git a/go.sum b/go.sum
+index 0b5edd30..f747ed99 100644
+--- a/go.sum
++++ b/go.sum
+@@ -165,8 +165,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
+-golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.13.0 h1:jDDenyj+WgFtmV3zYVoi8aE2BwtXFLWOA67ZfNWftiY=
+ golang.org/x/oauth2 v0.13.0/go.mod h1:/JMhi4ZRXAf4HG9LiNmxvk+45+96RUlVThiH8FzNBn0=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -181,12 +181,12 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.14.0 h1:LGK9IlZ8T9jvdy6cTdfKUCltatMFOehAQo9SRC46UQ8=
+-golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90d..43557ab7 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984f..3b9f06b9 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c640..ce2e8b40 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 00000000..61075bd1
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86..ce375c8c 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4b..b0e41985 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/fcntl.go b/vendor/golang.org/x/sys/unix/fcntl.go
+index 58c6bfc7..6200876f 100644
+--- a/vendor/golang.org/x/sys/unix/fcntl.go
++++ b/vendor/golang.org/x/sys/unix/fcntl.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build dragonfly || freebsd || linux || netbsd || openbsd
++//go:build dragonfly || freebsd || linux || netbsd
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/ioctl_linux.go b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+index 0d12c085..dbe680ea 100644
+--- a/vendor/golang.org/x/sys/unix/ioctl_linux.go
++++ b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+@@ -231,3 +231,8 @@ func IoctlLoopGetStatus64(fd int) (*LoopInfo64, error) {
+ func IoctlLoopSetStatus64(fd int, value *LoopInfo64) error {
+ 	return ioctlPtr(fd, LOOP_SET_STATUS64, unsafe.Pointer(value))
+ }
++
++// IoctlLoopConfigure configures all loop device parameters in a single step
++func IoctlLoopConfigure(fd int, value *LoopConfig) error {
++	return ioctlPtr(fd, LOOP_CONFIGURE, unsafe.Pointer(value))
++}
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index cbe24150..fdcaa974 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -519,6 +521,7 @@ ccflags="$@"
+ 		$2 ~ /^LOCK_(SH|EX|NB|UN)$/ ||
+ 		$2 ~ /^LO_(KEY|NAME)_SIZE$/ ||
+ 		$2 ~ /^LOOP_(CLR|CTL|GET|SET)_/ ||
++		$2 == "LOOP_CONFIGURE" ||
+ 		$2 ~ /^(AF|SOCK|SO|SOL|IPPROTO|IP|IPV6|TCP|MCAST|EVFILT|NOTE|SHUT|PROT|MAP|MREMAP|MFD|T?PACKET|MSG|SCM|MCL|DT|MADV|PR|LOCAL|TCPOPT|UDP)_/ ||
+ 		$2 ~ /^NFC_(GENL|PROTO|COMM|RF|SE|DIRECTION|LLCP|SOCKPROTO)_/ ||
+ 		$2 ~ /^NFC_.*_(MAX)?SIZE$/ ||
+@@ -560,7 +563,7 @@ ccflags="$@"
+ 		$2 ~ /^RLIMIT_(AS|CORE|CPU|DATA|FSIZE|LOCKS|MEMLOCK|MSGQUEUE|NICE|NOFILE|NPROC|RSS|RTPRIO|RTTIME|SIGPENDING|STACK)|RLIM_INFINITY/ ||
+ 		$2 ~ /^PRIO_(PROCESS|PGRP|USER)/ ||
+ 		$2 ~ /^CLONE_[A-Z_]+/ ||
+-		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+)$/ &&
++		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+|BPF_F_LINK)$/ &&
+ 		$2 ~ /^(BPF|DLT)_/ ||
+ 		$2 ~ /^AUDIT_/ ||
+ 		$2 ~ /^(CLOCK|TIMER)_/ ||
+@@ -581,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -602,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_bsd.go b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+index 6f328e3a..a00c3e54 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_bsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+@@ -316,7 +316,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ //sys	recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Socklen) (n int, err error)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc6993..2f0fa76e 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4d..2b57e0f7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index a5e1c10e..5682e262 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -61,15 +61,23 @@ func FanotifyMark(fd int, flags uint, mask uint64, dirFd int, pathname string) (
+ }
+ 
+ //sys	fchmodat(dirfd int, path string, mode uint32) (err error)
+-
+-func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+-	// Linux fchmodat doesn't support the flags parameter. Mimick glibc's behavior
+-	// and check the flags. Otherwise the mode would be applied to the symlink
+-	// destination which is not what the user expects.
+-	if flags&^AT_SYMLINK_NOFOLLOW != 0 {
+-		return EINVAL
+-	} else if flags&AT_SYMLINK_NOFOLLOW != 0 {
+-		return EOPNOTSUPP
++//sys	fchmodat2(dirfd int, path string, mode uint32, flags int) (err error)
++
++func Fchmodat(dirfd int, path string, mode uint32, flags int) error {
++	// Linux fchmodat doesn't support the flags parameter, but fchmodat2 does.
++	// Try fchmodat2 if flags are specified.
++	if flags != 0 {
++		err := fchmodat2(dirfd, path, mode, flags)
++		if err == ENOSYS {
++			// fchmodat2 isn't available. If the flags are known to be valid,
++			// return EOPNOTSUPP to indicate that fchmodat doesn't support them.
++			if flags&^(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EINVAL
++			} else if flags&(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EOPNOTSUPP
++			}
++		}
++		return err
+ 	}
+ 	return fchmodat(dirfd, path, mode)
+ }
+@@ -1302,7 +1310,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 			return "", err
+ 		}
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func GetsockoptTpacketStats(fd, level, opt int) (*TpacketStats, error) {
+@@ -1841,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_openbsd.go b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+index d2882ee0..b25343c7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_openbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+@@ -166,6 +166,20 @@ func Getresgid() (rgid, egid, sgid int) {
+ 
+ //sys	sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) = SYS___SYSCTL
+ 
++//sys	fcntl(fd int, cmd int, arg int) (n int, err error)
++//sys	fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) = SYS_FCNTL
++
++// FcntlInt performs a fcntl syscall on fd with the provided command and argument.
++func FcntlInt(fd uintptr, cmd, arg int) (int, error) {
++	return fcntl(int(fd), cmd, arg)
++}
++
++// FcntlFlock performs a fcntl syscall for the F_GETLK, F_SETLK or F_SETLKW command.
++func FcntlFlock(fd uintptr, cmd int, lk *Flock_t) error {
++	_, err := fcntlPtr(int(fd), cmd, unsafe.Pointer(lk))
++	return err
++}
++
+ //sys	ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error)
+ 
+ func Ppoll(fds []PollFd, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_solaris.go b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+index 60c8142d..21974af0 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
++++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+@@ -158,7 +158,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ const ImplementsGetwd = true
+diff --git a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+index d99d05f1..b473038c 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+@@ -1104,7 +1104,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 		return "", err
+ 	}
+ 
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func Recvmsg(fd int, p, oob []byte, flags int) (n, oobn int, recvflags int, from Sockaddr, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index 9c00cbf5..36bf8399 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -486,7 +486,6 @@ const (
+ 	BPF_F_ANY_ALIGNMENT                         = 0x2
+ 	BPF_F_BEFORE                                = 0x8
+ 	BPF_F_ID                                    = 0x20
+-	BPF_F_LINK                                  = 0x2000
+ 	BPF_F_NETFILTER_IP_DEFRAG                   = 0x1
+ 	BPF_F_QUERY_EFFECTIVE                       = 0x1
+ 	BPF_F_REPLACE                               = 0x4
+@@ -1786,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -1802,6 +1803,7 @@ const (
+ 	LOCK_SH                                     = 0x1
+ 	LOCK_UN                                     = 0x8
+ 	LOOP_CLR_FD                                 = 0x4c01
++	LOOP_CONFIGURE                              = 0x4c0a
+ 	LOOP_CTL_ADD                                = 0x4c80
+ 	LOOP_CTL_GET_FREE                           = 0x4c82
+ 	LOOP_CTL_REMOVE                             = 0x4c81
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821c..42ff8c3c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e411..dca43600 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c6398556..5cca668a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e2..d8cae6d1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09..28e39afd 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642..cd66e92c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d7..c1595eba 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0..ee9456b0 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84..8cfca81e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d..60b0deb3 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc7..f90aa728 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e..ba9e0150 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813e..07cdfd6e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4e..2f1dd214 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994d..f40519d9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index faca7a55..87d8612a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -37,6 +37,21 @@ func fchmodat(dirfd int, path string, mode uint32) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fchmodat2(dirfd int, path string, mode uint32, flags int) (err error) {
++	var _p0 *byte
++	_p0, err = BytePtrFromString(path)
++	if err != nil {
++		return
++	}
++	_, _, e1 := Syscall6(SYS_FCHMODAT2, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	_, _, e1 := Syscall(SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -891,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index 88bfc288..9dc42410 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+index 4cbeff17..41b56173 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index b8a67b99..0d3a0751 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+index 1123f275..4019a656 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index af50a65c..c39f7776 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+index 82badae3..ac4af24f 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 8fb4ff36..57571d07 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+index 24d7eecb..f77d5321 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index f469a83e..e62963e6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+index 9a498a06..fae140b6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index c26ca2e1..00831354 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+index 1f224aa4..9d1e0ff0 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+@@ -213,6 +213,12 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	CALL	libc_fcntl(SB)
++	RET
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	CALL	libc_ppoll(SB)
+ 	RET
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index bcc920dd..79029ed5 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+index 87a79c70..da115f9a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbd..0cc3ce49 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc250..856d92d6 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf246..8d467094 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e..edc17324 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77..445eba20 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362e..adba01bc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4f..014c4e9c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca8..ccc97d74 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d3..ec2b64a9 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e374..21a839e3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c..c11121ec 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e59..909b631f 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195..e49bed16 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943b..66017d2d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc5..47bab18d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index 997bcd55..eff6bcde 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -2671,6 +2735,7 @@ const (
+ 	BPF_PROG_TYPE_LSM                          = 0x1d
+ 	BPF_PROG_TYPE_SK_LOOKUP                    = 0x1e
+ 	BPF_PROG_TYPE_SYSCALL                      = 0x1f
++	BPF_PROG_TYPE_NETFILTER                    = 0x20
+ 	BPF_CGROUP_INET_INGRESS                    = 0x0
+ 	BPF_CGROUP_INET_EGRESS                     = 0x1
+ 	BPF_CGROUP_INET_SOCK_CREATE                = 0x2
+@@ -2715,6 +2780,11 @@ const (
+ 	BPF_PERF_EVENT                             = 0x29
+ 	BPF_TRACE_KPROBE_MULTI                     = 0x2a
+ 	BPF_LSM_CGROUP                             = 0x2b
++	BPF_STRUCT_OPS                             = 0x2c
++	BPF_NETFILTER                              = 0x2d
++	BPF_TCX_INGRESS                            = 0x2e
++	BPF_TCX_EGRESS                             = 0x2f
++	BPF_TRACE_UPROBE_MULTI                     = 0x30
+ 	BPF_LINK_TYPE_UNSPEC                       = 0x0
+ 	BPF_LINK_TYPE_RAW_TRACEPOINT               = 0x1
+ 	BPF_LINK_TYPE_TRACING                      = 0x2
+@@ -2725,6 +2795,18 @@ const (
+ 	BPF_LINK_TYPE_PERF_EVENT                   = 0x7
+ 	BPF_LINK_TYPE_KPROBE_MULTI                 = 0x8
+ 	BPF_LINK_TYPE_STRUCT_OPS                   = 0x9
++	BPF_LINK_TYPE_NETFILTER                    = 0xa
++	BPF_LINK_TYPE_TCX                          = 0xb
++	BPF_LINK_TYPE_UPROBE_MULTI                 = 0xc
++	BPF_PERF_EVENT_UNSPEC                      = 0x0
++	BPF_PERF_EVENT_UPROBE                      = 0x1
++	BPF_PERF_EVENT_URETPROBE                   = 0x2
++	BPF_PERF_EVENT_KPROBE                      = 0x3
++	BPF_PERF_EVENT_KRETPROBE                   = 0x4
++	BPF_PERF_EVENT_TRACEPOINT                  = 0x5
++	BPF_PERF_EVENT_EVENT                       = 0x6
++	BPF_F_KPROBE_MULTI_RETURN                  = 0x1
++	BPF_F_UPROBE_MULTI_RETURN                  = 0x1
+ 	BPF_ANY                                    = 0x0
+ 	BPF_NOEXIST                                = 0x1
+ 	BPF_EXIST                                  = 0x2
+@@ -2742,6 +2824,8 @@ const (
+ 	BPF_F_MMAPABLE                             = 0x400
+ 	BPF_F_PRESERVE_ELEMS                       = 0x800
+ 	BPF_F_INNER_MAP                            = 0x1000
++	BPF_F_LINK                                 = 0x2000
++	BPF_F_PATH_FD                              = 0x4000
+ 	BPF_STATS_RUN_TIME                         = 0x0
+ 	BPF_STACK_BUILD_ID_EMPTY                   = 0x0
+ 	BPF_STACK_BUILD_ID_VALID                   = 0x1
+@@ -2762,6 +2846,7 @@ const (
+ 	BPF_F_ZERO_CSUM_TX                         = 0x2
+ 	BPF_F_DONT_FRAGMENT                        = 0x4
+ 	BPF_F_SEQ_NUMBER                           = 0x8
++	BPF_F_NO_TUNNEL_KEY                        = 0x10
+ 	BPF_F_TUNINFO_FLAGS                        = 0x10
+ 	BPF_F_INDEX_MASK                           = 0xffffffff
+ 	BPF_F_CURRENT_CPU                          = 0xffffffff
+@@ -2778,6 +2863,8 @@ const (
+ 	BPF_F_ADJ_ROOM_ENCAP_L4_UDP                = 0x10
+ 	BPF_F_ADJ_ROOM_NO_CSUM_RESET               = 0x20
+ 	BPF_F_ADJ_ROOM_ENCAP_L2_ETH                = 0x40
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV4               = 0x80
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV6               = 0x100
+ 	BPF_ADJ_ROOM_ENCAP_L2_MASK                 = 0xff
+ 	BPF_ADJ_ROOM_ENCAP_L2_SHIFT                = 0x38
+ 	BPF_F_SYSCTL_BASE_NAME                     = 0x1
+@@ -2866,6 +2953,8 @@ const (
+ 	BPF_DEVCG_DEV_CHAR                         = 0x2
+ 	BPF_FIB_LOOKUP_DIRECT                      = 0x1
+ 	BPF_FIB_LOOKUP_OUTPUT                      = 0x2
++	BPF_FIB_LOOKUP_SKIP_NEIGH                  = 0x4
++	BPF_FIB_LOOKUP_TBID                        = 0x8
+ 	BPF_FIB_LKUP_RET_SUCCESS                   = 0x0
+ 	BPF_FIB_LKUP_RET_BLACKHOLE                 = 0x1
+ 	BPF_FIB_LKUP_RET_UNREACHABLE               = 0x2
+@@ -2901,6 +2990,7 @@ const (
+ 	BPF_CORE_ENUMVAL_EXISTS                    = 0xa
+ 	BPF_CORE_ENUMVAL_VALUE                     = 0xb
+ 	BPF_CORE_TYPE_MATCHES                      = 0xc
++	BPF_F_TIMER_ABS                            = 0x1
+ )
+ 
+ const (
+@@ -2979,6 +3069,12 @@ type LoopInfo64 struct {
+ 	Encrypt_key      [32]uint8
+ 	Init             [2]uint64
+ }
++type LoopConfig struct {
++	Fd   uint32
++	Size uint32
++	Info LoopInfo64
++	_    [8]uint64
++}
+ 
+ type TIPCSocketAddr struct {
+ 	Ref  uint32
+@@ -3367,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4151,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5102,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5515,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad1925..d4577a42 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index fb6cfd04..6395a031 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -155,6 +154,8 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetModuleFileName(module Handle, filename *uint16, size uint32) (n uint32, err error) = kernel32.GetModuleFileNameW
+ //sys	GetModuleHandleEx(flags uint32, moduleName *uint16, module *Handle) (err error) = kernel32.GetModuleHandleExW
+ //sys	SetDefaultDllDirectories(directoryFlags uint32) (err error)
++//sys	AddDllDirectory(path *uint16) (cookie uintptr, err error) = kernel32.AddDllDirectory
++//sys	RemoveDllDirectory(cookie uintptr) (err error) = kernel32.RemoveDllDirectory
+ //sys	SetDllDirectory(path string) (err error) = kernel32.SetDllDirectoryW
+ //sys	GetVersion() (ver uint32, err error)
+ //sys	FormatMessage(flags uint32, msgsrc uintptr, msgid uint32, langid uint32, buf []uint16, args *byte) (n uint32, err error) = FormatMessageW
+@@ -192,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index db6282e0..e8791c82 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -184,6 +184,7 @@ var (
+ 	procGetAdaptersInfo                                      = modiphlpapi.NewProc("GetAdaptersInfo")
+ 	procGetBestInterfaceEx                                   = modiphlpapi.NewProc("GetBestInterfaceEx")
+ 	procGetIfEntry                                           = modiphlpapi.NewProc("GetIfEntry")
++	procAddDllDirectory                                      = modkernel32.NewProc("AddDllDirectory")
+ 	procAssignProcessToJobObject                             = modkernel32.NewProc("AssignProcessToJobObject")
+ 	procCancelIo                                             = modkernel32.NewProc("CancelIo")
+ 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
+@@ -330,6 +331,7 @@ var (
+ 	procReadProcessMemory                                    = modkernel32.NewProc("ReadProcessMemory")
+ 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
+ 	procRemoveDirectoryW                                     = modkernel32.NewProc("RemoveDirectoryW")
++	procRemoveDllDirectory                                   = modkernel32.NewProc("RemoveDllDirectory")
+ 	procResetEvent                                           = modkernel32.NewProc("ResetEvent")
+ 	procResizePseudoConsole                                  = modkernel32.NewProc("ResizePseudoConsole")
+ 	procResumeThread                                         = modkernel32.NewProc("ResumeThread")
+@@ -340,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -1605,6 +1608,15 @@ func GetIfEntry(pIfRow *MibIfRow) (errcode error) {
+ 	return
+ }
+ 
++func AddDllDirectory(path *uint16) (cookie uintptr, err error) {
++	r0, _, e1 := syscall.Syscall(procAddDllDirectory.Addr(), 1, uintptr(unsafe.Pointer(path)), 0, 0)
++	cookie = uintptr(r0)
++	if cookie == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func AssignProcessToJobObject(job Handle, process Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procAssignProcessToJobObject.Addr(), 2, uintptr(job), uintptr(process), 0)
+ 	if r1 == 0 {
+@@ -2879,6 +2891,14 @@ func RemoveDirectory(path *uint16) (err error) {
+ 	return
+ }
+ 
++func RemoveDllDirectory(cookie uintptr) (err error) {
++	r1, _, e1 := syscall.Syscall(procRemoveDllDirectory.Addr(), 1, uintptr(cookie), 0, 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func ResetEvent(event Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procResetEvent.Addr(), 1, uintptr(event), 0, 0)
+ 	if r1 == 0 {
+@@ -2969,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index f56ffc95..a6f82bb3 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -185,7 +185,7 @@ go.uber.org/zap/internal/bufferpool
+ go.uber.org/zap/internal/color
+ go.uber.org/zap/internal/exit
+ go.uber.org/zap/zapcore
+-# golang.org/x/net v0.18.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -197,12 +197,12 @@ golang.org/x/net/trace
+ ## explicit; go 1.18
+ golang.org/x/oauth2
+ golang.org/x/oauth2/internal
+-# golang.org/x/sys v0.14.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-# golang.org/x/term v0.14.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/external-resizer/1-27/CHECKSUMS
+++ b/projects/kubernetes-csi/external-resizer/1-27/CHECKSUMS
@@ -1,2 +1,2 @@
-cb05f08b5873e5fce1048b88bd97dd848544328464768b64a9d5f790361cd725  _output/1-27/bin/external-resizer/linux-amd64/csi-resizer
-4be58b892ed0dec5bd6ad0ae28ceabfc9183d92b3d1ca6ed8126de969d25b413  _output/1-27/bin/external-resizer/linux-arm64/csi-resizer
+a73c82508caf8a3c9eef44001c5f909efe535ac08d913522d93c141c167368e3  _output/1-27/bin/external-resizer/linux-amd64/csi-resizer
+2fb169baa87202c1e4c64658b87758cb12aa9818bb6b52cd595767a864541752  _output/1-27/bin/external-resizer/linux-arm64/csi-resizer

--- a/projects/kubernetes-csi/external-resizer/1-27/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
+++ b/projects/kubernetes-csi/external-resizer/1-27/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
@@ -1,0 +1,3278 @@
+From 6f30bd8a770c0000df2176d1feccf54db95c72f3 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:21:40 +0000
+Subject: [PATCH] Fix CVE CVE-2023-45288 by bumping /x/net to 0.23.0
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |   6 +-
+ go.sum                                        |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/fcntl.go         |   2 +-
+ vendor/golang.org/x/sys/unix/ioctl_linux.go   |   5 +
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  42 ++-
+ vendor/golang.org/x/sys/unix/syscall_bsd.go   |   2 +-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go | 127 ++++++-
+ .../golang.org/x/sys/unix/syscall_openbsd.go  |  14 +
+ .../golang.org/x/sys/unix/syscall_solaris.go  |   2 +-
+ .../x/sys/unix/syscall_zos_s390x.go           |   2 +-
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  92 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  25 ++
+ .../x/sys/unix/zsyscall_openbsd_386.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_386.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_amd64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_mips64.s      |   5 +
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_ppc64.s       |   6 +
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_riscv64.s     |   5 +
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 217 ++++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   6 +-
+ .../x/sys/windows/zsyscall_windows.go         |  28 ++
+ vendor/modules.txt                            |   6 +-
+ 69 files changed, 1451 insertions(+), 210 deletions(-)
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index 408a4aa5..08785a0f 100644
+--- a/go.mod
++++ b/go.mod
+@@ -9,7 +9,7 @@ require (
+ 	github.com/imdario/mergo v0.3.12 // indirect
+ 	github.com/kubernetes-csi/csi-lib-utils v0.17.0
+ 	golang.org/x/oauth2 v0.13.0 // indirect
+-	golang.org/x/term v0.14.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	google.golang.org/appengine v1.6.8 // indirect
+ 	google.golang.org/grpc v1.60.1
+ 	k8s.io/api v0.29.0
+@@ -62,8 +62,8 @@ require (
+ 	go.uber.org/goleak v1.3.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.19.0 // indirect
+-	golang.org/x/net v0.18.0 // indirect
+-	golang.org/x/sys v0.14.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.3.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
+diff --git a/go.sum b/go.sum
+index 0b5edd30..f747ed99 100644
+--- a/go.sum
++++ b/go.sum
+@@ -165,8 +165,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
+-golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.13.0 h1:jDDenyj+WgFtmV3zYVoi8aE2BwtXFLWOA67ZfNWftiY=
+ golang.org/x/oauth2 v0.13.0/go.mod h1:/JMhi4ZRXAf4HG9LiNmxvk+45+96RUlVThiH8FzNBn0=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -181,12 +181,12 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.14.0 h1:LGK9IlZ8T9jvdy6cTdfKUCltatMFOehAQo9SRC46UQ8=
+-golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90d..43557ab7 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984f..3b9f06b9 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c640..ce2e8b40 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 00000000..61075bd1
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86..ce375c8c 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4b..b0e41985 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/fcntl.go b/vendor/golang.org/x/sys/unix/fcntl.go
+index 58c6bfc7..6200876f 100644
+--- a/vendor/golang.org/x/sys/unix/fcntl.go
++++ b/vendor/golang.org/x/sys/unix/fcntl.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build dragonfly || freebsd || linux || netbsd || openbsd
++//go:build dragonfly || freebsd || linux || netbsd
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/ioctl_linux.go b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+index 0d12c085..dbe680ea 100644
+--- a/vendor/golang.org/x/sys/unix/ioctl_linux.go
++++ b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+@@ -231,3 +231,8 @@ func IoctlLoopGetStatus64(fd int) (*LoopInfo64, error) {
+ func IoctlLoopSetStatus64(fd int, value *LoopInfo64) error {
+ 	return ioctlPtr(fd, LOOP_SET_STATUS64, unsafe.Pointer(value))
+ }
++
++// IoctlLoopConfigure configures all loop device parameters in a single step
++func IoctlLoopConfigure(fd int, value *LoopConfig) error {
++	return ioctlPtr(fd, LOOP_CONFIGURE, unsafe.Pointer(value))
++}
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index cbe24150..fdcaa974 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -519,6 +521,7 @@ ccflags="$@"
+ 		$2 ~ /^LOCK_(SH|EX|NB|UN)$/ ||
+ 		$2 ~ /^LO_(KEY|NAME)_SIZE$/ ||
+ 		$2 ~ /^LOOP_(CLR|CTL|GET|SET)_/ ||
++		$2 == "LOOP_CONFIGURE" ||
+ 		$2 ~ /^(AF|SOCK|SO|SOL|IPPROTO|IP|IPV6|TCP|MCAST|EVFILT|NOTE|SHUT|PROT|MAP|MREMAP|MFD|T?PACKET|MSG|SCM|MCL|DT|MADV|PR|LOCAL|TCPOPT|UDP)_/ ||
+ 		$2 ~ /^NFC_(GENL|PROTO|COMM|RF|SE|DIRECTION|LLCP|SOCKPROTO)_/ ||
+ 		$2 ~ /^NFC_.*_(MAX)?SIZE$/ ||
+@@ -560,7 +563,7 @@ ccflags="$@"
+ 		$2 ~ /^RLIMIT_(AS|CORE|CPU|DATA|FSIZE|LOCKS|MEMLOCK|MSGQUEUE|NICE|NOFILE|NPROC|RSS|RTPRIO|RTTIME|SIGPENDING|STACK)|RLIM_INFINITY/ ||
+ 		$2 ~ /^PRIO_(PROCESS|PGRP|USER)/ ||
+ 		$2 ~ /^CLONE_[A-Z_]+/ ||
+-		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+)$/ &&
++		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+|BPF_F_LINK)$/ &&
+ 		$2 ~ /^(BPF|DLT)_/ ||
+ 		$2 ~ /^AUDIT_/ ||
+ 		$2 ~ /^(CLOCK|TIMER)_/ ||
+@@ -581,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -602,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_bsd.go b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+index 6f328e3a..a00c3e54 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_bsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+@@ -316,7 +316,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ //sys	recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Socklen) (n int, err error)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc6993..2f0fa76e 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4d..2b57e0f7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index a5e1c10e..5682e262 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -61,15 +61,23 @@ func FanotifyMark(fd int, flags uint, mask uint64, dirFd int, pathname string) (
+ }
+ 
+ //sys	fchmodat(dirfd int, path string, mode uint32) (err error)
+-
+-func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+-	// Linux fchmodat doesn't support the flags parameter. Mimick glibc's behavior
+-	// and check the flags. Otherwise the mode would be applied to the symlink
+-	// destination which is not what the user expects.
+-	if flags&^AT_SYMLINK_NOFOLLOW != 0 {
+-		return EINVAL
+-	} else if flags&AT_SYMLINK_NOFOLLOW != 0 {
+-		return EOPNOTSUPP
++//sys	fchmodat2(dirfd int, path string, mode uint32, flags int) (err error)
++
++func Fchmodat(dirfd int, path string, mode uint32, flags int) error {
++	// Linux fchmodat doesn't support the flags parameter, but fchmodat2 does.
++	// Try fchmodat2 if flags are specified.
++	if flags != 0 {
++		err := fchmodat2(dirfd, path, mode, flags)
++		if err == ENOSYS {
++			// fchmodat2 isn't available. If the flags are known to be valid,
++			// return EOPNOTSUPP to indicate that fchmodat doesn't support them.
++			if flags&^(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EINVAL
++			} else if flags&(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EOPNOTSUPP
++			}
++		}
++		return err
+ 	}
+ 	return fchmodat(dirfd, path, mode)
+ }
+@@ -1302,7 +1310,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 			return "", err
+ 		}
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func GetsockoptTpacketStats(fd, level, opt int) (*TpacketStats, error) {
+@@ -1841,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_openbsd.go b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+index d2882ee0..b25343c7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_openbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+@@ -166,6 +166,20 @@ func Getresgid() (rgid, egid, sgid int) {
+ 
+ //sys	sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) = SYS___SYSCTL
+ 
++//sys	fcntl(fd int, cmd int, arg int) (n int, err error)
++//sys	fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) = SYS_FCNTL
++
++// FcntlInt performs a fcntl syscall on fd with the provided command and argument.
++func FcntlInt(fd uintptr, cmd, arg int) (int, error) {
++	return fcntl(int(fd), cmd, arg)
++}
++
++// FcntlFlock performs a fcntl syscall for the F_GETLK, F_SETLK or F_SETLKW command.
++func FcntlFlock(fd uintptr, cmd int, lk *Flock_t) error {
++	_, err := fcntlPtr(int(fd), cmd, unsafe.Pointer(lk))
++	return err
++}
++
+ //sys	ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error)
+ 
+ func Ppoll(fds []PollFd, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_solaris.go b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+index 60c8142d..21974af0 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
++++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+@@ -158,7 +158,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ const ImplementsGetwd = true
+diff --git a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+index d99d05f1..b473038c 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+@@ -1104,7 +1104,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 		return "", err
+ 	}
+ 
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func Recvmsg(fd int, p, oob []byte, flags int) (n, oobn int, recvflags int, from Sockaddr, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index 9c00cbf5..36bf8399 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -486,7 +486,6 @@ const (
+ 	BPF_F_ANY_ALIGNMENT                         = 0x2
+ 	BPF_F_BEFORE                                = 0x8
+ 	BPF_F_ID                                    = 0x20
+-	BPF_F_LINK                                  = 0x2000
+ 	BPF_F_NETFILTER_IP_DEFRAG                   = 0x1
+ 	BPF_F_QUERY_EFFECTIVE                       = 0x1
+ 	BPF_F_REPLACE                               = 0x4
+@@ -1786,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -1802,6 +1803,7 @@ const (
+ 	LOCK_SH                                     = 0x1
+ 	LOCK_UN                                     = 0x8
+ 	LOOP_CLR_FD                                 = 0x4c01
++	LOOP_CONFIGURE                              = 0x4c0a
+ 	LOOP_CTL_ADD                                = 0x4c80
+ 	LOOP_CTL_GET_FREE                           = 0x4c82
+ 	LOOP_CTL_REMOVE                             = 0x4c81
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821c..42ff8c3c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e411..dca43600 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c6398556..5cca668a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e2..d8cae6d1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09..28e39afd 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642..cd66e92c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d7..c1595eba 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0..ee9456b0 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84..8cfca81e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d..60b0deb3 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc7..f90aa728 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e..ba9e0150 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813e..07cdfd6e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4e..2f1dd214 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994d..f40519d9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index faca7a55..87d8612a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -37,6 +37,21 @@ func fchmodat(dirfd int, path string, mode uint32) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fchmodat2(dirfd int, path string, mode uint32, flags int) (err error) {
++	var _p0 *byte
++	_p0, err = BytePtrFromString(path)
++	if err != nil {
++		return
++	}
++	_, _, e1 := Syscall6(SYS_FCHMODAT2, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	_, _, e1 := Syscall(SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -891,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index 88bfc288..9dc42410 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+index 4cbeff17..41b56173 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index b8a67b99..0d3a0751 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+index 1123f275..4019a656 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index af50a65c..c39f7776 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+index 82badae3..ac4af24f 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 8fb4ff36..57571d07 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+index 24d7eecb..f77d5321 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index f469a83e..e62963e6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+index 9a498a06..fae140b6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index c26ca2e1..00831354 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+index 1f224aa4..9d1e0ff0 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+@@ -213,6 +213,12 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	CALL	libc_fcntl(SB)
++	RET
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	CALL	libc_ppoll(SB)
+ 	RET
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index bcc920dd..79029ed5 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+index 87a79c70..da115f9a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbd..0cc3ce49 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc250..856d92d6 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf246..8d467094 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e..edc17324 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77..445eba20 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362e..adba01bc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4f..014c4e9c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca8..ccc97d74 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d3..ec2b64a9 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e374..21a839e3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c..c11121ec 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e59..909b631f 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195..e49bed16 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943b..66017d2d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc5..47bab18d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index 997bcd55..eff6bcde 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -2671,6 +2735,7 @@ const (
+ 	BPF_PROG_TYPE_LSM                          = 0x1d
+ 	BPF_PROG_TYPE_SK_LOOKUP                    = 0x1e
+ 	BPF_PROG_TYPE_SYSCALL                      = 0x1f
++	BPF_PROG_TYPE_NETFILTER                    = 0x20
+ 	BPF_CGROUP_INET_INGRESS                    = 0x0
+ 	BPF_CGROUP_INET_EGRESS                     = 0x1
+ 	BPF_CGROUP_INET_SOCK_CREATE                = 0x2
+@@ -2715,6 +2780,11 @@ const (
+ 	BPF_PERF_EVENT                             = 0x29
+ 	BPF_TRACE_KPROBE_MULTI                     = 0x2a
+ 	BPF_LSM_CGROUP                             = 0x2b
++	BPF_STRUCT_OPS                             = 0x2c
++	BPF_NETFILTER                              = 0x2d
++	BPF_TCX_INGRESS                            = 0x2e
++	BPF_TCX_EGRESS                             = 0x2f
++	BPF_TRACE_UPROBE_MULTI                     = 0x30
+ 	BPF_LINK_TYPE_UNSPEC                       = 0x0
+ 	BPF_LINK_TYPE_RAW_TRACEPOINT               = 0x1
+ 	BPF_LINK_TYPE_TRACING                      = 0x2
+@@ -2725,6 +2795,18 @@ const (
+ 	BPF_LINK_TYPE_PERF_EVENT                   = 0x7
+ 	BPF_LINK_TYPE_KPROBE_MULTI                 = 0x8
+ 	BPF_LINK_TYPE_STRUCT_OPS                   = 0x9
++	BPF_LINK_TYPE_NETFILTER                    = 0xa
++	BPF_LINK_TYPE_TCX                          = 0xb
++	BPF_LINK_TYPE_UPROBE_MULTI                 = 0xc
++	BPF_PERF_EVENT_UNSPEC                      = 0x0
++	BPF_PERF_EVENT_UPROBE                      = 0x1
++	BPF_PERF_EVENT_URETPROBE                   = 0x2
++	BPF_PERF_EVENT_KPROBE                      = 0x3
++	BPF_PERF_EVENT_KRETPROBE                   = 0x4
++	BPF_PERF_EVENT_TRACEPOINT                  = 0x5
++	BPF_PERF_EVENT_EVENT                       = 0x6
++	BPF_F_KPROBE_MULTI_RETURN                  = 0x1
++	BPF_F_UPROBE_MULTI_RETURN                  = 0x1
+ 	BPF_ANY                                    = 0x0
+ 	BPF_NOEXIST                                = 0x1
+ 	BPF_EXIST                                  = 0x2
+@@ -2742,6 +2824,8 @@ const (
+ 	BPF_F_MMAPABLE                             = 0x400
+ 	BPF_F_PRESERVE_ELEMS                       = 0x800
+ 	BPF_F_INNER_MAP                            = 0x1000
++	BPF_F_LINK                                 = 0x2000
++	BPF_F_PATH_FD                              = 0x4000
+ 	BPF_STATS_RUN_TIME                         = 0x0
+ 	BPF_STACK_BUILD_ID_EMPTY                   = 0x0
+ 	BPF_STACK_BUILD_ID_VALID                   = 0x1
+@@ -2762,6 +2846,7 @@ const (
+ 	BPF_F_ZERO_CSUM_TX                         = 0x2
+ 	BPF_F_DONT_FRAGMENT                        = 0x4
+ 	BPF_F_SEQ_NUMBER                           = 0x8
++	BPF_F_NO_TUNNEL_KEY                        = 0x10
+ 	BPF_F_TUNINFO_FLAGS                        = 0x10
+ 	BPF_F_INDEX_MASK                           = 0xffffffff
+ 	BPF_F_CURRENT_CPU                          = 0xffffffff
+@@ -2778,6 +2863,8 @@ const (
+ 	BPF_F_ADJ_ROOM_ENCAP_L4_UDP                = 0x10
+ 	BPF_F_ADJ_ROOM_NO_CSUM_RESET               = 0x20
+ 	BPF_F_ADJ_ROOM_ENCAP_L2_ETH                = 0x40
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV4               = 0x80
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV6               = 0x100
+ 	BPF_ADJ_ROOM_ENCAP_L2_MASK                 = 0xff
+ 	BPF_ADJ_ROOM_ENCAP_L2_SHIFT                = 0x38
+ 	BPF_F_SYSCTL_BASE_NAME                     = 0x1
+@@ -2866,6 +2953,8 @@ const (
+ 	BPF_DEVCG_DEV_CHAR                         = 0x2
+ 	BPF_FIB_LOOKUP_DIRECT                      = 0x1
+ 	BPF_FIB_LOOKUP_OUTPUT                      = 0x2
++	BPF_FIB_LOOKUP_SKIP_NEIGH                  = 0x4
++	BPF_FIB_LOOKUP_TBID                        = 0x8
+ 	BPF_FIB_LKUP_RET_SUCCESS                   = 0x0
+ 	BPF_FIB_LKUP_RET_BLACKHOLE                 = 0x1
+ 	BPF_FIB_LKUP_RET_UNREACHABLE               = 0x2
+@@ -2901,6 +2990,7 @@ const (
+ 	BPF_CORE_ENUMVAL_EXISTS                    = 0xa
+ 	BPF_CORE_ENUMVAL_VALUE                     = 0xb
+ 	BPF_CORE_TYPE_MATCHES                      = 0xc
++	BPF_F_TIMER_ABS                            = 0x1
+ )
+ 
+ const (
+@@ -2979,6 +3069,12 @@ type LoopInfo64 struct {
+ 	Encrypt_key      [32]uint8
+ 	Init             [2]uint64
+ }
++type LoopConfig struct {
++	Fd   uint32
++	Size uint32
++	Info LoopInfo64
++	_    [8]uint64
++}
+ 
+ type TIPCSocketAddr struct {
+ 	Ref  uint32
+@@ -3367,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4151,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5102,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5515,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad1925..d4577a42 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index fb6cfd04..6395a031 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -155,6 +154,8 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetModuleFileName(module Handle, filename *uint16, size uint32) (n uint32, err error) = kernel32.GetModuleFileNameW
+ //sys	GetModuleHandleEx(flags uint32, moduleName *uint16, module *Handle) (err error) = kernel32.GetModuleHandleExW
+ //sys	SetDefaultDllDirectories(directoryFlags uint32) (err error)
++//sys	AddDllDirectory(path *uint16) (cookie uintptr, err error) = kernel32.AddDllDirectory
++//sys	RemoveDllDirectory(cookie uintptr) (err error) = kernel32.RemoveDllDirectory
+ //sys	SetDllDirectory(path string) (err error) = kernel32.SetDllDirectoryW
+ //sys	GetVersion() (ver uint32, err error)
+ //sys	FormatMessage(flags uint32, msgsrc uintptr, msgid uint32, langid uint32, buf []uint16, args *byte) (n uint32, err error) = FormatMessageW
+@@ -192,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index db6282e0..e8791c82 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -184,6 +184,7 @@ var (
+ 	procGetAdaptersInfo                                      = modiphlpapi.NewProc("GetAdaptersInfo")
+ 	procGetBestInterfaceEx                                   = modiphlpapi.NewProc("GetBestInterfaceEx")
+ 	procGetIfEntry                                           = modiphlpapi.NewProc("GetIfEntry")
++	procAddDllDirectory                                      = modkernel32.NewProc("AddDllDirectory")
+ 	procAssignProcessToJobObject                             = modkernel32.NewProc("AssignProcessToJobObject")
+ 	procCancelIo                                             = modkernel32.NewProc("CancelIo")
+ 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
+@@ -330,6 +331,7 @@ var (
+ 	procReadProcessMemory                                    = modkernel32.NewProc("ReadProcessMemory")
+ 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
+ 	procRemoveDirectoryW                                     = modkernel32.NewProc("RemoveDirectoryW")
++	procRemoveDllDirectory                                   = modkernel32.NewProc("RemoveDllDirectory")
+ 	procResetEvent                                           = modkernel32.NewProc("ResetEvent")
+ 	procResizePseudoConsole                                  = modkernel32.NewProc("ResizePseudoConsole")
+ 	procResumeThread                                         = modkernel32.NewProc("ResumeThread")
+@@ -340,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -1605,6 +1608,15 @@ func GetIfEntry(pIfRow *MibIfRow) (errcode error) {
+ 	return
+ }
+ 
++func AddDllDirectory(path *uint16) (cookie uintptr, err error) {
++	r0, _, e1 := syscall.Syscall(procAddDllDirectory.Addr(), 1, uintptr(unsafe.Pointer(path)), 0, 0)
++	cookie = uintptr(r0)
++	if cookie == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func AssignProcessToJobObject(job Handle, process Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procAssignProcessToJobObject.Addr(), 2, uintptr(job), uintptr(process), 0)
+ 	if r1 == 0 {
+@@ -2879,6 +2891,14 @@ func RemoveDirectory(path *uint16) (err error) {
+ 	return
+ }
+ 
++func RemoveDllDirectory(cookie uintptr) (err error) {
++	r1, _, e1 := syscall.Syscall(procRemoveDllDirectory.Addr(), 1, uintptr(cookie), 0, 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func ResetEvent(event Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procResetEvent.Addr(), 1, uintptr(event), 0, 0)
+ 	if r1 == 0 {
+@@ -2969,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index f56ffc95..a6f82bb3 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -185,7 +185,7 @@ go.uber.org/zap/internal/bufferpool
+ go.uber.org/zap/internal/color
+ go.uber.org/zap/internal/exit
+ go.uber.org/zap/zapcore
+-# golang.org/x/net v0.18.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -197,12 +197,12 @@ golang.org/x/net/trace
+ ## explicit; go 1.18
+ golang.org/x/oauth2
+ golang.org/x/oauth2/internal
+-# golang.org/x/sys v0.14.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-# golang.org/x/term v0.14.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/external-resizer/1-28/CHECKSUMS
+++ b/projects/kubernetes-csi/external-resizer/1-28/CHECKSUMS
@@ -1,2 +1,2 @@
-cb05f08b5873e5fce1048b88bd97dd848544328464768b64a9d5f790361cd725  _output/1-28/bin/external-resizer/linux-amd64/csi-resizer
-4be58b892ed0dec5bd6ad0ae28ceabfc9183d92b3d1ca6ed8126de969d25b413  _output/1-28/bin/external-resizer/linux-arm64/csi-resizer
+a73c82508caf8a3c9eef44001c5f909efe535ac08d913522d93c141c167368e3  _output/1-28/bin/external-resizer/linux-amd64/csi-resizer
+2fb169baa87202c1e4c64658b87758cb12aa9818bb6b52cd595767a864541752  _output/1-28/bin/external-resizer/linux-arm64/csi-resizer

--- a/projects/kubernetes-csi/external-resizer/1-28/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
+++ b/projects/kubernetes-csi/external-resizer/1-28/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
@@ -1,0 +1,3278 @@
+From 6f30bd8a770c0000df2176d1feccf54db95c72f3 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:21:40 +0000
+Subject: [PATCH] Fix CVE CVE-2023-45288 by bumping /x/net to 0.23.0
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |   6 +-
+ go.sum                                        |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/fcntl.go         |   2 +-
+ vendor/golang.org/x/sys/unix/ioctl_linux.go   |   5 +
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  42 ++-
+ vendor/golang.org/x/sys/unix/syscall_bsd.go   |   2 +-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go | 127 ++++++-
+ .../golang.org/x/sys/unix/syscall_openbsd.go  |  14 +
+ .../golang.org/x/sys/unix/syscall_solaris.go  |   2 +-
+ .../x/sys/unix/syscall_zos_s390x.go           |   2 +-
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  92 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  25 ++
+ .../x/sys/unix/zsyscall_openbsd_386.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_386.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_amd64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_mips64.s      |   5 +
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_ppc64.s       |   6 +
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_riscv64.s     |   5 +
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 217 ++++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   6 +-
+ .../x/sys/windows/zsyscall_windows.go         |  28 ++
+ vendor/modules.txt                            |   6 +-
+ 69 files changed, 1451 insertions(+), 210 deletions(-)
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index 408a4aa5..08785a0f 100644
+--- a/go.mod
++++ b/go.mod
+@@ -9,7 +9,7 @@ require (
+ 	github.com/imdario/mergo v0.3.12 // indirect
+ 	github.com/kubernetes-csi/csi-lib-utils v0.17.0
+ 	golang.org/x/oauth2 v0.13.0 // indirect
+-	golang.org/x/term v0.14.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	google.golang.org/appengine v1.6.8 // indirect
+ 	google.golang.org/grpc v1.60.1
+ 	k8s.io/api v0.29.0
+@@ -62,8 +62,8 @@ require (
+ 	go.uber.org/goleak v1.3.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.19.0 // indirect
+-	golang.org/x/net v0.18.0 // indirect
+-	golang.org/x/sys v0.14.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.3.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
+diff --git a/go.sum b/go.sum
+index 0b5edd30..f747ed99 100644
+--- a/go.sum
++++ b/go.sum
+@@ -165,8 +165,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
+-golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.13.0 h1:jDDenyj+WgFtmV3zYVoi8aE2BwtXFLWOA67ZfNWftiY=
+ golang.org/x/oauth2 v0.13.0/go.mod h1:/JMhi4ZRXAf4HG9LiNmxvk+45+96RUlVThiH8FzNBn0=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -181,12 +181,12 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.14.0 h1:LGK9IlZ8T9jvdy6cTdfKUCltatMFOehAQo9SRC46UQ8=
+-golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90d..43557ab7 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984f..3b9f06b9 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c640..ce2e8b40 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 00000000..61075bd1
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86..ce375c8c 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4b..b0e41985 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/fcntl.go b/vendor/golang.org/x/sys/unix/fcntl.go
+index 58c6bfc7..6200876f 100644
+--- a/vendor/golang.org/x/sys/unix/fcntl.go
++++ b/vendor/golang.org/x/sys/unix/fcntl.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build dragonfly || freebsd || linux || netbsd || openbsd
++//go:build dragonfly || freebsd || linux || netbsd
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/ioctl_linux.go b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+index 0d12c085..dbe680ea 100644
+--- a/vendor/golang.org/x/sys/unix/ioctl_linux.go
++++ b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+@@ -231,3 +231,8 @@ func IoctlLoopGetStatus64(fd int) (*LoopInfo64, error) {
+ func IoctlLoopSetStatus64(fd int, value *LoopInfo64) error {
+ 	return ioctlPtr(fd, LOOP_SET_STATUS64, unsafe.Pointer(value))
+ }
++
++// IoctlLoopConfigure configures all loop device parameters in a single step
++func IoctlLoopConfigure(fd int, value *LoopConfig) error {
++	return ioctlPtr(fd, LOOP_CONFIGURE, unsafe.Pointer(value))
++}
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index cbe24150..fdcaa974 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -519,6 +521,7 @@ ccflags="$@"
+ 		$2 ~ /^LOCK_(SH|EX|NB|UN)$/ ||
+ 		$2 ~ /^LO_(KEY|NAME)_SIZE$/ ||
+ 		$2 ~ /^LOOP_(CLR|CTL|GET|SET)_/ ||
++		$2 == "LOOP_CONFIGURE" ||
+ 		$2 ~ /^(AF|SOCK|SO|SOL|IPPROTO|IP|IPV6|TCP|MCAST|EVFILT|NOTE|SHUT|PROT|MAP|MREMAP|MFD|T?PACKET|MSG|SCM|MCL|DT|MADV|PR|LOCAL|TCPOPT|UDP)_/ ||
+ 		$2 ~ /^NFC_(GENL|PROTO|COMM|RF|SE|DIRECTION|LLCP|SOCKPROTO)_/ ||
+ 		$2 ~ /^NFC_.*_(MAX)?SIZE$/ ||
+@@ -560,7 +563,7 @@ ccflags="$@"
+ 		$2 ~ /^RLIMIT_(AS|CORE|CPU|DATA|FSIZE|LOCKS|MEMLOCK|MSGQUEUE|NICE|NOFILE|NPROC|RSS|RTPRIO|RTTIME|SIGPENDING|STACK)|RLIM_INFINITY/ ||
+ 		$2 ~ /^PRIO_(PROCESS|PGRP|USER)/ ||
+ 		$2 ~ /^CLONE_[A-Z_]+/ ||
+-		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+)$/ &&
++		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+|BPF_F_LINK)$/ &&
+ 		$2 ~ /^(BPF|DLT)_/ ||
+ 		$2 ~ /^AUDIT_/ ||
+ 		$2 ~ /^(CLOCK|TIMER)_/ ||
+@@ -581,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -602,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_bsd.go b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+index 6f328e3a..a00c3e54 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_bsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+@@ -316,7 +316,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ //sys	recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Socklen) (n int, err error)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc6993..2f0fa76e 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4d..2b57e0f7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index a5e1c10e..5682e262 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -61,15 +61,23 @@ func FanotifyMark(fd int, flags uint, mask uint64, dirFd int, pathname string) (
+ }
+ 
+ //sys	fchmodat(dirfd int, path string, mode uint32) (err error)
+-
+-func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+-	// Linux fchmodat doesn't support the flags parameter. Mimick glibc's behavior
+-	// and check the flags. Otherwise the mode would be applied to the symlink
+-	// destination which is not what the user expects.
+-	if flags&^AT_SYMLINK_NOFOLLOW != 0 {
+-		return EINVAL
+-	} else if flags&AT_SYMLINK_NOFOLLOW != 0 {
+-		return EOPNOTSUPP
++//sys	fchmodat2(dirfd int, path string, mode uint32, flags int) (err error)
++
++func Fchmodat(dirfd int, path string, mode uint32, flags int) error {
++	// Linux fchmodat doesn't support the flags parameter, but fchmodat2 does.
++	// Try fchmodat2 if flags are specified.
++	if flags != 0 {
++		err := fchmodat2(dirfd, path, mode, flags)
++		if err == ENOSYS {
++			// fchmodat2 isn't available. If the flags are known to be valid,
++			// return EOPNOTSUPP to indicate that fchmodat doesn't support them.
++			if flags&^(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EINVAL
++			} else if flags&(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EOPNOTSUPP
++			}
++		}
++		return err
+ 	}
+ 	return fchmodat(dirfd, path, mode)
+ }
+@@ -1302,7 +1310,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 			return "", err
+ 		}
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func GetsockoptTpacketStats(fd, level, opt int) (*TpacketStats, error) {
+@@ -1841,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_openbsd.go b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+index d2882ee0..b25343c7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_openbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+@@ -166,6 +166,20 @@ func Getresgid() (rgid, egid, sgid int) {
+ 
+ //sys	sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) = SYS___SYSCTL
+ 
++//sys	fcntl(fd int, cmd int, arg int) (n int, err error)
++//sys	fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) = SYS_FCNTL
++
++// FcntlInt performs a fcntl syscall on fd with the provided command and argument.
++func FcntlInt(fd uintptr, cmd, arg int) (int, error) {
++	return fcntl(int(fd), cmd, arg)
++}
++
++// FcntlFlock performs a fcntl syscall for the F_GETLK, F_SETLK or F_SETLKW command.
++func FcntlFlock(fd uintptr, cmd int, lk *Flock_t) error {
++	_, err := fcntlPtr(int(fd), cmd, unsafe.Pointer(lk))
++	return err
++}
++
+ //sys	ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error)
+ 
+ func Ppoll(fds []PollFd, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_solaris.go b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+index 60c8142d..21974af0 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
++++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+@@ -158,7 +158,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ const ImplementsGetwd = true
+diff --git a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+index d99d05f1..b473038c 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+@@ -1104,7 +1104,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 		return "", err
+ 	}
+ 
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func Recvmsg(fd int, p, oob []byte, flags int) (n, oobn int, recvflags int, from Sockaddr, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index 9c00cbf5..36bf8399 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -486,7 +486,6 @@ const (
+ 	BPF_F_ANY_ALIGNMENT                         = 0x2
+ 	BPF_F_BEFORE                                = 0x8
+ 	BPF_F_ID                                    = 0x20
+-	BPF_F_LINK                                  = 0x2000
+ 	BPF_F_NETFILTER_IP_DEFRAG                   = 0x1
+ 	BPF_F_QUERY_EFFECTIVE                       = 0x1
+ 	BPF_F_REPLACE                               = 0x4
+@@ -1786,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -1802,6 +1803,7 @@ const (
+ 	LOCK_SH                                     = 0x1
+ 	LOCK_UN                                     = 0x8
+ 	LOOP_CLR_FD                                 = 0x4c01
++	LOOP_CONFIGURE                              = 0x4c0a
+ 	LOOP_CTL_ADD                                = 0x4c80
+ 	LOOP_CTL_GET_FREE                           = 0x4c82
+ 	LOOP_CTL_REMOVE                             = 0x4c81
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821c..42ff8c3c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e411..dca43600 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c6398556..5cca668a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e2..d8cae6d1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09..28e39afd 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642..cd66e92c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d7..c1595eba 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0..ee9456b0 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84..8cfca81e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d..60b0deb3 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc7..f90aa728 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e..ba9e0150 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813e..07cdfd6e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4e..2f1dd214 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994d..f40519d9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index faca7a55..87d8612a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -37,6 +37,21 @@ func fchmodat(dirfd int, path string, mode uint32) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fchmodat2(dirfd int, path string, mode uint32, flags int) (err error) {
++	var _p0 *byte
++	_p0, err = BytePtrFromString(path)
++	if err != nil {
++		return
++	}
++	_, _, e1 := Syscall6(SYS_FCHMODAT2, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	_, _, e1 := Syscall(SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -891,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index 88bfc288..9dc42410 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+index 4cbeff17..41b56173 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index b8a67b99..0d3a0751 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+index 1123f275..4019a656 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index af50a65c..c39f7776 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+index 82badae3..ac4af24f 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 8fb4ff36..57571d07 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+index 24d7eecb..f77d5321 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index f469a83e..e62963e6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+index 9a498a06..fae140b6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index c26ca2e1..00831354 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+index 1f224aa4..9d1e0ff0 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+@@ -213,6 +213,12 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	CALL	libc_fcntl(SB)
++	RET
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	CALL	libc_ppoll(SB)
+ 	RET
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index bcc920dd..79029ed5 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+index 87a79c70..da115f9a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbd..0cc3ce49 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc250..856d92d6 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf246..8d467094 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e..edc17324 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77..445eba20 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362e..adba01bc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4f..014c4e9c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca8..ccc97d74 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d3..ec2b64a9 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e374..21a839e3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c..c11121ec 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e59..909b631f 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195..e49bed16 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943b..66017d2d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc5..47bab18d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index 997bcd55..eff6bcde 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -2671,6 +2735,7 @@ const (
+ 	BPF_PROG_TYPE_LSM                          = 0x1d
+ 	BPF_PROG_TYPE_SK_LOOKUP                    = 0x1e
+ 	BPF_PROG_TYPE_SYSCALL                      = 0x1f
++	BPF_PROG_TYPE_NETFILTER                    = 0x20
+ 	BPF_CGROUP_INET_INGRESS                    = 0x0
+ 	BPF_CGROUP_INET_EGRESS                     = 0x1
+ 	BPF_CGROUP_INET_SOCK_CREATE                = 0x2
+@@ -2715,6 +2780,11 @@ const (
+ 	BPF_PERF_EVENT                             = 0x29
+ 	BPF_TRACE_KPROBE_MULTI                     = 0x2a
+ 	BPF_LSM_CGROUP                             = 0x2b
++	BPF_STRUCT_OPS                             = 0x2c
++	BPF_NETFILTER                              = 0x2d
++	BPF_TCX_INGRESS                            = 0x2e
++	BPF_TCX_EGRESS                             = 0x2f
++	BPF_TRACE_UPROBE_MULTI                     = 0x30
+ 	BPF_LINK_TYPE_UNSPEC                       = 0x0
+ 	BPF_LINK_TYPE_RAW_TRACEPOINT               = 0x1
+ 	BPF_LINK_TYPE_TRACING                      = 0x2
+@@ -2725,6 +2795,18 @@ const (
+ 	BPF_LINK_TYPE_PERF_EVENT                   = 0x7
+ 	BPF_LINK_TYPE_KPROBE_MULTI                 = 0x8
+ 	BPF_LINK_TYPE_STRUCT_OPS                   = 0x9
++	BPF_LINK_TYPE_NETFILTER                    = 0xa
++	BPF_LINK_TYPE_TCX                          = 0xb
++	BPF_LINK_TYPE_UPROBE_MULTI                 = 0xc
++	BPF_PERF_EVENT_UNSPEC                      = 0x0
++	BPF_PERF_EVENT_UPROBE                      = 0x1
++	BPF_PERF_EVENT_URETPROBE                   = 0x2
++	BPF_PERF_EVENT_KPROBE                      = 0x3
++	BPF_PERF_EVENT_KRETPROBE                   = 0x4
++	BPF_PERF_EVENT_TRACEPOINT                  = 0x5
++	BPF_PERF_EVENT_EVENT                       = 0x6
++	BPF_F_KPROBE_MULTI_RETURN                  = 0x1
++	BPF_F_UPROBE_MULTI_RETURN                  = 0x1
+ 	BPF_ANY                                    = 0x0
+ 	BPF_NOEXIST                                = 0x1
+ 	BPF_EXIST                                  = 0x2
+@@ -2742,6 +2824,8 @@ const (
+ 	BPF_F_MMAPABLE                             = 0x400
+ 	BPF_F_PRESERVE_ELEMS                       = 0x800
+ 	BPF_F_INNER_MAP                            = 0x1000
++	BPF_F_LINK                                 = 0x2000
++	BPF_F_PATH_FD                              = 0x4000
+ 	BPF_STATS_RUN_TIME                         = 0x0
+ 	BPF_STACK_BUILD_ID_EMPTY                   = 0x0
+ 	BPF_STACK_BUILD_ID_VALID                   = 0x1
+@@ -2762,6 +2846,7 @@ const (
+ 	BPF_F_ZERO_CSUM_TX                         = 0x2
+ 	BPF_F_DONT_FRAGMENT                        = 0x4
+ 	BPF_F_SEQ_NUMBER                           = 0x8
++	BPF_F_NO_TUNNEL_KEY                        = 0x10
+ 	BPF_F_TUNINFO_FLAGS                        = 0x10
+ 	BPF_F_INDEX_MASK                           = 0xffffffff
+ 	BPF_F_CURRENT_CPU                          = 0xffffffff
+@@ -2778,6 +2863,8 @@ const (
+ 	BPF_F_ADJ_ROOM_ENCAP_L4_UDP                = 0x10
+ 	BPF_F_ADJ_ROOM_NO_CSUM_RESET               = 0x20
+ 	BPF_F_ADJ_ROOM_ENCAP_L2_ETH                = 0x40
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV4               = 0x80
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV6               = 0x100
+ 	BPF_ADJ_ROOM_ENCAP_L2_MASK                 = 0xff
+ 	BPF_ADJ_ROOM_ENCAP_L2_SHIFT                = 0x38
+ 	BPF_F_SYSCTL_BASE_NAME                     = 0x1
+@@ -2866,6 +2953,8 @@ const (
+ 	BPF_DEVCG_DEV_CHAR                         = 0x2
+ 	BPF_FIB_LOOKUP_DIRECT                      = 0x1
+ 	BPF_FIB_LOOKUP_OUTPUT                      = 0x2
++	BPF_FIB_LOOKUP_SKIP_NEIGH                  = 0x4
++	BPF_FIB_LOOKUP_TBID                        = 0x8
+ 	BPF_FIB_LKUP_RET_SUCCESS                   = 0x0
+ 	BPF_FIB_LKUP_RET_BLACKHOLE                 = 0x1
+ 	BPF_FIB_LKUP_RET_UNREACHABLE               = 0x2
+@@ -2901,6 +2990,7 @@ const (
+ 	BPF_CORE_ENUMVAL_EXISTS                    = 0xa
+ 	BPF_CORE_ENUMVAL_VALUE                     = 0xb
+ 	BPF_CORE_TYPE_MATCHES                      = 0xc
++	BPF_F_TIMER_ABS                            = 0x1
+ )
+ 
+ const (
+@@ -2979,6 +3069,12 @@ type LoopInfo64 struct {
+ 	Encrypt_key      [32]uint8
+ 	Init             [2]uint64
+ }
++type LoopConfig struct {
++	Fd   uint32
++	Size uint32
++	Info LoopInfo64
++	_    [8]uint64
++}
+ 
+ type TIPCSocketAddr struct {
+ 	Ref  uint32
+@@ -3367,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4151,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5102,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5515,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad1925..d4577a42 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index fb6cfd04..6395a031 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -155,6 +154,8 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetModuleFileName(module Handle, filename *uint16, size uint32) (n uint32, err error) = kernel32.GetModuleFileNameW
+ //sys	GetModuleHandleEx(flags uint32, moduleName *uint16, module *Handle) (err error) = kernel32.GetModuleHandleExW
+ //sys	SetDefaultDllDirectories(directoryFlags uint32) (err error)
++//sys	AddDllDirectory(path *uint16) (cookie uintptr, err error) = kernel32.AddDllDirectory
++//sys	RemoveDllDirectory(cookie uintptr) (err error) = kernel32.RemoveDllDirectory
+ //sys	SetDllDirectory(path string) (err error) = kernel32.SetDllDirectoryW
+ //sys	GetVersion() (ver uint32, err error)
+ //sys	FormatMessage(flags uint32, msgsrc uintptr, msgid uint32, langid uint32, buf []uint16, args *byte) (n uint32, err error) = FormatMessageW
+@@ -192,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index db6282e0..e8791c82 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -184,6 +184,7 @@ var (
+ 	procGetAdaptersInfo                                      = modiphlpapi.NewProc("GetAdaptersInfo")
+ 	procGetBestInterfaceEx                                   = modiphlpapi.NewProc("GetBestInterfaceEx")
+ 	procGetIfEntry                                           = modiphlpapi.NewProc("GetIfEntry")
++	procAddDllDirectory                                      = modkernel32.NewProc("AddDllDirectory")
+ 	procAssignProcessToJobObject                             = modkernel32.NewProc("AssignProcessToJobObject")
+ 	procCancelIo                                             = modkernel32.NewProc("CancelIo")
+ 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
+@@ -330,6 +331,7 @@ var (
+ 	procReadProcessMemory                                    = modkernel32.NewProc("ReadProcessMemory")
+ 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
+ 	procRemoveDirectoryW                                     = modkernel32.NewProc("RemoveDirectoryW")
++	procRemoveDllDirectory                                   = modkernel32.NewProc("RemoveDllDirectory")
+ 	procResetEvent                                           = modkernel32.NewProc("ResetEvent")
+ 	procResizePseudoConsole                                  = modkernel32.NewProc("ResizePseudoConsole")
+ 	procResumeThread                                         = modkernel32.NewProc("ResumeThread")
+@@ -340,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -1605,6 +1608,15 @@ func GetIfEntry(pIfRow *MibIfRow) (errcode error) {
+ 	return
+ }
+ 
++func AddDllDirectory(path *uint16) (cookie uintptr, err error) {
++	r0, _, e1 := syscall.Syscall(procAddDllDirectory.Addr(), 1, uintptr(unsafe.Pointer(path)), 0, 0)
++	cookie = uintptr(r0)
++	if cookie == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func AssignProcessToJobObject(job Handle, process Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procAssignProcessToJobObject.Addr(), 2, uintptr(job), uintptr(process), 0)
+ 	if r1 == 0 {
+@@ -2879,6 +2891,14 @@ func RemoveDirectory(path *uint16) (err error) {
+ 	return
+ }
+ 
++func RemoveDllDirectory(cookie uintptr) (err error) {
++	r1, _, e1 := syscall.Syscall(procRemoveDllDirectory.Addr(), 1, uintptr(cookie), 0, 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func ResetEvent(event Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procResetEvent.Addr(), 1, uintptr(event), 0, 0)
+ 	if r1 == 0 {
+@@ -2969,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index f56ffc95..a6f82bb3 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -185,7 +185,7 @@ go.uber.org/zap/internal/bufferpool
+ go.uber.org/zap/internal/color
+ go.uber.org/zap/internal/exit
+ go.uber.org/zap/zapcore
+-# golang.org/x/net v0.18.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -197,12 +197,12 @@ golang.org/x/net/trace
+ ## explicit; go 1.18
+ golang.org/x/oauth2
+ golang.org/x/oauth2/internal
+-# golang.org/x/sys v0.14.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-# golang.org/x/term v0.14.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/external-resizer/1-29/CHECKSUMS
+++ b/projects/kubernetes-csi/external-resizer/1-29/CHECKSUMS
@@ -1,2 +1,2 @@
-cb05f08b5873e5fce1048b88bd97dd848544328464768b64a9d5f790361cd725  _output/1-29/bin/external-resizer/linux-amd64/csi-resizer
-4be58b892ed0dec5bd6ad0ae28ceabfc9183d92b3d1ca6ed8126de969d25b413  _output/1-29/bin/external-resizer/linux-arm64/csi-resizer
+a73c82508caf8a3c9eef44001c5f909efe535ac08d913522d93c141c167368e3  _output/1-29/bin/external-resizer/linux-amd64/csi-resizer
+2fb169baa87202c1e4c64658b87758cb12aa9818bb6b52cd595767a864541752  _output/1-29/bin/external-resizer/linux-arm64/csi-resizer

--- a/projects/kubernetes-csi/external-resizer/1-29/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
+++ b/projects/kubernetes-csi/external-resizer/1-29/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
@@ -1,0 +1,3278 @@
+From 6f30bd8a770c0000df2176d1feccf54db95c72f3 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:21:40 +0000
+Subject: [PATCH] Fix CVE CVE-2023-45288 by bumping /x/net to 0.23.0
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |   6 +-
+ go.sum                                        |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/fcntl.go         |   2 +-
+ vendor/golang.org/x/sys/unix/ioctl_linux.go   |   5 +
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  42 ++-
+ vendor/golang.org/x/sys/unix/syscall_bsd.go   |   2 +-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go | 127 ++++++-
+ .../golang.org/x/sys/unix/syscall_openbsd.go  |  14 +
+ .../golang.org/x/sys/unix/syscall_solaris.go  |   2 +-
+ .../x/sys/unix/syscall_zos_s390x.go           |   2 +-
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  92 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  25 ++
+ .../x/sys/unix/zsyscall_openbsd_386.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_386.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_amd64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_mips64.s      |   5 +
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_ppc64.s       |   6 +
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_riscv64.s     |   5 +
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 217 ++++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   6 +-
+ .../x/sys/windows/zsyscall_windows.go         |  28 ++
+ vendor/modules.txt                            |   6 +-
+ 69 files changed, 1451 insertions(+), 210 deletions(-)
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index 408a4aa5..08785a0f 100644
+--- a/go.mod
++++ b/go.mod
+@@ -9,7 +9,7 @@ require (
+ 	github.com/imdario/mergo v0.3.12 // indirect
+ 	github.com/kubernetes-csi/csi-lib-utils v0.17.0
+ 	golang.org/x/oauth2 v0.13.0 // indirect
+-	golang.org/x/term v0.14.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	google.golang.org/appengine v1.6.8 // indirect
+ 	google.golang.org/grpc v1.60.1
+ 	k8s.io/api v0.29.0
+@@ -62,8 +62,8 @@ require (
+ 	go.uber.org/goleak v1.3.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.19.0 // indirect
+-	golang.org/x/net v0.18.0 // indirect
+-	golang.org/x/sys v0.14.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.3.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
+diff --git a/go.sum b/go.sum
+index 0b5edd30..f747ed99 100644
+--- a/go.sum
++++ b/go.sum
+@@ -165,8 +165,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
+-golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.13.0 h1:jDDenyj+WgFtmV3zYVoi8aE2BwtXFLWOA67ZfNWftiY=
+ golang.org/x/oauth2 v0.13.0/go.mod h1:/JMhi4ZRXAf4HG9LiNmxvk+45+96RUlVThiH8FzNBn0=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -181,12 +181,12 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.14.0 h1:LGK9IlZ8T9jvdy6cTdfKUCltatMFOehAQo9SRC46UQ8=
+-golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90d..43557ab7 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984f..3b9f06b9 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c640..ce2e8b40 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 00000000..61075bd1
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86..ce375c8c 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4b..b0e41985 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/fcntl.go b/vendor/golang.org/x/sys/unix/fcntl.go
+index 58c6bfc7..6200876f 100644
+--- a/vendor/golang.org/x/sys/unix/fcntl.go
++++ b/vendor/golang.org/x/sys/unix/fcntl.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build dragonfly || freebsd || linux || netbsd || openbsd
++//go:build dragonfly || freebsd || linux || netbsd
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/ioctl_linux.go b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+index 0d12c085..dbe680ea 100644
+--- a/vendor/golang.org/x/sys/unix/ioctl_linux.go
++++ b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+@@ -231,3 +231,8 @@ func IoctlLoopGetStatus64(fd int) (*LoopInfo64, error) {
+ func IoctlLoopSetStatus64(fd int, value *LoopInfo64) error {
+ 	return ioctlPtr(fd, LOOP_SET_STATUS64, unsafe.Pointer(value))
+ }
++
++// IoctlLoopConfigure configures all loop device parameters in a single step
++func IoctlLoopConfigure(fd int, value *LoopConfig) error {
++	return ioctlPtr(fd, LOOP_CONFIGURE, unsafe.Pointer(value))
++}
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index cbe24150..fdcaa974 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -519,6 +521,7 @@ ccflags="$@"
+ 		$2 ~ /^LOCK_(SH|EX|NB|UN)$/ ||
+ 		$2 ~ /^LO_(KEY|NAME)_SIZE$/ ||
+ 		$2 ~ /^LOOP_(CLR|CTL|GET|SET)_/ ||
++		$2 == "LOOP_CONFIGURE" ||
+ 		$2 ~ /^(AF|SOCK|SO|SOL|IPPROTO|IP|IPV6|TCP|MCAST|EVFILT|NOTE|SHUT|PROT|MAP|MREMAP|MFD|T?PACKET|MSG|SCM|MCL|DT|MADV|PR|LOCAL|TCPOPT|UDP)_/ ||
+ 		$2 ~ /^NFC_(GENL|PROTO|COMM|RF|SE|DIRECTION|LLCP|SOCKPROTO)_/ ||
+ 		$2 ~ /^NFC_.*_(MAX)?SIZE$/ ||
+@@ -560,7 +563,7 @@ ccflags="$@"
+ 		$2 ~ /^RLIMIT_(AS|CORE|CPU|DATA|FSIZE|LOCKS|MEMLOCK|MSGQUEUE|NICE|NOFILE|NPROC|RSS|RTPRIO|RTTIME|SIGPENDING|STACK)|RLIM_INFINITY/ ||
+ 		$2 ~ /^PRIO_(PROCESS|PGRP|USER)/ ||
+ 		$2 ~ /^CLONE_[A-Z_]+/ ||
+-		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+)$/ &&
++		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+|BPF_F_LINK)$/ &&
+ 		$2 ~ /^(BPF|DLT)_/ ||
+ 		$2 ~ /^AUDIT_/ ||
+ 		$2 ~ /^(CLOCK|TIMER)_/ ||
+@@ -581,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -602,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_bsd.go b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+index 6f328e3a..a00c3e54 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_bsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+@@ -316,7 +316,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ //sys	recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Socklen) (n int, err error)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc6993..2f0fa76e 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4d..2b57e0f7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index a5e1c10e..5682e262 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -61,15 +61,23 @@ func FanotifyMark(fd int, flags uint, mask uint64, dirFd int, pathname string) (
+ }
+ 
+ //sys	fchmodat(dirfd int, path string, mode uint32) (err error)
+-
+-func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+-	// Linux fchmodat doesn't support the flags parameter. Mimick glibc's behavior
+-	// and check the flags. Otherwise the mode would be applied to the symlink
+-	// destination which is not what the user expects.
+-	if flags&^AT_SYMLINK_NOFOLLOW != 0 {
+-		return EINVAL
+-	} else if flags&AT_SYMLINK_NOFOLLOW != 0 {
+-		return EOPNOTSUPP
++//sys	fchmodat2(dirfd int, path string, mode uint32, flags int) (err error)
++
++func Fchmodat(dirfd int, path string, mode uint32, flags int) error {
++	// Linux fchmodat doesn't support the flags parameter, but fchmodat2 does.
++	// Try fchmodat2 if flags are specified.
++	if flags != 0 {
++		err := fchmodat2(dirfd, path, mode, flags)
++		if err == ENOSYS {
++			// fchmodat2 isn't available. If the flags are known to be valid,
++			// return EOPNOTSUPP to indicate that fchmodat doesn't support them.
++			if flags&^(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EINVAL
++			} else if flags&(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EOPNOTSUPP
++			}
++		}
++		return err
+ 	}
+ 	return fchmodat(dirfd, path, mode)
+ }
+@@ -1302,7 +1310,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 			return "", err
+ 		}
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func GetsockoptTpacketStats(fd, level, opt int) (*TpacketStats, error) {
+@@ -1841,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_openbsd.go b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+index d2882ee0..b25343c7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_openbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+@@ -166,6 +166,20 @@ func Getresgid() (rgid, egid, sgid int) {
+ 
+ //sys	sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) = SYS___SYSCTL
+ 
++//sys	fcntl(fd int, cmd int, arg int) (n int, err error)
++//sys	fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) = SYS_FCNTL
++
++// FcntlInt performs a fcntl syscall on fd with the provided command and argument.
++func FcntlInt(fd uintptr, cmd, arg int) (int, error) {
++	return fcntl(int(fd), cmd, arg)
++}
++
++// FcntlFlock performs a fcntl syscall for the F_GETLK, F_SETLK or F_SETLKW command.
++func FcntlFlock(fd uintptr, cmd int, lk *Flock_t) error {
++	_, err := fcntlPtr(int(fd), cmd, unsafe.Pointer(lk))
++	return err
++}
++
+ //sys	ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error)
+ 
+ func Ppoll(fds []PollFd, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_solaris.go b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+index 60c8142d..21974af0 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
++++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+@@ -158,7 +158,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ const ImplementsGetwd = true
+diff --git a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+index d99d05f1..b473038c 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+@@ -1104,7 +1104,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 		return "", err
+ 	}
+ 
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func Recvmsg(fd int, p, oob []byte, flags int) (n, oobn int, recvflags int, from Sockaddr, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index 9c00cbf5..36bf8399 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -486,7 +486,6 @@ const (
+ 	BPF_F_ANY_ALIGNMENT                         = 0x2
+ 	BPF_F_BEFORE                                = 0x8
+ 	BPF_F_ID                                    = 0x20
+-	BPF_F_LINK                                  = 0x2000
+ 	BPF_F_NETFILTER_IP_DEFRAG                   = 0x1
+ 	BPF_F_QUERY_EFFECTIVE                       = 0x1
+ 	BPF_F_REPLACE                               = 0x4
+@@ -1786,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -1802,6 +1803,7 @@ const (
+ 	LOCK_SH                                     = 0x1
+ 	LOCK_UN                                     = 0x8
+ 	LOOP_CLR_FD                                 = 0x4c01
++	LOOP_CONFIGURE                              = 0x4c0a
+ 	LOOP_CTL_ADD                                = 0x4c80
+ 	LOOP_CTL_GET_FREE                           = 0x4c82
+ 	LOOP_CTL_REMOVE                             = 0x4c81
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821c..42ff8c3c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e411..dca43600 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c6398556..5cca668a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e2..d8cae6d1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09..28e39afd 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642..cd66e92c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d7..c1595eba 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0..ee9456b0 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84..8cfca81e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d..60b0deb3 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc7..f90aa728 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e..ba9e0150 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813e..07cdfd6e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4e..2f1dd214 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994d..f40519d9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index faca7a55..87d8612a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -37,6 +37,21 @@ func fchmodat(dirfd int, path string, mode uint32) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fchmodat2(dirfd int, path string, mode uint32, flags int) (err error) {
++	var _p0 *byte
++	_p0, err = BytePtrFromString(path)
++	if err != nil {
++		return
++	}
++	_, _, e1 := Syscall6(SYS_FCHMODAT2, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	_, _, e1 := Syscall(SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -891,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index 88bfc288..9dc42410 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+index 4cbeff17..41b56173 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index b8a67b99..0d3a0751 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+index 1123f275..4019a656 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index af50a65c..c39f7776 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+index 82badae3..ac4af24f 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 8fb4ff36..57571d07 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+index 24d7eecb..f77d5321 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index f469a83e..e62963e6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+index 9a498a06..fae140b6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index c26ca2e1..00831354 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+index 1f224aa4..9d1e0ff0 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+@@ -213,6 +213,12 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	CALL	libc_fcntl(SB)
++	RET
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	CALL	libc_ppoll(SB)
+ 	RET
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index bcc920dd..79029ed5 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+index 87a79c70..da115f9a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbd..0cc3ce49 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc250..856d92d6 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf246..8d467094 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e..edc17324 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77..445eba20 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362e..adba01bc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4f..014c4e9c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca8..ccc97d74 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d3..ec2b64a9 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e374..21a839e3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c..c11121ec 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e59..909b631f 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195..e49bed16 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943b..66017d2d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc5..47bab18d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index 997bcd55..eff6bcde 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -2671,6 +2735,7 @@ const (
+ 	BPF_PROG_TYPE_LSM                          = 0x1d
+ 	BPF_PROG_TYPE_SK_LOOKUP                    = 0x1e
+ 	BPF_PROG_TYPE_SYSCALL                      = 0x1f
++	BPF_PROG_TYPE_NETFILTER                    = 0x20
+ 	BPF_CGROUP_INET_INGRESS                    = 0x0
+ 	BPF_CGROUP_INET_EGRESS                     = 0x1
+ 	BPF_CGROUP_INET_SOCK_CREATE                = 0x2
+@@ -2715,6 +2780,11 @@ const (
+ 	BPF_PERF_EVENT                             = 0x29
+ 	BPF_TRACE_KPROBE_MULTI                     = 0x2a
+ 	BPF_LSM_CGROUP                             = 0x2b
++	BPF_STRUCT_OPS                             = 0x2c
++	BPF_NETFILTER                              = 0x2d
++	BPF_TCX_INGRESS                            = 0x2e
++	BPF_TCX_EGRESS                             = 0x2f
++	BPF_TRACE_UPROBE_MULTI                     = 0x30
+ 	BPF_LINK_TYPE_UNSPEC                       = 0x0
+ 	BPF_LINK_TYPE_RAW_TRACEPOINT               = 0x1
+ 	BPF_LINK_TYPE_TRACING                      = 0x2
+@@ -2725,6 +2795,18 @@ const (
+ 	BPF_LINK_TYPE_PERF_EVENT                   = 0x7
+ 	BPF_LINK_TYPE_KPROBE_MULTI                 = 0x8
+ 	BPF_LINK_TYPE_STRUCT_OPS                   = 0x9
++	BPF_LINK_TYPE_NETFILTER                    = 0xa
++	BPF_LINK_TYPE_TCX                          = 0xb
++	BPF_LINK_TYPE_UPROBE_MULTI                 = 0xc
++	BPF_PERF_EVENT_UNSPEC                      = 0x0
++	BPF_PERF_EVENT_UPROBE                      = 0x1
++	BPF_PERF_EVENT_URETPROBE                   = 0x2
++	BPF_PERF_EVENT_KPROBE                      = 0x3
++	BPF_PERF_EVENT_KRETPROBE                   = 0x4
++	BPF_PERF_EVENT_TRACEPOINT                  = 0x5
++	BPF_PERF_EVENT_EVENT                       = 0x6
++	BPF_F_KPROBE_MULTI_RETURN                  = 0x1
++	BPF_F_UPROBE_MULTI_RETURN                  = 0x1
+ 	BPF_ANY                                    = 0x0
+ 	BPF_NOEXIST                                = 0x1
+ 	BPF_EXIST                                  = 0x2
+@@ -2742,6 +2824,8 @@ const (
+ 	BPF_F_MMAPABLE                             = 0x400
+ 	BPF_F_PRESERVE_ELEMS                       = 0x800
+ 	BPF_F_INNER_MAP                            = 0x1000
++	BPF_F_LINK                                 = 0x2000
++	BPF_F_PATH_FD                              = 0x4000
+ 	BPF_STATS_RUN_TIME                         = 0x0
+ 	BPF_STACK_BUILD_ID_EMPTY                   = 0x0
+ 	BPF_STACK_BUILD_ID_VALID                   = 0x1
+@@ -2762,6 +2846,7 @@ const (
+ 	BPF_F_ZERO_CSUM_TX                         = 0x2
+ 	BPF_F_DONT_FRAGMENT                        = 0x4
+ 	BPF_F_SEQ_NUMBER                           = 0x8
++	BPF_F_NO_TUNNEL_KEY                        = 0x10
+ 	BPF_F_TUNINFO_FLAGS                        = 0x10
+ 	BPF_F_INDEX_MASK                           = 0xffffffff
+ 	BPF_F_CURRENT_CPU                          = 0xffffffff
+@@ -2778,6 +2863,8 @@ const (
+ 	BPF_F_ADJ_ROOM_ENCAP_L4_UDP                = 0x10
+ 	BPF_F_ADJ_ROOM_NO_CSUM_RESET               = 0x20
+ 	BPF_F_ADJ_ROOM_ENCAP_L2_ETH                = 0x40
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV4               = 0x80
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV6               = 0x100
+ 	BPF_ADJ_ROOM_ENCAP_L2_MASK                 = 0xff
+ 	BPF_ADJ_ROOM_ENCAP_L2_SHIFT                = 0x38
+ 	BPF_F_SYSCTL_BASE_NAME                     = 0x1
+@@ -2866,6 +2953,8 @@ const (
+ 	BPF_DEVCG_DEV_CHAR                         = 0x2
+ 	BPF_FIB_LOOKUP_DIRECT                      = 0x1
+ 	BPF_FIB_LOOKUP_OUTPUT                      = 0x2
++	BPF_FIB_LOOKUP_SKIP_NEIGH                  = 0x4
++	BPF_FIB_LOOKUP_TBID                        = 0x8
+ 	BPF_FIB_LKUP_RET_SUCCESS                   = 0x0
+ 	BPF_FIB_LKUP_RET_BLACKHOLE                 = 0x1
+ 	BPF_FIB_LKUP_RET_UNREACHABLE               = 0x2
+@@ -2901,6 +2990,7 @@ const (
+ 	BPF_CORE_ENUMVAL_EXISTS                    = 0xa
+ 	BPF_CORE_ENUMVAL_VALUE                     = 0xb
+ 	BPF_CORE_TYPE_MATCHES                      = 0xc
++	BPF_F_TIMER_ABS                            = 0x1
+ )
+ 
+ const (
+@@ -2979,6 +3069,12 @@ type LoopInfo64 struct {
+ 	Encrypt_key      [32]uint8
+ 	Init             [2]uint64
+ }
++type LoopConfig struct {
++	Fd   uint32
++	Size uint32
++	Info LoopInfo64
++	_    [8]uint64
++}
+ 
+ type TIPCSocketAddr struct {
+ 	Ref  uint32
+@@ -3367,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4151,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5102,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5515,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad1925..d4577a42 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index fb6cfd04..6395a031 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -155,6 +154,8 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetModuleFileName(module Handle, filename *uint16, size uint32) (n uint32, err error) = kernel32.GetModuleFileNameW
+ //sys	GetModuleHandleEx(flags uint32, moduleName *uint16, module *Handle) (err error) = kernel32.GetModuleHandleExW
+ //sys	SetDefaultDllDirectories(directoryFlags uint32) (err error)
++//sys	AddDllDirectory(path *uint16) (cookie uintptr, err error) = kernel32.AddDllDirectory
++//sys	RemoveDllDirectory(cookie uintptr) (err error) = kernel32.RemoveDllDirectory
+ //sys	SetDllDirectory(path string) (err error) = kernel32.SetDllDirectoryW
+ //sys	GetVersion() (ver uint32, err error)
+ //sys	FormatMessage(flags uint32, msgsrc uintptr, msgid uint32, langid uint32, buf []uint16, args *byte) (n uint32, err error) = FormatMessageW
+@@ -192,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index db6282e0..e8791c82 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -184,6 +184,7 @@ var (
+ 	procGetAdaptersInfo                                      = modiphlpapi.NewProc("GetAdaptersInfo")
+ 	procGetBestInterfaceEx                                   = modiphlpapi.NewProc("GetBestInterfaceEx")
+ 	procGetIfEntry                                           = modiphlpapi.NewProc("GetIfEntry")
++	procAddDllDirectory                                      = modkernel32.NewProc("AddDllDirectory")
+ 	procAssignProcessToJobObject                             = modkernel32.NewProc("AssignProcessToJobObject")
+ 	procCancelIo                                             = modkernel32.NewProc("CancelIo")
+ 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
+@@ -330,6 +331,7 @@ var (
+ 	procReadProcessMemory                                    = modkernel32.NewProc("ReadProcessMemory")
+ 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
+ 	procRemoveDirectoryW                                     = modkernel32.NewProc("RemoveDirectoryW")
++	procRemoveDllDirectory                                   = modkernel32.NewProc("RemoveDllDirectory")
+ 	procResetEvent                                           = modkernel32.NewProc("ResetEvent")
+ 	procResizePseudoConsole                                  = modkernel32.NewProc("ResizePseudoConsole")
+ 	procResumeThread                                         = modkernel32.NewProc("ResumeThread")
+@@ -340,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -1605,6 +1608,15 @@ func GetIfEntry(pIfRow *MibIfRow) (errcode error) {
+ 	return
+ }
+ 
++func AddDllDirectory(path *uint16) (cookie uintptr, err error) {
++	r0, _, e1 := syscall.Syscall(procAddDllDirectory.Addr(), 1, uintptr(unsafe.Pointer(path)), 0, 0)
++	cookie = uintptr(r0)
++	if cookie == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func AssignProcessToJobObject(job Handle, process Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procAssignProcessToJobObject.Addr(), 2, uintptr(job), uintptr(process), 0)
+ 	if r1 == 0 {
+@@ -2879,6 +2891,14 @@ func RemoveDirectory(path *uint16) (err error) {
+ 	return
+ }
+ 
++func RemoveDllDirectory(cookie uintptr) (err error) {
++	r1, _, e1 := syscall.Syscall(procRemoveDllDirectory.Addr(), 1, uintptr(cookie), 0, 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func ResetEvent(event Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procResetEvent.Addr(), 1, uintptr(event), 0, 0)
+ 	if r1 == 0 {
+@@ -2969,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index f56ffc95..a6f82bb3 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -185,7 +185,7 @@ go.uber.org/zap/internal/bufferpool
+ go.uber.org/zap/internal/color
+ go.uber.org/zap/internal/exit
+ go.uber.org/zap/zapcore
+-# golang.org/x/net v0.18.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -197,12 +197,12 @@ golang.org/x/net/trace
+ ## explicit; go 1.18
+ golang.org/x/oauth2
+ golang.org/x/oauth2/internal
+-# golang.org/x/sys v0.14.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-# golang.org/x/term v0.14.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/external-resizer/1-30/CHECKSUMS
+++ b/projects/kubernetes-csi/external-resizer/1-30/CHECKSUMS
@@ -1,2 +1,2 @@
-cb05f08b5873e5fce1048b88bd97dd848544328464768b64a9d5f790361cd725  _output/1-30/bin/external-resizer/linux-amd64/csi-resizer
-4be58b892ed0dec5bd6ad0ae28ceabfc9183d92b3d1ca6ed8126de969d25b413  _output/1-30/bin/external-resizer/linux-arm64/csi-resizer
+a73c82508caf8a3c9eef44001c5f909efe535ac08d913522d93c141c167368e3  _output/1-30/bin/external-resizer/linux-amd64/csi-resizer
+2fb169baa87202c1e4c64658b87758cb12aa9818bb6b52cd595767a864541752  _output/1-30/bin/external-resizer/linux-arm64/csi-resizer

--- a/projects/kubernetes-csi/external-resizer/1-30/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
+++ b/projects/kubernetes-csi/external-resizer/1-30/patches/0002-Fix-CVE-2023-45288-by-bumping-x-net-to-0.23.0.patch
@@ -1,0 +1,3278 @@
+From 6f30bd8a770c0000df2176d1feccf54db95c72f3 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:21:40 +0000
+Subject: [PATCH] Fix CVE CVE-2023-45288 by bumping /x/net to 0.23.0
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |   6 +-
+ go.sum                                        |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/fcntl.go         |   2 +-
+ vendor/golang.org/x/sys/unix/ioctl_linux.go   |   5 +
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  42 ++-
+ vendor/golang.org/x/sys/unix/syscall_bsd.go   |   2 +-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go | 127 ++++++-
+ .../golang.org/x/sys/unix/syscall_openbsd.go  |  14 +
+ .../golang.org/x/sys/unix/syscall_solaris.go  |   2 +-
+ .../x/sys/unix/syscall_zos_s390x.go           |   2 +-
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  92 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  25 ++
+ .../x/sys/unix/zsyscall_openbsd_386.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_386.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_amd64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm.s         |   5 +
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_arm64.s       |   5 +
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_mips64.s      |   5 +
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_ppc64.s       |   6 +
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |  28 +-
+ .../x/sys/unix/zsyscall_openbsd_riscv64.s     |   5 +
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 217 ++++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   6 +-
+ .../x/sys/windows/zsyscall_windows.go         |  28 ++
+ vendor/modules.txt                            |   6 +-
+ 69 files changed, 1451 insertions(+), 210 deletions(-)
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index 408a4aa5..08785a0f 100644
+--- a/go.mod
++++ b/go.mod
+@@ -9,7 +9,7 @@ require (
+ 	github.com/imdario/mergo v0.3.12 // indirect
+ 	github.com/kubernetes-csi/csi-lib-utils v0.17.0
+ 	golang.org/x/oauth2 v0.13.0 // indirect
+-	golang.org/x/term v0.14.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	google.golang.org/appengine v1.6.8 // indirect
+ 	google.golang.org/grpc v1.60.1
+ 	k8s.io/api v0.29.0
+@@ -62,8 +62,8 @@ require (
+ 	go.uber.org/goleak v1.3.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.19.0 // indirect
+-	golang.org/x/net v0.18.0 // indirect
+-	golang.org/x/sys v0.14.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.3.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
+diff --git a/go.sum b/go.sum
+index 0b5edd30..f747ed99 100644
+--- a/go.sum
++++ b/go.sum
+@@ -165,8 +165,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
+-golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.13.0 h1:jDDenyj+WgFtmV3zYVoi8aE2BwtXFLWOA67ZfNWftiY=
+ golang.org/x/oauth2 v0.13.0/go.mod h1:/JMhi4ZRXAf4HG9LiNmxvk+45+96RUlVThiH8FzNBn0=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -181,12 +181,12 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.14.0 h1:LGK9IlZ8T9jvdy6cTdfKUCltatMFOehAQo9SRC46UQ8=
+-golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90d..43557ab7 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984f..3b9f06b9 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c640..ce2e8b40 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 00000000..61075bd1
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86..ce375c8c 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4b..b0e41985 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/fcntl.go b/vendor/golang.org/x/sys/unix/fcntl.go
+index 58c6bfc7..6200876f 100644
+--- a/vendor/golang.org/x/sys/unix/fcntl.go
++++ b/vendor/golang.org/x/sys/unix/fcntl.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build dragonfly || freebsd || linux || netbsd || openbsd
++//go:build dragonfly || freebsd || linux || netbsd
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/ioctl_linux.go b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+index 0d12c085..dbe680ea 100644
+--- a/vendor/golang.org/x/sys/unix/ioctl_linux.go
++++ b/vendor/golang.org/x/sys/unix/ioctl_linux.go
+@@ -231,3 +231,8 @@ func IoctlLoopGetStatus64(fd int) (*LoopInfo64, error) {
+ func IoctlLoopSetStatus64(fd int, value *LoopInfo64) error {
+ 	return ioctlPtr(fd, LOOP_SET_STATUS64, unsafe.Pointer(value))
+ }
++
++// IoctlLoopConfigure configures all loop device parameters in a single step
++func IoctlLoopConfigure(fd int, value *LoopConfig) error {
++	return ioctlPtr(fd, LOOP_CONFIGURE, unsafe.Pointer(value))
++}
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index cbe24150..fdcaa974 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -519,6 +521,7 @@ ccflags="$@"
+ 		$2 ~ /^LOCK_(SH|EX|NB|UN)$/ ||
+ 		$2 ~ /^LO_(KEY|NAME)_SIZE$/ ||
+ 		$2 ~ /^LOOP_(CLR|CTL|GET|SET)_/ ||
++		$2 == "LOOP_CONFIGURE" ||
+ 		$2 ~ /^(AF|SOCK|SO|SOL|IPPROTO|IP|IPV6|TCP|MCAST|EVFILT|NOTE|SHUT|PROT|MAP|MREMAP|MFD|T?PACKET|MSG|SCM|MCL|DT|MADV|PR|LOCAL|TCPOPT|UDP)_/ ||
+ 		$2 ~ /^NFC_(GENL|PROTO|COMM|RF|SE|DIRECTION|LLCP|SOCKPROTO)_/ ||
+ 		$2 ~ /^NFC_.*_(MAX)?SIZE$/ ||
+@@ -560,7 +563,7 @@ ccflags="$@"
+ 		$2 ~ /^RLIMIT_(AS|CORE|CPU|DATA|FSIZE|LOCKS|MEMLOCK|MSGQUEUE|NICE|NOFILE|NPROC|RSS|RTPRIO|RTTIME|SIGPENDING|STACK)|RLIM_INFINITY/ ||
+ 		$2 ~ /^PRIO_(PROCESS|PGRP|USER)/ ||
+ 		$2 ~ /^CLONE_[A-Z_]+/ ||
+-		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+)$/ &&
++		$2 !~ /^(BPF_TIMEVAL|BPF_FIB_LOOKUP_[A-Z]+|BPF_F_LINK)$/ &&
+ 		$2 ~ /^(BPF|DLT)_/ ||
+ 		$2 ~ /^AUDIT_/ ||
+ 		$2 ~ /^(CLOCK|TIMER)_/ ||
+@@ -581,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -602,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_bsd.go b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+index 6f328e3a..a00c3e54 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_bsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_bsd.go
+@@ -316,7 +316,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ //sys	recvfrom(fd int, p []byte, flags int, from *RawSockaddrAny, fromlen *_Socklen) (n int, err error)
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc6993..2f0fa76e 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4d..2b57e0f7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index a5e1c10e..5682e262 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -61,15 +61,23 @@ func FanotifyMark(fd int, flags uint, mask uint64, dirFd int, pathname string) (
+ }
+ 
+ //sys	fchmodat(dirfd int, path string, mode uint32) (err error)
+-
+-func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+-	// Linux fchmodat doesn't support the flags parameter. Mimick glibc's behavior
+-	// and check the flags. Otherwise the mode would be applied to the symlink
+-	// destination which is not what the user expects.
+-	if flags&^AT_SYMLINK_NOFOLLOW != 0 {
+-		return EINVAL
+-	} else if flags&AT_SYMLINK_NOFOLLOW != 0 {
+-		return EOPNOTSUPP
++//sys	fchmodat2(dirfd int, path string, mode uint32, flags int) (err error)
++
++func Fchmodat(dirfd int, path string, mode uint32, flags int) error {
++	// Linux fchmodat doesn't support the flags parameter, but fchmodat2 does.
++	// Try fchmodat2 if flags are specified.
++	if flags != 0 {
++		err := fchmodat2(dirfd, path, mode, flags)
++		if err == ENOSYS {
++			// fchmodat2 isn't available. If the flags are known to be valid,
++			// return EOPNOTSUPP to indicate that fchmodat doesn't support them.
++			if flags&^(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EINVAL
++			} else if flags&(AT_SYMLINK_NOFOLLOW|AT_EMPTY_PATH) != 0 {
++				return EOPNOTSUPP
++			}
++		}
++		return err
+ 	}
+ 	return fchmodat(dirfd, path, mode)
+ }
+@@ -1302,7 +1310,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 			return "", err
+ 		}
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func GetsockoptTpacketStats(fd, level, opt int) (*TpacketStats, error) {
+@@ -1841,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_openbsd.go b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+index d2882ee0..b25343c7 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_openbsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_openbsd.go
+@@ -166,6 +166,20 @@ func Getresgid() (rgid, egid, sgid int) {
+ 
+ //sys	sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) = SYS___SYSCTL
+ 
++//sys	fcntl(fd int, cmd int, arg int) (n int, err error)
++//sys	fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) = SYS_FCNTL
++
++// FcntlInt performs a fcntl syscall on fd with the provided command and argument.
++func FcntlInt(fd uintptr, cmd, arg int) (int, error) {
++	return fcntl(int(fd), cmd, arg)
++}
++
++// FcntlFlock performs a fcntl syscall for the F_GETLK, F_SETLK or F_SETLKW command.
++func FcntlFlock(fd uintptr, cmd int, lk *Flock_t) error {
++	_, err := fcntlPtr(int(fd), cmd, unsafe.Pointer(lk))
++	return err
++}
++
+ //sys	ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error)
+ 
+ func Ppoll(fds []PollFd, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/syscall_solaris.go b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+index 60c8142d..21974af0 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
++++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
+@@ -158,7 +158,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ const ImplementsGetwd = true
+diff --git a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+index d99d05f1..b473038c 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
++++ b/vendor/golang.org/x/sys/unix/syscall_zos_s390x.go
+@@ -1104,7 +1104,7 @@ func GetsockoptString(fd, level, opt int) (string, error) {
+ 		return "", err
+ 	}
+ 
+-	return string(buf[:vallen-1]), nil
++	return ByteSliceToString(buf[:vallen]), nil
+ }
+ 
+ func Recvmsg(fd int, p, oob []byte, flags int) (n, oobn int, recvflags int, from Sockaddr, err error) {
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index 9c00cbf5..36bf8399 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -486,7 +486,6 @@ const (
+ 	BPF_F_ANY_ALIGNMENT                         = 0x2
+ 	BPF_F_BEFORE                                = 0x8
+ 	BPF_F_ID                                    = 0x20
+-	BPF_F_LINK                                  = 0x2000
+ 	BPF_F_NETFILTER_IP_DEFRAG                   = 0x1
+ 	BPF_F_QUERY_EFFECTIVE                       = 0x1
+ 	BPF_F_REPLACE                               = 0x4
+@@ -1786,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -1802,6 +1803,7 @@ const (
+ 	LOCK_SH                                     = 0x1
+ 	LOCK_UN                                     = 0x8
+ 	LOOP_CLR_FD                                 = 0x4c01
++	LOOP_CONFIGURE                              = 0x4c0a
+ 	LOOP_CTL_ADD                                = 0x4c80
+ 	LOOP_CTL_GET_FREE                           = 0x4c82
+ 	LOOP_CTL_REMOVE                             = 0x4c81
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821c..42ff8c3c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e411..dca43600 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c6398556..5cca668a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e2..d8cae6d1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09..28e39afd 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642..cd66e92c 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d7..c1595eba 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0..ee9456b0 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84..8cfca81e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d..60b0deb3 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc7..f90aa728 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e..ba9e0150 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813e..07cdfd6e 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4e..2f1dd214 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994d..f40519d9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index faca7a55..87d8612a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -37,6 +37,21 @@ func fchmodat(dirfd int, path string, mode uint32) (err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fchmodat2(dirfd int, path string, mode uint32, flags int) (err error) {
++	var _p0 *byte
++	_p0, err = BytePtrFromString(path)
++	if err != nil {
++		return
++	}
++	_, _, e1 := Syscall6(SYS_FCHMODAT2, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(mode), uintptr(flags), 0, 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ioctl(fd int, req uint, arg uintptr) (err error) {
+ 	_, _, e1 := Syscall(SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
+ 	if e1 != 0 {
+@@ -891,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index 88bfc288..9dc42410 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+index 4cbeff17..41b56173 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index b8a67b99..0d3a0751 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+index 1123f275..4019a656 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index af50a65c..c39f7776 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+index 82badae3..ac4af24f 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $4
+ DATA	·libc_sysctl_trampoline_addr(SB)/4, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $4
++DATA	·libc_fcntl_trampoline_addr(SB)/4, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $4
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 8fb4ff36..57571d07 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+index 24d7eecb..f77d5321 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index f469a83e..e62963e6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+index 9a498a06..fae140b6 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index c26ca2e1..00831354 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+index 1f224aa4..9d1e0ff0 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.s
+@@ -213,6 +213,12 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	CALL	libc_fcntl(SB)
++	RET
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	CALL	libc_ppoll(SB)
+ 	RET
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index bcc920dd..79029ed5 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -584,6 +584,32 @@ var libc_sysctl_trampoline_addr uintptr
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fcntl(fd int, cmd int, arg int) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++var libc_fcntl_trampoline_addr uintptr
++
++//go:cgo_import_dynamic libc_fcntl fcntl "libc.so"
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
++func fcntlPtr(fd int, cmd int, arg unsafe.Pointer) (n int, err error) {
++	r0, _, e1 := syscall_syscall(libc_fcntl_trampoline_addr, uintptr(fd), uintptr(cmd), uintptr(arg))
++	n = int(r0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func ppoll(fds *PollFd, nfds int, timeout *Timespec, sigmask *Sigset_t) (n int, err error) {
+ 	r0, _, e1 := syscall_syscall6(libc_ppoll_trampoline_addr, uintptr(unsafe.Pointer(fds)), uintptr(nfds), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(sigmask)), 0, 0)
+ 	n = int(r0)
+@@ -2271,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+index 87a79c70..da115f9a 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.s
+@@ -178,6 +178,11 @@ TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
+ GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
+ DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
+ 
++TEXT libc_fcntl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_fcntl(SB)
++GLOBL	·libc_fcntl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_fcntl_trampoline_addr(SB)/8, $libc_fcntl_trampoline<>(SB)
++
+ TEXT libc_ppoll_trampoline<>(SB),NOSPLIT,$0-0
+ 	JMP	libc_ppoll(SB)
+ GLOBL	·libc_ppoll_trampoline_addr(SB), RODATA, $8
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbd..0cc3ce49 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc250..856d92d6 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf246..8d467094 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e..edc17324 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77..445eba20 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362e..adba01bc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4f..014c4e9c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca8..ccc97d74 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d3..ec2b64a9 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e374..21a839e3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c..c11121ec 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e59..909b631f 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195..e49bed16 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943b..66017d2d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc5..47bab18d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index 997bcd55..eff6bcde 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -2671,6 +2735,7 @@ const (
+ 	BPF_PROG_TYPE_LSM                          = 0x1d
+ 	BPF_PROG_TYPE_SK_LOOKUP                    = 0x1e
+ 	BPF_PROG_TYPE_SYSCALL                      = 0x1f
++	BPF_PROG_TYPE_NETFILTER                    = 0x20
+ 	BPF_CGROUP_INET_INGRESS                    = 0x0
+ 	BPF_CGROUP_INET_EGRESS                     = 0x1
+ 	BPF_CGROUP_INET_SOCK_CREATE                = 0x2
+@@ -2715,6 +2780,11 @@ const (
+ 	BPF_PERF_EVENT                             = 0x29
+ 	BPF_TRACE_KPROBE_MULTI                     = 0x2a
+ 	BPF_LSM_CGROUP                             = 0x2b
++	BPF_STRUCT_OPS                             = 0x2c
++	BPF_NETFILTER                              = 0x2d
++	BPF_TCX_INGRESS                            = 0x2e
++	BPF_TCX_EGRESS                             = 0x2f
++	BPF_TRACE_UPROBE_MULTI                     = 0x30
+ 	BPF_LINK_TYPE_UNSPEC                       = 0x0
+ 	BPF_LINK_TYPE_RAW_TRACEPOINT               = 0x1
+ 	BPF_LINK_TYPE_TRACING                      = 0x2
+@@ -2725,6 +2795,18 @@ const (
+ 	BPF_LINK_TYPE_PERF_EVENT                   = 0x7
+ 	BPF_LINK_TYPE_KPROBE_MULTI                 = 0x8
+ 	BPF_LINK_TYPE_STRUCT_OPS                   = 0x9
++	BPF_LINK_TYPE_NETFILTER                    = 0xa
++	BPF_LINK_TYPE_TCX                          = 0xb
++	BPF_LINK_TYPE_UPROBE_MULTI                 = 0xc
++	BPF_PERF_EVENT_UNSPEC                      = 0x0
++	BPF_PERF_EVENT_UPROBE                      = 0x1
++	BPF_PERF_EVENT_URETPROBE                   = 0x2
++	BPF_PERF_EVENT_KPROBE                      = 0x3
++	BPF_PERF_EVENT_KRETPROBE                   = 0x4
++	BPF_PERF_EVENT_TRACEPOINT                  = 0x5
++	BPF_PERF_EVENT_EVENT                       = 0x6
++	BPF_F_KPROBE_MULTI_RETURN                  = 0x1
++	BPF_F_UPROBE_MULTI_RETURN                  = 0x1
+ 	BPF_ANY                                    = 0x0
+ 	BPF_NOEXIST                                = 0x1
+ 	BPF_EXIST                                  = 0x2
+@@ -2742,6 +2824,8 @@ const (
+ 	BPF_F_MMAPABLE                             = 0x400
+ 	BPF_F_PRESERVE_ELEMS                       = 0x800
+ 	BPF_F_INNER_MAP                            = 0x1000
++	BPF_F_LINK                                 = 0x2000
++	BPF_F_PATH_FD                              = 0x4000
+ 	BPF_STATS_RUN_TIME                         = 0x0
+ 	BPF_STACK_BUILD_ID_EMPTY                   = 0x0
+ 	BPF_STACK_BUILD_ID_VALID                   = 0x1
+@@ -2762,6 +2846,7 @@ const (
+ 	BPF_F_ZERO_CSUM_TX                         = 0x2
+ 	BPF_F_DONT_FRAGMENT                        = 0x4
+ 	BPF_F_SEQ_NUMBER                           = 0x8
++	BPF_F_NO_TUNNEL_KEY                        = 0x10
+ 	BPF_F_TUNINFO_FLAGS                        = 0x10
+ 	BPF_F_INDEX_MASK                           = 0xffffffff
+ 	BPF_F_CURRENT_CPU                          = 0xffffffff
+@@ -2778,6 +2863,8 @@ const (
+ 	BPF_F_ADJ_ROOM_ENCAP_L4_UDP                = 0x10
+ 	BPF_F_ADJ_ROOM_NO_CSUM_RESET               = 0x20
+ 	BPF_F_ADJ_ROOM_ENCAP_L2_ETH                = 0x40
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV4               = 0x80
++	BPF_F_ADJ_ROOM_DECAP_L3_IPV6               = 0x100
+ 	BPF_ADJ_ROOM_ENCAP_L2_MASK                 = 0xff
+ 	BPF_ADJ_ROOM_ENCAP_L2_SHIFT                = 0x38
+ 	BPF_F_SYSCTL_BASE_NAME                     = 0x1
+@@ -2866,6 +2953,8 @@ const (
+ 	BPF_DEVCG_DEV_CHAR                         = 0x2
+ 	BPF_FIB_LOOKUP_DIRECT                      = 0x1
+ 	BPF_FIB_LOOKUP_OUTPUT                      = 0x2
++	BPF_FIB_LOOKUP_SKIP_NEIGH                  = 0x4
++	BPF_FIB_LOOKUP_TBID                        = 0x8
+ 	BPF_FIB_LKUP_RET_SUCCESS                   = 0x0
+ 	BPF_FIB_LKUP_RET_BLACKHOLE                 = 0x1
+ 	BPF_FIB_LKUP_RET_UNREACHABLE               = 0x2
+@@ -2901,6 +2990,7 @@ const (
+ 	BPF_CORE_ENUMVAL_EXISTS                    = 0xa
+ 	BPF_CORE_ENUMVAL_VALUE                     = 0xb
+ 	BPF_CORE_TYPE_MATCHES                      = 0xc
++	BPF_F_TIMER_ABS                            = 0x1
+ )
+ 
+ const (
+@@ -2979,6 +3069,12 @@ type LoopInfo64 struct {
+ 	Encrypt_key      [32]uint8
+ 	Init             [2]uint64
+ }
++type LoopConfig struct {
++	Fd   uint32
++	Size uint32
++	Info LoopInfo64
++	_    [8]uint64
++}
+ 
+ type TIPCSocketAddr struct {
+ 	Ref  uint32
+@@ -3367,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4151,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5102,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5515,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad1925..d4577a42 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index fb6cfd04..6395a031 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -155,6 +154,8 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetModuleFileName(module Handle, filename *uint16, size uint32) (n uint32, err error) = kernel32.GetModuleFileNameW
+ //sys	GetModuleHandleEx(flags uint32, moduleName *uint16, module *Handle) (err error) = kernel32.GetModuleHandleExW
+ //sys	SetDefaultDllDirectories(directoryFlags uint32) (err error)
++//sys	AddDllDirectory(path *uint16) (cookie uintptr, err error) = kernel32.AddDllDirectory
++//sys	RemoveDllDirectory(cookie uintptr) (err error) = kernel32.RemoveDllDirectory
+ //sys	SetDllDirectory(path string) (err error) = kernel32.SetDllDirectoryW
+ //sys	GetVersion() (ver uint32, err error)
+ //sys	FormatMessage(flags uint32, msgsrc uintptr, msgid uint32, langid uint32, buf []uint16, args *byte) (n uint32, err error) = FormatMessageW
+@@ -192,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index db6282e0..e8791c82 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -184,6 +184,7 @@ var (
+ 	procGetAdaptersInfo                                      = modiphlpapi.NewProc("GetAdaptersInfo")
+ 	procGetBestInterfaceEx                                   = modiphlpapi.NewProc("GetBestInterfaceEx")
+ 	procGetIfEntry                                           = modiphlpapi.NewProc("GetIfEntry")
++	procAddDllDirectory                                      = modkernel32.NewProc("AddDllDirectory")
+ 	procAssignProcessToJobObject                             = modkernel32.NewProc("AssignProcessToJobObject")
+ 	procCancelIo                                             = modkernel32.NewProc("CancelIo")
+ 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
+@@ -330,6 +331,7 @@ var (
+ 	procReadProcessMemory                                    = modkernel32.NewProc("ReadProcessMemory")
+ 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
+ 	procRemoveDirectoryW                                     = modkernel32.NewProc("RemoveDirectoryW")
++	procRemoveDllDirectory                                   = modkernel32.NewProc("RemoveDllDirectory")
+ 	procResetEvent                                           = modkernel32.NewProc("ResetEvent")
+ 	procResizePseudoConsole                                  = modkernel32.NewProc("ResizePseudoConsole")
+ 	procResumeThread                                         = modkernel32.NewProc("ResumeThread")
+@@ -340,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -1605,6 +1608,15 @@ func GetIfEntry(pIfRow *MibIfRow) (errcode error) {
+ 	return
+ }
+ 
++func AddDllDirectory(path *uint16) (cookie uintptr, err error) {
++	r0, _, e1 := syscall.Syscall(procAddDllDirectory.Addr(), 1, uintptr(unsafe.Pointer(path)), 0, 0)
++	cookie = uintptr(r0)
++	if cookie == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func AssignProcessToJobObject(job Handle, process Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procAssignProcessToJobObject.Addr(), 2, uintptr(job), uintptr(process), 0)
+ 	if r1 == 0 {
+@@ -2879,6 +2891,14 @@ func RemoveDirectory(path *uint16) (err error) {
+ 	return
+ }
+ 
++func RemoveDllDirectory(cookie uintptr) (err error) {
++	r1, _, e1 := syscall.Syscall(procRemoveDllDirectory.Addr(), 1, uintptr(cookie), 0, 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func ResetEvent(event Handle) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procResetEvent.Addr(), 1, uintptr(event), 0, 0)
+ 	if r1 == 0 {
+@@ -2969,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index f56ffc95..a6f82bb3 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -185,7 +185,7 @@ go.uber.org/zap/internal/bufferpool
+ go.uber.org/zap/internal/color
+ go.uber.org/zap/internal/exit
+ go.uber.org/zap/zapcore
+-# golang.org/x/net v0.18.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -197,12 +197,12 @@ golang.org/x/net/trace
+ ## explicit; go 1.18
+ golang.org/x/oauth2
+ golang.org/x/oauth2/internal
+-# golang.org/x/sys v0.14.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-# golang.org/x/term v0.14.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+-- 
+2.40.1
+


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Patch external-resizer CVE-2023-45288 by bumping /x/net to 0.23.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
