### PR TITLE
catch go mod download overwriting changes to vendor

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -372,6 +372,7 @@ DOCKER_USE_ID_FOR_LINUX=$(shell if [ "$$(uname -s)" = "Linux" ] && [ -n "$${USER
 GO_MOD_CACHE=$(shell source $(BUILD_LIB)/common.sh && build::common::use_go_version $(GOLANG_VERSION) > /dev/null 2>&1 && go env GOMODCACHE)
 GO_BUILD_CACHE=$(shell source $(BUILD_LIB)/common.sh && build::common::use_go_version $(GOLANG_VERSION) > /dev/null 2>&1 && go env GOCACHE)
 CGO_TARGET?=
+GO_MODS_VENDORED?=false
 ######################
 
 #### BUILD FLAGS ####
@@ -520,7 +521,7 @@ $(GIT_PATCH_TARGET): $(GIT_CHECKOUT_TARGET)
 $(REPO)/%ks-distro-go-mod-download: REPO_SUBPATH=$(if $(filter e,$*),,$(*:%/e=%))
 $(REPO)/%ks-distro-go-mod-download: $(if $(PATCHES_DIR),$(GIT_PATCH_TARGET),$(GIT_CHECKOUT_TARGET))
 	@echo -e $(call TARGET_START_LOG)
-	$(BASE_DIRECTORY)/build/lib/go_mod_download.sh $(MAKE_ROOT) $(REPO) $(GIT_TAG) $(GOLANG_VERSION) "$(REPO_SUBPATH)"
+	if [[ "$(GO_MODS_VENDORED)" == "false" ]]; then $(BASE_DIRECTORY)/build/lib/go_mod_download.sh $(MAKE_ROOT) $(REPO) $(GIT_TAG) $(GOLANG_VERSION) "$(REPO_SUBPATH)"; fi
 	@touch $@
 	@echo -e $(call TARGET_END_LOG)
 

--- a/projects/kubernetes/cloud-provider-aws/Makefile
+++ b/projects/kubernetes/cloud-provider-aws/Makefile
@@ -19,7 +19,7 @@ HAS_S3_ARTIFACTS=true
 # 1-28 and 1-29 includes patches that add the vendor directory
 # as well as one that modifies content inside the vendor directory
 # set to true to avoid downloading deps overwriting this change/patch
-RELEASE_BRANCHES_VENDORED=1-28 1-29
+RELEASE_BRANCHES_VENDORED=1-26 1-27 1-28 1-29
 GO_MODS_VENDORED=$(if $(filter $(RELEASE_BRANCH),$(RELEASE_BRANCHES_VENDORED)),true,false)
 EXTRA_GO_LDFLAGS=-X k8s.io/component-base/version.gitVersion=$(GIT_TAG)
 

--- a/projects/kubernetes/cloud-provider-aws/Makefile
+++ b/projects/kubernetes/cloud-provider-aws/Makefile
@@ -16,11 +16,6 @@ BASE_IMAGE=$(GO_RUNNER_IMAGE)
 HAS_RELEASE_BRANCHES=true
 HAS_S3_ARTIFACTS=true
 
-# 1-28 and 1-29 includes patches that add the vendor directory
-# as well as one that modifies content inside the vendor directory
-# set to true to avoid downloading deps overwriting this change/patch
-RELEASE_BRANCHES_VENDORED=1-26 1-27 1-28 1-29
-GO_MODS_VENDORED=$(if $(filter $(RELEASE_BRANCH),$(RELEASE_BRANCHES_VENDORED)),true,false)
 EXTRA_GO_LDFLAGS=-X k8s.io/component-base/version.gitVersion=$(GIT_TAG)
 
 IMAGE_NAMES=cloud-controller-manager

--- a/projects/kubernetes/cloud-provider-aws/Makefile
+++ b/projects/kubernetes/cloud-provider-aws/Makefile
@@ -16,6 +16,11 @@ BASE_IMAGE=$(GO_RUNNER_IMAGE)
 HAS_RELEASE_BRANCHES=true
 HAS_S3_ARTIFACTS=true
 
+# 1-28 and 1-29 includes patches that add the vendor directory
+# as well as one that modifies content inside the vendor directory
+# set to true to avoid downloading deps overwriting this change/patch
+RELEASE_BRANCHES_VENDORED=1-28 1-29
+GO_MODS_VENDORED=$(if $(filter $(RELEASE_BRANCH),$(RELEASE_BRANCHES_VENDORED)),true,false)
 EXTRA_GO_LDFLAGS=-X k8s.io/component-base/version.gitVersion=$(GIT_TAG)
 
 IMAGE_NAMES=cloud-controller-manager


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

From pretty much the beginning of eks-d and then eks-a after it, we have run `go mod download` before building.  Some upstream projects, such as k/k, actually check in their vendor folder so in those cases we do not technically need to run `go mod vendor` (and in the case of k/k we actually do not, never have) but we do anyway to be consistent and avoid having to have made a case by case decision.  This was also important for reproducible builds, there is some oddities with go dependencies that have been download vs checked in and pulled. I have previous PRs which talk about this.  Always running `go mod vendor` ensured all projects would build regardless of if the vendor dir was checked in or not.

About a year ago, the `harbor` build in eks-a was updated with a patch that actually did patch something in the vendor directory.  At that time we added `GO_MODS_VENDORED` in https://github.com/aws/eks-anywhere-build-tooling/pull/2078 to allow projects to skip running `go mod vendor`.

Recently a patch was added to CCM for versions 1.28+ which 1) adds the vendor directory and 2) patches something in that directory.  As is, this patch is not actually taking affect because it gets overwritten when the `go mod vendor` call is ran.  The fix, which @markapruett is taking, is to port over the skipping mechanism from eks-a to eks-d and setting GO_MODS_VENDORED to true for the ccm build.

While discussing with Mark this nuance, I was thinking of ways we could catch this and avoid the silent "failure".  This is my attempt, if the vendor dir exists before running `go mod vendor` then use git to determine if anything changed in that folder due to `go mod vendor`, if so, then error.

With this change it will require that any time we patch a go.mod/sum file for a project with vendored deps, we need to make sure the patch includes the vendor folder updates, otherwise git will see a difference and trigger this error. The fix should be pretty easy/obvious in this case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
