### PR TITLE
Update CSI projects README.md to supported versions

### DIFF
--- a/projects/kubernetes-csi/external-attacher/README.md
+++ b/projects/kubernetes-csi/external-attacher/README.md
@@ -2,11 +2,10 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-25    | ![Version](https://img.shields.io/badge/version-v4.5.0-blue) |
-| 1-26    | ![Version](https://img.shields.io/badge/version-v4.5.0-blue) |
-| 1-27    | ![Version](https://img.shields.io/badge/version-v4.5.0-blue) |
-| 1-28    | ![Version](https://img.shields.io/badge/version-v4.5.0-blue) |
-
+| 1-26    | ![Version](https://img.shields.io/badge/version-v4.5.1-blue) |
+| 1-27    | ![Version](https://img.shields.io/badge/version-v4.5.1-blue) |
+| 1-28    | ![Version](https://img.shields.io/badge/version-v4.5.1-blue) |
+| 1-29    | ![Version](https://img.shields.io/badge/version-v4.5.1-blue) |
 
 ### Updating
 

--- a/projects/kubernetes-csi/external-provisioner/README.md
+++ b/projects/kubernetes-csi/external-provisioner/README.md
@@ -2,10 +2,11 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-25    | ![Version](https://img.shields.io/badge/version-v3.6.3-blue) |
-| 1-26    | ![Version](https://img.shields.io/badge/version-v3.6.3-blue) |
-| 1-27    | ![Version](https://img.shields.io/badge/version-v3.6.3-blue) |
-| 1-28    | ![Version](https://img.shields.io/badge/version-v3.6.3-blue) |
+| 1-26    | ![Version](https://img.shields.io/badge/version-v4.0.1-blue) |
+| 1-27    | ![Version](https://img.shields.io/badge/version-v4.0.1-blue) |
+| 1-28    | ![Version](https://img.shields.io/badge/version-v4.0.1-blue) |
+| 1-29    | ![Version](https://img.shields.io/badge/version-v4.0.1-blue) |
+
 ### Updating
 
 1. Determine the version of CSI external-provisioner to use.

--- a/projects/kubernetes-csi/external-resizer/README.md
+++ b/projects/kubernetes-csi/external-resizer/README.md
@@ -2,10 +2,10 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-25    | ![Version](https://img.shields.io/badge/version-v1.10.0-blue) |
-| 1-26    | ![Version](https://img.shields.io/badge/version-v1.10.0-blue) |
-| 1-27    | ![Version](https://img.shields.io/badge/version-v1.10.0-blue) |
-| 1-28    | ![Version](https://img.shields.io/badge/version-v1.10.0-blue) |
+| 1-26    | ![Version](https://img.shields.io/badge/version-v1.10.1-blue) |
+| 1-27    | ![Version](https://img.shields.io/badge/version-v1.10.1-blue) |
+| 1-28    | ![Version](https://img.shields.io/badge/version-v1.10.1-blue) |
+| 1-29    | ![Version](https://img.shields.io/badge/version-v1.10.1-blue) |
 
 ### Updating
 

--- a/projects/kubernetes-csi/external-snapshotter/README.md
+++ b/projects/kubernetes-csi/external-snapshotter/README.md
@@ -2,10 +2,10 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-25    | ![Version](https://img.shields.io/badge/version-v7.0.1-blue) |
-| 1-26    | ![Version](https://img.shields.io/badge/version-v7.0.1-blue) |
-| 1-27    | ![Version](https://img.shields.io/badge/version-v7.0.1-blue) |
-| 1-28    | ![Version](https://img.shields.io/badge/version-v7.0.1-blue) |
+| 1-26    | ![Version](https://img.shields.io/badge/version-v7.0.2-blue) |
+| 1-27    | ![Version](https://img.shields.io/badge/version-v7.0.2-blue) |
+| 1-28    | ![Version](https://img.shields.io/badge/version-v7.0.2-blue) |
+| 1-29    | ![Version](https://img.shields.io/badge/version-v7.0.2-blue) |
 
 ### Updating
 

--- a/projects/kubernetes-csi/livenessprobe/README.md
+++ b/projects/kubernetes-csi/livenessprobe/README.md
@@ -1,11 +1,11 @@
 ## CSI livenessprobe
 
-| Release | Version                                                       |
-|---------|---------------------------------------------------------------|
-| 1-25    | ![Version](https://img.shields.io/badge/version-v2.12.0-blue) |
+| Release | Version                                                      |
+|---------|--------------------------------------------------------------|
 | 1-26    | ![Version](https://img.shields.io/badge/version-v2.12.0-blue) |
 | 1-27    | ![Version](https://img.shields.io/badge/version-v2.12.0-blue) |
 | 1-28    | ![Version](https://img.shields.io/badge/version-v2.12.0-blue) |
+| 1-29    | ![Version](https://img.shields.io/badge/version-v2.12.0-blue) |
 
 ### Updating
 

--- a/projects/kubernetes-csi/node-driver-registrar/README.md
+++ b/projects/kubernetes-csi/node-driver-registrar/README.md
@@ -2,11 +2,10 @@
 
 | Release | Version                                                      |
 |---------|--------------------------------------------------------------|
-| 1-25    | ![Version](https://img.shields.io/badge/version-v2.10.0-blue) |
-| 1-26    | ![Version](https://img.shields.io/badge/version-v2.10.0-blue) |
-| 1-27    | ![Version](https://img.shields.io/badge/version-v2.10.0-blue) |
-| 1-28    | ![Version](https://img.shields.io/badge/version-v2.10.0-blue) |
-
+| 1-26    | ![Version](https://img.shields.io/badge/version-v2.10.1-blue) |
+| 1-27    | ![Version](https://img.shields.io/badge/version-v2.10.1-blue) |
+| 1-28    | ![Version](https://img.shields.io/badge/version-v2.10.1-blue) |
+| 1-29    | ![Version](https://img.shields.io/badge/version-v2.10.1-blue) |
 
 ### Updating
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update CSI README.md supported versions
To be merged in May 1st once  EKS 1.25 is no longer officially maintained. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
