### PR TITLE
test network cni without cilium

### DIFF
--- a/development/kops/cluster_wait.sh
+++ b/development/kops/cluster_wait.sh
@@ -53,10 +53,10 @@ k apply -f metrics-server-0.6-clusterrole.yaml
 # kops doesnt support setting these cilium values
 # session affinity for conformance tess
 # kube-proxy disabled to make sure we are validating our kube-proxy
-k -n kube-system patch cm/cilium-config --type merge -p '{"data":{"enable-session-affinity":"true"}}'
-k -n kube-system rollout restart deployment/cilium-operator
-k -n kube-system rollout status deployment/cilium-operator --timeout=30s
-k -n kube-system delete pods -lk8s-app=cilium
+# k -n kube-system patch cm/cilium-config --type merge -p '{"data":{"enable-session-affinity":"true"}}'
+# k -n kube-system rollout restart deployment/cilium-operator
+# k -n kube-system rollout status deployment/cilium-operator --timeout=30s
+# k -n kube-system delete pods -lk8s-app=cilium
 
 set -x
 ${KOPS} validate cluster --wait 15m

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -48,8 +48,7 @@ spec:
   masterPublicName: api.{{ .clusterName }}
   networkCIDR: 172.20.0.0/16
   networking:
-    cilium:
-      chainingMode: portmap
+    cni: {}
   {{if .ipv6}}
   nonMasqueradeCIDR: ::/0
   {{else}}

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -48,7 +48,7 @@ spec:
   masterPublicName: api.{{ .clusterName }}
   networkCIDR: 172.20.0.0/16
   networking:
-    cni: {}
+    calico: {}
   {{if .ipv6}}
   nonMasqueradeCIDR: ::/0
   {{else}}


### PR DESCRIPTION
*Issue #, if available:*
Get passing EKS-D conformance for 1.29 and 1.30. 
Due to dependency on upstream, updating networking cni to calico. 

**Summarizing 1 Failure - test case with cilium:**
  [FAIL] [sig-network] Services [It] should serve endpoints on same port and different protocols [Conformance] [sig-network, Conformance]
  k8s.io/kubernetes/test/e2e/network/service.go:3737

Ran 402 of 7197 Specs in 6751.204 seconds
FAIL! -- 401 Passed | 1 Failed | 0 Pending | 6795 Skipped. --- FAIL: TestE2E (6751.72s)
Ginkgo ran 1 suite in 1h52m33.934433518s

Test Suite Failed

-------------------------------------------------------------------------------------------------------------------
 **Test results after the fix**
Ran 402 of 7197 Specs in 6364.067 seconds  SUCCESS! -- 402 Passed | 0 Failed | 0 Pending | 6795 Skipped
PASS

Ginkgo ran 1 suite in 1h46m5.790052881s

**Test Suite Passed**
2024/08/06 05:59:23 Saving results at /tmp/sonobuoy/results

