### PR TITLE
Add CVE-2024-24786 coreDNS patches for 1.25

### DIFF
--- a/projects/coredns/coredns/1-25/CHECKSUMS
+++ b/projects/coredns/coredns/1-25/CHECKSUMS
@@ -1,2 +1,2 @@
-e275eadb74dd7ba0e045b591babf3ed9fe9f5ae6f0a6ec5d0816e0d4b98c6f6c  _output/1-25/bin/coredns/linux-amd64/coredns
-8fd1e885c0b29e7ba3c1a1753e82ef55fd45d4c72f5c92685fc08c0f1783a726  _output/1-25/bin/coredns/linux-arm64/coredns
+53f8a8b675d9b562a31fe49b82305b0642cd27838558a4986c0e1131ce4b689e  _output/1-25/bin/coredns/linux-amd64/coredns
+3d20be6296f2b0716883e3b54b228401ed816309c7e3d4639086ad7225b97409  _output/1-25/bin/coredns/linux-arm64/coredns

--- a/projects/coredns/coredns/1-25/patches/0006-Fix-for-CVE-2024-24786.patch
+++ b/projects/coredns/coredns/1-25/patches/0006-Fix-for-CVE-2024-24786.patch
@@ -1,0 +1,41 @@
+From 5712ef3d875ddc6f0f12bb5be5454c28ac3c5eab Mon Sep 17 00:00:00 2001
+From: Jay Deokar <jsdeokar@amazon.com>
+Date: Wed, 3 Apr 2024 01:57:42 +0000
+Subject: [PATCH] Fix for CVE-2024-24786
+
+---
+ go.mod | 2 +-
+ go.sum | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index c49039ed7..20cc39170 100644
+--- a/go.mod
++++ b/go.mod
+@@ -28,7 +28,7 @@ require (
+ 	golang.org/x/sys v0.15.0
+ 	google.golang.org/api v0.126.0
+ 	google.golang.org/grpc v1.58.3
+-	google.golang.org/protobuf v1.31.0
++	google.golang.org/protobuf v1.33.0
+ 	gopkg.in/DataDog/dd-trace-go.v1 v1.38.1
+ 	k8s.io/api v0.24.0
+ 	k8s.io/apimachinery v0.24.0
+diff --git a/go.sum b/go.sum
+index ff71dba34..a4f46a0d5 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1380,8 +1380,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
+ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
++google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
++google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+ gopkg.in/DataDog/dd-trace-go.v1 v1.38.1 h1:nAKgcpJLXRHF56cKCP3bN8gTTQmmNAZFEblbyGKhKTo=
+ gopkg.in/DataDog/dd-trace-go.v1 v1.38.1/go.mod h1:GBhK4yaMJ1h329ivtKAqRNe1EZ944UnZwtz5lh7CnJc=
+ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
+-- 
+2.40.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
