### PR TITLE
Revert "fixes conf failures due to cilium upstream issue (#3093)"

### DIFF
--- a/development/kops/cluster_wait.sh
+++ b/development/kops/cluster_wait.sh
@@ -53,7 +53,7 @@ k apply -f metrics-server-0.6-clusterrole.yaml
 # kops doesnt support setting these cilium values
 # session affinity for conformance tess
 # kube-proxy disabled to make sure we are validating our kube-proxy
-k -n kube-system patch cm/cilium-config --type merge -p '{"data":{"enable-session-affinity":"true","k8s-service-proxy-name":"cilium"}}'
+k -n kube-system patch cm/cilium-config --type merge -p '{"data":{"enable-session-affinity":"true"}}'
 k -n kube-system rollout restart deployment/cilium-operator
 k -n kube-system rollout status deployment/cilium-operator --timeout=30s
 k -n kube-system delete pods -lk8s-app=cilium


### PR DESCRIPTION
This reverts commit c8c5fefb67d64c517159e15acd8ce69af04897cd.

*Issue #, if available:*

*Description of changes:*
Additional failures occurred after this change. Reverting to fix for the time being

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
