### PR TITLE
Created and updated docs for 1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Source: https://github.com/cncf/artwork/tree/master/projects/kubernetes/certifie
 
 | Release | Manifest | Kubernetes Version |
 | -- | --- | --- |
-| 38 | [v1-28-eks-38](https://distro.eks.amazonaws.com/kubernetes-1-28/kubernetes-1-28-eks-38.yaml) | [v1.28.15](https://github.com/kubernetes/kubernetes/release/tag/v1.28.15) |
+| 39 | [v1-28-eks-39](https://distro.eks.amazonaws.com/kubernetes-1-28/kubernetes-1-28-eks-39.yaml) | [v1.28.15](https://github.com/kubernetes/kubernetes/release/tag/v1.28.15) |
 
 ### Kubernetes 1.18 - 1.27: DEPRECATED
 

--- a/docs/contents/index.md
+++ b/docs/contents/index.md
@@ -179,6 +179,7 @@ if you are interested in the AL2 container runtime kernel version.
 * [v1-29-eks-1](releases/1-29/1/index.md) (December 16, 2023)
 
 #### EKS-D 1.28 Version Dependencies
+* [v1-28-eks-39](releases/1-28/39/index.md) (January 06, 2025)
 * [v1-28-eks-38](releases/1-28/38/index.md) (December 06, 2024)
 * [v1-28-eks-37](releases/1-28/37/index.md) (November 22, 2024)
 * [v1-28-eks-36](releases/1-28/36/index.md) (November 7, 2024)

--- a/docs/contents/releases/1-28/39/CHANGELOG-v1-28-eks-39.md
+++ b/docs/contents/releases/1-28/39/CHANGELOG-v1-28-eks-39.md
@@ -1,0 +1,16 @@
+# Changelog for v1-28-eks-39
+
+This changelog highlights the changes for [v1-28-eks-39](https://github.com/aws/eks-distro/tree/v1-28-eks-39).
+
+## Changes
+
+### Patches
+* Upgrade external-provisioner crypto v0.31.0 for CVE-2024-45337 ([3465](https://github.com/aws/eks-distro/pull/3465))
+* Update CHECKSUMS files ([3460](https://github.com/aws/eks-distro/pull/3460))
+
+### Projects
+* Bump kubernetes-csi/external-snapshotter to v8.2.0; Remove Snapshot Validation Webhook ([3458](https://github.com/aws/eks-distro/pull/3458))
+
+### Base Image
+* Update base image in tag file(s) ([3476](https://github.com/aws/eks-distro/pull/3476))
+

--- a/docs/contents/releases/1-28/39/index.md
+++ b/docs/contents/releases/1-28/39/index.md
@@ -1,0 +1,28 @@
+# EKS-D v1-28-eks-39 Release
+
+For additional information, see the [changelog](CHANGELOG-v1-28-eks-39.md) for this release.
+
+## Release Manifest
+
+Download the release manifest here: [kubernetes-1-28-eks-39.yaml](https://distro.eks.amazonaws.com/kubernetes-1-28/kubernetes-1-28-eks-39.yaml)
+
+| Name | Version | URI |
+|------|---------|-----|
+| aws-iam-authenticator | v0.6.28 | public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.6.28-eks-1-28-39 |
+| coredns | v1.11.1 | public.ecr.aws/eks-distro/coredns/coredns:v1.11.1-eks-1-28-39 |
+| csi-snapshotter | v8.2.0 | public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v8.2.0-eks-1-28-39 |
+| etcd | v3.5.15 | public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.15-eks-1-28-39 |
+| external-attacher | v4.7.0 | public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.7.0-eks-1-28-39 |
+| external-provisioner | v5.1.0 | public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v5.1.0-eks-1-28-39 |
+| external-resizer | v1.12.0 | public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.12.0-eks-1-28-39 |
+| go-runner | v0.15.1 | public.ecr.aws/eks-distro/kubernetes/go-runner:v0.15.1-eks-1-28-39 |
+| kube-apiserver | v1.28.15 | public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.28.15-eks-1-28-39 |
+| kube-controller-manager | v1.28.15 | public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.28.15-eks-1-28-39 |
+| kube-proxy | v1.28.15 | public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.28.15-eks-1-28-39 |
+| kube-proxy-base | v0.15.1 | public.ecr.aws/eks-distro/kubernetes/kube-proxy-base:v0.15.1-eks-1-28-39 |
+| kube-scheduler | v1.28.15 | public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.28.15-eks-1-28-39 |
+| livenessprobe | v2.14.0 | public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.14.0-eks-1-28-39 |
+| metrics-server | v0.7.2 | public.ecr.aws/eks-distro/kubernetes-sigs/metrics-server:v0.7.2-eks-1-28-39 |
+| node-driver-registrar | v2.12.0 | public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.12.0-eks-1-28-39 |
+| pause | v1.28.15 | public.ecr.aws/eks-distro/kubernetes/pause:v1.28.15-eks-1-28-39 |
+| snapshot-controller | v8.2.0 | public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/snapshot-controller:v8.2.0-eks-1-28-39 |

--- a/docs/contents/releases/1-28/39/release-announcement.txt
+++ b/docs/contents/releases/1-28/39/release-announcement.txt
@@ -1,0 +1,2 @@
+Amazon EKS Distro v1-28-eks-39 is now available. Builds are available through ECR Public Gallery (https://gallery.ecr.aws/eks-distro). The changelog and release manifest are available on GitHub (https://github.com/aws/eks-distro/releases).
+	


### PR DESCRIPTION
This is retroactively make up for the release on 12/26/2024.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.