### PR TITLE
Fix external-provisioner CVE-2024-3177 by bumping k8s.io/kubernetes to v1.29.4

### DIFF
--- a/projects/kubernetes-csi/external-provisioner/1-25/CHECKSUMS
+++ b/projects/kubernetes-csi/external-provisioner/1-25/CHECKSUMS
@@ -1,2 +1,2 @@
-f090fe1d3e9e0b7e15c235537a649785921f5704d216b27bca4a1e84536e2572  _output/1-25/bin/external-provisioner/linux-amd64/csi-provisioner
-952edef97a4caa19b92d2bbb13f72d737775e972f07feca64468061f982ca75b  _output/1-25/bin/external-provisioner/linux-arm64/csi-provisioner
+a554f31f0d5ac26b61efbe6fa3b8e76194f0026ddec9335db9136dcbc345f4e1  _output/1-25/bin/external-provisioner/linux-amd64/csi-provisioner
+96967e52e5f700d3830d73bd43242308395f4d07ab66879c706aad72875df4fe  _output/1-25/bin/external-provisioner/linux-arm64/csi-provisioner

--- a/projects/kubernetes-csi/external-provisioner/1-25/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
+++ b/projects/kubernetes-csi/external-provisioner/1-25/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
@@ -1,0 +1,3220 @@
+From 272caf23aea9e18489bbe26e27e047bc5f09d753 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:41:12 +0000
+Subject: [PATCH] Fix external-provisioner CVE-2024-3177 by bumping
+ k8s.io/kubernetes to 1.29.4
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |  10 +-
+ go.sum                                        |  20 +-
+ .../x/crypto/internal/poly1305/bits_compat.go |  39 ---
+ .../x/crypto/internal/poly1305/bits_go1.13.go |  21 --
+ .../x/crypto/internal/poly1305/sum_generic.go |  43 +--
+ .../x/crypto/internal/poly1305/sum_ppc64le.s  |  14 +-
+ vendor/golang.org/x/net/html/token.go         |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/net/websocket/client.go   |  55 ++-
+ vendor/golang.org/x/net/websocket/dial.go     |  11 +-
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  39 ++-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go |  99 ++++++
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  90 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  10 +
+ .../x/sys/unix/zsyscall_openbsd_386.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |   2 -
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |   2 -
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 185 ++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   4 +-
+ .../x/sys/windows/zsyscall_windows.go         |   9 +
+ .../k8s.io/kubernetes/pkg/apis/core/types.go  |   2 +-
+ .../pkg/apis/core/validation/validation.go    |  42 ++-
+ .../kubernetes/pkg/features/kube_features.go  |   8 +-
+ .../k8s.io/kubernetes/pkg/volume/plugins.go   |   2 +-
+ .../kubernetes/pkg/volume/util/types/types.go |  17 +
+ .../kubernetes/test/utils/image/manifest.go   |   6 +-
+ vendor/modules.txt                            |  10 +-
+ 69 files changed, 1287 insertions(+), 316 deletions(-)
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index fff06492a..a2be5719c 100644
+--- a/go.mod
++++ b/go.mod
+@@ -33,7 +33,7 @@ require (
+ require (
+ 	github.com/onsi/ginkgo/v2 v2.13.2
+ 	github.com/onsi/gomega v1.30.0
+-	k8s.io/kubernetes v1.29.0
++	k8s.io/kubernetes v1.29.4
+ )
+ 
+ require (
+@@ -106,14 +106,14 @@ require (
+ 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.26.0 // indirect
+-	golang.org/x/crypto v0.17.0 // indirect
++	golang.org/x/crypto v0.21.0 // indirect
+ 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+ 	golang.org/x/mod v0.14.0 // indirect
+-	golang.org/x/net v0.19.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
+ 	golang.org/x/oauth2 v0.15.0 // indirect
+ 	golang.org/x/sync v0.5.0 // indirect
+-	golang.org/x/sys v0.15.0 // indirect
+-	golang.org/x/term v0.15.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.5.0 // indirect
+ 	golang.org/x/tools v0.16.1 // indirect
+diff --git a/go.sum b/go.sum
+index 56c808a77..c0444fa2f 100644
+--- a/go.sum
++++ b/go.sum
+@@ -248,8 +248,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
+ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+-golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+-golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
++golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
++golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -265,8 +265,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+-golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.15.0 h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ=
+ golang.org/x/oauth2 v0.15.0/go.mod h1:q48ptWNTY5XWf+JNten23lcvHpLJ0ZSxF5ttTHKVCAM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -286,12 +286,12 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+-golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+@@ -371,8 +371,8 @@ k8s.io/kubectl v0.29.0 h1:Oqi48gXjikDhrBF67AYuZRTcJV4lg2l42GmvsP7FmYI=
+ k8s.io/kubectl v0.29.0/go.mod h1:0jMjGWIcMIQzmUaMgAzhSELv5WtHo2a8pq67DtviAJs=
+ k8s.io/kubelet v0.29.0 h1:SX5hlznTBcGIrS1scaf8r8p6m3e475KMifwt9i12iOk=
+ k8s.io/kubelet v0.29.0/go.mod h1:kvKS2+Bz2tgDOG1S1q0TH2z1DasNuVF+8p6Aw7xvKkI=
+-k8s.io/kubernetes v1.29.0 h1:DOLN7g8+nnAYBi8JHoW0+/MCrZKDPIqAxzLCXDXd0cg=
+-k8s.io/kubernetes v1.29.0/go.mod h1:9kztbUQf9stVDcIYXx+BX3nuGCsAQDsuClkGMpPs3pA=
++k8s.io/kubernetes v1.29.4 h1:n4VCbX9cUhxHI+zw+m2iZlzT73/mrEJBHIMeauh9g4U=
++k8s.io/kubernetes v1.29.4/go.mod h1:28sDhcb87LX5z3GWAKYmLrhrifxi4W9bEWua4DRTIvk=
+ k8s.io/mount-utils v0.29.0 h1:KcUE0bFHONQC10V3SuLWQ6+l8nmJggw9lKLpDftIshI=
+ k8s.io/mount-utils v0.29.0/go.mod h1:N3lDK/G1B8R/IkAt4NhHyqB07OqEr7P763z3TNge94U=
+ k8s.io/pod-security-admission v0.29.0 h1:tY/ldtkbBCulMYVSWg6ZDLlgDYDWy6rLj8e/AgmwSj4=
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+deleted file mode 100644
+index d33c8890f..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
++++ /dev/null
+@@ -1,39 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !go1.13
+-
+-package poly1305
+-
+-// Generic fallbacks for the math/bits intrinsics, copied from
+-// src/math/bits/bits.go. They were added in Go 1.12, but Add64 and Sum64 had
+-// variable time fallbacks until Go 1.13.
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	sum = x + y + carry
+-	carryOut = ((x & y) | ((x | y) &^ sum)) >> 63
+-	return
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	diff = x - y - borrow
+-	borrowOut = ((^x & y) | (^(x ^ y) & diff)) >> 63
+-	return
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	const mask32 = 1<<32 - 1
+-	x0 := x & mask32
+-	x1 := x >> 32
+-	y0 := y & mask32
+-	y1 := y >> 32
+-	w0 := x0 * y0
+-	t := x1*y0 + w0>>32
+-	w1 := t & mask32
+-	w2 := t >> 32
+-	w1 += x0 * y1
+-	hi = x1*y1 + w2 + w1>>32
+-	lo = x * y
+-	return
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+deleted file mode 100644
+index 495c1fa69..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
++++ /dev/null
+@@ -1,21 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build go1.13
+-
+-package poly1305
+-
+-import "math/bits"
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	return bits.Add64(x, y, carry)
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	return bits.Sub64(x, y, borrow)
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	return bits.Mul64(x, y)
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+index e041da5ea..ec2202bd7 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+@@ -7,7 +7,10 @@
+ 
+ package poly1305
+ 
+-import "encoding/binary"
++import (
++	"encoding/binary"
++	"math/bits"
++)
+ 
+ // Poly1305 [RFC 7539] is a relatively simple algorithm: the authentication tag
+ // for a 64 bytes message is approximately
+@@ -114,13 +117,13 @@ type uint128 struct {
+ }
+ 
+ func mul64(a, b uint64) uint128 {
+-	hi, lo := bitsMul64(a, b)
++	hi, lo := bits.Mul64(a, b)
+ 	return uint128{lo, hi}
+ }
+ 
+ func add128(a, b uint128) uint128 {
+-	lo, c := bitsAdd64(a.lo, b.lo, 0)
+-	hi, c := bitsAdd64(a.hi, b.hi, c)
++	lo, c := bits.Add64(a.lo, b.lo, 0)
++	hi, c := bits.Add64(a.hi, b.hi, c)
+ 	if c != 0 {
+ 		panic("poly1305: unexpected overflow")
+ 	}
+@@ -155,8 +158,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 		// hide leading zeroes. For full chunks, that's 1 << 128, so we can just
+ 		// add 1 to the most significant (2¹²⁸) limb, h2.
+ 		if len(msg) >= TagSize {
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
+ 			h2 += c + 1
+ 
+ 			msg = msg[TagSize:]
+@@ -165,8 +168,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 			copy(buf[:], msg)
+ 			buf[len(msg)] = 1
+ 
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
+ 			h2 += c
+ 
+ 			msg = nil
+@@ -219,9 +222,9 @@ func updateGeneric(state *macState, msg []byte) {
+ 		m3 := h2r1
+ 
+ 		t0 := m0.lo
+-		t1, c := bitsAdd64(m1.lo, m0.hi, 0)
+-		t2, c := bitsAdd64(m2.lo, m1.hi, c)
+-		t3, _ := bitsAdd64(m3.lo, m2.hi, c)
++		t1, c := bits.Add64(m1.lo, m0.hi, 0)
++		t2, c := bits.Add64(m2.lo, m1.hi, c)
++		t3, _ := bits.Add64(m3.lo, m2.hi, c)
+ 
+ 		// Now we have the result as 4 64-bit limbs, and we need to reduce it
+ 		// modulo 2¹³⁰ - 5. The special shape of this Crandall prime lets us do
+@@ -243,14 +246,14 @@ func updateGeneric(state *macState, msg []byte) {
+ 
+ 		// To add c * 5 to h, we first add cc = c * 4, and then add (cc >> 2) = c.
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		cc = shiftRightBy2(cc)
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		// h2 is at most 3 + 1 + 1 = 5, making the whole of h at most
+@@ -287,9 +290,9 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	// in constant time, we compute t = h - (2¹³⁰ - 5), and select h as the
+ 	// result if the subtraction underflows, and t otherwise.
+ 
+-	hMinusP0, b := bitsSub64(h0, p0, 0)
+-	hMinusP1, b := bitsSub64(h1, p1, b)
+-	_, b = bitsSub64(h2, p2, b)
++	hMinusP0, b := bits.Sub64(h0, p0, 0)
++	hMinusP1, b := bits.Sub64(h1, p1, b)
++	_, b = bits.Sub64(h2, p2, b)
+ 
+ 	// h = h if h < p else h - p
+ 	h0 = select64(b, h0, hMinusP0)
+@@ -301,8 +304,8 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	//
+ 	// by just doing a wide addition with the 128 low bits of h and discarding
+ 	// the overflow.
+-	h0, c := bitsAdd64(h0, s[0], 0)
+-	h1, _ = bitsAdd64(h1, s[1], c)
++	h0, c := bits.Add64(h0, s[0], 0)
++	h1, _ = bits.Add64(h1, s[1], c)
+ 
+ 	binary.LittleEndian.PutUint64(out[0:8], h0)
+ 	binary.LittleEndian.PutUint64(out[8:16], h1)
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+index d2ca5deeb..b3c1699bf 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+@@ -19,15 +19,14 @@
+ 
+ #define POLY1305_MUL(h0, h1, h2, r0, r1, t0, t1, t2, t3, t4, t5) \
+ 	MULLD  r0, h0, t0;  \
+-	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h0, t1;  \
++	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h1, t5;  \
+ 	ADDC   t4, t1, t1;  \
+ 	MULLD  r0, h2, t2;  \
+-	ADDZE  t5;          \
+ 	MULHDU r1, h0, t4;  \
+ 	MULLD  r1, h0, h0;  \
+-	ADD    t5, t2, t2;  \
++	ADDE   t5, t2, t2;  \
+ 	ADDC   h0, t1, t1;  \
+ 	MULLD  h2, r1, t3;  \
+ 	ADDZE  t4, h0;      \
+@@ -37,13 +36,11 @@
+ 	ADDE   t5, t3, t3;  \
+ 	ADDC   h0, t2, t2;  \
+ 	MOVD   $-4, t4;     \
+-	MOVD   t0, h0;      \
+-	MOVD   t1, h1;      \
+ 	ADDZE  t3;          \
+-	ANDCC  $3, t2, h2;  \
+-	AND    t2, t4, t0;  \
++	RLDICL $0, t2, $62, h2; \
++	AND    t2, t4, h0;  \
+ 	ADDC   t0, h0, h0;  \
+-	ADDE   t3, h1, h1;  \
++	ADDE   t3, t1, h1;  \
+ 	SLD    $62, t3, t4; \
+ 	SRD    $2, t2;      \
+ 	ADDZE  h2;          \
+@@ -75,6 +72,7 @@ TEXT ·update(SB), $0-32
+ loop:
+ 	POLY1305_ADD(R4, R8, R9, R10, R20, R21, R22)
+ 
++	PCALIGN $16
+ multiply:
+ 	POLY1305_MUL(R8, R9, R10, R11, R12, R16, R17, R18, R14, R20, R21)
+ 	ADD $-16, R5
+diff --git a/vendor/golang.org/x/net/html/token.go b/vendor/golang.org/x/net/html/token.go
+index de67f938a..3c57880d6 100644
+--- a/vendor/golang.org/x/net/html/token.go
++++ b/vendor/golang.org/x/net/html/token.go
+@@ -910,9 +910,6 @@ func (z *Tokenizer) readTagAttrKey() {
+ 			return
+ 		}
+ 		switch c {
+-		case ' ', '\n', '\r', '\t', '\f', '/':
+-			z.pendingAttr[0].end = z.raw.end - 1
+-			return
+ 		case '=':
+ 			if z.pendingAttr[0].start+1 == z.raw.end {
+ 				// WHATWG 13.2.5.32, if we see an equals sign before the attribute name
+@@ -920,7 +917,9 @@ func (z *Tokenizer) readTagAttrKey() {
+ 				continue
+ 			}
+ 			fallthrough
+-		case '>':
++		case ' ', '\n', '\r', '\t', '\f', '/', '>':
++			// WHATWG 13.2.5.33 Attribute name state
++			// We need to reconsume the char in the after attribute name state to support the / character
+ 			z.raw.end--
+ 			z.pendingAttr[0].end = z.raw.end
+ 			return
+@@ -939,6 +938,11 @@ func (z *Tokenizer) readTagAttrVal() {
+ 	if z.err != nil {
+ 		return
+ 	}
++	if c == '/' {
++		// WHATWG 13.2.5.34 After attribute name state
++		// U+002F SOLIDUS (/) - Switch to the self-closing start tag state.
++		return
++	}
+ 	if c != '=' {
+ 		z.raw.end--
+ 		return
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90dc..43557ab7e 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984fd..3b9f06b96 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c6408..ce2e8b40e 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 000000000..61075bd16
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86c..ce375c8c7 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/net/websocket/client.go b/vendor/golang.org/x/net/websocket/client.go
+index 69a4ac7ee..1e64157f3 100644
+--- a/vendor/golang.org/x/net/websocket/client.go
++++ b/vendor/golang.org/x/net/websocket/client.go
+@@ -6,10 +6,12 @@ package websocket
+ 
+ import (
+ 	"bufio"
++	"context"
+ 	"io"
+ 	"net"
+ 	"net/http"
+ 	"net/url"
++	"time"
+ )
+ 
+ // DialError is an error that occurs while dialling a websocket server.
+@@ -79,28 +81,59 @@ func parseAuthority(location *url.URL) string {
+ 
+ // DialConfig opens a new client connection to a WebSocket with a config.
+ func DialConfig(config *Config) (ws *Conn, err error) {
+-	var client net.Conn
++	return config.DialContext(context.Background())
++}
++
++// DialContext opens a new client connection to a WebSocket, with context support for timeouts/cancellation.
++func (config *Config) DialContext(ctx context.Context) (*Conn, error) {
+ 	if config.Location == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketLocation}
+ 	}
+ 	if config.Origin == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketOrigin}
+ 	}
++
+ 	dialer := config.Dialer
+ 	if dialer == nil {
+ 		dialer = &net.Dialer{}
+ 	}
+-	client, err = dialWithDialer(dialer, config)
+-	if err != nil {
+-		goto Error
+-	}
+-	ws, err = NewClient(config, client)
++
++	client, err := dialWithDialer(ctx, dialer, config)
+ 	if err != nil {
+-		client.Close()
+-		goto Error
++		return nil, &DialError{config, err}
+ 	}
+-	return
+ 
+-Error:
+-	return nil, &DialError{config, err}
++	// Cleanup the connection if we fail to create the websocket successfully
++	success := false
++	defer func() {
++		if !success {
++			_ = client.Close()
++		}
++	}()
++
++	var ws *Conn
++	var wsErr error
++	doneConnecting := make(chan struct{})
++	go func() {
++		defer close(doneConnecting)
++		ws, err = NewClient(config, client)
++		if err != nil {
++			wsErr = &DialError{config, err}
++		}
++	}()
++
++	// The websocket.NewClient() function can block indefinitely, make sure that we
++	// respect the deadlines specified by the context.
++	select {
++	case <-ctx.Done():
++		// Force the pending operations to fail, terminating the pending connection attempt
++		_ = client.SetDeadline(time.Now())
++		<-doneConnecting // Wait for the goroutine that tries to establish the connection to finish
++		return nil, &DialError{config, ctx.Err()}
++	case <-doneConnecting:
++		if wsErr == nil {
++			success = true // Disarm the deferred connection cleanup
++		}
++		return ws, wsErr
++	}
+ }
+diff --git a/vendor/golang.org/x/net/websocket/dial.go b/vendor/golang.org/x/net/websocket/dial.go
+index 2dab943a4..8a2d83c47 100644
+--- a/vendor/golang.org/x/net/websocket/dial.go
++++ b/vendor/golang.org/x/net/websocket/dial.go
+@@ -5,18 +5,23 @@
+ package websocket
+ 
+ import (
++	"context"
+ 	"crypto/tls"
+ 	"net"
+ )
+ 
+-func dialWithDialer(dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
++func dialWithDialer(ctx context.Context, dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
+ 	switch config.Location.Scheme {
+ 	case "ws":
+-		conn, err = dialer.Dial("tcp", parseAuthority(config.Location))
++		conn, err = dialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 
+ 	case "wss":
+-		conn, err = tls.DialWithDialer(dialer, "tcp", parseAuthority(config.Location), config.TlsConfig)
++		tlsDialer := &tls.Dialer{
++			NetDialer: dialer,
++			Config:    config.TlsConfig,
++		}
+ 
++		conn, err = tlsDialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 	default:
+ 		err = ErrBadScheme
+ 	}
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4bd..b0e419857 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index 6202638ba..fdcaa974d 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -582,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -603,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc69937..2f0fa76e4 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4db..2b57e0f73 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index 0f85e29e6..5682e2628 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -1849,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index c73cfe2f1..36bf8399f 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -1785,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821cf..42ff8c3c1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e4112..dca436004 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c63985560..5cca668ac 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e25..d8cae6d15 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09e..28e39afdc 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642a..cd66e92cb 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d75..c1595eba7 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0d..ee9456b0d 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84f..8cfca81e1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d6..60b0deb3a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc72..f90aa7281 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e2..ba9e01503 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813ed..07cdfd6e9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4ec..2f1dd214a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994da..f40519d90 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index 1488d2712..87d8612a1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -906,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index a1d061597..9dc42410b 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index 5b2a74097..0d3a0751c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index f6eda1344..c39f7776d 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 55df20ae9..57571d072 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index 8c1155cbc..e62963e67 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index 7cc80c58d..00831354c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index 0688737f4..79029ed58 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbdd..0cc3ce496 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc2504..856d92d69 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf2467..8d467094c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e2..edc173244 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77e..445eba206 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362ef..adba01bca 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4fd..014c4e9c7 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca81..ccc97d74d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d39..ec2b64a95 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e3747..21a839e33 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c8..c11121ec3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e591..909b631fc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195a..e49bed16e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943bc..66017d2d3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc51..47bab18dc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index bbf8399ff..eff6bcdef 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -3399,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4183,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5134,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5547,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad19250..d4577a423 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index 47dc57967..6395a031d 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -194,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index 146a1f019..e8791c82c 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -342,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -2988,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+index fa1242b8a..6a3f888ab 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+@@ -392,7 +392,7 @@ type PersistentVolumeStatus struct {
+ 	Reason string
+ 	// LastPhaseTransitionTime is the time the phase transitioned from one to another
+ 	// and automatically resets to current time everytime a volume phase transitions.
+-	// This is an alpha field and requires enabling PersistentVolumeLastPhaseTransitionTime feature.
++	// This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
+ 	// +featureGate=PersistentVolumeLastPhaseTransitionTime
+ 	// +optional
+ 	LastPhaseTransitionTime *metav1.Time
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+index a6f7fef30..1885531f8 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+@@ -5141,6 +5141,46 @@ func ValidateContainerStateTransition(newStatuses, oldStatuses []core.ContainerS
+ 	return allErrs
+ }
+ 
++// ValidateInitContainerStateTransition test to if any illegal init container state transitions are being attempted
++func ValidateInitContainerStateTransition(newStatuses, oldStatuses []core.ContainerStatus, fldpath *field.Path, podSpec *core.PodSpec) field.ErrorList {
++	allErrs := field.ErrorList{}
++	// If we should always restart, containers are allowed to leave the terminated state
++	if podSpec.RestartPolicy == core.RestartPolicyAlways {
++		return allErrs
++	}
++	for i, oldStatus := range oldStatuses {
++		// Skip any container that is not terminated
++		if oldStatus.State.Terminated == nil {
++			continue
++		}
++		// Skip any container that failed but is allowed to restart
++		if oldStatus.State.Terminated.ExitCode != 0 && podSpec.RestartPolicy == core.RestartPolicyOnFailure {
++			continue
++		}
++
++		// Skip any restartable init container that is allowed to restart
++		isRestartableInitContainer := false
++		for _, c := range podSpec.InitContainers {
++			if oldStatus.Name == c.Name {
++				if c.RestartPolicy != nil && *c.RestartPolicy == core.ContainerRestartPolicyAlways {
++					isRestartableInitContainer = true
++				}
++				break
++			}
++		}
++		if isRestartableInitContainer {
++			continue
++		}
++
++		for _, newStatus := range newStatuses {
++			if oldStatus.Name == newStatus.Name && newStatus.State.Terminated == nil {
++				allErrs = append(allErrs, field.Forbidden(fldpath.Index(i).Child("state"), "may not be transitioned to non-terminated state"))
++			}
++		}
++	}
++	return allErrs
++}
++
+ // ValidatePodStatusUpdate checks for changes to status that shouldn't occur in normal operation.
+ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) field.ErrorList {
+ 	fldPath := field.NewPath("metadata")
+@@ -5162,7 +5202,7 @@ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions
+ 	// If pod should not restart, make sure the status update does not transition
+ 	// any terminated containers to a non-terminated state.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.ContainerStatuses, oldPod.Status.ContainerStatuses, fldPath.Child("containerStatuses"), oldPod.Spec.RestartPolicy)...)
+-	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), oldPod.Spec.RestartPolicy)...)
++	allErrs = append(allErrs, ValidateInitContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), &oldPod.Spec)...)
+ 	// The kubelet will never restart ephemeral containers, so treat them like they have an implicit RestartPolicyNever.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.EphemeralContainerStatuses, oldPod.Status.EphemeralContainerStatuses, fldPath.Child("ephemeralContainerStatuses"), core.RestartPolicyNever)...)
+ 	allErrs = append(allErrs, validatePodResourceClaimStatuses(newPod.Status.ResourceClaimStatuses, newPod.Spec.ResourceClaims, fldPath.Child("resourceClaimStatuses"))...)
+diff --git a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+index edd33feb7..b0b12d6eb 100644
+--- a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
++++ b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+@@ -259,7 +259,6 @@ const (
+ 	// owner: @harche
+ 	// kep: http://kep.k8s.io/3386
+ 	// alpha: v1.25
+-	// beta: v1.27
+ 	//
+ 	// Allows using event-driven PLEG (pod lifecycle event generator) through kubelet
+ 	// which avoids frequent relisting of containers which helps optimize performance.
+@@ -617,6 +616,7 @@ const (
+ 	// owner: @RomanBednar
+ 	// kep: https://kep.k8s.io/3762
+ 	// alpha: v1.28
++	// beta: v1.29
+ 	//
+ 	// Adds a new field to persistent volumes which holds a timestamp of when the volume last transitioned its phase.
+ 	PersistentVolumeLastPhaseTransitionTime featuregate.Feature = "PersistentVolumeLastPhaseTransitionTime"
+@@ -1048,7 +1048,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
+ 
+-	EventedPLEG: {Default: false, PreRelease: featuregate.Beta}, // off by default, requires CRI Runtime support
++	EventedPLEG: {Default: false, PreRelease: featuregate.Alpha},
+ 
+ 	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
+ 
+@@ -1263,6 +1263,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.SeparateCacheWatchRPC: {Default: true, PreRelease: featuregate.Beta},
++
+ 	genericfeatures.ServerSideApply: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+ 
+ 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+@@ -1273,6 +1275,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.ZeroLimitedNominalConcurrencyShares: {Default: false, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.WatchFromStorageWithoutResourceVersion: {Default: false, PreRelease: featuregate.Beta},
++
+ 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
+ 	// unintentionally on either side:
+ 
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+index 94c2330af..6ce01755f 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+@@ -1064,7 +1064,7 @@ func NewPersistentVolumeRecyclerPodTemplate() *v1.Pod {
+ 			Containers: []v1.Container{
+ 				{
+ 					Name:    "pv-recycler",
+-					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.0",
++					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.2",
+ 					Command: []string{"/bin/sh"},
+ 					Args:    []string{"-c", "test -e /scrub && find /scrub -mindepth 1 -delete && test -z \"$(ls -A /scrub)\" || exit 1"},
+ 					VolumeMounts: []v1.VolumeMount{
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+index af309353b..238e919b3 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+@@ -102,6 +102,23 @@ func IsFailedPreconditionError(err error) bool {
+ 	return errors.As(err, &failedPreconditionError)
+ }
+ 
++type OperationNotSupported struct {
++	msg string
++}
++
++func (err *OperationNotSupported) Error() string {
++	return err.msg
++}
++
++func NewOperationNotSupportedError(msg string) *OperationNotSupported {
++	return &OperationNotSupported{msg: msg}
++}
++
++func IsOperationNotSupportedError(err error) bool {
++	var operationNotSupportedError *OperationNotSupported
++	return errors.As(err, &operationNotSupportedError)
++}
++
+ // TransientOperationFailure indicates operation failed with a transient error
+ // and may fix itself when retried.
+ type TransientOperationFailure struct {
+diff --git a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+index 72f2394e9..0d83a7cc8 100644
+--- a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
++++ b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+@@ -232,7 +232,7 @@ const (
+ 
+ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
+ 	configs := map[ImageID]Config{}
+-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.45"}
++	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.47"}
+ 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
+ 	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
+ 	configs[AuthenticatedWindowsNanoServer] = Config{list.GcAuthenticatedRegistry, "windows-nanoserver", "v1"}
+@@ -241,8 +241,8 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
+ 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.36.1-1"}
+ 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
+ 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
+-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.3"}
+-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.10-0"}
++	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.7"}
++	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.12-0"}
+ 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
+ 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}
+ 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index ebde30f57..ab47b0cca 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -406,7 +406,7 @@ go.uber.org/zap/internal/pool
+ go.uber.org/zap/internal/stacktrace
+ go.uber.org/zap/zapcore
+ go.uber.org/zap/zapgrpc
+-# golang.org/x/crypto v0.17.0
++# golang.org/x/crypto v0.21.0
+ ## explicit; go 1.18
+ golang.org/x/crypto/blowfish
+ golang.org/x/crypto/chacha20
+@@ -430,7 +430,7 @@ golang.org/x/exp/slices
+ # golang.org/x/mod v0.14.0
+ ## explicit; go 1.18
+ golang.org/x/mod/semver
+-# golang.org/x/net v0.19.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/bpf
+ golang.org/x/net/context
+@@ -457,14 +457,14 @@ golang.org/x/oauth2/internal
+ # golang.org/x/sync v0.5.0
+ ## explicit; go 1.18
+ golang.org/x/sync/singleflight
+-# golang.org/x/sys v0.15.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/cpu
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+ golang.org/x/sys/windows/registry
+-# golang.org/x/term v0.15.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+@@ -1355,7 +1355,7 @@ k8s.io/kubectl/pkg/util/podutils
+ # k8s.io/kubelet v0.27.0 => k8s.io/kubelet v0.29.0
+ ## explicit; go 1.21
+ k8s.io/kubelet/pkg/apis
+-# k8s.io/kubernetes v1.29.0
++# k8s.io/kubernetes v1.29.4
+ ## explicit; go 1.21
+ k8s.io/kubernetes/pkg/api/legacyscheme
+ k8s.io/kubernetes/pkg/api/service
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/external-provisioner/1-26/CHECKSUMS
+++ b/projects/kubernetes-csi/external-provisioner/1-26/CHECKSUMS
@@ -1,2 +1,2 @@
-f090fe1d3e9e0b7e15c235537a649785921f5704d216b27bca4a1e84536e2572  _output/1-26/bin/external-provisioner/linux-amd64/csi-provisioner
-952edef97a4caa19b92d2bbb13f72d737775e972f07feca64468061f982ca75b  _output/1-26/bin/external-provisioner/linux-arm64/csi-provisioner
+a554f31f0d5ac26b61efbe6fa3b8e76194f0026ddec9335db9136dcbc345f4e1  _output/1-26/bin/external-provisioner/linux-amd64/csi-provisioner
+96967e52e5f700d3830d73bd43242308395f4d07ab66879c706aad72875df4fe  _output/1-26/bin/external-provisioner/linux-arm64/csi-provisioner

--- a/projects/kubernetes-csi/external-provisioner/1-26/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
+++ b/projects/kubernetes-csi/external-provisioner/1-26/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
@@ -1,0 +1,3220 @@
+From 272caf23aea9e18489bbe26e27e047bc5f09d753 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:41:12 +0000
+Subject: [PATCH] Fix external-provisioner CVE-2024-3177 by bumping
+ k8s.io/kubernetes to 1.29.4
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |  10 +-
+ go.sum                                        |  20 +-
+ .../x/crypto/internal/poly1305/bits_compat.go |  39 ---
+ .../x/crypto/internal/poly1305/bits_go1.13.go |  21 --
+ .../x/crypto/internal/poly1305/sum_generic.go |  43 +--
+ .../x/crypto/internal/poly1305/sum_ppc64le.s  |  14 +-
+ vendor/golang.org/x/net/html/token.go         |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/net/websocket/client.go   |  55 ++-
+ vendor/golang.org/x/net/websocket/dial.go     |  11 +-
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  39 ++-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go |  99 ++++++
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  90 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  10 +
+ .../x/sys/unix/zsyscall_openbsd_386.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |   2 -
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |   2 -
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 185 ++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   4 +-
+ .../x/sys/windows/zsyscall_windows.go         |   9 +
+ .../k8s.io/kubernetes/pkg/apis/core/types.go  |   2 +-
+ .../pkg/apis/core/validation/validation.go    |  42 ++-
+ .../kubernetes/pkg/features/kube_features.go  |   8 +-
+ .../k8s.io/kubernetes/pkg/volume/plugins.go   |   2 +-
+ .../kubernetes/pkg/volume/util/types/types.go |  17 +
+ .../kubernetes/test/utils/image/manifest.go   |   6 +-
+ vendor/modules.txt                            |  10 +-
+ 69 files changed, 1287 insertions(+), 316 deletions(-)
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index fff06492a..a2be5719c 100644
+--- a/go.mod
++++ b/go.mod
+@@ -33,7 +33,7 @@ require (
+ require (
+ 	github.com/onsi/ginkgo/v2 v2.13.2
+ 	github.com/onsi/gomega v1.30.0
+-	k8s.io/kubernetes v1.29.0
++	k8s.io/kubernetes v1.29.4
+ )
+ 
+ require (
+@@ -106,14 +106,14 @@ require (
+ 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.26.0 // indirect
+-	golang.org/x/crypto v0.17.0 // indirect
++	golang.org/x/crypto v0.21.0 // indirect
+ 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+ 	golang.org/x/mod v0.14.0 // indirect
+-	golang.org/x/net v0.19.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
+ 	golang.org/x/oauth2 v0.15.0 // indirect
+ 	golang.org/x/sync v0.5.0 // indirect
+-	golang.org/x/sys v0.15.0 // indirect
+-	golang.org/x/term v0.15.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.5.0 // indirect
+ 	golang.org/x/tools v0.16.1 // indirect
+diff --git a/go.sum b/go.sum
+index 56c808a77..c0444fa2f 100644
+--- a/go.sum
++++ b/go.sum
+@@ -248,8 +248,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
+ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+-golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+-golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
++golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
++golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -265,8 +265,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+-golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.15.0 h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ=
+ golang.org/x/oauth2 v0.15.0/go.mod h1:q48ptWNTY5XWf+JNten23lcvHpLJ0ZSxF5ttTHKVCAM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -286,12 +286,12 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+-golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+@@ -371,8 +371,8 @@ k8s.io/kubectl v0.29.0 h1:Oqi48gXjikDhrBF67AYuZRTcJV4lg2l42GmvsP7FmYI=
+ k8s.io/kubectl v0.29.0/go.mod h1:0jMjGWIcMIQzmUaMgAzhSELv5WtHo2a8pq67DtviAJs=
+ k8s.io/kubelet v0.29.0 h1:SX5hlznTBcGIrS1scaf8r8p6m3e475KMifwt9i12iOk=
+ k8s.io/kubelet v0.29.0/go.mod h1:kvKS2+Bz2tgDOG1S1q0TH2z1DasNuVF+8p6Aw7xvKkI=
+-k8s.io/kubernetes v1.29.0 h1:DOLN7g8+nnAYBi8JHoW0+/MCrZKDPIqAxzLCXDXd0cg=
+-k8s.io/kubernetes v1.29.0/go.mod h1:9kztbUQf9stVDcIYXx+BX3nuGCsAQDsuClkGMpPs3pA=
++k8s.io/kubernetes v1.29.4 h1:n4VCbX9cUhxHI+zw+m2iZlzT73/mrEJBHIMeauh9g4U=
++k8s.io/kubernetes v1.29.4/go.mod h1:28sDhcb87LX5z3GWAKYmLrhrifxi4W9bEWua4DRTIvk=
+ k8s.io/mount-utils v0.29.0 h1:KcUE0bFHONQC10V3SuLWQ6+l8nmJggw9lKLpDftIshI=
+ k8s.io/mount-utils v0.29.0/go.mod h1:N3lDK/G1B8R/IkAt4NhHyqB07OqEr7P763z3TNge94U=
+ k8s.io/pod-security-admission v0.29.0 h1:tY/ldtkbBCulMYVSWg6ZDLlgDYDWy6rLj8e/AgmwSj4=
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+deleted file mode 100644
+index d33c8890f..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
++++ /dev/null
+@@ -1,39 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !go1.13
+-
+-package poly1305
+-
+-// Generic fallbacks for the math/bits intrinsics, copied from
+-// src/math/bits/bits.go. They were added in Go 1.12, but Add64 and Sum64 had
+-// variable time fallbacks until Go 1.13.
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	sum = x + y + carry
+-	carryOut = ((x & y) | ((x | y) &^ sum)) >> 63
+-	return
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	diff = x - y - borrow
+-	borrowOut = ((^x & y) | (^(x ^ y) & diff)) >> 63
+-	return
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	const mask32 = 1<<32 - 1
+-	x0 := x & mask32
+-	x1 := x >> 32
+-	y0 := y & mask32
+-	y1 := y >> 32
+-	w0 := x0 * y0
+-	t := x1*y0 + w0>>32
+-	w1 := t & mask32
+-	w2 := t >> 32
+-	w1 += x0 * y1
+-	hi = x1*y1 + w2 + w1>>32
+-	lo = x * y
+-	return
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+deleted file mode 100644
+index 495c1fa69..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
++++ /dev/null
+@@ -1,21 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build go1.13
+-
+-package poly1305
+-
+-import "math/bits"
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	return bits.Add64(x, y, carry)
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	return bits.Sub64(x, y, borrow)
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	return bits.Mul64(x, y)
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+index e041da5ea..ec2202bd7 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+@@ -7,7 +7,10 @@
+ 
+ package poly1305
+ 
+-import "encoding/binary"
++import (
++	"encoding/binary"
++	"math/bits"
++)
+ 
+ // Poly1305 [RFC 7539] is a relatively simple algorithm: the authentication tag
+ // for a 64 bytes message is approximately
+@@ -114,13 +117,13 @@ type uint128 struct {
+ }
+ 
+ func mul64(a, b uint64) uint128 {
+-	hi, lo := bitsMul64(a, b)
++	hi, lo := bits.Mul64(a, b)
+ 	return uint128{lo, hi}
+ }
+ 
+ func add128(a, b uint128) uint128 {
+-	lo, c := bitsAdd64(a.lo, b.lo, 0)
+-	hi, c := bitsAdd64(a.hi, b.hi, c)
++	lo, c := bits.Add64(a.lo, b.lo, 0)
++	hi, c := bits.Add64(a.hi, b.hi, c)
+ 	if c != 0 {
+ 		panic("poly1305: unexpected overflow")
+ 	}
+@@ -155,8 +158,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 		// hide leading zeroes. For full chunks, that's 1 << 128, so we can just
+ 		// add 1 to the most significant (2¹²⁸) limb, h2.
+ 		if len(msg) >= TagSize {
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
+ 			h2 += c + 1
+ 
+ 			msg = msg[TagSize:]
+@@ -165,8 +168,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 			copy(buf[:], msg)
+ 			buf[len(msg)] = 1
+ 
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
+ 			h2 += c
+ 
+ 			msg = nil
+@@ -219,9 +222,9 @@ func updateGeneric(state *macState, msg []byte) {
+ 		m3 := h2r1
+ 
+ 		t0 := m0.lo
+-		t1, c := bitsAdd64(m1.lo, m0.hi, 0)
+-		t2, c := bitsAdd64(m2.lo, m1.hi, c)
+-		t3, _ := bitsAdd64(m3.lo, m2.hi, c)
++		t1, c := bits.Add64(m1.lo, m0.hi, 0)
++		t2, c := bits.Add64(m2.lo, m1.hi, c)
++		t3, _ := bits.Add64(m3.lo, m2.hi, c)
+ 
+ 		// Now we have the result as 4 64-bit limbs, and we need to reduce it
+ 		// modulo 2¹³⁰ - 5. The special shape of this Crandall prime lets us do
+@@ -243,14 +246,14 @@ func updateGeneric(state *macState, msg []byte) {
+ 
+ 		// To add c * 5 to h, we first add cc = c * 4, and then add (cc >> 2) = c.
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		cc = shiftRightBy2(cc)
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		// h2 is at most 3 + 1 + 1 = 5, making the whole of h at most
+@@ -287,9 +290,9 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	// in constant time, we compute t = h - (2¹³⁰ - 5), and select h as the
+ 	// result if the subtraction underflows, and t otherwise.
+ 
+-	hMinusP0, b := bitsSub64(h0, p0, 0)
+-	hMinusP1, b := bitsSub64(h1, p1, b)
+-	_, b = bitsSub64(h2, p2, b)
++	hMinusP0, b := bits.Sub64(h0, p0, 0)
++	hMinusP1, b := bits.Sub64(h1, p1, b)
++	_, b = bits.Sub64(h2, p2, b)
+ 
+ 	// h = h if h < p else h - p
+ 	h0 = select64(b, h0, hMinusP0)
+@@ -301,8 +304,8 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	//
+ 	// by just doing a wide addition with the 128 low bits of h and discarding
+ 	// the overflow.
+-	h0, c := bitsAdd64(h0, s[0], 0)
+-	h1, _ = bitsAdd64(h1, s[1], c)
++	h0, c := bits.Add64(h0, s[0], 0)
++	h1, _ = bits.Add64(h1, s[1], c)
+ 
+ 	binary.LittleEndian.PutUint64(out[0:8], h0)
+ 	binary.LittleEndian.PutUint64(out[8:16], h1)
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+index d2ca5deeb..b3c1699bf 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+@@ -19,15 +19,14 @@
+ 
+ #define POLY1305_MUL(h0, h1, h2, r0, r1, t0, t1, t2, t3, t4, t5) \
+ 	MULLD  r0, h0, t0;  \
+-	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h0, t1;  \
++	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h1, t5;  \
+ 	ADDC   t4, t1, t1;  \
+ 	MULLD  r0, h2, t2;  \
+-	ADDZE  t5;          \
+ 	MULHDU r1, h0, t4;  \
+ 	MULLD  r1, h0, h0;  \
+-	ADD    t5, t2, t2;  \
++	ADDE   t5, t2, t2;  \
+ 	ADDC   h0, t1, t1;  \
+ 	MULLD  h2, r1, t3;  \
+ 	ADDZE  t4, h0;      \
+@@ -37,13 +36,11 @@
+ 	ADDE   t5, t3, t3;  \
+ 	ADDC   h0, t2, t2;  \
+ 	MOVD   $-4, t4;     \
+-	MOVD   t0, h0;      \
+-	MOVD   t1, h1;      \
+ 	ADDZE  t3;          \
+-	ANDCC  $3, t2, h2;  \
+-	AND    t2, t4, t0;  \
++	RLDICL $0, t2, $62, h2; \
++	AND    t2, t4, h0;  \
+ 	ADDC   t0, h0, h0;  \
+-	ADDE   t3, h1, h1;  \
++	ADDE   t3, t1, h1;  \
+ 	SLD    $62, t3, t4; \
+ 	SRD    $2, t2;      \
+ 	ADDZE  h2;          \
+@@ -75,6 +72,7 @@ TEXT ·update(SB), $0-32
+ loop:
+ 	POLY1305_ADD(R4, R8, R9, R10, R20, R21, R22)
+ 
++	PCALIGN $16
+ multiply:
+ 	POLY1305_MUL(R8, R9, R10, R11, R12, R16, R17, R18, R14, R20, R21)
+ 	ADD $-16, R5
+diff --git a/vendor/golang.org/x/net/html/token.go b/vendor/golang.org/x/net/html/token.go
+index de67f938a..3c57880d6 100644
+--- a/vendor/golang.org/x/net/html/token.go
++++ b/vendor/golang.org/x/net/html/token.go
+@@ -910,9 +910,6 @@ func (z *Tokenizer) readTagAttrKey() {
+ 			return
+ 		}
+ 		switch c {
+-		case ' ', '\n', '\r', '\t', '\f', '/':
+-			z.pendingAttr[0].end = z.raw.end - 1
+-			return
+ 		case '=':
+ 			if z.pendingAttr[0].start+1 == z.raw.end {
+ 				// WHATWG 13.2.5.32, if we see an equals sign before the attribute name
+@@ -920,7 +917,9 @@ func (z *Tokenizer) readTagAttrKey() {
+ 				continue
+ 			}
+ 			fallthrough
+-		case '>':
++		case ' ', '\n', '\r', '\t', '\f', '/', '>':
++			// WHATWG 13.2.5.33 Attribute name state
++			// We need to reconsume the char in the after attribute name state to support the / character
+ 			z.raw.end--
+ 			z.pendingAttr[0].end = z.raw.end
+ 			return
+@@ -939,6 +938,11 @@ func (z *Tokenizer) readTagAttrVal() {
+ 	if z.err != nil {
+ 		return
+ 	}
++	if c == '/' {
++		// WHATWG 13.2.5.34 After attribute name state
++		// U+002F SOLIDUS (/) - Switch to the self-closing start tag state.
++		return
++	}
+ 	if c != '=' {
+ 		z.raw.end--
+ 		return
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90dc..43557ab7e 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984fd..3b9f06b96 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c6408..ce2e8b40e 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 000000000..61075bd16
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86c..ce375c8c7 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/net/websocket/client.go b/vendor/golang.org/x/net/websocket/client.go
+index 69a4ac7ee..1e64157f3 100644
+--- a/vendor/golang.org/x/net/websocket/client.go
++++ b/vendor/golang.org/x/net/websocket/client.go
+@@ -6,10 +6,12 @@ package websocket
+ 
+ import (
+ 	"bufio"
++	"context"
+ 	"io"
+ 	"net"
+ 	"net/http"
+ 	"net/url"
++	"time"
+ )
+ 
+ // DialError is an error that occurs while dialling a websocket server.
+@@ -79,28 +81,59 @@ func parseAuthority(location *url.URL) string {
+ 
+ // DialConfig opens a new client connection to a WebSocket with a config.
+ func DialConfig(config *Config) (ws *Conn, err error) {
+-	var client net.Conn
++	return config.DialContext(context.Background())
++}
++
++// DialContext opens a new client connection to a WebSocket, with context support for timeouts/cancellation.
++func (config *Config) DialContext(ctx context.Context) (*Conn, error) {
+ 	if config.Location == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketLocation}
+ 	}
+ 	if config.Origin == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketOrigin}
+ 	}
++
+ 	dialer := config.Dialer
+ 	if dialer == nil {
+ 		dialer = &net.Dialer{}
+ 	}
+-	client, err = dialWithDialer(dialer, config)
+-	if err != nil {
+-		goto Error
+-	}
+-	ws, err = NewClient(config, client)
++
++	client, err := dialWithDialer(ctx, dialer, config)
+ 	if err != nil {
+-		client.Close()
+-		goto Error
++		return nil, &DialError{config, err}
+ 	}
+-	return
+ 
+-Error:
+-	return nil, &DialError{config, err}
++	// Cleanup the connection if we fail to create the websocket successfully
++	success := false
++	defer func() {
++		if !success {
++			_ = client.Close()
++		}
++	}()
++
++	var ws *Conn
++	var wsErr error
++	doneConnecting := make(chan struct{})
++	go func() {
++		defer close(doneConnecting)
++		ws, err = NewClient(config, client)
++		if err != nil {
++			wsErr = &DialError{config, err}
++		}
++	}()
++
++	// The websocket.NewClient() function can block indefinitely, make sure that we
++	// respect the deadlines specified by the context.
++	select {
++	case <-ctx.Done():
++		// Force the pending operations to fail, terminating the pending connection attempt
++		_ = client.SetDeadline(time.Now())
++		<-doneConnecting // Wait for the goroutine that tries to establish the connection to finish
++		return nil, &DialError{config, ctx.Err()}
++	case <-doneConnecting:
++		if wsErr == nil {
++			success = true // Disarm the deferred connection cleanup
++		}
++		return ws, wsErr
++	}
+ }
+diff --git a/vendor/golang.org/x/net/websocket/dial.go b/vendor/golang.org/x/net/websocket/dial.go
+index 2dab943a4..8a2d83c47 100644
+--- a/vendor/golang.org/x/net/websocket/dial.go
++++ b/vendor/golang.org/x/net/websocket/dial.go
+@@ -5,18 +5,23 @@
+ package websocket
+ 
+ import (
++	"context"
+ 	"crypto/tls"
+ 	"net"
+ )
+ 
+-func dialWithDialer(dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
++func dialWithDialer(ctx context.Context, dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
+ 	switch config.Location.Scheme {
+ 	case "ws":
+-		conn, err = dialer.Dial("tcp", parseAuthority(config.Location))
++		conn, err = dialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 
+ 	case "wss":
+-		conn, err = tls.DialWithDialer(dialer, "tcp", parseAuthority(config.Location), config.TlsConfig)
++		tlsDialer := &tls.Dialer{
++			NetDialer: dialer,
++			Config:    config.TlsConfig,
++		}
+ 
++		conn, err = tlsDialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 	default:
+ 		err = ErrBadScheme
+ 	}
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4bd..b0e419857 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index 6202638ba..fdcaa974d 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -582,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -603,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc69937..2f0fa76e4 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4db..2b57e0f73 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index 0f85e29e6..5682e2628 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -1849,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index c73cfe2f1..36bf8399f 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -1785,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821cf..42ff8c3c1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e4112..dca436004 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c63985560..5cca668ac 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e25..d8cae6d15 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09e..28e39afdc 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642a..cd66e92cb 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d75..c1595eba7 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0d..ee9456b0d 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84f..8cfca81e1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d6..60b0deb3a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc72..f90aa7281 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e2..ba9e01503 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813ed..07cdfd6e9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4ec..2f1dd214a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994da..f40519d90 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index 1488d2712..87d8612a1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -906,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index a1d061597..9dc42410b 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index 5b2a74097..0d3a0751c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index f6eda1344..c39f7776d 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 55df20ae9..57571d072 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index 8c1155cbc..e62963e67 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index 7cc80c58d..00831354c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index 0688737f4..79029ed58 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbdd..0cc3ce496 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc2504..856d92d69 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf2467..8d467094c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e2..edc173244 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77e..445eba206 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362ef..adba01bca 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4fd..014c4e9c7 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca81..ccc97d74d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d39..ec2b64a95 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e3747..21a839e33 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c8..c11121ec3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e591..909b631fc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195a..e49bed16e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943bc..66017d2d3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc51..47bab18dc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index bbf8399ff..eff6bcdef 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -3399,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4183,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5134,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5547,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad19250..d4577a423 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index 47dc57967..6395a031d 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -194,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index 146a1f019..e8791c82c 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -342,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -2988,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+index fa1242b8a..6a3f888ab 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+@@ -392,7 +392,7 @@ type PersistentVolumeStatus struct {
+ 	Reason string
+ 	// LastPhaseTransitionTime is the time the phase transitioned from one to another
+ 	// and automatically resets to current time everytime a volume phase transitions.
+-	// This is an alpha field and requires enabling PersistentVolumeLastPhaseTransitionTime feature.
++	// This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
+ 	// +featureGate=PersistentVolumeLastPhaseTransitionTime
+ 	// +optional
+ 	LastPhaseTransitionTime *metav1.Time
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+index a6f7fef30..1885531f8 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+@@ -5141,6 +5141,46 @@ func ValidateContainerStateTransition(newStatuses, oldStatuses []core.ContainerS
+ 	return allErrs
+ }
+ 
++// ValidateInitContainerStateTransition test to if any illegal init container state transitions are being attempted
++func ValidateInitContainerStateTransition(newStatuses, oldStatuses []core.ContainerStatus, fldpath *field.Path, podSpec *core.PodSpec) field.ErrorList {
++	allErrs := field.ErrorList{}
++	// If we should always restart, containers are allowed to leave the terminated state
++	if podSpec.RestartPolicy == core.RestartPolicyAlways {
++		return allErrs
++	}
++	for i, oldStatus := range oldStatuses {
++		// Skip any container that is not terminated
++		if oldStatus.State.Terminated == nil {
++			continue
++		}
++		// Skip any container that failed but is allowed to restart
++		if oldStatus.State.Terminated.ExitCode != 0 && podSpec.RestartPolicy == core.RestartPolicyOnFailure {
++			continue
++		}
++
++		// Skip any restartable init container that is allowed to restart
++		isRestartableInitContainer := false
++		for _, c := range podSpec.InitContainers {
++			if oldStatus.Name == c.Name {
++				if c.RestartPolicy != nil && *c.RestartPolicy == core.ContainerRestartPolicyAlways {
++					isRestartableInitContainer = true
++				}
++				break
++			}
++		}
++		if isRestartableInitContainer {
++			continue
++		}
++
++		for _, newStatus := range newStatuses {
++			if oldStatus.Name == newStatus.Name && newStatus.State.Terminated == nil {
++				allErrs = append(allErrs, field.Forbidden(fldpath.Index(i).Child("state"), "may not be transitioned to non-terminated state"))
++			}
++		}
++	}
++	return allErrs
++}
++
+ // ValidatePodStatusUpdate checks for changes to status that shouldn't occur in normal operation.
+ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) field.ErrorList {
+ 	fldPath := field.NewPath("metadata")
+@@ -5162,7 +5202,7 @@ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions
+ 	// If pod should not restart, make sure the status update does not transition
+ 	// any terminated containers to a non-terminated state.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.ContainerStatuses, oldPod.Status.ContainerStatuses, fldPath.Child("containerStatuses"), oldPod.Spec.RestartPolicy)...)
+-	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), oldPod.Spec.RestartPolicy)...)
++	allErrs = append(allErrs, ValidateInitContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), &oldPod.Spec)...)
+ 	// The kubelet will never restart ephemeral containers, so treat them like they have an implicit RestartPolicyNever.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.EphemeralContainerStatuses, oldPod.Status.EphemeralContainerStatuses, fldPath.Child("ephemeralContainerStatuses"), core.RestartPolicyNever)...)
+ 	allErrs = append(allErrs, validatePodResourceClaimStatuses(newPod.Status.ResourceClaimStatuses, newPod.Spec.ResourceClaims, fldPath.Child("resourceClaimStatuses"))...)
+diff --git a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+index edd33feb7..b0b12d6eb 100644
+--- a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
++++ b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+@@ -259,7 +259,6 @@ const (
+ 	// owner: @harche
+ 	// kep: http://kep.k8s.io/3386
+ 	// alpha: v1.25
+-	// beta: v1.27
+ 	//
+ 	// Allows using event-driven PLEG (pod lifecycle event generator) through kubelet
+ 	// which avoids frequent relisting of containers which helps optimize performance.
+@@ -617,6 +616,7 @@ const (
+ 	// owner: @RomanBednar
+ 	// kep: https://kep.k8s.io/3762
+ 	// alpha: v1.28
++	// beta: v1.29
+ 	//
+ 	// Adds a new field to persistent volumes which holds a timestamp of when the volume last transitioned its phase.
+ 	PersistentVolumeLastPhaseTransitionTime featuregate.Feature = "PersistentVolumeLastPhaseTransitionTime"
+@@ -1048,7 +1048,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
+ 
+-	EventedPLEG: {Default: false, PreRelease: featuregate.Beta}, // off by default, requires CRI Runtime support
++	EventedPLEG: {Default: false, PreRelease: featuregate.Alpha},
+ 
+ 	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
+ 
+@@ -1263,6 +1263,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.SeparateCacheWatchRPC: {Default: true, PreRelease: featuregate.Beta},
++
+ 	genericfeatures.ServerSideApply: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+ 
+ 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+@@ -1273,6 +1275,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.ZeroLimitedNominalConcurrencyShares: {Default: false, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.WatchFromStorageWithoutResourceVersion: {Default: false, PreRelease: featuregate.Beta},
++
+ 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
+ 	// unintentionally on either side:
+ 
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+index 94c2330af..6ce01755f 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+@@ -1064,7 +1064,7 @@ func NewPersistentVolumeRecyclerPodTemplate() *v1.Pod {
+ 			Containers: []v1.Container{
+ 				{
+ 					Name:    "pv-recycler",
+-					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.0",
++					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.2",
+ 					Command: []string{"/bin/sh"},
+ 					Args:    []string{"-c", "test -e /scrub && find /scrub -mindepth 1 -delete && test -z \"$(ls -A /scrub)\" || exit 1"},
+ 					VolumeMounts: []v1.VolumeMount{
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+index af309353b..238e919b3 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+@@ -102,6 +102,23 @@ func IsFailedPreconditionError(err error) bool {
+ 	return errors.As(err, &failedPreconditionError)
+ }
+ 
++type OperationNotSupported struct {
++	msg string
++}
++
++func (err *OperationNotSupported) Error() string {
++	return err.msg
++}
++
++func NewOperationNotSupportedError(msg string) *OperationNotSupported {
++	return &OperationNotSupported{msg: msg}
++}
++
++func IsOperationNotSupportedError(err error) bool {
++	var operationNotSupportedError *OperationNotSupported
++	return errors.As(err, &operationNotSupportedError)
++}
++
+ // TransientOperationFailure indicates operation failed with a transient error
+ // and may fix itself when retried.
+ type TransientOperationFailure struct {
+diff --git a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+index 72f2394e9..0d83a7cc8 100644
+--- a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
++++ b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+@@ -232,7 +232,7 @@ const (
+ 
+ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
+ 	configs := map[ImageID]Config{}
+-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.45"}
++	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.47"}
+ 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
+ 	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
+ 	configs[AuthenticatedWindowsNanoServer] = Config{list.GcAuthenticatedRegistry, "windows-nanoserver", "v1"}
+@@ -241,8 +241,8 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
+ 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.36.1-1"}
+ 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
+ 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
+-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.3"}
+-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.10-0"}
++	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.7"}
++	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.12-0"}
+ 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
+ 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}
+ 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index ebde30f57..ab47b0cca 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -406,7 +406,7 @@ go.uber.org/zap/internal/pool
+ go.uber.org/zap/internal/stacktrace
+ go.uber.org/zap/zapcore
+ go.uber.org/zap/zapgrpc
+-# golang.org/x/crypto v0.17.0
++# golang.org/x/crypto v0.21.0
+ ## explicit; go 1.18
+ golang.org/x/crypto/blowfish
+ golang.org/x/crypto/chacha20
+@@ -430,7 +430,7 @@ golang.org/x/exp/slices
+ # golang.org/x/mod v0.14.0
+ ## explicit; go 1.18
+ golang.org/x/mod/semver
+-# golang.org/x/net v0.19.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/bpf
+ golang.org/x/net/context
+@@ -457,14 +457,14 @@ golang.org/x/oauth2/internal
+ # golang.org/x/sync v0.5.0
+ ## explicit; go 1.18
+ golang.org/x/sync/singleflight
+-# golang.org/x/sys v0.15.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/cpu
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+ golang.org/x/sys/windows/registry
+-# golang.org/x/term v0.15.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+@@ -1355,7 +1355,7 @@ k8s.io/kubectl/pkg/util/podutils
+ # k8s.io/kubelet v0.27.0 => k8s.io/kubelet v0.29.0
+ ## explicit; go 1.21
+ k8s.io/kubelet/pkg/apis
+-# k8s.io/kubernetes v1.29.0
++# k8s.io/kubernetes v1.29.4
+ ## explicit; go 1.21
+ k8s.io/kubernetes/pkg/api/legacyscheme
+ k8s.io/kubernetes/pkg/api/service
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/external-provisioner/1-27/CHECKSUMS
+++ b/projects/kubernetes-csi/external-provisioner/1-27/CHECKSUMS
@@ -1,2 +1,2 @@
-f090fe1d3e9e0b7e15c235537a649785921f5704d216b27bca4a1e84536e2572  _output/1-27/bin/external-provisioner/linux-amd64/csi-provisioner
-952edef97a4caa19b92d2bbb13f72d737775e972f07feca64468061f982ca75b  _output/1-27/bin/external-provisioner/linux-arm64/csi-provisioner
+a554f31f0d5ac26b61efbe6fa3b8e76194f0026ddec9335db9136dcbc345f4e1  _output/1-27/bin/external-provisioner/linux-amd64/csi-provisioner
+96967e52e5f700d3830d73bd43242308395f4d07ab66879c706aad72875df4fe  _output/1-27/bin/external-provisioner/linux-arm64/csi-provisioner

--- a/projects/kubernetes-csi/external-provisioner/1-27/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
+++ b/projects/kubernetes-csi/external-provisioner/1-27/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
@@ -1,0 +1,3220 @@
+From 272caf23aea9e18489bbe26e27e047bc5f09d753 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:41:12 +0000
+Subject: [PATCH] Fix external-provisioner CVE-2024-3177 by bumping
+ k8s.io/kubernetes to 1.29.4
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |  10 +-
+ go.sum                                        |  20 +-
+ .../x/crypto/internal/poly1305/bits_compat.go |  39 ---
+ .../x/crypto/internal/poly1305/bits_go1.13.go |  21 --
+ .../x/crypto/internal/poly1305/sum_generic.go |  43 +--
+ .../x/crypto/internal/poly1305/sum_ppc64le.s  |  14 +-
+ vendor/golang.org/x/net/html/token.go         |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/net/websocket/client.go   |  55 ++-
+ vendor/golang.org/x/net/websocket/dial.go     |  11 +-
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  39 ++-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go |  99 ++++++
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  90 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  10 +
+ .../x/sys/unix/zsyscall_openbsd_386.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |   2 -
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |   2 -
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 185 ++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   4 +-
+ .../x/sys/windows/zsyscall_windows.go         |   9 +
+ .../k8s.io/kubernetes/pkg/apis/core/types.go  |   2 +-
+ .../pkg/apis/core/validation/validation.go    |  42 ++-
+ .../kubernetes/pkg/features/kube_features.go  |   8 +-
+ .../k8s.io/kubernetes/pkg/volume/plugins.go   |   2 +-
+ .../kubernetes/pkg/volume/util/types/types.go |  17 +
+ .../kubernetes/test/utils/image/manifest.go   |   6 +-
+ vendor/modules.txt                            |  10 +-
+ 69 files changed, 1287 insertions(+), 316 deletions(-)
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index fff06492a..a2be5719c 100644
+--- a/go.mod
++++ b/go.mod
+@@ -33,7 +33,7 @@ require (
+ require (
+ 	github.com/onsi/ginkgo/v2 v2.13.2
+ 	github.com/onsi/gomega v1.30.0
+-	k8s.io/kubernetes v1.29.0
++	k8s.io/kubernetes v1.29.4
+ )
+ 
+ require (
+@@ -106,14 +106,14 @@ require (
+ 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.26.0 // indirect
+-	golang.org/x/crypto v0.17.0 // indirect
++	golang.org/x/crypto v0.21.0 // indirect
+ 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+ 	golang.org/x/mod v0.14.0 // indirect
+-	golang.org/x/net v0.19.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
+ 	golang.org/x/oauth2 v0.15.0 // indirect
+ 	golang.org/x/sync v0.5.0 // indirect
+-	golang.org/x/sys v0.15.0 // indirect
+-	golang.org/x/term v0.15.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.5.0 // indirect
+ 	golang.org/x/tools v0.16.1 // indirect
+diff --git a/go.sum b/go.sum
+index 56c808a77..c0444fa2f 100644
+--- a/go.sum
++++ b/go.sum
+@@ -248,8 +248,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
+ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+-golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+-golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
++golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
++golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -265,8 +265,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+-golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.15.0 h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ=
+ golang.org/x/oauth2 v0.15.0/go.mod h1:q48ptWNTY5XWf+JNten23lcvHpLJ0ZSxF5ttTHKVCAM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -286,12 +286,12 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+-golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+@@ -371,8 +371,8 @@ k8s.io/kubectl v0.29.0 h1:Oqi48gXjikDhrBF67AYuZRTcJV4lg2l42GmvsP7FmYI=
+ k8s.io/kubectl v0.29.0/go.mod h1:0jMjGWIcMIQzmUaMgAzhSELv5WtHo2a8pq67DtviAJs=
+ k8s.io/kubelet v0.29.0 h1:SX5hlznTBcGIrS1scaf8r8p6m3e475KMifwt9i12iOk=
+ k8s.io/kubelet v0.29.0/go.mod h1:kvKS2+Bz2tgDOG1S1q0TH2z1DasNuVF+8p6Aw7xvKkI=
+-k8s.io/kubernetes v1.29.0 h1:DOLN7g8+nnAYBi8JHoW0+/MCrZKDPIqAxzLCXDXd0cg=
+-k8s.io/kubernetes v1.29.0/go.mod h1:9kztbUQf9stVDcIYXx+BX3nuGCsAQDsuClkGMpPs3pA=
++k8s.io/kubernetes v1.29.4 h1:n4VCbX9cUhxHI+zw+m2iZlzT73/mrEJBHIMeauh9g4U=
++k8s.io/kubernetes v1.29.4/go.mod h1:28sDhcb87LX5z3GWAKYmLrhrifxi4W9bEWua4DRTIvk=
+ k8s.io/mount-utils v0.29.0 h1:KcUE0bFHONQC10V3SuLWQ6+l8nmJggw9lKLpDftIshI=
+ k8s.io/mount-utils v0.29.0/go.mod h1:N3lDK/G1B8R/IkAt4NhHyqB07OqEr7P763z3TNge94U=
+ k8s.io/pod-security-admission v0.29.0 h1:tY/ldtkbBCulMYVSWg6ZDLlgDYDWy6rLj8e/AgmwSj4=
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+deleted file mode 100644
+index d33c8890f..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
++++ /dev/null
+@@ -1,39 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !go1.13
+-
+-package poly1305
+-
+-// Generic fallbacks for the math/bits intrinsics, copied from
+-// src/math/bits/bits.go. They were added in Go 1.12, but Add64 and Sum64 had
+-// variable time fallbacks until Go 1.13.
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	sum = x + y + carry
+-	carryOut = ((x & y) | ((x | y) &^ sum)) >> 63
+-	return
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	diff = x - y - borrow
+-	borrowOut = ((^x & y) | (^(x ^ y) & diff)) >> 63
+-	return
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	const mask32 = 1<<32 - 1
+-	x0 := x & mask32
+-	x1 := x >> 32
+-	y0 := y & mask32
+-	y1 := y >> 32
+-	w0 := x0 * y0
+-	t := x1*y0 + w0>>32
+-	w1 := t & mask32
+-	w2 := t >> 32
+-	w1 += x0 * y1
+-	hi = x1*y1 + w2 + w1>>32
+-	lo = x * y
+-	return
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+deleted file mode 100644
+index 495c1fa69..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
++++ /dev/null
+@@ -1,21 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build go1.13
+-
+-package poly1305
+-
+-import "math/bits"
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	return bits.Add64(x, y, carry)
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	return bits.Sub64(x, y, borrow)
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	return bits.Mul64(x, y)
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+index e041da5ea..ec2202bd7 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+@@ -7,7 +7,10 @@
+ 
+ package poly1305
+ 
+-import "encoding/binary"
++import (
++	"encoding/binary"
++	"math/bits"
++)
+ 
+ // Poly1305 [RFC 7539] is a relatively simple algorithm: the authentication tag
+ // for a 64 bytes message is approximately
+@@ -114,13 +117,13 @@ type uint128 struct {
+ }
+ 
+ func mul64(a, b uint64) uint128 {
+-	hi, lo := bitsMul64(a, b)
++	hi, lo := bits.Mul64(a, b)
+ 	return uint128{lo, hi}
+ }
+ 
+ func add128(a, b uint128) uint128 {
+-	lo, c := bitsAdd64(a.lo, b.lo, 0)
+-	hi, c := bitsAdd64(a.hi, b.hi, c)
++	lo, c := bits.Add64(a.lo, b.lo, 0)
++	hi, c := bits.Add64(a.hi, b.hi, c)
+ 	if c != 0 {
+ 		panic("poly1305: unexpected overflow")
+ 	}
+@@ -155,8 +158,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 		// hide leading zeroes. For full chunks, that's 1 << 128, so we can just
+ 		// add 1 to the most significant (2¹²⁸) limb, h2.
+ 		if len(msg) >= TagSize {
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
+ 			h2 += c + 1
+ 
+ 			msg = msg[TagSize:]
+@@ -165,8 +168,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 			copy(buf[:], msg)
+ 			buf[len(msg)] = 1
+ 
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
+ 			h2 += c
+ 
+ 			msg = nil
+@@ -219,9 +222,9 @@ func updateGeneric(state *macState, msg []byte) {
+ 		m3 := h2r1
+ 
+ 		t0 := m0.lo
+-		t1, c := bitsAdd64(m1.lo, m0.hi, 0)
+-		t2, c := bitsAdd64(m2.lo, m1.hi, c)
+-		t3, _ := bitsAdd64(m3.lo, m2.hi, c)
++		t1, c := bits.Add64(m1.lo, m0.hi, 0)
++		t2, c := bits.Add64(m2.lo, m1.hi, c)
++		t3, _ := bits.Add64(m3.lo, m2.hi, c)
+ 
+ 		// Now we have the result as 4 64-bit limbs, and we need to reduce it
+ 		// modulo 2¹³⁰ - 5. The special shape of this Crandall prime lets us do
+@@ -243,14 +246,14 @@ func updateGeneric(state *macState, msg []byte) {
+ 
+ 		// To add c * 5 to h, we first add cc = c * 4, and then add (cc >> 2) = c.
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		cc = shiftRightBy2(cc)
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		// h2 is at most 3 + 1 + 1 = 5, making the whole of h at most
+@@ -287,9 +290,9 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	// in constant time, we compute t = h - (2¹³⁰ - 5), and select h as the
+ 	// result if the subtraction underflows, and t otherwise.
+ 
+-	hMinusP0, b := bitsSub64(h0, p0, 0)
+-	hMinusP1, b := bitsSub64(h1, p1, b)
+-	_, b = bitsSub64(h2, p2, b)
++	hMinusP0, b := bits.Sub64(h0, p0, 0)
++	hMinusP1, b := bits.Sub64(h1, p1, b)
++	_, b = bits.Sub64(h2, p2, b)
+ 
+ 	// h = h if h < p else h - p
+ 	h0 = select64(b, h0, hMinusP0)
+@@ -301,8 +304,8 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	//
+ 	// by just doing a wide addition with the 128 low bits of h and discarding
+ 	// the overflow.
+-	h0, c := bitsAdd64(h0, s[0], 0)
+-	h1, _ = bitsAdd64(h1, s[1], c)
++	h0, c := bits.Add64(h0, s[0], 0)
++	h1, _ = bits.Add64(h1, s[1], c)
+ 
+ 	binary.LittleEndian.PutUint64(out[0:8], h0)
+ 	binary.LittleEndian.PutUint64(out[8:16], h1)
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+index d2ca5deeb..b3c1699bf 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+@@ -19,15 +19,14 @@
+ 
+ #define POLY1305_MUL(h0, h1, h2, r0, r1, t0, t1, t2, t3, t4, t5) \
+ 	MULLD  r0, h0, t0;  \
+-	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h0, t1;  \
++	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h1, t5;  \
+ 	ADDC   t4, t1, t1;  \
+ 	MULLD  r0, h2, t2;  \
+-	ADDZE  t5;          \
+ 	MULHDU r1, h0, t4;  \
+ 	MULLD  r1, h0, h0;  \
+-	ADD    t5, t2, t2;  \
++	ADDE   t5, t2, t2;  \
+ 	ADDC   h0, t1, t1;  \
+ 	MULLD  h2, r1, t3;  \
+ 	ADDZE  t4, h0;      \
+@@ -37,13 +36,11 @@
+ 	ADDE   t5, t3, t3;  \
+ 	ADDC   h0, t2, t2;  \
+ 	MOVD   $-4, t4;     \
+-	MOVD   t0, h0;      \
+-	MOVD   t1, h1;      \
+ 	ADDZE  t3;          \
+-	ANDCC  $3, t2, h2;  \
+-	AND    t2, t4, t0;  \
++	RLDICL $0, t2, $62, h2; \
++	AND    t2, t4, h0;  \
+ 	ADDC   t0, h0, h0;  \
+-	ADDE   t3, h1, h1;  \
++	ADDE   t3, t1, h1;  \
+ 	SLD    $62, t3, t4; \
+ 	SRD    $2, t2;      \
+ 	ADDZE  h2;          \
+@@ -75,6 +72,7 @@ TEXT ·update(SB), $0-32
+ loop:
+ 	POLY1305_ADD(R4, R8, R9, R10, R20, R21, R22)
+ 
++	PCALIGN $16
+ multiply:
+ 	POLY1305_MUL(R8, R9, R10, R11, R12, R16, R17, R18, R14, R20, R21)
+ 	ADD $-16, R5
+diff --git a/vendor/golang.org/x/net/html/token.go b/vendor/golang.org/x/net/html/token.go
+index de67f938a..3c57880d6 100644
+--- a/vendor/golang.org/x/net/html/token.go
++++ b/vendor/golang.org/x/net/html/token.go
+@@ -910,9 +910,6 @@ func (z *Tokenizer) readTagAttrKey() {
+ 			return
+ 		}
+ 		switch c {
+-		case ' ', '\n', '\r', '\t', '\f', '/':
+-			z.pendingAttr[0].end = z.raw.end - 1
+-			return
+ 		case '=':
+ 			if z.pendingAttr[0].start+1 == z.raw.end {
+ 				// WHATWG 13.2.5.32, if we see an equals sign before the attribute name
+@@ -920,7 +917,9 @@ func (z *Tokenizer) readTagAttrKey() {
+ 				continue
+ 			}
+ 			fallthrough
+-		case '>':
++		case ' ', '\n', '\r', '\t', '\f', '/', '>':
++			// WHATWG 13.2.5.33 Attribute name state
++			// We need to reconsume the char in the after attribute name state to support the / character
+ 			z.raw.end--
+ 			z.pendingAttr[0].end = z.raw.end
+ 			return
+@@ -939,6 +938,11 @@ func (z *Tokenizer) readTagAttrVal() {
+ 	if z.err != nil {
+ 		return
+ 	}
++	if c == '/' {
++		// WHATWG 13.2.5.34 After attribute name state
++		// U+002F SOLIDUS (/) - Switch to the self-closing start tag state.
++		return
++	}
+ 	if c != '=' {
+ 		z.raw.end--
+ 		return
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90dc..43557ab7e 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984fd..3b9f06b96 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c6408..ce2e8b40e 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 000000000..61075bd16
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86c..ce375c8c7 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/net/websocket/client.go b/vendor/golang.org/x/net/websocket/client.go
+index 69a4ac7ee..1e64157f3 100644
+--- a/vendor/golang.org/x/net/websocket/client.go
++++ b/vendor/golang.org/x/net/websocket/client.go
+@@ -6,10 +6,12 @@ package websocket
+ 
+ import (
+ 	"bufio"
++	"context"
+ 	"io"
+ 	"net"
+ 	"net/http"
+ 	"net/url"
++	"time"
+ )
+ 
+ // DialError is an error that occurs while dialling a websocket server.
+@@ -79,28 +81,59 @@ func parseAuthority(location *url.URL) string {
+ 
+ // DialConfig opens a new client connection to a WebSocket with a config.
+ func DialConfig(config *Config) (ws *Conn, err error) {
+-	var client net.Conn
++	return config.DialContext(context.Background())
++}
++
++// DialContext opens a new client connection to a WebSocket, with context support for timeouts/cancellation.
++func (config *Config) DialContext(ctx context.Context) (*Conn, error) {
+ 	if config.Location == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketLocation}
+ 	}
+ 	if config.Origin == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketOrigin}
+ 	}
++
+ 	dialer := config.Dialer
+ 	if dialer == nil {
+ 		dialer = &net.Dialer{}
+ 	}
+-	client, err = dialWithDialer(dialer, config)
+-	if err != nil {
+-		goto Error
+-	}
+-	ws, err = NewClient(config, client)
++
++	client, err := dialWithDialer(ctx, dialer, config)
+ 	if err != nil {
+-		client.Close()
+-		goto Error
++		return nil, &DialError{config, err}
+ 	}
+-	return
+ 
+-Error:
+-	return nil, &DialError{config, err}
++	// Cleanup the connection if we fail to create the websocket successfully
++	success := false
++	defer func() {
++		if !success {
++			_ = client.Close()
++		}
++	}()
++
++	var ws *Conn
++	var wsErr error
++	doneConnecting := make(chan struct{})
++	go func() {
++		defer close(doneConnecting)
++		ws, err = NewClient(config, client)
++		if err != nil {
++			wsErr = &DialError{config, err}
++		}
++	}()
++
++	// The websocket.NewClient() function can block indefinitely, make sure that we
++	// respect the deadlines specified by the context.
++	select {
++	case <-ctx.Done():
++		// Force the pending operations to fail, terminating the pending connection attempt
++		_ = client.SetDeadline(time.Now())
++		<-doneConnecting // Wait for the goroutine that tries to establish the connection to finish
++		return nil, &DialError{config, ctx.Err()}
++	case <-doneConnecting:
++		if wsErr == nil {
++			success = true // Disarm the deferred connection cleanup
++		}
++		return ws, wsErr
++	}
+ }
+diff --git a/vendor/golang.org/x/net/websocket/dial.go b/vendor/golang.org/x/net/websocket/dial.go
+index 2dab943a4..8a2d83c47 100644
+--- a/vendor/golang.org/x/net/websocket/dial.go
++++ b/vendor/golang.org/x/net/websocket/dial.go
+@@ -5,18 +5,23 @@
+ package websocket
+ 
+ import (
++	"context"
+ 	"crypto/tls"
+ 	"net"
+ )
+ 
+-func dialWithDialer(dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
++func dialWithDialer(ctx context.Context, dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
+ 	switch config.Location.Scheme {
+ 	case "ws":
+-		conn, err = dialer.Dial("tcp", parseAuthority(config.Location))
++		conn, err = dialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 
+ 	case "wss":
+-		conn, err = tls.DialWithDialer(dialer, "tcp", parseAuthority(config.Location), config.TlsConfig)
++		tlsDialer := &tls.Dialer{
++			NetDialer: dialer,
++			Config:    config.TlsConfig,
++		}
+ 
++		conn, err = tlsDialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 	default:
+ 		err = ErrBadScheme
+ 	}
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4bd..b0e419857 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index 6202638ba..fdcaa974d 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -582,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -603,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc69937..2f0fa76e4 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4db..2b57e0f73 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index 0f85e29e6..5682e2628 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -1849,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index c73cfe2f1..36bf8399f 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -1785,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821cf..42ff8c3c1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e4112..dca436004 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c63985560..5cca668ac 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e25..d8cae6d15 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09e..28e39afdc 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642a..cd66e92cb 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d75..c1595eba7 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0d..ee9456b0d 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84f..8cfca81e1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d6..60b0deb3a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc72..f90aa7281 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e2..ba9e01503 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813ed..07cdfd6e9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4ec..2f1dd214a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994da..f40519d90 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index 1488d2712..87d8612a1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -906,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index a1d061597..9dc42410b 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index 5b2a74097..0d3a0751c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index f6eda1344..c39f7776d 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 55df20ae9..57571d072 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index 8c1155cbc..e62963e67 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index 7cc80c58d..00831354c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index 0688737f4..79029ed58 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbdd..0cc3ce496 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc2504..856d92d69 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf2467..8d467094c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e2..edc173244 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77e..445eba206 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362ef..adba01bca 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4fd..014c4e9c7 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca81..ccc97d74d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d39..ec2b64a95 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e3747..21a839e33 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c8..c11121ec3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e591..909b631fc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195a..e49bed16e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943bc..66017d2d3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc51..47bab18dc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index bbf8399ff..eff6bcdef 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -3399,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4183,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5134,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5547,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad19250..d4577a423 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index 47dc57967..6395a031d 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -194,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index 146a1f019..e8791c82c 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -342,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -2988,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+index fa1242b8a..6a3f888ab 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+@@ -392,7 +392,7 @@ type PersistentVolumeStatus struct {
+ 	Reason string
+ 	// LastPhaseTransitionTime is the time the phase transitioned from one to another
+ 	// and automatically resets to current time everytime a volume phase transitions.
+-	// This is an alpha field and requires enabling PersistentVolumeLastPhaseTransitionTime feature.
++	// This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
+ 	// +featureGate=PersistentVolumeLastPhaseTransitionTime
+ 	// +optional
+ 	LastPhaseTransitionTime *metav1.Time
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+index a6f7fef30..1885531f8 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+@@ -5141,6 +5141,46 @@ func ValidateContainerStateTransition(newStatuses, oldStatuses []core.ContainerS
+ 	return allErrs
+ }
+ 
++// ValidateInitContainerStateTransition test to if any illegal init container state transitions are being attempted
++func ValidateInitContainerStateTransition(newStatuses, oldStatuses []core.ContainerStatus, fldpath *field.Path, podSpec *core.PodSpec) field.ErrorList {
++	allErrs := field.ErrorList{}
++	// If we should always restart, containers are allowed to leave the terminated state
++	if podSpec.RestartPolicy == core.RestartPolicyAlways {
++		return allErrs
++	}
++	for i, oldStatus := range oldStatuses {
++		// Skip any container that is not terminated
++		if oldStatus.State.Terminated == nil {
++			continue
++		}
++		// Skip any container that failed but is allowed to restart
++		if oldStatus.State.Terminated.ExitCode != 0 && podSpec.RestartPolicy == core.RestartPolicyOnFailure {
++			continue
++		}
++
++		// Skip any restartable init container that is allowed to restart
++		isRestartableInitContainer := false
++		for _, c := range podSpec.InitContainers {
++			if oldStatus.Name == c.Name {
++				if c.RestartPolicy != nil && *c.RestartPolicy == core.ContainerRestartPolicyAlways {
++					isRestartableInitContainer = true
++				}
++				break
++			}
++		}
++		if isRestartableInitContainer {
++			continue
++		}
++
++		for _, newStatus := range newStatuses {
++			if oldStatus.Name == newStatus.Name && newStatus.State.Terminated == nil {
++				allErrs = append(allErrs, field.Forbidden(fldpath.Index(i).Child("state"), "may not be transitioned to non-terminated state"))
++			}
++		}
++	}
++	return allErrs
++}
++
+ // ValidatePodStatusUpdate checks for changes to status that shouldn't occur in normal operation.
+ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) field.ErrorList {
+ 	fldPath := field.NewPath("metadata")
+@@ -5162,7 +5202,7 @@ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions
+ 	// If pod should not restart, make sure the status update does not transition
+ 	// any terminated containers to a non-terminated state.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.ContainerStatuses, oldPod.Status.ContainerStatuses, fldPath.Child("containerStatuses"), oldPod.Spec.RestartPolicy)...)
+-	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), oldPod.Spec.RestartPolicy)...)
++	allErrs = append(allErrs, ValidateInitContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), &oldPod.Spec)...)
+ 	// The kubelet will never restart ephemeral containers, so treat them like they have an implicit RestartPolicyNever.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.EphemeralContainerStatuses, oldPod.Status.EphemeralContainerStatuses, fldPath.Child("ephemeralContainerStatuses"), core.RestartPolicyNever)...)
+ 	allErrs = append(allErrs, validatePodResourceClaimStatuses(newPod.Status.ResourceClaimStatuses, newPod.Spec.ResourceClaims, fldPath.Child("resourceClaimStatuses"))...)
+diff --git a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+index edd33feb7..b0b12d6eb 100644
+--- a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
++++ b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+@@ -259,7 +259,6 @@ const (
+ 	// owner: @harche
+ 	// kep: http://kep.k8s.io/3386
+ 	// alpha: v1.25
+-	// beta: v1.27
+ 	//
+ 	// Allows using event-driven PLEG (pod lifecycle event generator) through kubelet
+ 	// which avoids frequent relisting of containers which helps optimize performance.
+@@ -617,6 +616,7 @@ const (
+ 	// owner: @RomanBednar
+ 	// kep: https://kep.k8s.io/3762
+ 	// alpha: v1.28
++	// beta: v1.29
+ 	//
+ 	// Adds a new field to persistent volumes which holds a timestamp of when the volume last transitioned its phase.
+ 	PersistentVolumeLastPhaseTransitionTime featuregate.Feature = "PersistentVolumeLastPhaseTransitionTime"
+@@ -1048,7 +1048,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
+ 
+-	EventedPLEG: {Default: false, PreRelease: featuregate.Beta}, // off by default, requires CRI Runtime support
++	EventedPLEG: {Default: false, PreRelease: featuregate.Alpha},
+ 
+ 	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
+ 
+@@ -1263,6 +1263,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.SeparateCacheWatchRPC: {Default: true, PreRelease: featuregate.Beta},
++
+ 	genericfeatures.ServerSideApply: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+ 
+ 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+@@ -1273,6 +1275,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.ZeroLimitedNominalConcurrencyShares: {Default: false, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.WatchFromStorageWithoutResourceVersion: {Default: false, PreRelease: featuregate.Beta},
++
+ 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
+ 	// unintentionally on either side:
+ 
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+index 94c2330af..6ce01755f 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+@@ -1064,7 +1064,7 @@ func NewPersistentVolumeRecyclerPodTemplate() *v1.Pod {
+ 			Containers: []v1.Container{
+ 				{
+ 					Name:    "pv-recycler",
+-					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.0",
++					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.2",
+ 					Command: []string{"/bin/sh"},
+ 					Args:    []string{"-c", "test -e /scrub && find /scrub -mindepth 1 -delete && test -z \"$(ls -A /scrub)\" || exit 1"},
+ 					VolumeMounts: []v1.VolumeMount{
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+index af309353b..238e919b3 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+@@ -102,6 +102,23 @@ func IsFailedPreconditionError(err error) bool {
+ 	return errors.As(err, &failedPreconditionError)
+ }
+ 
++type OperationNotSupported struct {
++	msg string
++}
++
++func (err *OperationNotSupported) Error() string {
++	return err.msg
++}
++
++func NewOperationNotSupportedError(msg string) *OperationNotSupported {
++	return &OperationNotSupported{msg: msg}
++}
++
++func IsOperationNotSupportedError(err error) bool {
++	var operationNotSupportedError *OperationNotSupported
++	return errors.As(err, &operationNotSupportedError)
++}
++
+ // TransientOperationFailure indicates operation failed with a transient error
+ // and may fix itself when retried.
+ type TransientOperationFailure struct {
+diff --git a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+index 72f2394e9..0d83a7cc8 100644
+--- a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
++++ b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+@@ -232,7 +232,7 @@ const (
+ 
+ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
+ 	configs := map[ImageID]Config{}
+-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.45"}
++	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.47"}
+ 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
+ 	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
+ 	configs[AuthenticatedWindowsNanoServer] = Config{list.GcAuthenticatedRegistry, "windows-nanoserver", "v1"}
+@@ -241,8 +241,8 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
+ 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.36.1-1"}
+ 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
+ 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
+-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.3"}
+-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.10-0"}
++	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.7"}
++	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.12-0"}
+ 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
+ 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}
+ 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index ebde30f57..ab47b0cca 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -406,7 +406,7 @@ go.uber.org/zap/internal/pool
+ go.uber.org/zap/internal/stacktrace
+ go.uber.org/zap/zapcore
+ go.uber.org/zap/zapgrpc
+-# golang.org/x/crypto v0.17.0
++# golang.org/x/crypto v0.21.0
+ ## explicit; go 1.18
+ golang.org/x/crypto/blowfish
+ golang.org/x/crypto/chacha20
+@@ -430,7 +430,7 @@ golang.org/x/exp/slices
+ # golang.org/x/mod v0.14.0
+ ## explicit; go 1.18
+ golang.org/x/mod/semver
+-# golang.org/x/net v0.19.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/bpf
+ golang.org/x/net/context
+@@ -457,14 +457,14 @@ golang.org/x/oauth2/internal
+ # golang.org/x/sync v0.5.0
+ ## explicit; go 1.18
+ golang.org/x/sync/singleflight
+-# golang.org/x/sys v0.15.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/cpu
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+ golang.org/x/sys/windows/registry
+-# golang.org/x/term v0.15.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+@@ -1355,7 +1355,7 @@ k8s.io/kubectl/pkg/util/podutils
+ # k8s.io/kubelet v0.27.0 => k8s.io/kubelet v0.29.0
+ ## explicit; go 1.21
+ k8s.io/kubelet/pkg/apis
+-# k8s.io/kubernetes v1.29.0
++# k8s.io/kubernetes v1.29.4
+ ## explicit; go 1.21
+ k8s.io/kubernetes/pkg/api/legacyscheme
+ k8s.io/kubernetes/pkg/api/service
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/external-provisioner/1-28/CHECKSUMS
+++ b/projects/kubernetes-csi/external-provisioner/1-28/CHECKSUMS
@@ -1,2 +1,2 @@
-f090fe1d3e9e0b7e15c235537a649785921f5704d216b27bca4a1e84536e2572  _output/1-28/bin/external-provisioner/linux-amd64/csi-provisioner
-952edef97a4caa19b92d2bbb13f72d737775e972f07feca64468061f982ca75b  _output/1-28/bin/external-provisioner/linux-arm64/csi-provisioner
+a554f31f0d5ac26b61efbe6fa3b8e76194f0026ddec9335db9136dcbc345f4e1  _output/1-28/bin/external-provisioner/linux-amd64/csi-provisioner
+96967e52e5f700d3830d73bd43242308395f4d07ab66879c706aad72875df4fe  _output/1-28/bin/external-provisioner/linux-arm64/csi-provisioner

--- a/projects/kubernetes-csi/external-provisioner/1-28/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
+++ b/projects/kubernetes-csi/external-provisioner/1-28/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
@@ -1,0 +1,3220 @@
+From 272caf23aea9e18489bbe26e27e047bc5f09d753 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:41:12 +0000
+Subject: [PATCH] Fix external-provisioner CVE-2024-3177 by bumping
+ k8s.io/kubernetes to 1.29.4
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |  10 +-
+ go.sum                                        |  20 +-
+ .../x/crypto/internal/poly1305/bits_compat.go |  39 ---
+ .../x/crypto/internal/poly1305/bits_go1.13.go |  21 --
+ .../x/crypto/internal/poly1305/sum_generic.go |  43 +--
+ .../x/crypto/internal/poly1305/sum_ppc64le.s  |  14 +-
+ vendor/golang.org/x/net/html/token.go         |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/net/websocket/client.go   |  55 ++-
+ vendor/golang.org/x/net/websocket/dial.go     |  11 +-
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  39 ++-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go |  99 ++++++
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  90 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  10 +
+ .../x/sys/unix/zsyscall_openbsd_386.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |   2 -
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |   2 -
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 185 ++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   4 +-
+ .../x/sys/windows/zsyscall_windows.go         |   9 +
+ .../k8s.io/kubernetes/pkg/apis/core/types.go  |   2 +-
+ .../pkg/apis/core/validation/validation.go    |  42 ++-
+ .../kubernetes/pkg/features/kube_features.go  |   8 +-
+ .../k8s.io/kubernetes/pkg/volume/plugins.go   |   2 +-
+ .../kubernetes/pkg/volume/util/types/types.go |  17 +
+ .../kubernetes/test/utils/image/manifest.go   |   6 +-
+ vendor/modules.txt                            |  10 +-
+ 69 files changed, 1287 insertions(+), 316 deletions(-)
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index fff06492a..a2be5719c 100644
+--- a/go.mod
++++ b/go.mod
+@@ -33,7 +33,7 @@ require (
+ require (
+ 	github.com/onsi/ginkgo/v2 v2.13.2
+ 	github.com/onsi/gomega v1.30.0
+-	k8s.io/kubernetes v1.29.0
++	k8s.io/kubernetes v1.29.4
+ )
+ 
+ require (
+@@ -106,14 +106,14 @@ require (
+ 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.26.0 // indirect
+-	golang.org/x/crypto v0.17.0 // indirect
++	golang.org/x/crypto v0.21.0 // indirect
+ 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+ 	golang.org/x/mod v0.14.0 // indirect
+-	golang.org/x/net v0.19.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
+ 	golang.org/x/oauth2 v0.15.0 // indirect
+ 	golang.org/x/sync v0.5.0 // indirect
+-	golang.org/x/sys v0.15.0 // indirect
+-	golang.org/x/term v0.15.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.5.0 // indirect
+ 	golang.org/x/tools v0.16.1 // indirect
+diff --git a/go.sum b/go.sum
+index 56c808a77..c0444fa2f 100644
+--- a/go.sum
++++ b/go.sum
+@@ -248,8 +248,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
+ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+-golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+-golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
++golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
++golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -265,8 +265,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+-golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.15.0 h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ=
+ golang.org/x/oauth2 v0.15.0/go.mod h1:q48ptWNTY5XWf+JNten23lcvHpLJ0ZSxF5ttTHKVCAM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -286,12 +286,12 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+-golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+@@ -371,8 +371,8 @@ k8s.io/kubectl v0.29.0 h1:Oqi48gXjikDhrBF67AYuZRTcJV4lg2l42GmvsP7FmYI=
+ k8s.io/kubectl v0.29.0/go.mod h1:0jMjGWIcMIQzmUaMgAzhSELv5WtHo2a8pq67DtviAJs=
+ k8s.io/kubelet v0.29.0 h1:SX5hlznTBcGIrS1scaf8r8p6m3e475KMifwt9i12iOk=
+ k8s.io/kubelet v0.29.0/go.mod h1:kvKS2+Bz2tgDOG1S1q0TH2z1DasNuVF+8p6Aw7xvKkI=
+-k8s.io/kubernetes v1.29.0 h1:DOLN7g8+nnAYBi8JHoW0+/MCrZKDPIqAxzLCXDXd0cg=
+-k8s.io/kubernetes v1.29.0/go.mod h1:9kztbUQf9stVDcIYXx+BX3nuGCsAQDsuClkGMpPs3pA=
++k8s.io/kubernetes v1.29.4 h1:n4VCbX9cUhxHI+zw+m2iZlzT73/mrEJBHIMeauh9g4U=
++k8s.io/kubernetes v1.29.4/go.mod h1:28sDhcb87LX5z3GWAKYmLrhrifxi4W9bEWua4DRTIvk=
+ k8s.io/mount-utils v0.29.0 h1:KcUE0bFHONQC10V3SuLWQ6+l8nmJggw9lKLpDftIshI=
+ k8s.io/mount-utils v0.29.0/go.mod h1:N3lDK/G1B8R/IkAt4NhHyqB07OqEr7P763z3TNge94U=
+ k8s.io/pod-security-admission v0.29.0 h1:tY/ldtkbBCulMYVSWg6ZDLlgDYDWy6rLj8e/AgmwSj4=
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+deleted file mode 100644
+index d33c8890f..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
++++ /dev/null
+@@ -1,39 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !go1.13
+-
+-package poly1305
+-
+-// Generic fallbacks for the math/bits intrinsics, copied from
+-// src/math/bits/bits.go. They were added in Go 1.12, but Add64 and Sum64 had
+-// variable time fallbacks until Go 1.13.
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	sum = x + y + carry
+-	carryOut = ((x & y) | ((x | y) &^ sum)) >> 63
+-	return
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	diff = x - y - borrow
+-	borrowOut = ((^x & y) | (^(x ^ y) & diff)) >> 63
+-	return
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	const mask32 = 1<<32 - 1
+-	x0 := x & mask32
+-	x1 := x >> 32
+-	y0 := y & mask32
+-	y1 := y >> 32
+-	w0 := x0 * y0
+-	t := x1*y0 + w0>>32
+-	w1 := t & mask32
+-	w2 := t >> 32
+-	w1 += x0 * y1
+-	hi = x1*y1 + w2 + w1>>32
+-	lo = x * y
+-	return
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+deleted file mode 100644
+index 495c1fa69..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
++++ /dev/null
+@@ -1,21 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build go1.13
+-
+-package poly1305
+-
+-import "math/bits"
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	return bits.Add64(x, y, carry)
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	return bits.Sub64(x, y, borrow)
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	return bits.Mul64(x, y)
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+index e041da5ea..ec2202bd7 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+@@ -7,7 +7,10 @@
+ 
+ package poly1305
+ 
+-import "encoding/binary"
++import (
++	"encoding/binary"
++	"math/bits"
++)
+ 
+ // Poly1305 [RFC 7539] is a relatively simple algorithm: the authentication tag
+ // for a 64 bytes message is approximately
+@@ -114,13 +117,13 @@ type uint128 struct {
+ }
+ 
+ func mul64(a, b uint64) uint128 {
+-	hi, lo := bitsMul64(a, b)
++	hi, lo := bits.Mul64(a, b)
+ 	return uint128{lo, hi}
+ }
+ 
+ func add128(a, b uint128) uint128 {
+-	lo, c := bitsAdd64(a.lo, b.lo, 0)
+-	hi, c := bitsAdd64(a.hi, b.hi, c)
++	lo, c := bits.Add64(a.lo, b.lo, 0)
++	hi, c := bits.Add64(a.hi, b.hi, c)
+ 	if c != 0 {
+ 		panic("poly1305: unexpected overflow")
+ 	}
+@@ -155,8 +158,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 		// hide leading zeroes. For full chunks, that's 1 << 128, so we can just
+ 		// add 1 to the most significant (2¹²⁸) limb, h2.
+ 		if len(msg) >= TagSize {
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
+ 			h2 += c + 1
+ 
+ 			msg = msg[TagSize:]
+@@ -165,8 +168,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 			copy(buf[:], msg)
+ 			buf[len(msg)] = 1
+ 
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
+ 			h2 += c
+ 
+ 			msg = nil
+@@ -219,9 +222,9 @@ func updateGeneric(state *macState, msg []byte) {
+ 		m3 := h2r1
+ 
+ 		t0 := m0.lo
+-		t1, c := bitsAdd64(m1.lo, m0.hi, 0)
+-		t2, c := bitsAdd64(m2.lo, m1.hi, c)
+-		t3, _ := bitsAdd64(m3.lo, m2.hi, c)
++		t1, c := bits.Add64(m1.lo, m0.hi, 0)
++		t2, c := bits.Add64(m2.lo, m1.hi, c)
++		t3, _ := bits.Add64(m3.lo, m2.hi, c)
+ 
+ 		// Now we have the result as 4 64-bit limbs, and we need to reduce it
+ 		// modulo 2¹³⁰ - 5. The special shape of this Crandall prime lets us do
+@@ -243,14 +246,14 @@ func updateGeneric(state *macState, msg []byte) {
+ 
+ 		// To add c * 5 to h, we first add cc = c * 4, and then add (cc >> 2) = c.
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		cc = shiftRightBy2(cc)
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		// h2 is at most 3 + 1 + 1 = 5, making the whole of h at most
+@@ -287,9 +290,9 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	// in constant time, we compute t = h - (2¹³⁰ - 5), and select h as the
+ 	// result if the subtraction underflows, and t otherwise.
+ 
+-	hMinusP0, b := bitsSub64(h0, p0, 0)
+-	hMinusP1, b := bitsSub64(h1, p1, b)
+-	_, b = bitsSub64(h2, p2, b)
++	hMinusP0, b := bits.Sub64(h0, p0, 0)
++	hMinusP1, b := bits.Sub64(h1, p1, b)
++	_, b = bits.Sub64(h2, p2, b)
+ 
+ 	// h = h if h < p else h - p
+ 	h0 = select64(b, h0, hMinusP0)
+@@ -301,8 +304,8 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	//
+ 	// by just doing a wide addition with the 128 low bits of h and discarding
+ 	// the overflow.
+-	h0, c := bitsAdd64(h0, s[0], 0)
+-	h1, _ = bitsAdd64(h1, s[1], c)
++	h0, c := bits.Add64(h0, s[0], 0)
++	h1, _ = bits.Add64(h1, s[1], c)
+ 
+ 	binary.LittleEndian.PutUint64(out[0:8], h0)
+ 	binary.LittleEndian.PutUint64(out[8:16], h1)
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+index d2ca5deeb..b3c1699bf 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+@@ -19,15 +19,14 @@
+ 
+ #define POLY1305_MUL(h0, h1, h2, r0, r1, t0, t1, t2, t3, t4, t5) \
+ 	MULLD  r0, h0, t0;  \
+-	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h0, t1;  \
++	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h1, t5;  \
+ 	ADDC   t4, t1, t1;  \
+ 	MULLD  r0, h2, t2;  \
+-	ADDZE  t5;          \
+ 	MULHDU r1, h0, t4;  \
+ 	MULLD  r1, h0, h0;  \
+-	ADD    t5, t2, t2;  \
++	ADDE   t5, t2, t2;  \
+ 	ADDC   h0, t1, t1;  \
+ 	MULLD  h2, r1, t3;  \
+ 	ADDZE  t4, h0;      \
+@@ -37,13 +36,11 @@
+ 	ADDE   t5, t3, t3;  \
+ 	ADDC   h0, t2, t2;  \
+ 	MOVD   $-4, t4;     \
+-	MOVD   t0, h0;      \
+-	MOVD   t1, h1;      \
+ 	ADDZE  t3;          \
+-	ANDCC  $3, t2, h2;  \
+-	AND    t2, t4, t0;  \
++	RLDICL $0, t2, $62, h2; \
++	AND    t2, t4, h0;  \
+ 	ADDC   t0, h0, h0;  \
+-	ADDE   t3, h1, h1;  \
++	ADDE   t3, t1, h1;  \
+ 	SLD    $62, t3, t4; \
+ 	SRD    $2, t2;      \
+ 	ADDZE  h2;          \
+@@ -75,6 +72,7 @@ TEXT ·update(SB), $0-32
+ loop:
+ 	POLY1305_ADD(R4, R8, R9, R10, R20, R21, R22)
+ 
++	PCALIGN $16
+ multiply:
+ 	POLY1305_MUL(R8, R9, R10, R11, R12, R16, R17, R18, R14, R20, R21)
+ 	ADD $-16, R5
+diff --git a/vendor/golang.org/x/net/html/token.go b/vendor/golang.org/x/net/html/token.go
+index de67f938a..3c57880d6 100644
+--- a/vendor/golang.org/x/net/html/token.go
++++ b/vendor/golang.org/x/net/html/token.go
+@@ -910,9 +910,6 @@ func (z *Tokenizer) readTagAttrKey() {
+ 			return
+ 		}
+ 		switch c {
+-		case ' ', '\n', '\r', '\t', '\f', '/':
+-			z.pendingAttr[0].end = z.raw.end - 1
+-			return
+ 		case '=':
+ 			if z.pendingAttr[0].start+1 == z.raw.end {
+ 				// WHATWG 13.2.5.32, if we see an equals sign before the attribute name
+@@ -920,7 +917,9 @@ func (z *Tokenizer) readTagAttrKey() {
+ 				continue
+ 			}
+ 			fallthrough
+-		case '>':
++		case ' ', '\n', '\r', '\t', '\f', '/', '>':
++			// WHATWG 13.2.5.33 Attribute name state
++			// We need to reconsume the char in the after attribute name state to support the / character
+ 			z.raw.end--
+ 			z.pendingAttr[0].end = z.raw.end
+ 			return
+@@ -939,6 +938,11 @@ func (z *Tokenizer) readTagAttrVal() {
+ 	if z.err != nil {
+ 		return
+ 	}
++	if c == '/' {
++		// WHATWG 13.2.5.34 After attribute name state
++		// U+002F SOLIDUS (/) - Switch to the self-closing start tag state.
++		return
++	}
+ 	if c != '=' {
+ 		z.raw.end--
+ 		return
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90dc..43557ab7e 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984fd..3b9f06b96 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c6408..ce2e8b40e 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 000000000..61075bd16
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86c..ce375c8c7 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/net/websocket/client.go b/vendor/golang.org/x/net/websocket/client.go
+index 69a4ac7ee..1e64157f3 100644
+--- a/vendor/golang.org/x/net/websocket/client.go
++++ b/vendor/golang.org/x/net/websocket/client.go
+@@ -6,10 +6,12 @@ package websocket
+ 
+ import (
+ 	"bufio"
++	"context"
+ 	"io"
+ 	"net"
+ 	"net/http"
+ 	"net/url"
++	"time"
+ )
+ 
+ // DialError is an error that occurs while dialling a websocket server.
+@@ -79,28 +81,59 @@ func parseAuthority(location *url.URL) string {
+ 
+ // DialConfig opens a new client connection to a WebSocket with a config.
+ func DialConfig(config *Config) (ws *Conn, err error) {
+-	var client net.Conn
++	return config.DialContext(context.Background())
++}
++
++// DialContext opens a new client connection to a WebSocket, with context support for timeouts/cancellation.
++func (config *Config) DialContext(ctx context.Context) (*Conn, error) {
+ 	if config.Location == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketLocation}
+ 	}
+ 	if config.Origin == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketOrigin}
+ 	}
++
+ 	dialer := config.Dialer
+ 	if dialer == nil {
+ 		dialer = &net.Dialer{}
+ 	}
+-	client, err = dialWithDialer(dialer, config)
+-	if err != nil {
+-		goto Error
+-	}
+-	ws, err = NewClient(config, client)
++
++	client, err := dialWithDialer(ctx, dialer, config)
+ 	if err != nil {
+-		client.Close()
+-		goto Error
++		return nil, &DialError{config, err}
+ 	}
+-	return
+ 
+-Error:
+-	return nil, &DialError{config, err}
++	// Cleanup the connection if we fail to create the websocket successfully
++	success := false
++	defer func() {
++		if !success {
++			_ = client.Close()
++		}
++	}()
++
++	var ws *Conn
++	var wsErr error
++	doneConnecting := make(chan struct{})
++	go func() {
++		defer close(doneConnecting)
++		ws, err = NewClient(config, client)
++		if err != nil {
++			wsErr = &DialError{config, err}
++		}
++	}()
++
++	// The websocket.NewClient() function can block indefinitely, make sure that we
++	// respect the deadlines specified by the context.
++	select {
++	case <-ctx.Done():
++		// Force the pending operations to fail, terminating the pending connection attempt
++		_ = client.SetDeadline(time.Now())
++		<-doneConnecting // Wait for the goroutine that tries to establish the connection to finish
++		return nil, &DialError{config, ctx.Err()}
++	case <-doneConnecting:
++		if wsErr == nil {
++			success = true // Disarm the deferred connection cleanup
++		}
++		return ws, wsErr
++	}
+ }
+diff --git a/vendor/golang.org/x/net/websocket/dial.go b/vendor/golang.org/x/net/websocket/dial.go
+index 2dab943a4..8a2d83c47 100644
+--- a/vendor/golang.org/x/net/websocket/dial.go
++++ b/vendor/golang.org/x/net/websocket/dial.go
+@@ -5,18 +5,23 @@
+ package websocket
+ 
+ import (
++	"context"
+ 	"crypto/tls"
+ 	"net"
+ )
+ 
+-func dialWithDialer(dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
++func dialWithDialer(ctx context.Context, dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
+ 	switch config.Location.Scheme {
+ 	case "ws":
+-		conn, err = dialer.Dial("tcp", parseAuthority(config.Location))
++		conn, err = dialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 
+ 	case "wss":
+-		conn, err = tls.DialWithDialer(dialer, "tcp", parseAuthority(config.Location), config.TlsConfig)
++		tlsDialer := &tls.Dialer{
++			NetDialer: dialer,
++			Config:    config.TlsConfig,
++		}
+ 
++		conn, err = tlsDialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 	default:
+ 		err = ErrBadScheme
+ 	}
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4bd..b0e419857 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index 6202638ba..fdcaa974d 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -582,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -603,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc69937..2f0fa76e4 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4db..2b57e0f73 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index 0f85e29e6..5682e2628 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -1849,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index c73cfe2f1..36bf8399f 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -1785,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821cf..42ff8c3c1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e4112..dca436004 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c63985560..5cca668ac 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e25..d8cae6d15 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09e..28e39afdc 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642a..cd66e92cb 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d75..c1595eba7 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0d..ee9456b0d 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84f..8cfca81e1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d6..60b0deb3a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc72..f90aa7281 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e2..ba9e01503 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813ed..07cdfd6e9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4ec..2f1dd214a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994da..f40519d90 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index 1488d2712..87d8612a1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -906,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index a1d061597..9dc42410b 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index 5b2a74097..0d3a0751c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index f6eda1344..c39f7776d 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 55df20ae9..57571d072 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index 8c1155cbc..e62963e67 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index 7cc80c58d..00831354c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index 0688737f4..79029ed58 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbdd..0cc3ce496 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc2504..856d92d69 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf2467..8d467094c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e2..edc173244 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77e..445eba206 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362ef..adba01bca 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4fd..014c4e9c7 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca81..ccc97d74d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d39..ec2b64a95 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e3747..21a839e33 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c8..c11121ec3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e591..909b631fc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195a..e49bed16e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943bc..66017d2d3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc51..47bab18dc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index bbf8399ff..eff6bcdef 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -3399,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4183,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5134,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5547,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad19250..d4577a423 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index 47dc57967..6395a031d 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -194,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index 146a1f019..e8791c82c 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -342,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -2988,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+index fa1242b8a..6a3f888ab 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+@@ -392,7 +392,7 @@ type PersistentVolumeStatus struct {
+ 	Reason string
+ 	// LastPhaseTransitionTime is the time the phase transitioned from one to another
+ 	// and automatically resets to current time everytime a volume phase transitions.
+-	// This is an alpha field and requires enabling PersistentVolumeLastPhaseTransitionTime feature.
++	// This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
+ 	// +featureGate=PersistentVolumeLastPhaseTransitionTime
+ 	// +optional
+ 	LastPhaseTransitionTime *metav1.Time
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+index a6f7fef30..1885531f8 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+@@ -5141,6 +5141,46 @@ func ValidateContainerStateTransition(newStatuses, oldStatuses []core.ContainerS
+ 	return allErrs
+ }
+ 
++// ValidateInitContainerStateTransition test to if any illegal init container state transitions are being attempted
++func ValidateInitContainerStateTransition(newStatuses, oldStatuses []core.ContainerStatus, fldpath *field.Path, podSpec *core.PodSpec) field.ErrorList {
++	allErrs := field.ErrorList{}
++	// If we should always restart, containers are allowed to leave the terminated state
++	if podSpec.RestartPolicy == core.RestartPolicyAlways {
++		return allErrs
++	}
++	for i, oldStatus := range oldStatuses {
++		// Skip any container that is not terminated
++		if oldStatus.State.Terminated == nil {
++			continue
++		}
++		// Skip any container that failed but is allowed to restart
++		if oldStatus.State.Terminated.ExitCode != 0 && podSpec.RestartPolicy == core.RestartPolicyOnFailure {
++			continue
++		}
++
++		// Skip any restartable init container that is allowed to restart
++		isRestartableInitContainer := false
++		for _, c := range podSpec.InitContainers {
++			if oldStatus.Name == c.Name {
++				if c.RestartPolicy != nil && *c.RestartPolicy == core.ContainerRestartPolicyAlways {
++					isRestartableInitContainer = true
++				}
++				break
++			}
++		}
++		if isRestartableInitContainer {
++			continue
++		}
++
++		for _, newStatus := range newStatuses {
++			if oldStatus.Name == newStatus.Name && newStatus.State.Terminated == nil {
++				allErrs = append(allErrs, field.Forbidden(fldpath.Index(i).Child("state"), "may not be transitioned to non-terminated state"))
++			}
++		}
++	}
++	return allErrs
++}
++
+ // ValidatePodStatusUpdate checks for changes to status that shouldn't occur in normal operation.
+ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) field.ErrorList {
+ 	fldPath := field.NewPath("metadata")
+@@ -5162,7 +5202,7 @@ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions
+ 	// If pod should not restart, make sure the status update does not transition
+ 	// any terminated containers to a non-terminated state.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.ContainerStatuses, oldPod.Status.ContainerStatuses, fldPath.Child("containerStatuses"), oldPod.Spec.RestartPolicy)...)
+-	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), oldPod.Spec.RestartPolicy)...)
++	allErrs = append(allErrs, ValidateInitContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), &oldPod.Spec)...)
+ 	// The kubelet will never restart ephemeral containers, so treat them like they have an implicit RestartPolicyNever.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.EphemeralContainerStatuses, oldPod.Status.EphemeralContainerStatuses, fldPath.Child("ephemeralContainerStatuses"), core.RestartPolicyNever)...)
+ 	allErrs = append(allErrs, validatePodResourceClaimStatuses(newPod.Status.ResourceClaimStatuses, newPod.Spec.ResourceClaims, fldPath.Child("resourceClaimStatuses"))...)
+diff --git a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+index edd33feb7..b0b12d6eb 100644
+--- a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
++++ b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+@@ -259,7 +259,6 @@ const (
+ 	// owner: @harche
+ 	// kep: http://kep.k8s.io/3386
+ 	// alpha: v1.25
+-	// beta: v1.27
+ 	//
+ 	// Allows using event-driven PLEG (pod lifecycle event generator) through kubelet
+ 	// which avoids frequent relisting of containers which helps optimize performance.
+@@ -617,6 +616,7 @@ const (
+ 	// owner: @RomanBednar
+ 	// kep: https://kep.k8s.io/3762
+ 	// alpha: v1.28
++	// beta: v1.29
+ 	//
+ 	// Adds a new field to persistent volumes which holds a timestamp of when the volume last transitioned its phase.
+ 	PersistentVolumeLastPhaseTransitionTime featuregate.Feature = "PersistentVolumeLastPhaseTransitionTime"
+@@ -1048,7 +1048,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
+ 
+-	EventedPLEG: {Default: false, PreRelease: featuregate.Beta}, // off by default, requires CRI Runtime support
++	EventedPLEG: {Default: false, PreRelease: featuregate.Alpha},
+ 
+ 	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
+ 
+@@ -1263,6 +1263,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.SeparateCacheWatchRPC: {Default: true, PreRelease: featuregate.Beta},
++
+ 	genericfeatures.ServerSideApply: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+ 
+ 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+@@ -1273,6 +1275,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.ZeroLimitedNominalConcurrencyShares: {Default: false, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.WatchFromStorageWithoutResourceVersion: {Default: false, PreRelease: featuregate.Beta},
++
+ 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
+ 	// unintentionally on either side:
+ 
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+index 94c2330af..6ce01755f 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+@@ -1064,7 +1064,7 @@ func NewPersistentVolumeRecyclerPodTemplate() *v1.Pod {
+ 			Containers: []v1.Container{
+ 				{
+ 					Name:    "pv-recycler",
+-					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.0",
++					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.2",
+ 					Command: []string{"/bin/sh"},
+ 					Args:    []string{"-c", "test -e /scrub && find /scrub -mindepth 1 -delete && test -z \"$(ls -A /scrub)\" || exit 1"},
+ 					VolumeMounts: []v1.VolumeMount{
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+index af309353b..238e919b3 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+@@ -102,6 +102,23 @@ func IsFailedPreconditionError(err error) bool {
+ 	return errors.As(err, &failedPreconditionError)
+ }
+ 
++type OperationNotSupported struct {
++	msg string
++}
++
++func (err *OperationNotSupported) Error() string {
++	return err.msg
++}
++
++func NewOperationNotSupportedError(msg string) *OperationNotSupported {
++	return &OperationNotSupported{msg: msg}
++}
++
++func IsOperationNotSupportedError(err error) bool {
++	var operationNotSupportedError *OperationNotSupported
++	return errors.As(err, &operationNotSupportedError)
++}
++
+ // TransientOperationFailure indicates operation failed with a transient error
+ // and may fix itself when retried.
+ type TransientOperationFailure struct {
+diff --git a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+index 72f2394e9..0d83a7cc8 100644
+--- a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
++++ b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+@@ -232,7 +232,7 @@ const (
+ 
+ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
+ 	configs := map[ImageID]Config{}
+-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.45"}
++	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.47"}
+ 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
+ 	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
+ 	configs[AuthenticatedWindowsNanoServer] = Config{list.GcAuthenticatedRegistry, "windows-nanoserver", "v1"}
+@@ -241,8 +241,8 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
+ 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.36.1-1"}
+ 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
+ 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
+-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.3"}
+-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.10-0"}
++	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.7"}
++	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.12-0"}
+ 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
+ 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}
+ 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index ebde30f57..ab47b0cca 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -406,7 +406,7 @@ go.uber.org/zap/internal/pool
+ go.uber.org/zap/internal/stacktrace
+ go.uber.org/zap/zapcore
+ go.uber.org/zap/zapgrpc
+-# golang.org/x/crypto v0.17.0
++# golang.org/x/crypto v0.21.0
+ ## explicit; go 1.18
+ golang.org/x/crypto/blowfish
+ golang.org/x/crypto/chacha20
+@@ -430,7 +430,7 @@ golang.org/x/exp/slices
+ # golang.org/x/mod v0.14.0
+ ## explicit; go 1.18
+ golang.org/x/mod/semver
+-# golang.org/x/net v0.19.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/bpf
+ golang.org/x/net/context
+@@ -457,14 +457,14 @@ golang.org/x/oauth2/internal
+ # golang.org/x/sync v0.5.0
+ ## explicit; go 1.18
+ golang.org/x/sync/singleflight
+-# golang.org/x/sys v0.15.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/cpu
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+ golang.org/x/sys/windows/registry
+-# golang.org/x/term v0.15.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+@@ -1355,7 +1355,7 @@ k8s.io/kubectl/pkg/util/podutils
+ # k8s.io/kubelet v0.27.0 => k8s.io/kubelet v0.29.0
+ ## explicit; go 1.21
+ k8s.io/kubelet/pkg/apis
+-# k8s.io/kubernetes v1.29.0
++# k8s.io/kubernetes v1.29.4
+ ## explicit; go 1.21
+ k8s.io/kubernetes/pkg/api/legacyscheme
+ k8s.io/kubernetes/pkg/api/service
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/external-provisioner/1-29/CHECKSUMS
+++ b/projects/kubernetes-csi/external-provisioner/1-29/CHECKSUMS
@@ -1,2 +1,2 @@
-f090fe1d3e9e0b7e15c235537a649785921f5704d216b27bca4a1e84536e2572  _output/1-29/bin/external-provisioner/linux-amd64/csi-provisioner
-952edef97a4caa19b92d2bbb13f72d737775e972f07feca64468061f982ca75b  _output/1-29/bin/external-provisioner/linux-arm64/csi-provisioner
+a554f31f0d5ac26b61efbe6fa3b8e76194f0026ddec9335db9136dcbc345f4e1  _output/1-29/bin/external-provisioner/linux-amd64/csi-provisioner
+96967e52e5f700d3830d73bd43242308395f4d07ab66879c706aad72875df4fe  _output/1-29/bin/external-provisioner/linux-arm64/csi-provisioner

--- a/projects/kubernetes-csi/external-provisioner/1-29/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
+++ b/projects/kubernetes-csi/external-provisioner/1-29/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
@@ -1,0 +1,3220 @@
+From 272caf23aea9e18489bbe26e27e047bc5f09d753 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:41:12 +0000
+Subject: [PATCH] Fix external-provisioner CVE-2024-3177 by bumping
+ k8s.io/kubernetes to 1.29.4
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |  10 +-
+ go.sum                                        |  20 +-
+ .../x/crypto/internal/poly1305/bits_compat.go |  39 ---
+ .../x/crypto/internal/poly1305/bits_go1.13.go |  21 --
+ .../x/crypto/internal/poly1305/sum_generic.go |  43 +--
+ .../x/crypto/internal/poly1305/sum_ppc64le.s  |  14 +-
+ vendor/golang.org/x/net/html/token.go         |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/net/websocket/client.go   |  55 ++-
+ vendor/golang.org/x/net/websocket/dial.go     |  11 +-
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  39 ++-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go |  99 ++++++
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  90 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  10 +
+ .../x/sys/unix/zsyscall_openbsd_386.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |   2 -
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |   2 -
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 185 ++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   4 +-
+ .../x/sys/windows/zsyscall_windows.go         |   9 +
+ .../k8s.io/kubernetes/pkg/apis/core/types.go  |   2 +-
+ .../pkg/apis/core/validation/validation.go    |  42 ++-
+ .../kubernetes/pkg/features/kube_features.go  |   8 +-
+ .../k8s.io/kubernetes/pkg/volume/plugins.go   |   2 +-
+ .../kubernetes/pkg/volume/util/types/types.go |  17 +
+ .../kubernetes/test/utils/image/manifest.go   |   6 +-
+ vendor/modules.txt                            |  10 +-
+ 69 files changed, 1287 insertions(+), 316 deletions(-)
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index fff06492a..a2be5719c 100644
+--- a/go.mod
++++ b/go.mod
+@@ -33,7 +33,7 @@ require (
+ require (
+ 	github.com/onsi/ginkgo/v2 v2.13.2
+ 	github.com/onsi/gomega v1.30.0
+-	k8s.io/kubernetes v1.29.0
++	k8s.io/kubernetes v1.29.4
+ )
+ 
+ require (
+@@ -106,14 +106,14 @@ require (
+ 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.26.0 // indirect
+-	golang.org/x/crypto v0.17.0 // indirect
++	golang.org/x/crypto v0.21.0 // indirect
+ 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+ 	golang.org/x/mod v0.14.0 // indirect
+-	golang.org/x/net v0.19.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
+ 	golang.org/x/oauth2 v0.15.0 // indirect
+ 	golang.org/x/sync v0.5.0 // indirect
+-	golang.org/x/sys v0.15.0 // indirect
+-	golang.org/x/term v0.15.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.5.0 // indirect
+ 	golang.org/x/tools v0.16.1 // indirect
+diff --git a/go.sum b/go.sum
+index 56c808a77..c0444fa2f 100644
+--- a/go.sum
++++ b/go.sum
+@@ -248,8 +248,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
+ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+-golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+-golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
++golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
++golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -265,8 +265,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+-golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.15.0 h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ=
+ golang.org/x/oauth2 v0.15.0/go.mod h1:q48ptWNTY5XWf+JNten23lcvHpLJ0ZSxF5ttTHKVCAM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -286,12 +286,12 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+-golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+@@ -371,8 +371,8 @@ k8s.io/kubectl v0.29.0 h1:Oqi48gXjikDhrBF67AYuZRTcJV4lg2l42GmvsP7FmYI=
+ k8s.io/kubectl v0.29.0/go.mod h1:0jMjGWIcMIQzmUaMgAzhSELv5WtHo2a8pq67DtviAJs=
+ k8s.io/kubelet v0.29.0 h1:SX5hlznTBcGIrS1scaf8r8p6m3e475KMifwt9i12iOk=
+ k8s.io/kubelet v0.29.0/go.mod h1:kvKS2+Bz2tgDOG1S1q0TH2z1DasNuVF+8p6Aw7xvKkI=
+-k8s.io/kubernetes v1.29.0 h1:DOLN7g8+nnAYBi8JHoW0+/MCrZKDPIqAxzLCXDXd0cg=
+-k8s.io/kubernetes v1.29.0/go.mod h1:9kztbUQf9stVDcIYXx+BX3nuGCsAQDsuClkGMpPs3pA=
++k8s.io/kubernetes v1.29.4 h1:n4VCbX9cUhxHI+zw+m2iZlzT73/mrEJBHIMeauh9g4U=
++k8s.io/kubernetes v1.29.4/go.mod h1:28sDhcb87LX5z3GWAKYmLrhrifxi4W9bEWua4DRTIvk=
+ k8s.io/mount-utils v0.29.0 h1:KcUE0bFHONQC10V3SuLWQ6+l8nmJggw9lKLpDftIshI=
+ k8s.io/mount-utils v0.29.0/go.mod h1:N3lDK/G1B8R/IkAt4NhHyqB07OqEr7P763z3TNge94U=
+ k8s.io/pod-security-admission v0.29.0 h1:tY/ldtkbBCulMYVSWg6ZDLlgDYDWy6rLj8e/AgmwSj4=
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+deleted file mode 100644
+index d33c8890f..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
++++ /dev/null
+@@ -1,39 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !go1.13
+-
+-package poly1305
+-
+-// Generic fallbacks for the math/bits intrinsics, copied from
+-// src/math/bits/bits.go. They were added in Go 1.12, but Add64 and Sum64 had
+-// variable time fallbacks until Go 1.13.
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	sum = x + y + carry
+-	carryOut = ((x & y) | ((x | y) &^ sum)) >> 63
+-	return
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	diff = x - y - borrow
+-	borrowOut = ((^x & y) | (^(x ^ y) & diff)) >> 63
+-	return
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	const mask32 = 1<<32 - 1
+-	x0 := x & mask32
+-	x1 := x >> 32
+-	y0 := y & mask32
+-	y1 := y >> 32
+-	w0 := x0 * y0
+-	t := x1*y0 + w0>>32
+-	w1 := t & mask32
+-	w2 := t >> 32
+-	w1 += x0 * y1
+-	hi = x1*y1 + w2 + w1>>32
+-	lo = x * y
+-	return
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+deleted file mode 100644
+index 495c1fa69..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
++++ /dev/null
+@@ -1,21 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build go1.13
+-
+-package poly1305
+-
+-import "math/bits"
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	return bits.Add64(x, y, carry)
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	return bits.Sub64(x, y, borrow)
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	return bits.Mul64(x, y)
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+index e041da5ea..ec2202bd7 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+@@ -7,7 +7,10 @@
+ 
+ package poly1305
+ 
+-import "encoding/binary"
++import (
++	"encoding/binary"
++	"math/bits"
++)
+ 
+ // Poly1305 [RFC 7539] is a relatively simple algorithm: the authentication tag
+ // for a 64 bytes message is approximately
+@@ -114,13 +117,13 @@ type uint128 struct {
+ }
+ 
+ func mul64(a, b uint64) uint128 {
+-	hi, lo := bitsMul64(a, b)
++	hi, lo := bits.Mul64(a, b)
+ 	return uint128{lo, hi}
+ }
+ 
+ func add128(a, b uint128) uint128 {
+-	lo, c := bitsAdd64(a.lo, b.lo, 0)
+-	hi, c := bitsAdd64(a.hi, b.hi, c)
++	lo, c := bits.Add64(a.lo, b.lo, 0)
++	hi, c := bits.Add64(a.hi, b.hi, c)
+ 	if c != 0 {
+ 		panic("poly1305: unexpected overflow")
+ 	}
+@@ -155,8 +158,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 		// hide leading zeroes. For full chunks, that's 1 << 128, so we can just
+ 		// add 1 to the most significant (2¹²⁸) limb, h2.
+ 		if len(msg) >= TagSize {
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
+ 			h2 += c + 1
+ 
+ 			msg = msg[TagSize:]
+@@ -165,8 +168,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 			copy(buf[:], msg)
+ 			buf[len(msg)] = 1
+ 
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
+ 			h2 += c
+ 
+ 			msg = nil
+@@ -219,9 +222,9 @@ func updateGeneric(state *macState, msg []byte) {
+ 		m3 := h2r1
+ 
+ 		t0 := m0.lo
+-		t1, c := bitsAdd64(m1.lo, m0.hi, 0)
+-		t2, c := bitsAdd64(m2.lo, m1.hi, c)
+-		t3, _ := bitsAdd64(m3.lo, m2.hi, c)
++		t1, c := bits.Add64(m1.lo, m0.hi, 0)
++		t2, c := bits.Add64(m2.lo, m1.hi, c)
++		t3, _ := bits.Add64(m3.lo, m2.hi, c)
+ 
+ 		// Now we have the result as 4 64-bit limbs, and we need to reduce it
+ 		// modulo 2¹³⁰ - 5. The special shape of this Crandall prime lets us do
+@@ -243,14 +246,14 @@ func updateGeneric(state *macState, msg []byte) {
+ 
+ 		// To add c * 5 to h, we first add cc = c * 4, and then add (cc >> 2) = c.
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		cc = shiftRightBy2(cc)
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		// h2 is at most 3 + 1 + 1 = 5, making the whole of h at most
+@@ -287,9 +290,9 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	// in constant time, we compute t = h - (2¹³⁰ - 5), and select h as the
+ 	// result if the subtraction underflows, and t otherwise.
+ 
+-	hMinusP0, b := bitsSub64(h0, p0, 0)
+-	hMinusP1, b := bitsSub64(h1, p1, b)
+-	_, b = bitsSub64(h2, p2, b)
++	hMinusP0, b := bits.Sub64(h0, p0, 0)
++	hMinusP1, b := bits.Sub64(h1, p1, b)
++	_, b = bits.Sub64(h2, p2, b)
+ 
+ 	// h = h if h < p else h - p
+ 	h0 = select64(b, h0, hMinusP0)
+@@ -301,8 +304,8 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	//
+ 	// by just doing a wide addition with the 128 low bits of h and discarding
+ 	// the overflow.
+-	h0, c := bitsAdd64(h0, s[0], 0)
+-	h1, _ = bitsAdd64(h1, s[1], c)
++	h0, c := bits.Add64(h0, s[0], 0)
++	h1, _ = bits.Add64(h1, s[1], c)
+ 
+ 	binary.LittleEndian.PutUint64(out[0:8], h0)
+ 	binary.LittleEndian.PutUint64(out[8:16], h1)
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+index d2ca5deeb..b3c1699bf 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+@@ -19,15 +19,14 @@
+ 
+ #define POLY1305_MUL(h0, h1, h2, r0, r1, t0, t1, t2, t3, t4, t5) \
+ 	MULLD  r0, h0, t0;  \
+-	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h0, t1;  \
++	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h1, t5;  \
+ 	ADDC   t4, t1, t1;  \
+ 	MULLD  r0, h2, t2;  \
+-	ADDZE  t5;          \
+ 	MULHDU r1, h0, t4;  \
+ 	MULLD  r1, h0, h0;  \
+-	ADD    t5, t2, t2;  \
++	ADDE   t5, t2, t2;  \
+ 	ADDC   h0, t1, t1;  \
+ 	MULLD  h2, r1, t3;  \
+ 	ADDZE  t4, h0;      \
+@@ -37,13 +36,11 @@
+ 	ADDE   t5, t3, t3;  \
+ 	ADDC   h0, t2, t2;  \
+ 	MOVD   $-4, t4;     \
+-	MOVD   t0, h0;      \
+-	MOVD   t1, h1;      \
+ 	ADDZE  t3;          \
+-	ANDCC  $3, t2, h2;  \
+-	AND    t2, t4, t0;  \
++	RLDICL $0, t2, $62, h2; \
++	AND    t2, t4, h0;  \
+ 	ADDC   t0, h0, h0;  \
+-	ADDE   t3, h1, h1;  \
++	ADDE   t3, t1, h1;  \
+ 	SLD    $62, t3, t4; \
+ 	SRD    $2, t2;      \
+ 	ADDZE  h2;          \
+@@ -75,6 +72,7 @@ TEXT ·update(SB), $0-32
+ loop:
+ 	POLY1305_ADD(R4, R8, R9, R10, R20, R21, R22)
+ 
++	PCALIGN $16
+ multiply:
+ 	POLY1305_MUL(R8, R9, R10, R11, R12, R16, R17, R18, R14, R20, R21)
+ 	ADD $-16, R5
+diff --git a/vendor/golang.org/x/net/html/token.go b/vendor/golang.org/x/net/html/token.go
+index de67f938a..3c57880d6 100644
+--- a/vendor/golang.org/x/net/html/token.go
++++ b/vendor/golang.org/x/net/html/token.go
+@@ -910,9 +910,6 @@ func (z *Tokenizer) readTagAttrKey() {
+ 			return
+ 		}
+ 		switch c {
+-		case ' ', '\n', '\r', '\t', '\f', '/':
+-			z.pendingAttr[0].end = z.raw.end - 1
+-			return
+ 		case '=':
+ 			if z.pendingAttr[0].start+1 == z.raw.end {
+ 				// WHATWG 13.2.5.32, if we see an equals sign before the attribute name
+@@ -920,7 +917,9 @@ func (z *Tokenizer) readTagAttrKey() {
+ 				continue
+ 			}
+ 			fallthrough
+-		case '>':
++		case ' ', '\n', '\r', '\t', '\f', '/', '>':
++			// WHATWG 13.2.5.33 Attribute name state
++			// We need to reconsume the char in the after attribute name state to support the / character
+ 			z.raw.end--
+ 			z.pendingAttr[0].end = z.raw.end
+ 			return
+@@ -939,6 +938,11 @@ func (z *Tokenizer) readTagAttrVal() {
+ 	if z.err != nil {
+ 		return
+ 	}
++	if c == '/' {
++		// WHATWG 13.2.5.34 After attribute name state
++		// U+002F SOLIDUS (/) - Switch to the self-closing start tag state.
++		return
++	}
+ 	if c != '=' {
+ 		z.raw.end--
+ 		return
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90dc..43557ab7e 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984fd..3b9f06b96 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c6408..ce2e8b40e 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 000000000..61075bd16
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86c..ce375c8c7 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/net/websocket/client.go b/vendor/golang.org/x/net/websocket/client.go
+index 69a4ac7ee..1e64157f3 100644
+--- a/vendor/golang.org/x/net/websocket/client.go
++++ b/vendor/golang.org/x/net/websocket/client.go
+@@ -6,10 +6,12 @@ package websocket
+ 
+ import (
+ 	"bufio"
++	"context"
+ 	"io"
+ 	"net"
+ 	"net/http"
+ 	"net/url"
++	"time"
+ )
+ 
+ // DialError is an error that occurs while dialling a websocket server.
+@@ -79,28 +81,59 @@ func parseAuthority(location *url.URL) string {
+ 
+ // DialConfig opens a new client connection to a WebSocket with a config.
+ func DialConfig(config *Config) (ws *Conn, err error) {
+-	var client net.Conn
++	return config.DialContext(context.Background())
++}
++
++// DialContext opens a new client connection to a WebSocket, with context support for timeouts/cancellation.
++func (config *Config) DialContext(ctx context.Context) (*Conn, error) {
+ 	if config.Location == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketLocation}
+ 	}
+ 	if config.Origin == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketOrigin}
+ 	}
++
+ 	dialer := config.Dialer
+ 	if dialer == nil {
+ 		dialer = &net.Dialer{}
+ 	}
+-	client, err = dialWithDialer(dialer, config)
+-	if err != nil {
+-		goto Error
+-	}
+-	ws, err = NewClient(config, client)
++
++	client, err := dialWithDialer(ctx, dialer, config)
+ 	if err != nil {
+-		client.Close()
+-		goto Error
++		return nil, &DialError{config, err}
+ 	}
+-	return
+ 
+-Error:
+-	return nil, &DialError{config, err}
++	// Cleanup the connection if we fail to create the websocket successfully
++	success := false
++	defer func() {
++		if !success {
++			_ = client.Close()
++		}
++	}()
++
++	var ws *Conn
++	var wsErr error
++	doneConnecting := make(chan struct{})
++	go func() {
++		defer close(doneConnecting)
++		ws, err = NewClient(config, client)
++		if err != nil {
++			wsErr = &DialError{config, err}
++		}
++	}()
++
++	// The websocket.NewClient() function can block indefinitely, make sure that we
++	// respect the deadlines specified by the context.
++	select {
++	case <-ctx.Done():
++		// Force the pending operations to fail, terminating the pending connection attempt
++		_ = client.SetDeadline(time.Now())
++		<-doneConnecting // Wait for the goroutine that tries to establish the connection to finish
++		return nil, &DialError{config, ctx.Err()}
++	case <-doneConnecting:
++		if wsErr == nil {
++			success = true // Disarm the deferred connection cleanup
++		}
++		return ws, wsErr
++	}
+ }
+diff --git a/vendor/golang.org/x/net/websocket/dial.go b/vendor/golang.org/x/net/websocket/dial.go
+index 2dab943a4..8a2d83c47 100644
+--- a/vendor/golang.org/x/net/websocket/dial.go
++++ b/vendor/golang.org/x/net/websocket/dial.go
+@@ -5,18 +5,23 @@
+ package websocket
+ 
+ import (
++	"context"
+ 	"crypto/tls"
+ 	"net"
+ )
+ 
+-func dialWithDialer(dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
++func dialWithDialer(ctx context.Context, dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
+ 	switch config.Location.Scheme {
+ 	case "ws":
+-		conn, err = dialer.Dial("tcp", parseAuthority(config.Location))
++		conn, err = dialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 
+ 	case "wss":
+-		conn, err = tls.DialWithDialer(dialer, "tcp", parseAuthority(config.Location), config.TlsConfig)
++		tlsDialer := &tls.Dialer{
++			NetDialer: dialer,
++			Config:    config.TlsConfig,
++		}
+ 
++		conn, err = tlsDialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 	default:
+ 		err = ErrBadScheme
+ 	}
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4bd..b0e419857 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index 6202638ba..fdcaa974d 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -582,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -603,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc69937..2f0fa76e4 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4db..2b57e0f73 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index 0f85e29e6..5682e2628 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -1849,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index c73cfe2f1..36bf8399f 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -1785,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821cf..42ff8c3c1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e4112..dca436004 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c63985560..5cca668ac 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e25..d8cae6d15 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09e..28e39afdc 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642a..cd66e92cb 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d75..c1595eba7 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0d..ee9456b0d 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84f..8cfca81e1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d6..60b0deb3a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc72..f90aa7281 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e2..ba9e01503 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813ed..07cdfd6e9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4ec..2f1dd214a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994da..f40519d90 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index 1488d2712..87d8612a1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -906,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index a1d061597..9dc42410b 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index 5b2a74097..0d3a0751c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index f6eda1344..c39f7776d 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 55df20ae9..57571d072 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index 8c1155cbc..e62963e67 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index 7cc80c58d..00831354c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index 0688737f4..79029ed58 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbdd..0cc3ce496 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc2504..856d92d69 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf2467..8d467094c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e2..edc173244 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77e..445eba206 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362ef..adba01bca 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4fd..014c4e9c7 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca81..ccc97d74d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d39..ec2b64a95 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e3747..21a839e33 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c8..c11121ec3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e591..909b631fc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195a..e49bed16e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943bc..66017d2d3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc51..47bab18dc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index bbf8399ff..eff6bcdef 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -3399,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4183,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5134,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5547,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad19250..d4577a423 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index 47dc57967..6395a031d 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -194,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index 146a1f019..e8791c82c 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -342,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -2988,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+index fa1242b8a..6a3f888ab 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+@@ -392,7 +392,7 @@ type PersistentVolumeStatus struct {
+ 	Reason string
+ 	// LastPhaseTransitionTime is the time the phase transitioned from one to another
+ 	// and automatically resets to current time everytime a volume phase transitions.
+-	// This is an alpha field and requires enabling PersistentVolumeLastPhaseTransitionTime feature.
++	// This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
+ 	// +featureGate=PersistentVolumeLastPhaseTransitionTime
+ 	// +optional
+ 	LastPhaseTransitionTime *metav1.Time
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+index a6f7fef30..1885531f8 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+@@ -5141,6 +5141,46 @@ func ValidateContainerStateTransition(newStatuses, oldStatuses []core.ContainerS
+ 	return allErrs
+ }
+ 
++// ValidateInitContainerStateTransition test to if any illegal init container state transitions are being attempted
++func ValidateInitContainerStateTransition(newStatuses, oldStatuses []core.ContainerStatus, fldpath *field.Path, podSpec *core.PodSpec) field.ErrorList {
++	allErrs := field.ErrorList{}
++	// If we should always restart, containers are allowed to leave the terminated state
++	if podSpec.RestartPolicy == core.RestartPolicyAlways {
++		return allErrs
++	}
++	for i, oldStatus := range oldStatuses {
++		// Skip any container that is not terminated
++		if oldStatus.State.Terminated == nil {
++			continue
++		}
++		// Skip any container that failed but is allowed to restart
++		if oldStatus.State.Terminated.ExitCode != 0 && podSpec.RestartPolicy == core.RestartPolicyOnFailure {
++			continue
++		}
++
++		// Skip any restartable init container that is allowed to restart
++		isRestartableInitContainer := false
++		for _, c := range podSpec.InitContainers {
++			if oldStatus.Name == c.Name {
++				if c.RestartPolicy != nil && *c.RestartPolicy == core.ContainerRestartPolicyAlways {
++					isRestartableInitContainer = true
++				}
++				break
++			}
++		}
++		if isRestartableInitContainer {
++			continue
++		}
++
++		for _, newStatus := range newStatuses {
++			if oldStatus.Name == newStatus.Name && newStatus.State.Terminated == nil {
++				allErrs = append(allErrs, field.Forbidden(fldpath.Index(i).Child("state"), "may not be transitioned to non-terminated state"))
++			}
++		}
++	}
++	return allErrs
++}
++
+ // ValidatePodStatusUpdate checks for changes to status that shouldn't occur in normal operation.
+ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) field.ErrorList {
+ 	fldPath := field.NewPath("metadata")
+@@ -5162,7 +5202,7 @@ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions
+ 	// If pod should not restart, make sure the status update does not transition
+ 	// any terminated containers to a non-terminated state.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.ContainerStatuses, oldPod.Status.ContainerStatuses, fldPath.Child("containerStatuses"), oldPod.Spec.RestartPolicy)...)
+-	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), oldPod.Spec.RestartPolicy)...)
++	allErrs = append(allErrs, ValidateInitContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), &oldPod.Spec)...)
+ 	// The kubelet will never restart ephemeral containers, so treat them like they have an implicit RestartPolicyNever.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.EphemeralContainerStatuses, oldPod.Status.EphemeralContainerStatuses, fldPath.Child("ephemeralContainerStatuses"), core.RestartPolicyNever)...)
+ 	allErrs = append(allErrs, validatePodResourceClaimStatuses(newPod.Status.ResourceClaimStatuses, newPod.Spec.ResourceClaims, fldPath.Child("resourceClaimStatuses"))...)
+diff --git a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+index edd33feb7..b0b12d6eb 100644
+--- a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
++++ b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+@@ -259,7 +259,6 @@ const (
+ 	// owner: @harche
+ 	// kep: http://kep.k8s.io/3386
+ 	// alpha: v1.25
+-	// beta: v1.27
+ 	//
+ 	// Allows using event-driven PLEG (pod lifecycle event generator) through kubelet
+ 	// which avoids frequent relisting of containers which helps optimize performance.
+@@ -617,6 +616,7 @@ const (
+ 	// owner: @RomanBednar
+ 	// kep: https://kep.k8s.io/3762
+ 	// alpha: v1.28
++	// beta: v1.29
+ 	//
+ 	// Adds a new field to persistent volumes which holds a timestamp of when the volume last transitioned its phase.
+ 	PersistentVolumeLastPhaseTransitionTime featuregate.Feature = "PersistentVolumeLastPhaseTransitionTime"
+@@ -1048,7 +1048,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
+ 
+-	EventedPLEG: {Default: false, PreRelease: featuregate.Beta}, // off by default, requires CRI Runtime support
++	EventedPLEG: {Default: false, PreRelease: featuregate.Alpha},
+ 
+ 	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
+ 
+@@ -1263,6 +1263,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.SeparateCacheWatchRPC: {Default: true, PreRelease: featuregate.Beta},
++
+ 	genericfeatures.ServerSideApply: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+ 
+ 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+@@ -1273,6 +1275,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.ZeroLimitedNominalConcurrencyShares: {Default: false, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.WatchFromStorageWithoutResourceVersion: {Default: false, PreRelease: featuregate.Beta},
++
+ 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
+ 	// unintentionally on either side:
+ 
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+index 94c2330af..6ce01755f 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+@@ -1064,7 +1064,7 @@ func NewPersistentVolumeRecyclerPodTemplate() *v1.Pod {
+ 			Containers: []v1.Container{
+ 				{
+ 					Name:    "pv-recycler",
+-					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.0",
++					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.2",
+ 					Command: []string{"/bin/sh"},
+ 					Args:    []string{"-c", "test -e /scrub && find /scrub -mindepth 1 -delete && test -z \"$(ls -A /scrub)\" || exit 1"},
+ 					VolumeMounts: []v1.VolumeMount{
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+index af309353b..238e919b3 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+@@ -102,6 +102,23 @@ func IsFailedPreconditionError(err error) bool {
+ 	return errors.As(err, &failedPreconditionError)
+ }
+ 
++type OperationNotSupported struct {
++	msg string
++}
++
++func (err *OperationNotSupported) Error() string {
++	return err.msg
++}
++
++func NewOperationNotSupportedError(msg string) *OperationNotSupported {
++	return &OperationNotSupported{msg: msg}
++}
++
++func IsOperationNotSupportedError(err error) bool {
++	var operationNotSupportedError *OperationNotSupported
++	return errors.As(err, &operationNotSupportedError)
++}
++
+ // TransientOperationFailure indicates operation failed with a transient error
+ // and may fix itself when retried.
+ type TransientOperationFailure struct {
+diff --git a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+index 72f2394e9..0d83a7cc8 100644
+--- a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
++++ b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+@@ -232,7 +232,7 @@ const (
+ 
+ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
+ 	configs := map[ImageID]Config{}
+-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.45"}
++	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.47"}
+ 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
+ 	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
+ 	configs[AuthenticatedWindowsNanoServer] = Config{list.GcAuthenticatedRegistry, "windows-nanoserver", "v1"}
+@@ -241,8 +241,8 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
+ 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.36.1-1"}
+ 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
+ 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
+-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.3"}
+-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.10-0"}
++	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.7"}
++	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.12-0"}
+ 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
+ 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}
+ 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index ebde30f57..ab47b0cca 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -406,7 +406,7 @@ go.uber.org/zap/internal/pool
+ go.uber.org/zap/internal/stacktrace
+ go.uber.org/zap/zapcore
+ go.uber.org/zap/zapgrpc
+-# golang.org/x/crypto v0.17.0
++# golang.org/x/crypto v0.21.0
+ ## explicit; go 1.18
+ golang.org/x/crypto/blowfish
+ golang.org/x/crypto/chacha20
+@@ -430,7 +430,7 @@ golang.org/x/exp/slices
+ # golang.org/x/mod v0.14.0
+ ## explicit; go 1.18
+ golang.org/x/mod/semver
+-# golang.org/x/net v0.19.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/bpf
+ golang.org/x/net/context
+@@ -457,14 +457,14 @@ golang.org/x/oauth2/internal
+ # golang.org/x/sync v0.5.0
+ ## explicit; go 1.18
+ golang.org/x/sync/singleflight
+-# golang.org/x/sys v0.15.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/cpu
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+ golang.org/x/sys/windows/registry
+-# golang.org/x/term v0.15.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+@@ -1355,7 +1355,7 @@ k8s.io/kubectl/pkg/util/podutils
+ # k8s.io/kubelet v0.27.0 => k8s.io/kubelet v0.29.0
+ ## explicit; go 1.21
+ k8s.io/kubelet/pkg/apis
+-# k8s.io/kubernetes v1.29.0
++# k8s.io/kubernetes v1.29.4
+ ## explicit; go 1.21
+ k8s.io/kubernetes/pkg/api/legacyscheme
+ k8s.io/kubernetes/pkg/api/service
+-- 
+2.40.1
+

--- a/projects/kubernetes-csi/external-provisioner/1-30/CHECKSUMS
+++ b/projects/kubernetes-csi/external-provisioner/1-30/CHECKSUMS
@@ -1,2 +1,2 @@
-f090fe1d3e9e0b7e15c235537a649785921f5704d216b27bca4a1e84536e2572  _output/1-30/bin/external-provisioner/linux-amd64/csi-provisioner
-952edef97a4caa19b92d2bbb13f72d737775e972f07feca64468061f982ca75b  _output/1-30/bin/external-provisioner/linux-arm64/csi-provisioner
+a554f31f0d5ac26b61efbe6fa3b8e76194f0026ddec9335db9136dcbc345f4e1  _output/1-30/bin/external-provisioner/linux-amd64/csi-provisioner
+96967e52e5f700d3830d73bd43242308395f4d07ab66879c706aad72875df4fe  _output/1-30/bin/external-provisioner/linux-arm64/csi-provisioner

--- a/projects/kubernetes-csi/external-provisioner/1-30/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
+++ b/projects/kubernetes-csi/external-provisioner/1-30/patches/0001-Fix-external-provisioner-CVE-2024-3177-by-bumping-k8.patch
@@ -1,0 +1,3220 @@
+From 272caf23aea9e18489bbe26e27e047bc5f09d753 Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Tue, 30 Apr 2024 14:41:12 +0000
+Subject: [PATCH] Fix external-provisioner CVE-2024-3177 by bumping
+ k8s.io/kubernetes to 1.29.4
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                        |  10 +-
+ go.sum                                        |  20 +-
+ .../x/crypto/internal/poly1305/bits_compat.go |  39 ---
+ .../x/crypto/internal/poly1305/bits_go1.13.go |  21 --
+ .../x/crypto/internal/poly1305/sum_generic.go |  43 +--
+ .../x/crypto/internal/poly1305/sum_ppc64le.s  |  14 +-
+ vendor/golang.org/x/net/html/token.go         |  12 +-
+ vendor/golang.org/x/net/http2/frame.go        |  42 ++-
+ vendor/golang.org/x/net/http2/pipe.go         |  11 +-
+ vendor/golang.org/x/net/http2/server.go       |  13 +-
+ vendor/golang.org/x/net/http2/testsync.go     | 331 ++++++++++++++++++
+ vendor/golang.org/x/net/http2/transport.go    | 307 ++++++++++++----
+ vendor/golang.org/x/net/websocket/client.go   |  55 ++-
+ vendor/golang.org/x/net/websocket/dial.go     |  11 +-
+ vendor/golang.org/x/sys/unix/aliases.go       |   2 +-
+ vendor/golang.org/x/sys/unix/mkerrors.sh      |  39 ++-
+ .../x/sys/unix/syscall_darwin_libSystem.go    |   2 +-
+ .../golang.org/x/sys/unix/syscall_freebsd.go  |  12 +-
+ vendor/golang.org/x/sys/unix/syscall_linux.go |  99 ++++++
+ vendor/golang.org/x/sys/unix/zerrors_linux.go |  90 ++++-
+ .../x/sys/unix/zerrors_linux_386.go           |   3 +
+ .../x/sys/unix/zerrors_linux_amd64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_arm.go           |   3 +
+ .../x/sys/unix/zerrors_linux_arm64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_loong64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_mips.go          |   3 +
+ .../x/sys/unix/zerrors_linux_mips64.go        |   3 +
+ .../x/sys/unix/zerrors_linux_mips64le.go      |   3 +
+ .../x/sys/unix/zerrors_linux_mipsle.go        |   3 +
+ .../x/sys/unix/zerrors_linux_ppc.go           |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64.go         |   3 +
+ .../x/sys/unix/zerrors_linux_ppc64le.go       |   3 +
+ .../x/sys/unix/zerrors_linux_riscv64.go       |   3 +
+ .../x/sys/unix/zerrors_linux_s390x.go         |   3 +
+ .../x/sys/unix/zerrors_linux_sparc64.go       |   3 +
+ .../golang.org/x/sys/unix/zsyscall_linux.go   |  10 +
+ .../x/sys/unix/zsyscall_openbsd_386.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_amd64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm.go        |   2 -
+ .../x/sys/unix/zsyscall_openbsd_arm64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_mips64.go     |   2 -
+ .../x/sys/unix/zsyscall_openbsd_ppc64.go      |   2 -
+ .../x/sys/unix/zsyscall_openbsd_riscv64.go    |   2 -
+ .../x/sys/unix/zsysnum_linux_386.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_amd64.go         |   3 +
+ .../x/sys/unix/zsysnum_linux_arm.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_arm64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_loong64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_mips.go          |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_mips64le.go      |   4 +
+ .../x/sys/unix/zsysnum_linux_mipsle.go        |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc.go           |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_ppc64le.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_riscv64.go       |   4 +
+ .../x/sys/unix/zsysnum_linux_s390x.go         |   4 +
+ .../x/sys/unix/zsysnum_linux_sparc64.go       |   4 +
+ vendor/golang.org/x/sys/unix/ztypes_linux.go  | 185 ++++++----
+ .../golang.org/x/sys/windows/env_windows.go   |  17 +-
+ .../x/sys/windows/syscall_windows.go          |   4 +-
+ .../x/sys/windows/zsyscall_windows.go         |   9 +
+ .../k8s.io/kubernetes/pkg/apis/core/types.go  |   2 +-
+ .../pkg/apis/core/validation/validation.go    |  42 ++-
+ .../kubernetes/pkg/features/kube_features.go  |   8 +-
+ .../k8s.io/kubernetes/pkg/volume/plugins.go   |   2 +-
+ .../kubernetes/pkg/volume/util/types/types.go |  17 +
+ .../kubernetes/test/utils/image/manifest.go   |   6 +-
+ vendor/modules.txt                            |  10 +-
+ 69 files changed, 1287 insertions(+), 316 deletions(-)
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+ delete mode 100644 vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+ create mode 100644 vendor/golang.org/x/net/http2/testsync.go
+
+diff --git a/go.mod b/go.mod
+index fff06492a..a2be5719c 100644
+--- a/go.mod
++++ b/go.mod
+@@ -33,7 +33,7 @@ require (
+ require (
+ 	github.com/onsi/ginkgo/v2 v2.13.2
+ 	github.com/onsi/gomega v1.30.0
+-	k8s.io/kubernetes v1.29.0
++	k8s.io/kubernetes v1.29.4
+ )
+ 
+ require (
+@@ -106,14 +106,14 @@ require (
+ 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.26.0 // indirect
+-	golang.org/x/crypto v0.17.0 // indirect
++	golang.org/x/crypto v0.21.0 // indirect
+ 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+ 	golang.org/x/mod v0.14.0 // indirect
+-	golang.org/x/net v0.19.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
+ 	golang.org/x/oauth2 v0.15.0 // indirect
+ 	golang.org/x/sync v0.5.0 // indirect
+-	golang.org/x/sys v0.15.0 // indirect
+-	golang.org/x/term v0.15.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
++	golang.org/x/term v0.18.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
+ 	golang.org/x/time v0.5.0 // indirect
+ 	golang.org/x/tools v0.16.1 // indirect
+diff --git a/go.sum b/go.sum
+index 56c808a77..c0444fa2f 100644
+--- a/go.sum
++++ b/go.sum
+@@ -248,8 +248,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
+ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+-golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+-golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
++golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
++golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+ golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -265,8 +265,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+-golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+-golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
++golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
++golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+ golang.org/x/oauth2 v0.15.0 h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ=
+ golang.org/x/oauth2 v0.15.0/go.mod h1:q48ptWNTY5XWf+JNten23lcvHpLJ0ZSxF5ttTHKVCAM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -286,12 +286,12 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
++golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+-golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+-golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
++golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
++golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+@@ -371,8 +371,8 @@ k8s.io/kubectl v0.29.0 h1:Oqi48gXjikDhrBF67AYuZRTcJV4lg2l42GmvsP7FmYI=
+ k8s.io/kubectl v0.29.0/go.mod h1:0jMjGWIcMIQzmUaMgAzhSELv5WtHo2a8pq67DtviAJs=
+ k8s.io/kubelet v0.29.0 h1:SX5hlznTBcGIrS1scaf8r8p6m3e475KMifwt9i12iOk=
+ k8s.io/kubelet v0.29.0/go.mod h1:kvKS2+Bz2tgDOG1S1q0TH2z1DasNuVF+8p6Aw7xvKkI=
+-k8s.io/kubernetes v1.29.0 h1:DOLN7g8+nnAYBi8JHoW0+/MCrZKDPIqAxzLCXDXd0cg=
+-k8s.io/kubernetes v1.29.0/go.mod h1:9kztbUQf9stVDcIYXx+BX3nuGCsAQDsuClkGMpPs3pA=
++k8s.io/kubernetes v1.29.4 h1:n4VCbX9cUhxHI+zw+m2iZlzT73/mrEJBHIMeauh9g4U=
++k8s.io/kubernetes v1.29.4/go.mod h1:28sDhcb87LX5z3GWAKYmLrhrifxi4W9bEWua4DRTIvk=
+ k8s.io/mount-utils v0.29.0 h1:KcUE0bFHONQC10V3SuLWQ6+l8nmJggw9lKLpDftIshI=
+ k8s.io/mount-utils v0.29.0/go.mod h1:N3lDK/G1B8R/IkAt4NhHyqB07OqEr7P763z3TNge94U=
+ k8s.io/pod-security-admission v0.29.0 h1:tY/ldtkbBCulMYVSWg6ZDLlgDYDWy6rLj8e/AgmwSj4=
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
+deleted file mode 100644
+index d33c8890f..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_compat.go
++++ /dev/null
+@@ -1,39 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !go1.13
+-
+-package poly1305
+-
+-// Generic fallbacks for the math/bits intrinsics, copied from
+-// src/math/bits/bits.go. They were added in Go 1.12, but Add64 and Sum64 had
+-// variable time fallbacks until Go 1.13.
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	sum = x + y + carry
+-	carryOut = ((x & y) | ((x | y) &^ sum)) >> 63
+-	return
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	diff = x - y - borrow
+-	borrowOut = ((^x & y) | (^(x ^ y) & diff)) >> 63
+-	return
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	const mask32 = 1<<32 - 1
+-	x0 := x & mask32
+-	x1 := x >> 32
+-	y0 := y & mask32
+-	y1 := y >> 32
+-	w0 := x0 * y0
+-	t := x1*y0 + w0>>32
+-	w1 := t & mask32
+-	w2 := t >> 32
+-	w1 += x0 * y1
+-	hi = x1*y1 + w2 + w1>>32
+-	lo = x * y
+-	return
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go b/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
+deleted file mode 100644
+index 495c1fa69..000000000
+--- a/vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
++++ /dev/null
+@@ -1,21 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build go1.13
+-
+-package poly1305
+-
+-import "math/bits"
+-
+-func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+-	return bits.Add64(x, y, carry)
+-}
+-
+-func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+-	return bits.Sub64(x, y, borrow)
+-}
+-
+-func bitsMul64(x, y uint64) (hi, lo uint64) {
+-	return bits.Mul64(x, y)
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+index e041da5ea..ec2202bd7 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_generic.go
+@@ -7,7 +7,10 @@
+ 
+ package poly1305
+ 
+-import "encoding/binary"
++import (
++	"encoding/binary"
++	"math/bits"
++)
+ 
+ // Poly1305 [RFC 7539] is a relatively simple algorithm: the authentication tag
+ // for a 64 bytes message is approximately
+@@ -114,13 +117,13 @@ type uint128 struct {
+ }
+ 
+ func mul64(a, b uint64) uint128 {
+-	hi, lo := bitsMul64(a, b)
++	hi, lo := bits.Mul64(a, b)
+ 	return uint128{lo, hi}
+ }
+ 
+ func add128(a, b uint128) uint128 {
+-	lo, c := bitsAdd64(a.lo, b.lo, 0)
+-	hi, c := bitsAdd64(a.hi, b.hi, c)
++	lo, c := bits.Add64(a.lo, b.lo, 0)
++	hi, c := bits.Add64(a.hi, b.hi, c)
+ 	if c != 0 {
+ 		panic("poly1305: unexpected overflow")
+ 	}
+@@ -155,8 +158,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 		// hide leading zeroes. For full chunks, that's 1 << 128, so we can just
+ 		// add 1 to the most significant (2¹²⁸) limb, h2.
+ 		if len(msg) >= TagSize {
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(msg[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(msg[8:16]), c)
+ 			h2 += c + 1
+ 
+ 			msg = msg[TagSize:]
+@@ -165,8 +168,8 @@ func updateGeneric(state *macState, msg []byte) {
+ 			copy(buf[:], msg)
+ 			buf[len(msg)] = 1
+ 
+-			h0, c = bitsAdd64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
+-			h1, c = bitsAdd64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
++			h0, c = bits.Add64(h0, binary.LittleEndian.Uint64(buf[0:8]), 0)
++			h1, c = bits.Add64(h1, binary.LittleEndian.Uint64(buf[8:16]), c)
+ 			h2 += c
+ 
+ 			msg = nil
+@@ -219,9 +222,9 @@ func updateGeneric(state *macState, msg []byte) {
+ 		m3 := h2r1
+ 
+ 		t0 := m0.lo
+-		t1, c := bitsAdd64(m1.lo, m0.hi, 0)
+-		t2, c := bitsAdd64(m2.lo, m1.hi, c)
+-		t3, _ := bitsAdd64(m3.lo, m2.hi, c)
++		t1, c := bits.Add64(m1.lo, m0.hi, 0)
++		t2, c := bits.Add64(m2.lo, m1.hi, c)
++		t3, _ := bits.Add64(m3.lo, m2.hi, c)
+ 
+ 		// Now we have the result as 4 64-bit limbs, and we need to reduce it
+ 		// modulo 2¹³⁰ - 5. The special shape of this Crandall prime lets us do
+@@ -243,14 +246,14 @@ func updateGeneric(state *macState, msg []byte) {
+ 
+ 		// To add c * 5 to h, we first add cc = c * 4, and then add (cc >> 2) = c.
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		cc = shiftRightBy2(cc)
+ 
+-		h0, c = bitsAdd64(h0, cc.lo, 0)
+-		h1, c = bitsAdd64(h1, cc.hi, c)
++		h0, c = bits.Add64(h0, cc.lo, 0)
++		h1, c = bits.Add64(h1, cc.hi, c)
+ 		h2 += c
+ 
+ 		// h2 is at most 3 + 1 + 1 = 5, making the whole of h at most
+@@ -287,9 +290,9 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	// in constant time, we compute t = h - (2¹³⁰ - 5), and select h as the
+ 	// result if the subtraction underflows, and t otherwise.
+ 
+-	hMinusP0, b := bitsSub64(h0, p0, 0)
+-	hMinusP1, b := bitsSub64(h1, p1, b)
+-	_, b = bitsSub64(h2, p2, b)
++	hMinusP0, b := bits.Sub64(h0, p0, 0)
++	hMinusP1, b := bits.Sub64(h1, p1, b)
++	_, b = bits.Sub64(h2, p2, b)
+ 
+ 	// h = h if h < p else h - p
+ 	h0 = select64(b, h0, hMinusP0)
+@@ -301,8 +304,8 @@ func finalize(out *[TagSize]byte, h *[3]uint64, s *[2]uint64) {
+ 	//
+ 	// by just doing a wide addition with the 128 low bits of h and discarding
+ 	// the overflow.
+-	h0, c := bitsAdd64(h0, s[0], 0)
+-	h1, _ = bitsAdd64(h1, s[1], c)
++	h0, c := bits.Add64(h0, s[0], 0)
++	h1, _ = bits.Add64(h1, s[1], c)
+ 
+ 	binary.LittleEndian.PutUint64(out[0:8], h0)
+ 	binary.LittleEndian.PutUint64(out[8:16], h1)
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+index d2ca5deeb..b3c1699bf 100644
+--- a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+@@ -19,15 +19,14 @@
+ 
+ #define POLY1305_MUL(h0, h1, h2, r0, r1, t0, t1, t2, t3, t4, t5) \
+ 	MULLD  r0, h0, t0;  \
+-	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h0, t1;  \
++	MULLD  r0, h1, t4;  \
+ 	MULHDU r0, h1, t5;  \
+ 	ADDC   t4, t1, t1;  \
+ 	MULLD  r0, h2, t2;  \
+-	ADDZE  t5;          \
+ 	MULHDU r1, h0, t4;  \
+ 	MULLD  r1, h0, h0;  \
+-	ADD    t5, t2, t2;  \
++	ADDE   t5, t2, t2;  \
+ 	ADDC   h0, t1, t1;  \
+ 	MULLD  h2, r1, t3;  \
+ 	ADDZE  t4, h0;      \
+@@ -37,13 +36,11 @@
+ 	ADDE   t5, t3, t3;  \
+ 	ADDC   h0, t2, t2;  \
+ 	MOVD   $-4, t4;     \
+-	MOVD   t0, h0;      \
+-	MOVD   t1, h1;      \
+ 	ADDZE  t3;          \
+-	ANDCC  $3, t2, h2;  \
+-	AND    t2, t4, t0;  \
++	RLDICL $0, t2, $62, h2; \
++	AND    t2, t4, h0;  \
+ 	ADDC   t0, h0, h0;  \
+-	ADDE   t3, h1, h1;  \
++	ADDE   t3, t1, h1;  \
+ 	SLD    $62, t3, t4; \
+ 	SRD    $2, t2;      \
+ 	ADDZE  h2;          \
+@@ -75,6 +72,7 @@ TEXT ·update(SB), $0-32
+ loop:
+ 	POLY1305_ADD(R4, R8, R9, R10, R20, R21, R22)
+ 
++	PCALIGN $16
+ multiply:
+ 	POLY1305_MUL(R8, R9, R10, R11, R12, R16, R17, R18, R14, R20, R21)
+ 	ADD $-16, R5
+diff --git a/vendor/golang.org/x/net/html/token.go b/vendor/golang.org/x/net/html/token.go
+index de67f938a..3c57880d6 100644
+--- a/vendor/golang.org/x/net/html/token.go
++++ b/vendor/golang.org/x/net/html/token.go
+@@ -910,9 +910,6 @@ func (z *Tokenizer) readTagAttrKey() {
+ 			return
+ 		}
+ 		switch c {
+-		case ' ', '\n', '\r', '\t', '\f', '/':
+-			z.pendingAttr[0].end = z.raw.end - 1
+-			return
+ 		case '=':
+ 			if z.pendingAttr[0].start+1 == z.raw.end {
+ 				// WHATWG 13.2.5.32, if we see an equals sign before the attribute name
+@@ -920,7 +917,9 @@ func (z *Tokenizer) readTagAttrKey() {
+ 				continue
+ 			}
+ 			fallthrough
+-		case '>':
++		case ' ', '\n', '\r', '\t', '\f', '/', '>':
++			// WHATWG 13.2.5.33 Attribute name state
++			// We need to reconsume the char in the after attribute name state to support the / character
+ 			z.raw.end--
+ 			z.pendingAttr[0].end = z.raw.end
+ 			return
+@@ -939,6 +938,11 @@ func (z *Tokenizer) readTagAttrVal() {
+ 	if z.err != nil {
+ 		return
+ 	}
++	if c == '/' {
++		// WHATWG 13.2.5.34 After attribute name state
++		// U+002F SOLIDUS (/) - Switch to the self-closing start tag state.
++		return
++	}
+ 	if c != '=' {
+ 		z.raw.end--
+ 		return
+diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
+index c1f6b90dc..43557ab7e 100644
+--- a/vendor/golang.org/x/net/http2/frame.go
++++ b/vendor/golang.org/x/net/http2/frame.go
+@@ -1510,13 +1510,12 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
+ }
+ 
+ func (fr *Framer) maxHeaderStringLen() int {
+-	v := fr.maxHeaderListSize()
+-	if uint32(int(v)) == v {
+-		return int(v)
++	v := int(fr.maxHeaderListSize())
++	if v < 0 {
++		// If maxHeaderListSize overflows an int, use no limit (0).
++		return 0
+ 	}
+-	// They had a crazy big number for MaxHeaderBytes anyway,
+-	// so give them unlimited header lengths:
+-	return 0
++	return v
+ }
+ 
+ // readMetaFrame returns 0 or more CONTINUATION frames from fr and
+@@ -1565,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 		if size > remainSize {
+ 			hdec.SetEmitEnabled(false)
+ 			mh.Truncated = true
++			remainSize = 0
+ 			return
+ 		}
+ 		remainSize -= size
+@@ -1577,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+ 	var hc headersOrContinuation = hf
+ 	for {
+ 		frag := hc.HeaderBlockFragment()
++
++		// Avoid parsing large amounts of headers that we will then discard.
++		// If the sender exceeds the max header list size by too much,
++		// skip parsing the fragment and close the connection.
++		//
++		// "Too much" is either any CONTINUATION frame after we've already
++		// exceeded the max header list size (in which case remainSize is 0),
++		// or a frame whose encoded size is more than twice the remaining
++		// header list bytes we're willing to accept.
++		if int64(len(frag)) > int64(2*remainSize) {
++			if VerboseLogs {
++				log.Printf("http2: header list too large")
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
++		// Also close the connection after any CONTINUATION frame following an
++		// invalid header, since we stop tracking the size of the headers after
++		// an invalid one.
++		if invalid != nil {
++			if VerboseLogs {
++				log.Printf("http2: invalid header: %v", invalid)
++			}
++			// It would be nice to send a RST_STREAM before sending the GOAWAY,
++			// but the structure of the server's frame writer makes this difficult.
++			return nil, ConnectionError(ErrCodeProtocol)
++		}
++
+ 		if _, err := hdec.Write(frag); err != nil {
+ 			return nil, ConnectionError(ErrCodeCompression)
+ 		}
+diff --git a/vendor/golang.org/x/net/http2/pipe.go b/vendor/golang.org/x/net/http2/pipe.go
+index 684d984fd..3b9f06b96 100644
+--- a/vendor/golang.org/x/net/http2/pipe.go
++++ b/vendor/golang.org/x/net/http2/pipe.go
+@@ -77,7 +77,10 @@ func (p *pipe) Read(d []byte) (n int, err error) {
+ 	}
+ }
+ 
+-var errClosedPipeWrite = errors.New("write on closed buffer")
++var (
++	errClosedPipeWrite        = errors.New("write on closed buffer")
++	errUninitializedPipeWrite = errors.New("write on uninitialized buffer")
++)
+ 
+ // Write copies bytes from p into the buffer and wakes a reader.
+ // It is an error to write more data than the buffer can hold.
+@@ -91,6 +94,12 @@ func (p *pipe) Write(d []byte) (n int, err error) {
+ 	if p.err != nil || p.breakErr != nil {
+ 		return 0, errClosedPipeWrite
+ 	}
++	// pipe.setBuffer is never invoked, leaving the buffer uninitialized.
++	// We shouldn't try to write to an uninitialized pipe,
++	// but returning an error is better than panicking.
++	if p.b == nil {
++		return 0, errUninitializedPipeWrite
++	}
+ 	return p.b.Write(d)
+ }
+ 
+diff --git a/vendor/golang.org/x/net/http2/server.go b/vendor/golang.org/x/net/http2/server.go
+index ae94c6408..ce2e8b40e 100644
+--- a/vendor/golang.org/x/net/http2/server.go
++++ b/vendor/golang.org/x/net/http2/server.go
+@@ -124,6 +124,7 @@ type Server struct {
+ 	// IdleTimeout specifies how long until idle clients should be
+ 	// closed with a GOAWAY frame. PING frames are not considered
+ 	// activity for the purposes of IdleTimeout.
++	// If zero or negative, there is no timeout.
+ 	IdleTimeout time.Duration
+ 
+ 	// MaxUploadBufferPerConnection is the size of the initial flow
+@@ -434,7 +435,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
+ 	// passes the connection off to us with the deadline already set.
+ 	// Write deadlines are set per stream in serverConn.newStream.
+ 	// Disarm the net.Conn write deadline here.
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		sc.conn.SetWriteDeadline(time.Time{})
+ 	}
+ 
+@@ -924,7 +925,7 @@ func (sc *serverConn) serve() {
+ 	sc.setConnState(http.StateActive)
+ 	sc.setConnState(http.StateIdle)
+ 
+-	if sc.srv.IdleTimeout != 0 {
++	if sc.srv.IdleTimeout > 0 {
+ 		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
+ 		defer sc.idleTimer.Stop()
+ 	}
+@@ -1637,7 +1638,7 @@ func (sc *serverConn) closeStream(st *stream, err error) {
+ 	delete(sc.streams, st.id)
+ 	if len(sc.streams) == 0 {
+ 		sc.setConnState(http.StateIdle)
+-		if sc.srv.IdleTimeout != 0 {
++		if sc.srv.IdleTimeout > 0 {
+ 			sc.idleTimer.Reset(sc.srv.IdleTimeout)
+ 		}
+ 		if h1ServerKeepAlivesDisabled(sc.hs) {
+@@ -2017,7 +2018,7 @@ func (sc *serverConn) processHeaders(f *MetaHeadersFrame) error {
+ 	// similar to how the http1 server works. Here it's
+ 	// technically more like the http1 Server's ReadHeaderTimeout
+ 	// (in Go 1.8), though. That's a more sane option anyway.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
+ 	}
+@@ -2038,7 +2039,7 @@ func (sc *serverConn) upgradeRequest(req *http.Request) {
+ 
+ 	// Disable any read deadline set by the net/http package
+ 	// prior to the upgrade.
+-	if sc.hs.ReadTimeout != 0 {
++	if sc.hs.ReadTimeout > 0 {
+ 		sc.conn.SetReadDeadline(time.Time{})
+ 	}
+ 
+@@ -2116,7 +2117,7 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
+ 	st.flow.conn = &sc.flow // link to conn-level counter
+ 	st.flow.add(sc.initialStreamSendWindowSize)
+ 	st.inflow.init(sc.srv.initialStreamRecvWindowSize())
+-	if sc.hs.WriteTimeout != 0 {
++	if sc.hs.WriteTimeout > 0 {
+ 		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
+ 	}
+ 
+diff --git a/vendor/golang.org/x/net/http2/testsync.go b/vendor/golang.org/x/net/http2/testsync.go
+new file mode 100644
+index 000000000..61075bd16
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/testsync.go
+@@ -0,0 +1,331 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import (
++	"context"
++	"sync"
++	"time"
++)
++
++// testSyncHooks coordinates goroutines in tests.
++//
++// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
++//   - the goroutine running RoundTrip;
++//   - the clientStream.doRequest goroutine, which writes the request; and
++//   - the clientStream.readLoop goroutine, which reads the response.
++//
++// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
++// are blocked waiting for some condition such as reading the Request.Body or waiting for
++// flow control to become available.
++//
++// The testSyncHooks also manage timers and synthetic time in tests.
++// This permits us to, for example, start a request and cause it to time out waiting for
++// response headers without resorting to time.Sleep calls.
++type testSyncHooks struct {
++	// active/inactive act as a mutex and condition variable.
++	//
++	//  - neither chan contains a value: testSyncHooks is locked.
++	//  - active contains a value: unlocked, and at least one goroutine is not blocked
++	//  - inactive contains a value: unlocked, and all goroutines are blocked
++	active   chan struct{}
++	inactive chan struct{}
++
++	// goroutine counts
++	total    int                     // total goroutines
++	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
++	blocked  []*testBlockedGoroutine // otherwise blocked
++
++	// fake time
++	now    time.Time
++	timers []*fakeTimer
++
++	// Transport testing: Report various events.
++	newclientconn func(*ClientConn)
++	newstream     func(*clientStream)
++}
++
++// testBlockedGoroutine is a blocked goroutine.
++type testBlockedGoroutine struct {
++	f  func() bool   // blocked until f returns true
++	ch chan struct{} // closed when unblocked
++}
++
++func newTestSyncHooks() *testSyncHooks {
++	h := &testSyncHooks{
++		active:   make(chan struct{}, 1),
++		inactive: make(chan struct{}, 1),
++		condwait: map[*sync.Cond]int{},
++	}
++	h.inactive <- struct{}{}
++	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
++	return h
++}
++
++// lock acquires the testSyncHooks mutex.
++func (h *testSyncHooks) lock() {
++	select {
++	case <-h.active:
++	case <-h.inactive:
++	}
++}
++
++// waitInactive waits for all goroutines to become inactive.
++func (h *testSyncHooks) waitInactive() {
++	for {
++		<-h.inactive
++		if !h.unlock() {
++			break
++		}
++	}
++}
++
++// unlock releases the testSyncHooks mutex.
++// It reports whether any goroutines are active.
++func (h *testSyncHooks) unlock() (active bool) {
++	// Look for a blocked goroutine which can be unblocked.
++	blocked := h.blocked[:0]
++	unblocked := false
++	for _, b := range h.blocked {
++		if !unblocked && b.f() {
++			unblocked = true
++			close(b.ch)
++		} else {
++			blocked = append(blocked, b)
++		}
++	}
++	h.blocked = blocked
++
++	// Count goroutines blocked on condition variables.
++	condwait := 0
++	for _, count := range h.condwait {
++		condwait += count
++	}
++
++	if h.total > condwait+len(blocked) {
++		h.active <- struct{}{}
++		return true
++	} else {
++		h.inactive <- struct{}{}
++		return false
++	}
++}
++
++// goRun starts a new goroutine.
++func (h *testSyncHooks) goRun(f func()) {
++	h.lock()
++	h.total++
++	h.unlock()
++	go func() {
++		defer func() {
++			h.lock()
++			h.total--
++			h.unlock()
++		}()
++		f()
++	}()
++}
++
++// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
++// It waits until f returns true before proceeding.
++//
++// Example usage:
++//
++//	h.blockUntil(func() bool {
++//		// Is the context done yet?
++//		select {
++//		case <-ctx.Done():
++//		default:
++//			return false
++//		}
++//		return true
++//	})
++//	// Wait for the context to become done.
++//	<-ctx.Done()
++//
++// The function f passed to blockUntil must be non-blocking and idempotent.
++func (h *testSyncHooks) blockUntil(f func() bool) {
++	if f() {
++		return
++	}
++	ch := make(chan struct{})
++	h.lock()
++	h.blocked = append(h.blocked, &testBlockedGoroutine{
++		f:  f,
++		ch: ch,
++	})
++	h.unlock()
++	<-ch
++}
++
++// broadcast is sync.Cond.Broadcast.
++func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
++	h.lock()
++	delete(h.condwait, cond)
++	h.unlock()
++	cond.Broadcast()
++}
++
++// broadcast is sync.Cond.Wait.
++func (h *testSyncHooks) condWait(cond *sync.Cond) {
++	h.lock()
++	h.condwait[cond]++
++	h.unlock()
++}
++
++// newTimer creates a new fake timer.
++func (h *testSyncHooks) newTimer(d time.Duration) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		c:     make(chan time.Time),
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++// afterFunc creates a new fake AfterFunc timer.
++func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
++	h.lock()
++	defer h.unlock()
++	t := &fakeTimer{
++		hooks: h,
++		when:  h.now.Add(d),
++		f:     f,
++	}
++	h.timers = append(h.timers, t)
++	return t
++}
++
++func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	ctx, cancel := context.WithCancel(ctx)
++	t := h.afterFunc(d, cancel)
++	return ctx, func() {
++		t.Stop()
++		cancel()
++	}
++}
++
++func (h *testSyncHooks) timeUntilEvent() time.Duration {
++	h.lock()
++	defer h.unlock()
++	var next time.Time
++	for _, t := range h.timers {
++		if next.IsZero() || t.when.Before(next) {
++			next = t.when
++		}
++	}
++	if d := next.Sub(h.now); d > 0 {
++		return d
++	}
++	return 0
++}
++
++// advance advances time and causes synthetic timers to fire.
++func (h *testSyncHooks) advance(d time.Duration) {
++	h.lock()
++	defer h.unlock()
++	h.now = h.now.Add(d)
++	timers := h.timers[:0]
++	for _, t := range h.timers {
++		t := t // remove after go.mod depends on go1.22
++		t.mu.Lock()
++		switch {
++		case t.when.After(h.now):
++			timers = append(timers, t)
++		case t.when.IsZero():
++			// stopped timer
++		default:
++			t.when = time.Time{}
++			if t.c != nil {
++				close(t.c)
++			}
++			if t.f != nil {
++				h.total++
++				go func() {
++					defer func() {
++						h.lock()
++						h.total--
++						h.unlock()
++					}()
++					t.f()
++				}()
++			}
++		}
++		t.mu.Unlock()
++	}
++	h.timers = timers
++}
++
++// A timer wraps a time.Timer, or a synthetic equivalent in tests.
++// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
++type timer interface {
++	C() <-chan time.Time
++	Stop() bool
++	Reset(d time.Duration) bool
++}
++
++// timeTimer implements timer using real time.
++type timeTimer struct {
++	t *time.Timer
++	c chan time.Time
++}
++
++// newTimeTimer creates a new timer using real time.
++func newTimeTimer(d time.Duration) timer {
++	ch := make(chan time.Time)
++	t := time.AfterFunc(d, func() {
++		close(ch)
++	})
++	return &timeTimer{t, ch}
++}
++
++// newTimeAfterFunc creates an AfterFunc timer using real time.
++func newTimeAfterFunc(d time.Duration, f func()) timer {
++	return &timeTimer{
++		t: time.AfterFunc(d, f),
++	}
++}
++
++func (t timeTimer) C() <-chan time.Time        { return t.c }
++func (t timeTimer) Stop() bool                 { return t.t.Stop() }
++func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
++
++// fakeTimer implements timer using fake time.
++type fakeTimer struct {
++	hooks *testSyncHooks
++
++	mu   sync.Mutex
++	when time.Time      // when the timer will fire
++	c    chan time.Time // closed when the timer fires; mutually exclusive with f
++	f    func()         // called when the timer fires; mutually exclusive with c
++}
++
++func (t *fakeTimer) C() <-chan time.Time { return t.c }
++
++func (t *fakeTimer) Stop() bool {
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	stopped := t.when.IsZero()
++	t.when = time.Time{}
++	return stopped
++}
++
++func (t *fakeTimer) Reset(d time.Duration) bool {
++	if t.c != nil || t.f == nil {
++		panic("fakeTimer only supports Reset on AfterFunc timers")
++	}
++	t.mu.Lock()
++	defer t.mu.Unlock()
++	t.hooks.lock()
++	defer t.hooks.unlock()
++	active := !t.when.IsZero()
++	t.when = t.hooks.now.Add(d)
++	if !active {
++		t.hooks.timers = append(t.hooks.timers, t)
++	}
++	return active
++}
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index df578b86c..ce375c8c7 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -147,6 +147,12 @@ type Transport struct {
+ 	// waiting for their turn.
+ 	StrictMaxConcurrentStreams bool
+ 
++	// IdleConnTimeout is the maximum amount of time an idle
++	// (keep-alive) connection will remain idle before closing
++	// itself.
++	// Zero means no limit.
++	IdleConnTimeout time.Duration
++
+ 	// ReadIdleTimeout is the timeout after which a health check using ping
+ 	// frame will be carried out if no frame is received on the connection.
+ 	// Note that a ping response will is considered a received frame, so if
+@@ -178,6 +184,8 @@ type Transport struct {
+ 
+ 	connPoolOnce  sync.Once
+ 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
++
++	syncHooks *testSyncHooks
+ }
+ 
+ func (t *Transport) maxHeaderListSize() uint32 {
+@@ -302,7 +310,7 @@ type ClientConn struct {
+ 	readerErr  error         // set before readerDone is closed
+ 
+ 	idleTimeout time.Duration // or 0 for never
+-	idleTimer   *time.Timer
++	idleTimer   timer
+ 
+ 	mu              sync.Mutex // guards following
+ 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
+@@ -344,6 +352,60 @@ type ClientConn struct {
+ 	werr error        // first write error that has occurred
+ 	hbuf bytes.Buffer // HPACK encoder writes into this
+ 	henc *hpack.Encoder
++
++	syncHooks *testSyncHooks // can be nil
++}
++
++// Hook points used for testing.
++// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
++// Inside tests, see the testSyncHooks function docs.
++
++// goRun starts a new goroutine.
++func (cc *ClientConn) goRun(f func()) {
++	if cc.syncHooks != nil {
++		cc.syncHooks.goRun(f)
++		return
++	}
++	go f()
++}
++
++// condBroadcast is cc.cond.Broadcast.
++func (cc *ClientConn) condBroadcast() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condBroadcast(cc.cond)
++	}
++	cc.cond.Broadcast()
++}
++
++// condWait is cc.cond.Wait.
++func (cc *ClientConn) condWait() {
++	if cc.syncHooks != nil {
++		cc.syncHooks.condWait(cc.cond)
++	}
++	cc.cond.Wait()
++}
++
++// newTimer creates a new time.Timer, or a synthetic timer in tests.
++func (cc *ClientConn) newTimer(d time.Duration) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.newTimer(d)
++	}
++	return newTimeTimer(d)
++}
++
++// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
++func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.afterFunc(d, f)
++	}
++	return newTimeAfterFunc(d, f)
++}
++
++func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
++	if cc.syncHooks != nil {
++		return cc.syncHooks.contextWithTimeout(ctx, d)
++	}
++	return context.WithTimeout(ctx, d)
+ }
+ 
+ // clientStream is the state for a single HTTP/2 stream. One of these
+@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
+ 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
+ 	if cs.cc.cond != nil {
+ 		// Wake up writeRequestBody if it is waiting on flow control.
+-		cs.cc.cond.Broadcast()
++		cs.cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
+ 	defer cc.mu.Unlock()
+ 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
+ 		cs.closeReqBodyLocked()
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 	}
+ }
+ 
+@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
+ 	}
+ 	cs.reqBodyClosed = make(chan struct{})
+ 	reqBodyClosed := cs.reqBodyClosed
+-	go func() {
++	cs.cc.goRun(func() {
+ 		cs.reqBody.Close()
+ 		close(reqBodyClosed)
+-	}()
++	})
+ }
+ 
+ type stickyErrWriter struct {
+@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
+ 	return net.JoinHostPort(host, port)
+ }
+ 
+-var retryBackoffHook func(time.Duration) *time.Timer
+-
+-func backoffNewTimer(d time.Duration) *time.Timer {
+-	if retryBackoffHook != nil {
+-		return retryBackoffHook(d)
+-	}
+-	return time.NewTimer(d)
+-}
+-
+ // RoundTripOpt is like RoundTrip, but takes options.
+ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
+ 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
+@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
+ 				backoff := float64(uint(1) << (uint(retry) - 1))
+ 				backoff += backoff * (0.1 * mathrand.Float64())
+ 				d := time.Second * time.Duration(backoff)
+-				timer := backoffNewTimer(d)
++				var tm timer
++				if t.syncHooks != nil {
++					tm = t.syncHooks.newTimer(d)
++					t.syncHooks.blockUntil(func() bool {
++						select {
++						case <-tm.C():
++						case <-req.Context().Done():
++						default:
++							return false
++						}
++						return true
++					})
++				} else {
++					tm = newTimeTimer(d)
++				}
+ 				select {
+-				case <-timer.C:
++				case <-tm.C():
+ 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
+ 					continue
+ 				case <-req.Context().Done():
+-					timer.Stop()
++					tm.Stop()
+ 					err = req.Context().Err()
+ 				}
+ 			}
+@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
+ }
+ 
+ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
++	if t.syncHooks != nil {
++		return t.newClientConn(nil, singleUse, t.syncHooks)
++	}
+ 	host, _, err := net.SplitHostPort(addr)
+ 	if err != nil {
+ 		return nil, err
+@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	return t.newClientConn(tconn, singleUse)
++	return t.newClientConn(tconn, singleUse, nil)
+ }
+ 
+ func (t *Transport) newTLSConfig(host string) *tls.Config {
+@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
+ }
+ 
+ func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
+-	return t.newClientConn(c, t.disableKeepAlives())
++	return t.newClientConn(c, t.disableKeepAlives(), nil)
+ }
+ 
+-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
++func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
+ 	cc := &ClientConn{
+ 		t:                     t,
+ 		tconn:                 c,
+@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		wantSettingsAck:       true,
+ 		pings:                 make(map[[8]byte]chan struct{}),
+ 		reqHeaderMu:           make(chan struct{}, 1),
++		syncHooks:             hooks,
++	}
++	if hooks != nil {
++		hooks.newclientconn(cc)
++		c = cc.tconn
+ 	}
+ 	if d := t.idleConnTimeout(); d != 0 {
+ 		cc.idleTimeout = d
+-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
++		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
+ 	}
+ 	if VerboseLogs {
+ 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
+@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
+ 		return nil, cc.werr
+ 	}
+ 
+-	go cc.readLoop()
++	cc.goRun(cc.readLoop)
+ 	return cc, nil
+ }
+ 
+@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
+ 	pingTimeout := cc.t.pingTimeout()
+ 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+ 	// trigger the healthCheck again if there is no frame received.
+-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
++	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
+ 	defer cancel()
+ 	cc.vlogf("http2: Transport sending health check")
+ 	err := cc.Ping(ctx)
+@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 	// Wait for all in-flight streams to complete or connection to close
+ 	done := make(chan struct{})
+ 	cancelled := false // guarded by cc.mu
+-	go func() {
++	cc.goRun(func() {
+ 		cc.mu.Lock()
+ 		defer cc.mu.Unlock()
+ 		for {
+@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 			if cancelled {
+ 				break
+ 			}
+-			cc.cond.Wait()
++			cc.condWait()
+ 		}
+-	}()
++	})
+ 	shutdownEnterWaitStateHook()
+ 	select {
+ 	case <-done:
+@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
+ 		cc.mu.Lock()
+ 		// Free the goroutine above
+ 		cancelled = true
+-		cc.cond.Broadcast()
++		cc.condBroadcast()
+ 		cc.mu.Unlock()
+ 		return ctx.Err()
+ 	}
+@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
+ 	for _, cs := range cc.streams {
+ 		cs.abortStreamLocked(err)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ 	cc.closeConn()
+ }
+@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
+ }
+ 
+ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
++	return cc.roundTrip(req, nil)
++}
++
++func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
+ 	ctx := req.Context()
+ 	cs := &clientStream{
+ 		cc:                   cc,
+@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		respHeaderRecv:       make(chan struct{}),
+ 		donec:                make(chan struct{}),
+ 	}
+-	go cs.doRequest(req)
++	cc.goRun(func() {
++		cs.doRequest(req)
++	})
+ 
+ 	waitDone := func() error {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.donec:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.donec:
+ 			return nil
+@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+ 		return err
+ 	}
+ 
++	if streamf != nil {
++		streamf(cs)
++	}
++
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.respHeaderRecv:
+ 			return handleResponseHeaders()
+@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	if cc.reqHeaderMu == nil {
+ 		panic("RoundTrip on uninitialized ClientConn") // for tests
+ 	}
++	var newStreamHook func(*clientStream)
++	if cc.syncHooks != nil {
++		newStreamHook = cc.syncHooks.newstream
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case cc.reqHeaderMu <- struct{}{}:
++				<-cc.reqHeaderMu
++			case <-cs.reqCancel:
++			case <-ctx.Done():
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case cc.reqHeaderMu <- struct{}{}:
+ 	case <-cs.reqCancel:
+@@ -1372,6 +1497,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	}
+ 	cc.mu.Unlock()
+ 
++	if newStreamHook != nil {
++		newStreamHook(cs)
++	}
++
+ 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
+ 	if !cc.t.disableCompression() &&
+ 		req.Header.Get("Accept-Encoding") == "" &&
+@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
+ 	var respHeaderTimer <-chan time.Time
+ 	var respHeaderRecv chan struct{}
+ 	if d := cc.responseHeaderTimeout(); d != 0 {
+-		timer := time.NewTimer(d)
++		timer := cc.newTimer(d)
+ 		defer timer.Stop()
+-		respHeaderTimer = timer.C
++		respHeaderTimer = timer.C()
+ 		respHeaderRecv = cs.respHeaderRecv
+ 	}
+ 	// Wait until the peer half-closes its end of the stream,
+ 	// or until the request is aborted (via context, error, or otherwise),
+ 	// whichever comes first.
+ 	for {
++		if cc.syncHooks != nil {
++			cc.syncHooks.blockUntil(func() bool {
++				select {
++				case <-cs.peerClosed:
++				case <-respHeaderTimer:
++				case <-respHeaderRecv:
++				case <-cs.abort:
++				case <-ctx.Done():
++				case <-cs.reqCancel:
++				default:
++					return false
++				}
++				return true
++			})
++		}
+ 		select {
+ 		case <-cs.peerClosed:
+ 			return nil
+@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
+ 			return nil
+ 		}
+ 		cc.pendingRequests++
+-		cc.cond.Wait()
++		cc.condWait()
+ 		cc.pendingRequests--
+ 		select {
+ 		case <-cs.abort:
+@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error)
+ 			cs.flow.take(take)
+ 			return take, nil
+ 		}
+-		cc.cond.Wait()
++		cc.condWait()
++	}
++}
++
++func validateHeaders(hdrs http.Header) string {
++	for k, vv := range hdrs {
++		if !httpguts.ValidHeaderFieldName(k) {
++			return fmt.Sprintf("name %q", k)
++		}
++		for _, v := range vv {
++			if !httpguts.ValidHeaderFieldValue(v) {
++				// Don't include the value in the error,
++				// because it may be sensitive.
++				return fmt.Sprintf("value for header %q", k)
++			}
++		}
+ 	}
++	return ""
+ }
+ 
+ var errNilRequestURL = errors.New("http2: Request.URI is nil")
+@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
+ 		}
+ 	}
+ 
+-	// Check for any invalid headers and return an error before we
++	// Check for any invalid headers+trailers and return an error before we
+ 	// potentially pollute our hpack state. (We want to be able to
+ 	// continue to reuse the hpack encoder for future requests)
+-	for k, vv := range req.Header {
+-		if !httpguts.ValidHeaderFieldName(k) {
+-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
+-		}
+-		for _, v := range vv {
+-			if !httpguts.ValidHeaderFieldValue(v) {
+-				// Don't include the value in the error, because it may be sensitive.
+-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
+-			}
+-		}
++	if err := validateHeaders(req.Header); err != "" {
++		return nil, fmt.Errorf("invalid HTTP header %s", err)
++	}
++	if err := validateHeaders(req.Trailer); err != "" {
++		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
+ 	}
+ 
+ 	enumerateHeaders := func(f func(name, value string)) {
+@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
+ 	}
+ 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
+ 	// wake up RoundTrip if there is a pending request.
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 
+ 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
+ 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
+@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
+ 			cs.abortStreamLocked(err)
+ 		}
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	cc.mu.Unlock()
+ }
+ 
+@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
+ 	cc := rl.cc
+ 	gotSettings := false
+ 	readIdleTimeout := cc.t.ReadIdleTimeout
+-	var t *time.Timer
++	var t timer
+ 	if readIdleTimeout != 0 {
+-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+-		defer t.Stop()
++		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
+ 	}
+ 	for {
+ 		f, err := cc.fr.ReadFrame()
+@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
+ 		})
+ 		return nil
+ 	}
+-	if !cs.firstByte {
++	if !cs.pastHeaders {
+ 		cc.logf("protocol error: received DATA before a HEADERS frame")
+ 		rl.endStreamError(cs, StreamError{
+ 			StreamID: f.StreamID,
+@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
+ 			for _, cs := range cc.streams {
+ 				cs.flow.add(delta)
+ 			}
+-			cc.cond.Broadcast()
++			cc.condBroadcast()
+ 
+ 			cc.initialWindowSize = s.Val
+ 		case SettingHeaderTableSize:
+@@ -2911,9 +3065,18 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
+ 		fl = &cs.flow
+ 	}
+ 	if !fl.add(int32(f.Increment)) {
++		// For stream, the sender sends RST_STREAM with an error code of FLOW_CONTROL_ERROR
++		if cs != nil {
++			rl.endStreamError(cs, StreamError{
++				StreamID: f.StreamID,
++				Code:     ErrCodeFlowControl,
++			})
++			return nil
++		}
++
+ 		return ConnectionError(ErrCodeFlowControl)
+ 	}
+-	cc.cond.Broadcast()
++	cc.condBroadcast()
+ 	return nil
+ }
+ 
+@@ -2955,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
+ 		}
+ 		cc.mu.Unlock()
+ 	}
+-	errc := make(chan error, 1)
+-	go func() {
++	var pingError error
++	errc := make(chan struct{})
++	cc.goRun(func() {
+ 		cc.wmu.Lock()
+ 		defer cc.wmu.Unlock()
+-		if err := cc.fr.WritePing(false, p); err != nil {
+-			errc <- err
++		if pingError = cc.fr.WritePing(false, p); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-		if err := cc.bw.Flush(); err != nil {
+-			errc <- err
++		if pingError = cc.bw.Flush(); pingError != nil {
++			close(errc)
+ 			return
+ 		}
+-	}()
++	})
++	if cc.syncHooks != nil {
++		cc.syncHooks.blockUntil(func() bool {
++			select {
++			case <-c:
++			case <-errc:
++			case <-ctx.Done():
++			case <-cc.readerDone:
++			default:
++				return false
++			}
++			return true
++		})
++	}
+ 	select {
+ 	case <-c:
+ 		return nil
+-	case err := <-errc:
+-		return err
++	case <-errc:
++		return pingError
+ 	case <-ctx.Done():
+ 		return ctx.Err()
+ 	case <-cc.readerDone:
+@@ -3141,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
+ }
+ 
+ func (t *Transport) idleConnTimeout() time.Duration {
++	// to keep things backwards compatible, we use non-zero values of
++	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
++	// http1 transport, followed by 0
++	if t.IdleConnTimeout != 0 {
++		return t.IdleConnTimeout
++	}
++
+ 	if t.t1 != nil {
+ 		return t.t1.IdleConnTimeout
+ 	}
++
+ 	return 0
+ }
+ 
+diff --git a/vendor/golang.org/x/net/websocket/client.go b/vendor/golang.org/x/net/websocket/client.go
+index 69a4ac7ee..1e64157f3 100644
+--- a/vendor/golang.org/x/net/websocket/client.go
++++ b/vendor/golang.org/x/net/websocket/client.go
+@@ -6,10 +6,12 @@ package websocket
+ 
+ import (
+ 	"bufio"
++	"context"
+ 	"io"
+ 	"net"
+ 	"net/http"
+ 	"net/url"
++	"time"
+ )
+ 
+ // DialError is an error that occurs while dialling a websocket server.
+@@ -79,28 +81,59 @@ func parseAuthority(location *url.URL) string {
+ 
+ // DialConfig opens a new client connection to a WebSocket with a config.
+ func DialConfig(config *Config) (ws *Conn, err error) {
+-	var client net.Conn
++	return config.DialContext(context.Background())
++}
++
++// DialContext opens a new client connection to a WebSocket, with context support for timeouts/cancellation.
++func (config *Config) DialContext(ctx context.Context) (*Conn, error) {
+ 	if config.Location == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketLocation}
+ 	}
+ 	if config.Origin == nil {
+ 		return nil, &DialError{config, ErrBadWebSocketOrigin}
+ 	}
++
+ 	dialer := config.Dialer
+ 	if dialer == nil {
+ 		dialer = &net.Dialer{}
+ 	}
+-	client, err = dialWithDialer(dialer, config)
+-	if err != nil {
+-		goto Error
+-	}
+-	ws, err = NewClient(config, client)
++
++	client, err := dialWithDialer(ctx, dialer, config)
+ 	if err != nil {
+-		client.Close()
+-		goto Error
++		return nil, &DialError{config, err}
+ 	}
+-	return
+ 
+-Error:
+-	return nil, &DialError{config, err}
++	// Cleanup the connection if we fail to create the websocket successfully
++	success := false
++	defer func() {
++		if !success {
++			_ = client.Close()
++		}
++	}()
++
++	var ws *Conn
++	var wsErr error
++	doneConnecting := make(chan struct{})
++	go func() {
++		defer close(doneConnecting)
++		ws, err = NewClient(config, client)
++		if err != nil {
++			wsErr = &DialError{config, err}
++		}
++	}()
++
++	// The websocket.NewClient() function can block indefinitely, make sure that we
++	// respect the deadlines specified by the context.
++	select {
++	case <-ctx.Done():
++		// Force the pending operations to fail, terminating the pending connection attempt
++		_ = client.SetDeadline(time.Now())
++		<-doneConnecting // Wait for the goroutine that tries to establish the connection to finish
++		return nil, &DialError{config, ctx.Err()}
++	case <-doneConnecting:
++		if wsErr == nil {
++			success = true // Disarm the deferred connection cleanup
++		}
++		return ws, wsErr
++	}
+ }
+diff --git a/vendor/golang.org/x/net/websocket/dial.go b/vendor/golang.org/x/net/websocket/dial.go
+index 2dab943a4..8a2d83c47 100644
+--- a/vendor/golang.org/x/net/websocket/dial.go
++++ b/vendor/golang.org/x/net/websocket/dial.go
+@@ -5,18 +5,23 @@
+ package websocket
+ 
+ import (
++	"context"
+ 	"crypto/tls"
+ 	"net"
+ )
+ 
+-func dialWithDialer(dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
++func dialWithDialer(ctx context.Context, dialer *net.Dialer, config *Config) (conn net.Conn, err error) {
+ 	switch config.Location.Scheme {
+ 	case "ws":
+-		conn, err = dialer.Dial("tcp", parseAuthority(config.Location))
++		conn, err = dialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 
+ 	case "wss":
+-		conn, err = tls.DialWithDialer(dialer, "tcp", parseAuthority(config.Location), config.TlsConfig)
++		tlsDialer := &tls.Dialer{
++			NetDialer: dialer,
++			Config:    config.TlsConfig,
++		}
+ 
++		conn, err = tlsDialer.DialContext(ctx, "tcp", parseAuthority(config.Location))
+ 	default:
+ 		err = ErrBadScheme
+ 	}
+diff --git a/vendor/golang.org/x/sys/unix/aliases.go b/vendor/golang.org/x/sys/unix/aliases.go
+index e7d3df4bd..b0e419857 100644
+--- a/vendor/golang.org/x/sys/unix/aliases.go
++++ b/vendor/golang.org/x/sys/unix/aliases.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos) && go1.9
++//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/mkerrors.sh b/vendor/golang.org/x/sys/unix/mkerrors.sh
+index 6202638ba..fdcaa974d 100644
+--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
++++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
+@@ -248,6 +248,7 @@ struct ltchars {
+ #include <linux/module.h>
+ #include <linux/mount.h>
+ #include <linux/netfilter/nfnetlink.h>
++#include <linux/netfilter/nf_tables.h>
+ #include <linux/netlink.h>
+ #include <linux/net_namespace.h>
+ #include <linux/nfc.h>
+@@ -283,10 +284,6 @@ struct ltchars {
+ #include <asm/termbits.h>
+ #endif
+ 
+-#ifndef MSG_FASTOPEN
+-#define MSG_FASTOPEN    0x20000000
+-#endif
+-
+ #ifndef PTRACE_GETREGS
+ #define PTRACE_GETREGS	0xc
+ #endif
+@@ -295,14 +292,6 @@ struct ltchars {
+ #define PTRACE_SETREGS	0xd
+ #endif
+ 
+-#ifndef SOL_NETLINK
+-#define SOL_NETLINK	270
+-#endif
+-
+-#ifndef SOL_SMC
+-#define SOL_SMC 286
+-#endif
+-
+ #ifdef SOL_BLUETOOTH
+ // SPARC includes this in /usr/include/sparc64-linux-gnu/bits/socket.h
+ // but it is already in bluetooth_linux.go
+@@ -319,10 +308,23 @@ struct ltchars {
+ #undef TIPC_WAIT_FOREVER
+ #define TIPC_WAIT_FOREVER 0xffffffff
+ 
+-// Copied from linux/l2tp.h
+-// Including linux/l2tp.h here causes conflicts between linux/in.h
+-// and netinet/in.h included via net/route.h above.
+-#define IPPROTO_L2TP		115
++// Copied from linux/netfilter/nf_nat.h
++// Including linux/netfilter/nf_nat.h here causes conflicts between linux/in.h
++// and netinet/in.h.
++#define NF_NAT_RANGE_MAP_IPS			(1 << 0)
++#define NF_NAT_RANGE_PROTO_SPECIFIED		(1 << 1)
++#define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
++#define NF_NAT_RANGE_PERSISTENT			(1 << 3)
++#define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_PROTO_OFFSET		(1 << 5)
++#define NF_NAT_RANGE_NETMAP			(1 << 6)
++#define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
++	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
++#define NF_NAT_RANGE_MASK					\
++	(NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED |	\
++	 NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PERSISTENT |	\
++	 NF_NAT_RANGE_PROTO_RANDOM_FULLY | NF_NAT_RANGE_PROTO_OFFSET | \
++	 NF_NAT_RANGE_NETMAP)
+ 
+ // Copied from linux/hid.h.
+ // Keep in sync with the size of the referenced fields.
+@@ -582,7 +584,7 @@ ccflags="$@"
+ 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
+ 		$2 ~ /^KEYCTL_/ ||
+ 		$2 ~ /^PERF_/ ||
+-		$2 ~ /^SECCOMP_MODE_/ ||
++		$2 ~ /^SECCOMP_/ ||
+ 		$2 ~ /^SEEK_/ ||
+ 		$2 ~ /^SCHED_/ ||
+ 		$2 ~ /^SPLICE_/ ||
+@@ -603,6 +605,9 @@ ccflags="$@"
+ 		$2 ~ /^FSOPT_/ ||
+ 		$2 ~ /^WDIO[CFS]_/ ||
+ 		$2 ~ /^NFN/ ||
++		$2 !~ /^NFT_META_IIFTYPE/ &&
++		$2 ~ /^NFT_/ ||
++		$2 ~ /^NF_NAT_/ ||
+ 		$2 ~ /^XDP_/ ||
+ 		$2 ~ /^RWF_/ ||
+ 		$2 ~ /^(HDIO|WIN|SMART)_/ ||
+diff --git a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+index 16dc69937..2f0fa76e4 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
++++ b/vendor/golang.org/x/sys/unix/syscall_darwin_libSystem.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build darwin && go1.12
++//go:build darwin
+ 
+ package unix
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_freebsd.go b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+index 64d1bb4db..2b57e0f73 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_freebsd.go
++++ b/vendor/golang.org/x/sys/unix/syscall_freebsd.go
+@@ -13,6 +13,7 @@
+ package unix
+ 
+ import (
++	"errors"
+ 	"sync"
+ 	"unsafe"
+ )
+@@ -169,25 +170,26 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
+ func Uname(uname *Utsname) error {
+ 	mib := []_C_int{CTL_KERN, KERN_OSTYPE}
+ 	n := unsafe.Sizeof(uname.Sysname)
+-	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil {
++	// Suppress ENOMEM errors to be compatible with the C library __xuname() implementation.
++	if err := sysctl(mib, &uname.Sysname[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_HOSTNAME}
+ 	n = unsafe.Sizeof(uname.Nodename)
+-	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Nodename[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_OSRELEASE}
+ 	n = unsafe.Sizeof(uname.Release)
+-	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Release[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+ 	mib = []_C_int{CTL_KERN, KERN_VERSION}
+ 	n = unsafe.Sizeof(uname.Version)
+-	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Version[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+@@ -205,7 +207,7 @@ func Uname(uname *Utsname) error {
+ 
+ 	mib = []_C_int{CTL_HW, HW_MACHINE}
+ 	n = unsafe.Sizeof(uname.Machine)
+-	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil {
++	if err := sysctl(mib, &uname.Machine[0], &n, nil, 0); err != nil && !errors.Is(err, ENOMEM) {
+ 		return err
+ 	}
+ 
+diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
+index 0f85e29e6..5682e2628 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/syscall_linux.go
+@@ -1849,6 +1849,105 @@ func Dup2(oldfd, newfd int) error {
+ //sys	Fsmount(fd int, flags int, mountAttrs int) (fsfd int, err error)
+ //sys	Fsopen(fsName string, flags int) (fd int, err error)
+ //sys	Fspick(dirfd int, pathName string, flags int) (fd int, err error)
++
++//sys	fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error)
++
++func fsconfigCommon(fd int, cmd uint, key string, value *byte, aux int) (err error) {
++	var keyp *byte
++	if keyp, err = BytePtrFromString(key); err != nil {
++		return
++	}
++	return fsconfig(fd, cmd, keyp, value, aux)
++}
++
++// FsconfigSetFlag is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FLAG.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++func FsconfigSetFlag(fd int, key string) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FLAG, key, nil, 0)
++}
++
++// FsconfigSetString is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_STRING.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetString(fd int, key string, value string) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(value); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_STRING, key, valuep, 0)
++}
++
++// FsconfigSetBinary is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_BINARY.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is the parameter value to set.
++func FsconfigSetBinary(fd int, key string, value []byte) (err error) {
++	if len(value) == 0 {
++		return EINVAL
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_BINARY, key, &value[0], len(value))
++}
++
++// FsconfigSetPath is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// path is a non-empty path for specified key.
++// atfd is a file descriptor at which to start lookup from or AT_FDCWD.
++func FsconfigSetPath(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH, key, valuep, atfd)
++}
++
++// FsconfigSetPathEmpty is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_PATH_EMPTY. The same as
++// FconfigSetPath but with AT_PATH_EMPTY implied.
++func FsconfigSetPathEmpty(fd int, key string, path string, atfd int) (err error) {
++	var valuep *byte
++	if valuep, err = BytePtrFromString(path); err != nil {
++		return
++	}
++	return fsconfigCommon(fd, FSCONFIG_SET_PATH_EMPTY, key, valuep, atfd)
++}
++
++// FsconfigSetFd is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_SET_FD.
++//
++// fd is the filesystem context to act upon.
++// key the parameter key to set.
++// value is a file descriptor to be assigned to specified key.
++func FsconfigSetFd(fd int, key string, value int) (err error) {
++	return fsconfigCommon(fd, FSCONFIG_SET_FD, key, nil, value)
++}
++
++// FsconfigCreate is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_CREATE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigCreate(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_CREATE, nil, nil, 0)
++}
++
++// FsconfigReconfigure is equivalent to fsconfig(2) called
++// with cmd == FSCONFIG_CMD_RECONFIGURE.
++//
++// fd is the filesystem context to act upon.
++func FsconfigReconfigure(fd int) (err error) {
++	return fsconfig(fd, FSCONFIG_CMD_RECONFIGURE, nil, nil, 0)
++}
++
+ //sys	Getdents(fd int, buf []byte) (n int, err error) = SYS_GETDENTS64
+ //sysnb	Getpgid(pid int) (pgid int, err error)
+ 
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux.go b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+index c73cfe2f1..36bf8399f 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
+@@ -1785,6 +1785,8 @@ const (
+ 	LANDLOCK_ACCESS_FS_REMOVE_FILE              = 0x20
+ 	LANDLOCK_ACCESS_FS_TRUNCATE                 = 0x4000
+ 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
++	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
++	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+ 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+ 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
+ 	LINUX_REBOOT_CMD_CAD_ON                     = 0x89abcdef
+@@ -2127,6 +2129,60 @@ const (
+ 	NFNL_SUBSYS_QUEUE                           = 0x3
+ 	NFNL_SUBSYS_ULOG                            = 0x4
+ 	NFS_SUPER_MAGIC                             = 0x6969
++	NFT_CHAIN_FLAGS                             = 0x7
++	NFT_CHAIN_MAXNAMELEN                        = 0x100
++	NFT_CT_MAX                                  = 0x17
++	NFT_DATA_RESERVED_MASK                      = 0xffffff00
++	NFT_DATA_VALUE_MAXLEN                       = 0x40
++	NFT_EXTHDR_OP_MAX                           = 0x4
++	NFT_FIB_RESULT_MAX                          = 0x3
++	NFT_INNER_MASK                              = 0xf
++	NFT_LOGLEVEL_MAX                            = 0x8
++	NFT_NAME_MAXLEN                             = 0x100
++	NFT_NG_MAX                                  = 0x1
++	NFT_OBJECT_CONNLIMIT                        = 0x5
++	NFT_OBJECT_COUNTER                          = 0x1
++	NFT_OBJECT_CT_EXPECT                        = 0x9
++	NFT_OBJECT_CT_HELPER                        = 0x3
++	NFT_OBJECT_CT_TIMEOUT                       = 0x7
++	NFT_OBJECT_LIMIT                            = 0x4
++	NFT_OBJECT_MAX                              = 0xa
++	NFT_OBJECT_QUOTA                            = 0x2
++	NFT_OBJECT_SECMARK                          = 0x8
++	NFT_OBJECT_SYNPROXY                         = 0xa
++	NFT_OBJECT_TUNNEL                           = 0x6
++	NFT_OBJECT_UNSPEC                           = 0x0
++	NFT_OBJ_MAXNAMELEN                          = 0x100
++	NFT_OSF_MAXGENRELEN                         = 0x10
++	NFT_QUEUE_FLAG_BYPASS                       = 0x1
++	NFT_QUEUE_FLAG_CPU_FANOUT                   = 0x2
++	NFT_QUEUE_FLAG_MASK                         = 0x3
++	NFT_REG32_COUNT                             = 0x10
++	NFT_REG32_SIZE                              = 0x4
++	NFT_REG_MAX                                 = 0x4
++	NFT_REG_SIZE                                = 0x10
++	NFT_REJECT_ICMPX_MAX                        = 0x3
++	NFT_RT_MAX                                  = 0x4
++	NFT_SECMARK_CTX_MAXLEN                      = 0x100
++	NFT_SET_MAXNAMELEN                          = 0x100
++	NFT_SOCKET_MAX                              = 0x3
++	NFT_TABLE_F_MASK                            = 0x3
++	NFT_TABLE_MAXNAMELEN                        = 0x100
++	NFT_TRACETYPE_MAX                           = 0x3
++	NFT_TUNNEL_F_MASK                           = 0x7
++	NFT_TUNNEL_MAX                              = 0x1
++	NFT_TUNNEL_MODE_MAX                         = 0x2
++	NFT_USERDATA_MAXLEN                         = 0x100
++	NFT_XFRM_KEY_MAX                            = 0x6
++	NF_NAT_RANGE_MAP_IPS                        = 0x1
++	NF_NAT_RANGE_MASK                           = 0x7f
++	NF_NAT_RANGE_NETMAP                         = 0x40
++	NF_NAT_RANGE_PERSISTENT                     = 0x8
++	NF_NAT_RANGE_PROTO_OFFSET                   = 0x20
++	NF_NAT_RANGE_PROTO_RANDOM                   = 0x4
++	NF_NAT_RANGE_PROTO_RANDOM_ALL               = 0x14
++	NF_NAT_RANGE_PROTO_RANDOM_FULLY             = 0x10
++	NF_NAT_RANGE_PROTO_SPECIFIED                = 0x2
+ 	NILFS_SUPER_MAGIC                           = 0x3434
+ 	NL0                                         = 0x0
+ 	NL1                                         = 0x100
+@@ -2411,6 +2467,7 @@ const (
+ 	PR_MCE_KILL_GET                             = 0x22
+ 	PR_MCE_KILL_LATE                            = 0x0
+ 	PR_MCE_KILL_SET                             = 0x1
++	PR_MDWE_NO_INHERIT                          = 0x2
+ 	PR_MDWE_REFUSE_EXEC_GAIN                    = 0x1
+ 	PR_MPX_DISABLE_MANAGEMENT                   = 0x2c
+ 	PR_MPX_ENABLE_MANAGEMENT                    = 0x2b
+@@ -2615,8 +2672,9 @@ const (
+ 	RTAX_FEATURES                               = 0xc
+ 	RTAX_FEATURE_ALLFRAG                        = 0x8
+ 	RTAX_FEATURE_ECN                            = 0x1
+-	RTAX_FEATURE_MASK                           = 0xf
++	RTAX_FEATURE_MASK                           = 0x1f
+ 	RTAX_FEATURE_SACK                           = 0x2
++	RTAX_FEATURE_TCP_USEC_TS                    = 0x10
+ 	RTAX_FEATURE_TIMESTAMP                      = 0x4
+ 	RTAX_HOPLIMIT                               = 0xa
+ 	RTAX_INITCWND                               = 0xb
+@@ -2859,9 +2917,38 @@ const (
+ 	SCM_RIGHTS                                  = 0x1
+ 	SCM_TIMESTAMP                               = 0x1d
+ 	SC_LOG_FLUSH                                = 0x100000
++	SECCOMP_ADDFD_FLAG_SEND                     = 0x2
++	SECCOMP_ADDFD_FLAG_SETFD                    = 0x1
++	SECCOMP_FILTER_FLAG_LOG                     = 0x2
++	SECCOMP_FILTER_FLAG_NEW_LISTENER            = 0x8
++	SECCOMP_FILTER_FLAG_SPEC_ALLOW              = 0x4
++	SECCOMP_FILTER_FLAG_TSYNC                   = 0x1
++	SECCOMP_FILTER_FLAG_TSYNC_ESRCH             = 0x10
++	SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV      = 0x20
++	SECCOMP_GET_ACTION_AVAIL                    = 0x2
++	SECCOMP_GET_NOTIF_SIZES                     = 0x3
++	SECCOMP_IOCTL_NOTIF_RECV                    = 0xc0502100
++	SECCOMP_IOCTL_NOTIF_SEND                    = 0xc0182101
++	SECCOMP_IOC_MAGIC                           = '!'
+ 	SECCOMP_MODE_DISABLED                       = 0x0
+ 	SECCOMP_MODE_FILTER                         = 0x2
+ 	SECCOMP_MODE_STRICT                         = 0x1
++	SECCOMP_RET_ACTION                          = 0x7fff0000
++	SECCOMP_RET_ACTION_FULL                     = 0xffff0000
++	SECCOMP_RET_ALLOW                           = 0x7fff0000
++	SECCOMP_RET_DATA                            = 0xffff
++	SECCOMP_RET_ERRNO                           = 0x50000
++	SECCOMP_RET_KILL                            = 0x0
++	SECCOMP_RET_KILL_PROCESS                    = 0x80000000
++	SECCOMP_RET_KILL_THREAD                     = 0x0
++	SECCOMP_RET_LOG                             = 0x7ffc0000
++	SECCOMP_RET_TRACE                           = 0x7ff00000
++	SECCOMP_RET_TRAP                            = 0x30000
++	SECCOMP_RET_USER_NOTIF                      = 0x7fc00000
++	SECCOMP_SET_MODE_FILTER                     = 0x1
++	SECCOMP_SET_MODE_STRICT                     = 0x0
++	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP          = 0x1
++	SECCOMP_USER_NOTIF_FLAG_CONTINUE            = 0x1
+ 	SECRETMEM_MAGIC                             = 0x5345434d
+ 	SECURITYFS_MAGIC                            = 0x73636673
+ 	SEEK_CUR                                    = 0x1
+@@ -3021,6 +3108,7 @@ const (
+ 	SOL_TIPC                                    = 0x10f
+ 	SOL_TLS                                     = 0x11a
+ 	SOL_UDP                                     = 0x11
++	SOL_VSOCK                                   = 0x11f
+ 	SOL_X25                                     = 0x106
+ 	SOL_XDP                                     = 0x11b
+ 	SOMAXCONN                                   = 0x1000
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+index 4920821cf..42ff8c3c1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+index a0c1e4112..dca436004 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+@@ -282,6 +282,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+index c63985560..5cca668ac 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+@@ -288,6 +288,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+index 47cc62e25..d8cae6d15 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+@@ -278,6 +278,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+index 27ac4a09e..28e39afdc 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+@@ -275,6 +275,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+index 54694642a..cd66e92cb 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+index 3adb81d75..c1595eba7 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+index 2dfe98f0d..ee9456b0d 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+index f5398f84f..8cfca81e1 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+@@ -281,6 +281,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x80
+ 	SIOCATMARK                       = 0x40047307
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+index c54f152d6..60b0deb3a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+@@ -336,6 +336,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+index 76057dc72..f90aa7281 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+index e0c3725e2..ba9e01503 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+@@ -340,6 +340,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+index 18f2813ed..07cdfd6e9 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+@@ -272,6 +272,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+index 11619d4ec..2f1dd214a 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+@@ -344,6 +344,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x23
+ 	SCM_TXTIME                       = 0x3d
+ 	SCM_WIFI_STATUS                  = 0x29
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x40182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x40082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x40082104
+ 	SFD_CLOEXEC                      = 0x80000
+ 	SFD_NONBLOCK                     = 0x800
+ 	SIOCATMARK                       = 0x8905
+diff --git a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+index 396d994da..f40519d90 100644
+--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+@@ -335,6 +335,9 @@ const (
+ 	SCM_TIMESTAMPNS                  = 0x21
+ 	SCM_TXTIME                       = 0x3f
+ 	SCM_WIFI_STATUS                  = 0x25
++	SECCOMP_IOCTL_NOTIF_ADDFD        = 0x80182103
++	SECCOMP_IOCTL_NOTIF_ID_VALID     = 0x80082102
++	SECCOMP_IOCTL_NOTIF_SET_FLAGS    = 0x80082104
+ 	SFD_CLOEXEC                      = 0x400000
+ 	SFD_NONBLOCK                     = 0x4000
+ 	SF_FP                            = 0x38
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_linux.go b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+index 1488d2712..87d8612a1 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
+@@ -906,6 +906,16 @@ func Fspick(dirfd int, pathName string, flags int) (fd int, err error) {
+ 
+ // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
+ 
++func fsconfig(fd int, cmd uint, key *byte, value *byte, aux int) (err error) {
++	_, _, e1 := Syscall6(SYS_FSCONFIG, uintptr(fd), uintptr(cmd), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uintptr(aux), 0)
++	if e1 != 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
++// THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
++
+ func Getdents(fd int, buf []byte) (n int, err error) {
+ 	var _p0 unsafe.Pointer
+ 	if len(buf) > 0 {
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+index a1d061597..9dc42410b 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+index 5b2a74097..0d3a0751c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+index f6eda1344..c39f7776d 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+index 55df20ae9..57571d072 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+index 8c1155cbc..e62963e67 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+index 7cc80c58d..00831354c 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+index 0688737f4..79029ed58 100644
+--- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
+@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
+ var libc_unveil_trampoline_addr uintptr
+ 
+ //go:cgo_import_dynamic libc_unveil unveil "libc.so"
+-
+-
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+index fcf3ecbdd..0cc3ce496 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+@@ -448,4 +448,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+index f56dc2504..856d92d69 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+@@ -371,4 +371,7 @@ const (
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
+ 	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+index 974bf2467..8d467094c 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+@@ -412,4 +412,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+index 39a2739e2..edc173244 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+@@ -315,4 +315,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+index cf9c9d77e..445eba206 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+@@ -309,4 +309,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+index 10b7362ef..adba01bca 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+index cd4d8b4fd..014c4e9c7 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+index 2c0efca81..ccc97d74d 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+@@ -362,4 +362,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
+ 	SYS_CACHESTAT               = 5451
+ 	SYS_FCHMODAT2               = 5452
++	SYS_MAP_SHADOW_STACK        = 5453
++	SYS_FUTEX_WAKE              = 5454
++	SYS_FUTEX_WAIT              = 5455
++	SYS_FUTEX_REQUEUE           = 5456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+index a72e31d39..ec2b64a95 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+@@ -432,4 +432,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
+ 	SYS_CACHESTAT                    = 4451
+ 	SYS_FCHMODAT2                    = 4452
++	SYS_MAP_SHADOW_STACK             = 4453
++	SYS_FUTEX_WAKE                   = 4454
++	SYS_FUTEX_WAIT                   = 4455
++	SYS_FUTEX_REQUEUE                = 4456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+index c7d1e3747..21a839e33 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+@@ -439,4 +439,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
+ 	SYS_CACHESTAT                    = 451
+ 	SYS_FCHMODAT2                    = 452
++	SYS_MAP_SHADOW_STACK             = 453
++	SYS_FUTEX_WAKE                   = 454
++	SYS_FUTEX_WAIT                   = 455
++	SYS_FUTEX_REQUEUE                = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+index f4d4838c8..c11121ec3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+index b64f0e591..909b631fc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+@@ -411,4 +411,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+index 95711195a..e49bed16e 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+@@ -316,4 +316,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+index f94e943bc..66017d2d3 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+@@ -377,4 +377,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+index ba0c2bc51..47bab18dc 100644
+--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
++++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+@@ -390,4 +390,8 @@ const (
+ 	SYS_SET_MEMPOLICY_HOME_NODE = 450
+ 	SYS_CACHESTAT               = 451
+ 	SYS_FCHMODAT2               = 452
++	SYS_MAP_SHADOW_STACK        = 453
++	SYS_FUTEX_WAKE              = 454
++	SYS_FUTEX_WAIT              = 455
++	SYS_FUTEX_REQUEUE           = 456
+ )
+diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+index bbf8399ff..eff6bcdef 100644
+--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
++++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
+@@ -174,7 +174,8 @@ type FscryptPolicyV2 struct {
+ 	Contents_encryption_mode  uint8
+ 	Filenames_encryption_mode uint8
+ 	Flags                     uint8
+-	_                         [4]uint8
++	Log2_data_unit_size       uint8
++	_                         [3]uint8
+ 	Master_key_identifier     [16]uint8
+ }
+ 
+@@ -455,60 +456,63 @@ type Ucred struct {
+ }
+ 
+ type TCPInfo struct {
+-	State           uint8
+-	Ca_state        uint8
+-	Retransmits     uint8
+-	Probes          uint8
+-	Backoff         uint8
+-	Options         uint8
+-	Rto             uint32
+-	Ato             uint32
+-	Snd_mss         uint32
+-	Rcv_mss         uint32
+-	Unacked         uint32
+-	Sacked          uint32
+-	Lost            uint32
+-	Retrans         uint32
+-	Fackets         uint32
+-	Last_data_sent  uint32
+-	Last_ack_sent   uint32
+-	Last_data_recv  uint32
+-	Last_ack_recv   uint32
+-	Pmtu            uint32
+-	Rcv_ssthresh    uint32
+-	Rtt             uint32
+-	Rttvar          uint32
+-	Snd_ssthresh    uint32
+-	Snd_cwnd        uint32
+-	Advmss          uint32
+-	Reordering      uint32
+-	Rcv_rtt         uint32
+-	Rcv_space       uint32
+-	Total_retrans   uint32
+-	Pacing_rate     uint64
+-	Max_pacing_rate uint64
+-	Bytes_acked     uint64
+-	Bytes_received  uint64
+-	Segs_out        uint32
+-	Segs_in         uint32
+-	Notsent_bytes   uint32
+-	Min_rtt         uint32
+-	Data_segs_in    uint32
+-	Data_segs_out   uint32
+-	Delivery_rate   uint64
+-	Busy_time       uint64
+-	Rwnd_limited    uint64
+-	Sndbuf_limited  uint64
+-	Delivered       uint32
+-	Delivered_ce    uint32
+-	Bytes_sent      uint64
+-	Bytes_retrans   uint64
+-	Dsack_dups      uint32
+-	Reord_seen      uint32
+-	Rcv_ooopack     uint32
+-	Snd_wnd         uint32
+-	Rcv_wnd         uint32
+-	Rehash          uint32
++	State                uint8
++	Ca_state             uint8
++	Retransmits          uint8
++	Probes               uint8
++	Backoff              uint8
++	Options              uint8
++	Rto                  uint32
++	Ato                  uint32
++	Snd_mss              uint32
++	Rcv_mss              uint32
++	Unacked              uint32
++	Sacked               uint32
++	Lost                 uint32
++	Retrans              uint32
++	Fackets              uint32
++	Last_data_sent       uint32
++	Last_ack_sent        uint32
++	Last_data_recv       uint32
++	Last_ack_recv        uint32
++	Pmtu                 uint32
++	Rcv_ssthresh         uint32
++	Rtt                  uint32
++	Rttvar               uint32
++	Snd_ssthresh         uint32
++	Snd_cwnd             uint32
++	Advmss               uint32
++	Reordering           uint32
++	Rcv_rtt              uint32
++	Rcv_space            uint32
++	Total_retrans        uint32
++	Pacing_rate          uint64
++	Max_pacing_rate      uint64
++	Bytes_acked          uint64
++	Bytes_received       uint64
++	Segs_out             uint32
++	Segs_in              uint32
++	Notsent_bytes        uint32
++	Min_rtt              uint32
++	Data_segs_in         uint32
++	Data_segs_out        uint32
++	Delivery_rate        uint64
++	Busy_time            uint64
++	Rwnd_limited         uint64
++	Sndbuf_limited       uint64
++	Delivered            uint32
++	Delivered_ce         uint32
++	Bytes_sent           uint64
++	Bytes_retrans        uint64
++	Dsack_dups           uint32
++	Reord_seen           uint32
++	Rcv_ooopack          uint32
++	Snd_wnd              uint32
++	Rcv_wnd              uint32
++	Rehash               uint32
++	Total_rto            uint16
++	Total_rto_recoveries uint16
++	Total_rto_time       uint32
+ }
+ 
+ type CanFilter struct {
+@@ -551,7 +555,7 @@ const (
+ 	SizeofIPv6MTUInfo       = 0x20
+ 	SizeofICMPv6Filter      = 0x20
+ 	SizeofUcred             = 0xc
+-	SizeofTCPInfo           = 0xf0
++	SizeofTCPInfo           = 0xf8
+ 	SizeofCanFilter         = 0x8
+ 	SizeofTCPRepairOpt      = 0x8
+ )
+@@ -832,6 +836,15 @@ const (
+ 	FSPICK_EMPTY_PATH       = 0x8
+ 
+ 	FSMOUNT_CLOEXEC = 0x1
++
++	FSCONFIG_SET_FLAG        = 0x0
++	FSCONFIG_SET_STRING      = 0x1
++	FSCONFIG_SET_BINARY      = 0x2
++	FSCONFIG_SET_PATH        = 0x3
++	FSCONFIG_SET_PATH_EMPTY  = 0x4
++	FSCONFIG_SET_FD          = 0x5
++	FSCONFIG_CMD_CREATE      = 0x6
++	FSCONFIG_CMD_RECONFIGURE = 0x7
+ )
+ 
+ type OpenHow struct {
+@@ -1546,6 +1559,7 @@ const (
+ 	IFLA_DEVLINK_PORT                          = 0x3e
+ 	IFLA_GSO_IPV4_MAX_SIZE                     = 0x3f
+ 	IFLA_GRO_IPV4_MAX_SIZE                     = 0x40
++	IFLA_DPLL_PIN                              = 0x41
+ 	IFLA_PROTO_DOWN_REASON_UNSPEC              = 0x0
+ 	IFLA_PROTO_DOWN_REASON_MASK                = 0x1
+ 	IFLA_PROTO_DOWN_REASON_VALUE               = 0x2
+@@ -1561,6 +1575,7 @@ const (
+ 	IFLA_INET6_ICMP6STATS                      = 0x6
+ 	IFLA_INET6_TOKEN                           = 0x7
+ 	IFLA_INET6_ADDR_GEN_MODE                   = 0x8
++	IFLA_INET6_RA_MTU                          = 0x9
+ 	IFLA_BR_UNSPEC                             = 0x0
+ 	IFLA_BR_FORWARD_DELAY                      = 0x1
+ 	IFLA_BR_HELLO_TIME                         = 0x2
+@@ -1608,6 +1623,9 @@ const (
+ 	IFLA_BR_MCAST_MLD_VERSION                  = 0x2c
+ 	IFLA_BR_VLAN_STATS_PER_PORT                = 0x2d
+ 	IFLA_BR_MULTI_BOOLOPT                      = 0x2e
++	IFLA_BR_MCAST_QUERIER_STATE                = 0x2f
++	IFLA_BR_FDB_N_LEARNED                      = 0x30
++	IFLA_BR_FDB_MAX_LEARNED                    = 0x31
+ 	IFLA_BRPORT_UNSPEC                         = 0x0
+ 	IFLA_BRPORT_STATE                          = 0x1
+ 	IFLA_BRPORT_PRIORITY                       = 0x2
+@@ -1645,6 +1663,14 @@ const (
+ 	IFLA_BRPORT_BACKUP_PORT                    = 0x22
+ 	IFLA_BRPORT_MRP_RING_OPEN                  = 0x23
+ 	IFLA_BRPORT_MRP_IN_OPEN                    = 0x24
++	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT          = 0x25
++	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT            = 0x26
++	IFLA_BRPORT_LOCKED                         = 0x27
++	IFLA_BRPORT_MAB                            = 0x28
++	IFLA_BRPORT_MCAST_N_GROUPS                 = 0x29
++	IFLA_BRPORT_MCAST_MAX_GROUPS               = 0x2a
++	IFLA_BRPORT_NEIGH_VLAN_SUPPRESS            = 0x2b
++	IFLA_BRPORT_BACKUP_NHID                    = 0x2c
+ 	IFLA_INFO_UNSPEC                           = 0x0
+ 	IFLA_INFO_KIND                             = 0x1
+ 	IFLA_INFO_DATA                             = 0x2
+@@ -1666,6 +1692,9 @@ const (
+ 	IFLA_MACVLAN_MACADDR                       = 0x4
+ 	IFLA_MACVLAN_MACADDR_DATA                  = 0x5
+ 	IFLA_MACVLAN_MACADDR_COUNT                 = 0x6
++	IFLA_MACVLAN_BC_QUEUE_LEN                  = 0x7
++	IFLA_MACVLAN_BC_QUEUE_LEN_USED             = 0x8
++	IFLA_MACVLAN_BC_CUTOFF                     = 0x9
+ 	IFLA_VRF_UNSPEC                            = 0x0
+ 	IFLA_VRF_TABLE                             = 0x1
+ 	IFLA_VRF_PORT_UNSPEC                       = 0x0
+@@ -1689,9 +1718,22 @@ const (
+ 	IFLA_XFRM_UNSPEC                           = 0x0
+ 	IFLA_XFRM_LINK                             = 0x1
+ 	IFLA_XFRM_IF_ID                            = 0x2
++	IFLA_XFRM_COLLECT_METADATA                 = 0x3
+ 	IFLA_IPVLAN_UNSPEC                         = 0x0
+ 	IFLA_IPVLAN_MODE                           = 0x1
+ 	IFLA_IPVLAN_FLAGS                          = 0x2
++	NETKIT_NEXT                                = -0x1
++	NETKIT_PASS                                = 0x0
++	NETKIT_DROP                                = 0x2
++	NETKIT_REDIRECT                            = 0x7
++	NETKIT_L2                                  = 0x0
++	NETKIT_L3                                  = 0x1
++	IFLA_NETKIT_UNSPEC                         = 0x0
++	IFLA_NETKIT_PEER_INFO                      = 0x1
++	IFLA_NETKIT_PRIMARY                        = 0x2
++	IFLA_NETKIT_POLICY                         = 0x3
++	IFLA_NETKIT_PEER_POLICY                    = 0x4
++	IFLA_NETKIT_MODE                           = 0x5
+ 	IFLA_VXLAN_UNSPEC                          = 0x0
+ 	IFLA_VXLAN_ID                              = 0x1
+ 	IFLA_VXLAN_GROUP                           = 0x2
+@@ -1722,6 +1764,8 @@ const (
+ 	IFLA_VXLAN_GPE                             = 0x1b
+ 	IFLA_VXLAN_TTL_INHERIT                     = 0x1c
+ 	IFLA_VXLAN_DF                              = 0x1d
++	IFLA_VXLAN_VNIFILTER                       = 0x1e
++	IFLA_VXLAN_LOCALBYPASS                     = 0x1f
+ 	IFLA_GENEVE_UNSPEC                         = 0x0
+ 	IFLA_GENEVE_ID                             = 0x1
+ 	IFLA_GENEVE_REMOTE                         = 0x2
+@@ -1736,6 +1780,7 @@ const (
+ 	IFLA_GENEVE_LABEL                          = 0xb
+ 	IFLA_GENEVE_TTL_INHERIT                    = 0xc
+ 	IFLA_GENEVE_DF                             = 0xd
++	IFLA_GENEVE_INNER_PROTO_INHERIT            = 0xe
+ 	IFLA_BAREUDP_UNSPEC                        = 0x0
+ 	IFLA_BAREUDP_PORT                          = 0x1
+ 	IFLA_BAREUDP_ETHERTYPE                     = 0x2
+@@ -1748,6 +1793,8 @@ const (
+ 	IFLA_GTP_FD1                               = 0x2
+ 	IFLA_GTP_PDP_HASHSIZE                      = 0x3
+ 	IFLA_GTP_ROLE                              = 0x4
++	IFLA_GTP_CREATE_SOCKETS                    = 0x5
++	IFLA_GTP_RESTART_COUNT                     = 0x6
+ 	IFLA_BOND_UNSPEC                           = 0x0
+ 	IFLA_BOND_MODE                             = 0x1
+ 	IFLA_BOND_ACTIVE_SLAVE                     = 0x2
+@@ -1777,6 +1824,9 @@ const (
+ 	IFLA_BOND_AD_ACTOR_SYSTEM                  = 0x1a
+ 	IFLA_BOND_TLB_DYNAMIC_LB                   = 0x1b
+ 	IFLA_BOND_PEER_NOTIF_DELAY                 = 0x1c
++	IFLA_BOND_AD_LACP_ACTIVE                   = 0x1d
++	IFLA_BOND_MISSED_MAX                       = 0x1e
++	IFLA_BOND_NS_IP6_TARGET                    = 0x1f
+ 	IFLA_BOND_AD_INFO_UNSPEC                   = 0x0
+ 	IFLA_BOND_AD_INFO_AGGREGATOR               = 0x1
+ 	IFLA_BOND_AD_INFO_NUM_PORTS                = 0x2
+@@ -1792,6 +1842,7 @@ const (
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID           = 0x6
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE   = 0x7
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE = 0x8
++	IFLA_BOND_SLAVE_PRIO                       = 0x9
+ 	IFLA_VF_INFO_UNSPEC                        = 0x0
+ 	IFLA_VF_INFO                               = 0x1
+ 	IFLA_VF_UNSPEC                             = 0x0
+@@ -1850,8 +1901,16 @@ const (
+ 	IFLA_STATS_LINK_XSTATS_SLAVE               = 0x3
+ 	IFLA_STATS_LINK_OFFLOAD_XSTATS             = 0x4
+ 	IFLA_STATS_AF_SPEC                         = 0x5
++	IFLA_STATS_GETSET_UNSPEC                   = 0x0
++	IFLA_STATS_GET_FILTERS                     = 0x1
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS     = 0x2
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC                 = 0x0
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT                = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO              = 0x2
++	IFLA_OFFLOAD_XSTATS_L3_STATS               = 0x3
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC       = 0x0
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST      = 0x1
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED         = 0x2
+ 	IFLA_XDP_UNSPEC                            = 0x0
+ 	IFLA_XDP_FD                                = 0x1
+ 	IFLA_XDP_ATTACHED                          = 0x2
+@@ -1881,6 +1940,11 @@ const (
+ 	IFLA_RMNET_UNSPEC                          = 0x0
+ 	IFLA_RMNET_MUX_ID                          = 0x1
+ 	IFLA_RMNET_FLAGS                           = 0x2
++	IFLA_MCTP_UNSPEC                           = 0x0
++	IFLA_MCTP_NET                              = 0x1
++	IFLA_DSA_UNSPEC                            = 0x0
++	IFLA_DSA_CONDUIT                           = 0x1
++	IFLA_DSA_MASTER                            = 0x1
+ )
+ 
+ const (
+@@ -3399,7 +3463,7 @@ const (
+ 	DEVLINK_PORT_FN_ATTR_STATE                         = 0x2
+ 	DEVLINK_PORT_FN_ATTR_OPSTATE                       = 0x3
+ 	DEVLINK_PORT_FN_ATTR_CAPS                          = 0x4
+-	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x4
++	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
+ )
+ 
+ type FsverityDigest struct {
+@@ -4183,7 +4247,8 @@ const (
+ )
+ 
+ type LandlockRulesetAttr struct {
+-	Access_fs uint64
++	Access_fs  uint64
++	Access_net uint64
+ }
+ 
+ type LandlockPathBeneathAttr struct {
+@@ -5134,7 +5199,7 @@ const (
+ 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
+ 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
+ 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
+-	NL80211_FREQUENCY_ATTR_MAX                              = 0x1b
++	NL80211_FREQUENCY_ATTR_MAX                              = 0x1c
+ 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
+ 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
+ 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
+@@ -5547,7 +5612,7 @@ const (
+ 	NL80211_REGDOM_TYPE_CUSTOM_WORLD                        = 0x2
+ 	NL80211_REGDOM_TYPE_INTERSECTION                        = 0x3
+ 	NL80211_REGDOM_TYPE_WORLD                               = 0x1
+-	NL80211_REG_RULE_ATTR_MAX                               = 0x7
++	NL80211_REG_RULE_ATTR_MAX                               = 0x8
+ 	NL80211_REKEY_DATA_AKM                                  = 0x4
+ 	NL80211_REKEY_DATA_KCK                                  = 0x2
+ 	NL80211_REKEY_DATA_KEK                                  = 0x1
+diff --git a/vendor/golang.org/x/sys/windows/env_windows.go b/vendor/golang.org/x/sys/windows/env_windows.go
+index b8ad19250..d4577a423 100644
+--- a/vendor/golang.org/x/sys/windows/env_windows.go
++++ b/vendor/golang.org/x/sys/windows/env_windows.go
+@@ -37,14 +37,17 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
+ 		return nil, err
+ 	}
+ 	defer DestroyEnvironmentBlock(block)
+-	blockp := unsafe.Pointer(block)
+-	for {
+-		entry := UTF16PtrToString((*uint16)(blockp))
+-		if len(entry) == 0 {
+-			break
++	size := unsafe.Sizeof(*block)
++	for *block != 0 {
++		// find NUL terminator
++		end := unsafe.Pointer(block)
++		for *(*uint16)(end) != 0 {
++			end = unsafe.Add(end, size)
+ 		}
+-		env = append(env, entry)
+-		blockp = unsafe.Add(blockp, 2*(len(entry)+1))
++
++		entry := unsafe.Slice(block, (uintptr(end)-uintptr(unsafe.Pointer(block)))/size)
++		env = append(env, UTF16ToString(entry))
++		block = (*uint16)(unsafe.Add(end, size))
+ 	}
+ 	return env, nil
+ }
+diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
+index 47dc57967..6395a031d 100644
+--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
+@@ -125,8 +125,7 @@ func UTF16PtrToString(p *uint16) string {
+ 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {
+ 		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(*p))
+ 	}
+-
+-	return string(utf16.Decode(unsafe.Slice(p, n)))
++	return UTF16ToString(unsafe.Slice(p, n))
+ }
+ 
+ func Getpagesize() int { return 4096 }
+@@ -194,6 +193,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
+ //sys	GetComputerName(buf *uint16, n *uint32) (err error) = GetComputerNameW
+ //sys	GetComputerNameEx(nametype uint32, buf *uint16, n *uint32) (err error) = GetComputerNameExW
+ //sys	SetEndOfFile(handle Handle) (err error)
++//sys	SetFileValidData(handle Handle, validDataLength int64) (err error)
+ //sys	GetSystemTimeAsFileTime(time *Filetime)
+ //sys	GetSystemTimePreciseAsFileTime(time *Filetime)
+ //sys	GetTimeZoneInformation(tzi *Timezoneinformation) (rc uint32, err error) [failretval==0xffffffff]
+diff --git a/vendor/golang.org/x/sys/windows/zsyscall_windows.go b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+index 146a1f019..e8791c82c 100644
+--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
++++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+@@ -342,6 +342,7 @@ var (
+ 	procSetDefaultDllDirectories                             = modkernel32.NewProc("SetDefaultDllDirectories")
+ 	procSetDllDirectoryW                                     = modkernel32.NewProc("SetDllDirectoryW")
+ 	procSetEndOfFile                                         = modkernel32.NewProc("SetEndOfFile")
++	procSetFileValidData                                     = modkernel32.NewProc("SetFileValidData")
+ 	procSetEnvironmentVariableW                              = modkernel32.NewProc("SetEnvironmentVariableW")
+ 	procSetErrorMode                                         = modkernel32.NewProc("SetErrorMode")
+ 	procSetEvent                                             = modkernel32.NewProc("SetEvent")
+@@ -2988,6 +2989,14 @@ func SetEndOfFile(handle Handle) (err error) {
+ 	return
+ }
+ 
++func SetFileValidData(handle Handle, validDataLength int64) (err error) {
++	r1, _, e1 := syscall.Syscall(procSetFileValidData.Addr(), 2, uintptr(handle), uintptr(validDataLength), 0)
++	if r1 == 0 {
++		err = errnoErr(e1)
++	}
++	return
++}
++
+ func SetEnvironmentVariable(name *uint16, value *uint16) (err error) {
+ 	r1, _, e1 := syscall.Syscall(procSetEnvironmentVariableW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), 0)
+ 	if r1 == 0 {
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+index fa1242b8a..6a3f888ab 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/types.go
+@@ -392,7 +392,7 @@ type PersistentVolumeStatus struct {
+ 	Reason string
+ 	// LastPhaseTransitionTime is the time the phase transitioned from one to another
+ 	// and automatically resets to current time everytime a volume phase transitions.
+-	// This is an alpha field and requires enabling PersistentVolumeLastPhaseTransitionTime feature.
++	// This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
+ 	// +featureGate=PersistentVolumeLastPhaseTransitionTime
+ 	// +optional
+ 	LastPhaseTransitionTime *metav1.Time
+diff --git a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+index a6f7fef30..1885531f8 100644
+--- a/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
++++ b/vendor/k8s.io/kubernetes/pkg/apis/core/validation/validation.go
+@@ -5141,6 +5141,46 @@ func ValidateContainerStateTransition(newStatuses, oldStatuses []core.ContainerS
+ 	return allErrs
+ }
+ 
++// ValidateInitContainerStateTransition test to if any illegal init container state transitions are being attempted
++func ValidateInitContainerStateTransition(newStatuses, oldStatuses []core.ContainerStatus, fldpath *field.Path, podSpec *core.PodSpec) field.ErrorList {
++	allErrs := field.ErrorList{}
++	// If we should always restart, containers are allowed to leave the terminated state
++	if podSpec.RestartPolicy == core.RestartPolicyAlways {
++		return allErrs
++	}
++	for i, oldStatus := range oldStatuses {
++		// Skip any container that is not terminated
++		if oldStatus.State.Terminated == nil {
++			continue
++		}
++		// Skip any container that failed but is allowed to restart
++		if oldStatus.State.Terminated.ExitCode != 0 && podSpec.RestartPolicy == core.RestartPolicyOnFailure {
++			continue
++		}
++
++		// Skip any restartable init container that is allowed to restart
++		isRestartableInitContainer := false
++		for _, c := range podSpec.InitContainers {
++			if oldStatus.Name == c.Name {
++				if c.RestartPolicy != nil && *c.RestartPolicy == core.ContainerRestartPolicyAlways {
++					isRestartableInitContainer = true
++				}
++				break
++			}
++		}
++		if isRestartableInitContainer {
++			continue
++		}
++
++		for _, newStatus := range newStatuses {
++			if oldStatus.Name == newStatus.Name && newStatus.State.Terminated == nil {
++				allErrs = append(allErrs, field.Forbidden(fldpath.Index(i).Child("state"), "may not be transitioned to non-terminated state"))
++			}
++		}
++	}
++	return allErrs
++}
++
+ // ValidatePodStatusUpdate checks for changes to status that shouldn't occur in normal operation.
+ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) field.ErrorList {
+ 	fldPath := field.NewPath("metadata")
+@@ -5162,7 +5202,7 @@ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions
+ 	// If pod should not restart, make sure the status update does not transition
+ 	// any terminated containers to a non-terminated state.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.ContainerStatuses, oldPod.Status.ContainerStatuses, fldPath.Child("containerStatuses"), oldPod.Spec.RestartPolicy)...)
+-	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), oldPod.Spec.RestartPolicy)...)
++	allErrs = append(allErrs, ValidateInitContainerStateTransition(newPod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses, fldPath.Child("initContainerStatuses"), &oldPod.Spec)...)
+ 	// The kubelet will never restart ephemeral containers, so treat them like they have an implicit RestartPolicyNever.
+ 	allErrs = append(allErrs, ValidateContainerStateTransition(newPod.Status.EphemeralContainerStatuses, oldPod.Status.EphemeralContainerStatuses, fldPath.Child("ephemeralContainerStatuses"), core.RestartPolicyNever)...)
+ 	allErrs = append(allErrs, validatePodResourceClaimStatuses(newPod.Status.ResourceClaimStatuses, newPod.Spec.ResourceClaims, fldPath.Child("resourceClaimStatuses"))...)
+diff --git a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+index edd33feb7..b0b12d6eb 100644
+--- a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
++++ b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+@@ -259,7 +259,6 @@ const (
+ 	// owner: @harche
+ 	// kep: http://kep.k8s.io/3386
+ 	// alpha: v1.25
+-	// beta: v1.27
+ 	//
+ 	// Allows using event-driven PLEG (pod lifecycle event generator) through kubelet
+ 	// which avoids frequent relisting of containers which helps optimize performance.
+@@ -617,6 +616,7 @@ const (
+ 	// owner: @RomanBednar
+ 	// kep: https://kep.k8s.io/3762
+ 	// alpha: v1.28
++	// beta: v1.29
+ 	//
+ 	// Adds a new field to persistent volumes which holds a timestamp of when the volume last transitioned its phase.
+ 	PersistentVolumeLastPhaseTransitionTime featuregate.Feature = "PersistentVolumeLastPhaseTransitionTime"
+@@ -1048,7 +1048,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
+ 
+-	EventedPLEG: {Default: false, PreRelease: featuregate.Beta}, // off by default, requires CRI Runtime support
++	EventedPLEG: {Default: false, PreRelease: featuregate.Alpha},
+ 
+ 	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
+ 
+@@ -1263,6 +1263,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.SeparateCacheWatchRPC: {Default: true, PreRelease: featuregate.Beta},
++
+ 	genericfeatures.ServerSideApply: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+ 
+ 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
+@@ -1273,6 +1275,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 
+ 	genericfeatures.ZeroLimitedNominalConcurrencyShares: {Default: false, PreRelease: featuregate.Beta},
+ 
++	genericfeatures.WatchFromStorageWithoutResourceVersion: {Default: false, PreRelease: featuregate.Beta},
++
+ 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
+ 	// unintentionally on either side:
+ 
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+index 94c2330af..6ce01755f 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+@@ -1064,7 +1064,7 @@ func NewPersistentVolumeRecyclerPodTemplate() *v1.Pod {
+ 			Containers: []v1.Container{
+ 				{
+ 					Name:    "pv-recycler",
+-					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.0",
++					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.2",
+ 					Command: []string{"/bin/sh"},
+ 					Args:    []string{"-c", "test -e /scrub && find /scrub -mindepth 1 -delete && test -z \"$(ls -A /scrub)\" || exit 1"},
+ 					VolumeMounts: []v1.VolumeMount{
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+index af309353b..238e919b3 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/util/types/types.go
+@@ -102,6 +102,23 @@ func IsFailedPreconditionError(err error) bool {
+ 	return errors.As(err, &failedPreconditionError)
+ }
+ 
++type OperationNotSupported struct {
++	msg string
++}
++
++func (err *OperationNotSupported) Error() string {
++	return err.msg
++}
++
++func NewOperationNotSupportedError(msg string) *OperationNotSupported {
++	return &OperationNotSupported{msg: msg}
++}
++
++func IsOperationNotSupportedError(err error) bool {
++	var operationNotSupportedError *OperationNotSupported
++	return errors.As(err, &operationNotSupportedError)
++}
++
+ // TransientOperationFailure indicates operation failed with a transient error
+ // and may fix itself when retried.
+ type TransientOperationFailure struct {
+diff --git a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+index 72f2394e9..0d83a7cc8 100644
+--- a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
++++ b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+@@ -232,7 +232,7 @@ const (
+ 
+ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
+ 	configs := map[ImageID]Config{}
+-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.45"}
++	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.47"}
+ 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
+ 	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
+ 	configs[AuthenticatedWindowsNanoServer] = Config{list.GcAuthenticatedRegistry, "windows-nanoserver", "v1"}
+@@ -241,8 +241,8 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
+ 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.36.1-1"}
+ 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
+ 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
+-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.3"}
+-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.10-0"}
++	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.7"}
++	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.12-0"}
+ 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
+ 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}
+ 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index ebde30f57..ab47b0cca 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -406,7 +406,7 @@ go.uber.org/zap/internal/pool
+ go.uber.org/zap/internal/stacktrace
+ go.uber.org/zap/zapcore
+ go.uber.org/zap/zapgrpc
+-# golang.org/x/crypto v0.17.0
++# golang.org/x/crypto v0.21.0
+ ## explicit; go 1.18
+ golang.org/x/crypto/blowfish
+ golang.org/x/crypto/chacha20
+@@ -430,7 +430,7 @@ golang.org/x/exp/slices
+ # golang.org/x/mod v0.14.0
+ ## explicit; go 1.18
+ golang.org/x/mod/semver
+-# golang.org/x/net v0.19.0
++# golang.org/x/net v0.23.0
+ ## explicit; go 1.18
+ golang.org/x/net/bpf
+ golang.org/x/net/context
+@@ -457,14 +457,14 @@ golang.org/x/oauth2/internal
+ # golang.org/x/sync v0.5.0
+ ## explicit; go 1.18
+ golang.org/x/sync/singleflight
+-# golang.org/x/sys v0.15.0
++# golang.org/x/sys v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/sys/cpu
+ golang.org/x/sys/plan9
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+ golang.org/x/sys/windows/registry
+-# golang.org/x/term v0.15.0
++# golang.org/x/term v0.18.0
+ ## explicit; go 1.18
+ golang.org/x/term
+ # golang.org/x/text v0.14.0
+@@ -1355,7 +1355,7 @@ k8s.io/kubectl/pkg/util/podutils
+ # k8s.io/kubelet v0.27.0 => k8s.io/kubelet v0.29.0
+ ## explicit; go 1.21
+ k8s.io/kubelet/pkg/apis
+-# k8s.io/kubernetes v1.29.0
++# k8s.io/kubernetes v1.29.4
+ ## explicit; go 1.21
+ k8s.io/kubernetes/pkg/api/legacyscheme
+ k8s.io/kubernetes/pkg/api/service
+-- 
+2.40.1
+


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Fix external-provisioner CVE-2024-3177 by bumping k8s.io/kubernetes to v1.29.4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
