### PR TITLE
Update make commands for releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,14 @@ update-release-numbers: update-dev-release-number update-prod-release-number
 update-all-release-numbers:
 	for r_b in $(SUPPORTED_RELEASE_BRANCHES); do RELEASE_BRANCH=$$r_b $(MAKE) update-release-numbers; done
 
+.PHONY: update-all-dev-release-numbers
+update-all-dev-release-numbers:
+	for r_b in $(SUPPORTED_RELEASE_BRANCHES); do RELEASE_BRANCH=$$r_b $(MAKE) update-dev-release-numbers; done
+
+.PHONY: update-all-prod-release-numbers
+update-all-prod-release-numbers:
+	for r_b in $(SUPPORTED_RELEASE_BRANCHES); do RELEASE_BRANCH=$$r_b $(MAKE) update-prod-release-numbers; done
+
 # See important note about minor releases in the Go function called.
 # release-docs is intended to be used to generate release docs for the latest release branch. If this command is used in
 # conjunction with release-docs-limited to make all the release docs for a new minor release, WITH_GIT_AND_PR should be

--- a/Makefile
+++ b/Makefile
@@ -234,11 +234,11 @@ update-all-release-numbers:
 
 .PHONY: update-all-dev-release-numbers
 update-all-dev-release-numbers:
-	for r_b in $(SUPPORTED_RELEASE_BRANCHES); do RELEASE_BRANCH=$$r_b $(MAKE) update-dev-release-numbers; done
+	for r_b in $(SUPPORTED_RELEASE_BRANCHES); do RELEASE_BRANCH=$$r_b $(MAKE) update-dev-release-number; done
 
 .PHONY: update-all-prod-release-numbers
 update-all-prod-release-numbers:
-	for r_b in $(SUPPORTED_RELEASE_BRANCHES); do RELEASE_BRANCH=$$r_b $(MAKE) update-prod-release-numbers; done
+	for r_b in $(SUPPORTED_RELEASE_BRANCHES); do RELEASE_BRANCH=$$r_b $(MAKE) update-prod-release-number; done
 
 # See important note about minor releases in the Go function called.
 # release-docs is intended to be used to generate release docs for the latest release branch. If this command is used in


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Due to the high number of K8s versions in the supported versions file, the make command to cut all release prs gets rate limited. To fix this adding two new make commands to cut all dev and all prod to be run separately and cuts down the number of commands to run.

Tested to cut this weeks dev releases: https://github.com/aws/eks-distro/pulls?q=is%3Apr+is%3Aopen+Bumped+development

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
