### PR TITLE
Set executable bit on /var/logs/pods so its files are readable by all

### DIFF
--- a/development/kops/gather_logs.sh
+++ b/development/kops/gather_logs.sh
@@ -42,6 +42,7 @@ function log_dump_custom_get_instances() {
     # Container logs are symlinks and need a slightly different chmod
     # log-dump-ssh comes the upstream log-dump.sh script
     for node in $nodes ; do log-dump-ssh $node "sudo chmod a+r /var/log/containers/*" || true ; done
+    for node in $nodes ; do log-dump-ssh $node "sudo chmod +x /var/log/pods" || true ; done
 
     echo "$nodes"
 }


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Fixes scp permission denied issues when getting pod logs like `scp: /var/log/containers/aws-cloud-controller-manager-xhgft_kube-system_aws-cloud-controller-manager-8ac53716d57d9958f9c5596a47f8beb53630812208083d85f1f40c2108395e7c.log: Permission denied` https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/build-1-30-postsubmit/1787928680282984448#2:build-container-build-log.txt%3A9535

Working example below. There are still some permission denied errors but I think they can be ignored.

```
bash -c 'export ARTIFACT_BUCKET=eks-d-postsubmit-artifacts; export KOPS_RUN_TOO_NEW_VERSION=1; export IMAGE_REPO=public.ecr.aws/h1r8a7l5; export RELEASE=5.pre; KOPS_VERSION=1.29.0-beta.1 AWS_REGION=us-west-2 KOPS_STATE_STORE=s3://aws-ebs-csi-driver-e2e KOPS_CLUSTER_NAME=mattwon-130-5pre.mattwon.people.aws.dev RELEASE_BRANCH=1-30 ./gather_logs.sh'

$ bash -c 'export ARTIFACT_BUCKET=eks-d-postsubmit-artifacts; export KOPS_RUN_TOO_NEW_VERSION=1; export IMAGE_REPO=public.ecr.aws/h1r8a7l5; export RELEASE=5.pre; KOPS_VERSION=1.29.0-beta.1 AWS_REGION=us-west-2 KOPS_STATE_STORE=s3://aws-ebs-csi-driver-e2e KOPS_CLUSTER_NAME=mattwon-130-5pre.mattwon.people.aws.dev RELEASE_BRANCH=1-30 ./gather_logs.sh'
✔ AWS_REGION=us-west-2
✔ AWS CLI authenticated
✔ KOPS_STATE_STORE=s3://aws-ebs-csi-driver-e2e
✔ KOPS_CLUSTER_NAME=mattwon-130-5pre.mattwon.people.aws.dev
Checking for custom logdump instances, if any
Dumping logs from control_plane locally to './_artifacts'
Changing logfiles to be world-readable for download
Copying 'kube-apiserver.log kube-apiserver-audit.log kube-scheduler.log kube-controller-manager.log etcd.log etcd-events.log glbc.log cluster-autoscaler.log kube-addon-manager.log konnectivity-server.log fluentd.log kubelet.cov cloud-init-output.log cloud-init.log kube-proxy.log containers/*' from ec2-35-161-10-13.us-west-2.compute.amazonaws.com
./_artifacts/ec2-35-161-10-13.us-west-2.compute.amazonaws.com/kube-apiserver.log: Permission denied
scp: /var/log/kube-apiserver-audit.log*: No such file or directory
./_artifacts/ec2-35-161-10-13.us-west-2.compute.amazonaws.com/kube-scheduler.log: Permission denied
./_artifacts/ec2-35-161-10-13.us-west-2.compute.amazonaws.com/kube-controller-manager.log: Permission denied
scp: /var/log/glbc.log*: No such file or directory
scp: /var/log/cluster-autoscaler.log*: No such file or directory
scp: /var/log/kube-addon-manager.log*: No such file or directory
scp: /var/log/konnectivity-server.log*: No such file or directory
scp: /var/log/fluentd.log*: No such file or directory
scp: /var/log/kubelet.cov*: No such file or directory
./_artifacts/ec2-35-161-10-13.us-west-2.compute.amazonaws.com/kube-proxy.log: Permission denied
Dumping logs from nodes locally to './_artifacts'
Dumping logs for nodes provided by log_dump_custom_get_instances() function
Changing logfiles to be world-readable for download
Changing logfiles to be world-readable for download
Changing logfiles to be world-readable for download
Copying 'kube-proxy.log fluentd.log node-problem-detector.log kubelet.cov cloud-init-output.log cloud-init.log kube-proxy.log containers/* kern.log docker/log kubelet.log supervisor/supervisord.log supervisor/kubelet-stdout.log supervisor/kubelet-stderr.log supervisor/docker-stdout.log supervisor/docker-stderr.log' from 
Copying 'kube-proxy.log fluentd.log node-problem-detector.log kubelet.cov cloud-init-output.log cloud-init.log kube-proxy.log containers/* kern.log docker/log kubelet.log supervisor/supervisord.log supervisor/kubelet-stdout.log supervisor/kubelet-stderr.log supervisor/docker-stdout.log supervisor/docker-stderr.log' from 
Copying 'kube-proxy.log fluentd.log node-problem-detector.log kubelet.cov cloud-init-output.log cloud-init.log kube-proxy.log containers/* kern.log docker/log kubelet.log supervisor/supervisord.log supervisor/kubelet-stdout.log supervisor/kubelet-stderr.log supervisor/docker-stdout.log supervisor/docker-stderr.log' from 
Changing logfiles to be world-readable for download
Copying 'kube-proxy.log fluentd.log node-problem-detector.log kubelet.cov cloud-init-output.log cloud-init.log kube-proxy.log containers/*' from ec2-35-94-27-221.us-west-2.compute.amazonaws.com
Changing logfiles to be world-readable for download
./_artifacts/ec2-35-94-27-221.us-west-2.compute.amazonaws.com/kube-proxy.log: Permission denied
scp: /var/log/fluentd.log*: No such file or directory
scp: /var/log/node-problem-detector.log*: No such file or directory
scp: /var/log/kubelet.cov*: No such file or directory
./_artifacts/ec2-35-94-27-221.us-west-2.compute.amazonaws.com/kube-proxy.log: Permission denied
Changing logfiles to be world-readable for download
Copying 'kube-proxy.log fluentd.log node-problem-detector.log kubelet.cov cloud-init-output.log cloud-init.log kube-proxy.log containers/*' from ec2-35-93-206-60.us-west-2.compute.amazonaws.com
Copying 'kube-proxy.log fluentd.log node-problem-detector.log kubelet.cov cloud-init-output.log cloud-init.log kube-proxy.log containers/*' from ec2-34-222-166-8.us-west-2.compute.amazonaws.com
./_artifacts/ec2-35-93-206-60.us-west-2.compute.amazonaws.com/kube-proxy.log: Permission denied
scp: /var/log/fluentd.log*: No such file or directory
scp: /var/log/node-problem-detector.log*: No such file or directory
scp: /var/log/kubelet.cov*: No such file or directory
./_artifacts/ec2-35-93-206-60.us-west-2.compute.amazonaws.com/kube-proxy.log: Permission denied
./_artifacts/ec2-34-222-166-8.us-west-2.compute.amazonaws.com/kube-proxy.log: Permission denied
scp: /var/log/fluentd.log*: No such file or directory
scp: /var/log/node-problem-detector.log*: No such file or directory
scp: /var/log/kubelet.cov*: No such file or directory
./_artifacts/ec2-34-222-166-8.us-west-2.compute.amazonaws.com/kube-proxy.log: Permission denied

# WORKER NODE
$ ls ./_artifacts/ec2-34-222-166-8.us-west-2.compute.amazonaws.com/
cilium-vlbwk_kube-system_apply-sysctl-overwrites-dd65a84882a0f9b959bf691e744491e254d62a8d0af4181f27f32c8309f83540.log
cilium-vlbwk_kube-system_cilium-agent-0cfed88a3a5b5ea39be7dbcb33a5b5bfa5398cee7fc70d79f549d0038b5ced2c.log
cilium-vlbwk_kube-system_clean-cilium-state-85f979a086e3c0782587f404d89bb6965870df55a8838cd66d4648ae9729848c.log
cilium-vlbwk_kube-system_config-0e8c346838076b1ea20091fdaf89bf33c60a58801d52c61c96fa29afdd5b2630.log
cilium-vlbwk_kube-system_install-cni-binaries-4d90972b9a806b8d88240b2793556e133c681decdea0add11602b80184322bad.log
cilium-vlbwk_kube-system_mount-cgroup-7910631c2c889f6b48bfd7d4576d9e9ea1a6e43bc660d8d7510b35681e7b6203.log
cloud-init.log
cloud-init-output.log
containerd.log
coredns-55c5d49d69-cw7f4_kube-system_coredns-78275cf5afb5116d831ec736de1048565f52a2860cbc856036c08179020cf20f.log
coredns-55c5d49d69-lxpt8_kube-system_coredns-7377946dd8abf0e667108f4fbc06989dd746812d5b1f63f991c313239043cd65.log
coredns-autoscaler-66cdf74f49-g9fmt_kube-system_autoscaler-669f5da285362d7d0986d7fb8aab3f10c23896863092ef1ccf309e8d408d8c7f.log
docker.log
ebs-csi-node-zk6fc_kube-system_ebs-plugin-3ae3e3a49d7e9ea6b60bd996f5c3c466f3df536f31d1f672f9a744a1ccd0cc90.log
ebs-csi-node-zk6fc_kube-system_liveness-probe-3d8239835d593df2d2c1f8831350916c4b8a20b5b27f0a2a31435085e9d1c148.log
ebs-csi-node-zk6fc_kube-system_node-driver-registrar-fcea306824bafd14377979380afb2764307ccd6f76c649bb139bae0ca8d0424a.log
kern.log
kops-configuration.log
kube-container-runtime-monitor.log
kubelet.log
kubelet-monitor.log
kube-node-configuration.log
kube-node-installation.log
kube-proxy-i-0a7904a09ad635482_kube-system_kube-proxy-78f2ea39f76e2e74122941464d729ff11fbc34e6f93f0a7ac35d3dbcb5512891.log
kube-proxy.log
node-problem-detector.log
protokube.log
systemd.log

# CONTROL PLANE NODE
$ ls ./_artifacts/ec2-35-161-10-13.us-west-2.compute.amazonaws.com/
aws-cloud-controller-manager-b42r9_kube-system_aws-cloud-controller-manager-e7e5d3b6ea8b156f6b926acc16b056ae8100ad320407b67376659165da84acea.log*
aws-iam-authenticator-sjx79_kube-system_aws-iam-authenticator-8067465b7a901a8271cab0343513ada12064c44a68b211d30b59e636195a32ab.log*
aws-node-termination-handler-9c559dd7-cnk5w_kube-system_aws-node-termination-handler-1167569e14662835f9c6537c8f9767d673a4768eebde9db6127fe8f8f90ba877.log*
cilium-operator-55b6b45795-l6dx9_kube-system_cilium-operator-8f78aa073265beabf9df083d8b0396755c09f46df2612763e517397f09336382.log*
cilium-zfvx2_kube-system_apply-sysctl-overwrites-88925307991c523a7a5b4d3f56b141b2b419ba7374e21c23dc4fdeefebd94e32.log*
cilium-zfvx2_kube-system_cilium-agent-12c8473c27d0c5d884d7aaef980610458484040c9976c7ff88a68823e175276c.log*
cilium-zfvx2_kube-system_clean-cilium-state-7899ec809655841ecb01b1756610ec6eca013bdce6bfb80e713cb8645dcda2d7.log*
cilium-zfvx2_kube-system_config-699bbab7844c5e684218ccae6434bff5207dfae5d54e5cdbe06c36825cd52ffb.log*
cilium-zfvx2_kube-system_install-cni-binaries-dab66c25605990af1acf4745f4ade2f0433a0cac043c3b855205ed5d0895de96.log*
cilium-zfvx2_kube-system_mount-cgroup-9e9e7b413540eb5f2a7a22437cd82e681bd75a70fd9e5a64d3676f828367d6d2.log*
cloud-init.log
cloud-init-output.log
containerd.log
dns-controller-5d656d8dcd-jk2g9_kube-system_dns-controller-b6ccf2c0421078bd637ef0d75a73cf01ae3c90ac19818b220ff70ad1d425c829.log*
docker.log
ebs-csi-controller-68577dd6c5-qbmnp_kube-system_csi-attacher-05e03b0c71a8616ed20235242538c04993c9d7d8f76d528317d6704ef7e127e7.log*
ebs-csi-controller-68577dd6c5-qbmnp_kube-system_csi-provisioner-76f3c1e677f0b374a1782056858a01f0753b7dfa1f066922a5de284ebb708ef4.log*
ebs-csi-controller-68577dd6c5-qbmnp_kube-system_csi-resizer-adc22ae300902fbf1467ed26b34e457e32d774e4f10d2a58bacf1fa8c8c0227c.log*
ebs-csi-controller-68577dd6c5-qbmnp_kube-system_ebs-plugin-30447351cd9df2466427246ea63e67f9b2b1a36b0028bab7b50491ed6b6f5097.log*
ebs-csi-controller-68577dd6c5-qbmnp_kube-system_liveness-probe-11f1756748932e19e81e3ea1bc390da98bbab502cfb9b4f4ae688fd88590f466.log*
ebs-csi-controller-68577dd6c5-qbmnp_kube-system_volumemodifier-4529a49f09c1b9436ac2f48e5b9ac24b6597e5a66723b4003da156d958aaf8b1.log*
ebs-csi-node-dvw64_kube-system_ebs-plugin-f781d4749d2fc3b1c16c3f4e2c6929822650c29c9ef026bca071467d3acd2e13.log*
ebs-csi-node-dvw64_kube-system_liveness-probe-6369b1bcc4cc8e1739c663fc131a9f87fb3b4b6bf8903ebcea0a8d7caaaa3d89.log*
ebs-csi-node-dvw64_kube-system_node-driver-registrar-cac42e846ba2da48ad756dd138c4e83b12a3800e085fe4597a7a7b9326fa7ff9.log*
etcd-events.log
etcd.log
etcd-manager-events-i-00ba7e3ab4af5bb67_kube-system_etcd-manager-da984228a390b33be59afa20738f442dd552da95b0c9ac2b771071a48cdc31b8.log*
etcd-manager-events-i-00ba7e3ab4af5bb67_kube-system_init-etcd-3-4-13-87004561266f8ec2be66bf8e0402309b1000f8357d0488af03aa28752131b932.log*
etcd-manager-events-i-00ba7e3ab4af5bb67_kube-system_init-etcd-3-5-9-b6ca3b653d66be1981620737f5f62f397b3aac8954458c85d6b6c958800e9fe3.log*
etcd-manager-events-i-00ba7e3ab4af5bb67_kube-system_init-etcd-symlinks-3-4-13-298d21584ea0b6f240f5c1257d292615192063d3f4dd5714da0eac9afa053397.log*
etcd-manager-events-i-00ba7e3ab4af5bb67_kube-system_init-etcd-symlinks-3-5-9-a1f24faeb922bf63a760093a13801e91b8ce6b91bed96074504539e6b868d6c3.log*
etcd-manager-events-i-00ba7e3ab4af5bb67_kube-system_kops-utils-cp-688d2507dda76aa31f96745740f08c5fefe41f83a3975e18925069e81e6c9682.log*
etcd-manager-main-i-00ba7e3ab4af5bb67_kube-system_etcd-manager-d3f759e8ec2aaf6c883520cd460e84eae48715a349df8506c1c37a2f630f94e4.log*
etcd-manager-main-i-00ba7e3ab4af5bb67_kube-system_init-etcd-3-4-13-71a4b0922387e9f17018d150f80802e0e8702ef89c802c7614b1fc2280813a71.log*
etcd-manager-main-i-00ba7e3ab4af5bb67_kube-system_init-etcd-3-5-9-d425b40c8c146dabd46ebfda820b18745cb421c0530f1a19aa079a9be77e91f0.log*
etcd-manager-main-i-00ba7e3ab4af5bb67_kube-system_init-etcd-symlinks-3-4-13-1af0752fa3e6e1ffcb070a927211b2e1164b203535d25b4977ccc7849c58fbf0.log*
etcd-manager-main-i-00ba7e3ab4af5bb67_kube-system_init-etcd-symlinks-3-5-9-912d2eac30500d87f818a7851a3eae0e76e6d2a7f40d51efa5abfd8e28e37cfe.log*
etcd-manager-main-i-00ba7e3ab4af5bb67_kube-system_kops-utils-cp-7739f4e4a8087cba0f3510aab19755f0b95cda9d88f8b9811f535f4fc9e079e8.log*
kern.log
kops-configuration.log
kops-controller-fnw2f_kube-system_kops-controller-a0aeef93ba75ac42d01a05f0ee9ab490aaa523bdc67d3c9525a8733d6eb24654.log*
kube-apiserver-i-00ba7e3ab4af5bb67_kube-system_healthcheck-dde4a275e88871950633addd5dd2af278c5f8da2d6247e4d19d771f98d8ea3a3.log*
kube-apiserver-i-00ba7e3ab4af5bb67_kube-system_kube-apiserver-2a3328c28b0c3f5ae7b92ea8e6130fdaeace9852f80fd357d75929d15b67b2d2.log*
kube-apiserver-i-00ba7e3ab4af5bb67_kube-system_kube-apiserver-ffbecca14f142ada8a4f5a54847877b7996a0f84be4427e0f157aeaac6e7cbb8.log*
kube-apiserver.log
kube-container-runtime-monitor.log
kube-controller-manager-i-00ba7e3ab4af5bb67_kube-system_kube-controller-manager-93551660c08339adfbb1eab82127ecb7a9ebf7804f5558d0b556f9d5fd1f58ab.log*
kube-controller-manager-i-00ba7e3ab4af5bb67_kube-system_kube-controller-manager-bc527431ea34faf79ea46314fd2808962ce4f682be42d8c862a237f4f5d1ee79.log*
kube-controller-manager.log
kube-control_plane-configuration.log
kube-control_plane-installation.log
kubelet.log
kubelet-monitor.log
kube-proxy-i-00ba7e3ab4af5bb67_kube-system_kube-proxy-c66d688a218d87e94dc5b30981df83381b7f08fa1f9bb9fe10060a119f479f30.log*
kube-proxy.log
kube-scheduler-i-00ba7e3ab4af5bb67_kube-system_kube-scheduler-8e30917a85da4f89b1ec8b658bfc6aab0916ee42119a1b92c99e9dc232e9a3ec.log*
kube-scheduler.log
protokube.log
systemd.log
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
