### PR TITLE
Update node driver registrar expect check

### DIFF
--- a/development/kops/run_tests.sh
+++ b/development/kops/run_tests.sh
@@ -48,7 +48,7 @@ function k {
 function node_driver_registrar_expect {
     echo "node_driver_registrar_expect"
     k logs --selector app=csi-mockplugin --container node-driver-registrar  | \
-        grep "Registration Server started at: /registration/io.kubernetes.storage.mock-reg.sock"
+        grep "Registration Server started"
 }
 
 function liveness_probe_expect {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
[run_tests.sh](https://github.com/aws/eks-distro/blob/0bbc33aa4308291569e372be5684500049b88e34/development/kops/run_tests.sh#L48) checks for the success log output of node driver registrar logs. The logging has been [changed]( https://github.com/kubernetes-csi/node-driver-registrar/blob/master/cmd/csi-node-driver-registrar/node_register.go#L66
) and needs to be updated to check for the new output format
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
