### PR TITLE
fixes conf failures due to cilium upstream issue

### DIFF
--- a/development/kops/cluster_wait.sh
+++ b/development/kops/cluster_wait.sh
@@ -53,7 +53,7 @@ k apply -f metrics-server-0.6-clusterrole.yaml
 # kops doesnt support setting these cilium values
 # session affinity for conformance tess
 # kube-proxy disabled to make sure we are validating our kube-proxy
-k -n kube-system patch cm/cilium-config --type merge -p '{"data":{"enable-session-affinity":"true"}}'
+k -n kube-system patch cm/cilium-config --type merge -p '{"data":{"enable-session-affinity":"true","k8s-service-proxy-name":"cilium"}}'
 k -n kube-system rollout restart deployment/cilium-operator
 k -n kube-system rollout status deployment/cilium-operator --timeout=30s
 k -n kube-system delete pods -lk8s-app=cilium


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upstream has identified a fix for the failing conformance test: https://github.com/cncf/k8s-conformance/pull/3049#issuecomment-2113044276

We dont install with helm since kops handles it, but I am fairly certain this the resulting field in the config map based on their [chart](https://github.com/cilium/cilium/blob/38e100194058f85c8dcbf9c5d6f0aceb99130ab5/install/kubernetes/cilium/templates/cilium-configmap.yaml#L1082)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
