### PR TITLE
Created and updated docs for 1.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Source: https://github.com/cncf/artwork/tree/master/projects/kubernetes/certifie
 
 | Release | Manifest | Kubernetes Version |
 | -- | --- | --- |
-| 27 | [v1-29-eks-27](https://distro.eks.amazonaws.com/kubernetes-1-29/kubernetes-1-29-eks-27.yaml) | [v1.29.11](https://github.com/kubernetes/kubernetes/release/tag/v1.29.11) |
+| 28 | [v1-29-eks-28](https://distro.eks.amazonaws.com/kubernetes-1-29/kubernetes-1-29-eks-28.yaml) | [v1.29.11](https://github.com/kubernetes/kubernetes/release/tag/v1.29.11) |
 
 ### Kubernetes 1-28
 

--- a/docs/contents/index.md
+++ b/docs/contents/index.md
@@ -150,6 +150,7 @@ if you are interested in the AL2 container runtime kernel version.
 * [v1-30-eks-5](releases/1-30/5/index.md) (May 28, 2024)
 
 #### EKS-D 1.29 Version Dependencies
+* [v1-29-eks-28](releases/1-29/28/index.md) (January 06, 2025)
 * [v1-29-eks-27](releases/1-29/27/index.md) (December 06, 2024)
 * [v1-29-eks-26](releases/1-29/26/index.md) (November 22, 2024)
 * [v1-29-eks-25](releases/1-29/25/index.md) (November 7, 2024)

--- a/docs/contents/releases/1-29/28/CHANGELOG-v1-29-eks-28.md
+++ b/docs/contents/releases/1-29/28/CHANGELOG-v1-29-eks-28.md
@@ -1,0 +1,19 @@
+# Changelog for v1-29-eks-28
+
+This changelog highlights the changes for [v1-29-eks-28](https://github.com/aws/eks-distro/tree/v1-29-eks-28).
+
+## Changes
+
+### Patches
+* livenessprobe: Address CVE-2024-45338 ([3481](https://github.com/aws/eks-distro/pull/3481))
+* external-attacher: Address CVE-2024-45338 ([3479](https://github.com/aws/eks-distro/pull/3479))
+* external-provisioner: Address CVE-2024-45338 ([3478](https://github.com/aws/eks-distro/pull/3478))
+* Upgrade external-provisioner crypto v0.31.0 for CVE-2024-45337 ([3465](https://github.com/aws/eks-distro/pull/3465))
+* Update CHECKSUMS files ([3460](https://github.com/aws/eks-distro/pull/3460))
+
+### Projects
+* Bump kubernetes-csi/external-snapshotter to v8.2.0; Remove Snapshot Validation Webhook ([3458](https://github.com/aws/eks-distro/pull/3458))
+
+### Base Image
+* Update base image in tag file(s) ([3476](https://github.com/aws/eks-distro/pull/3476))
+

--- a/docs/contents/releases/1-29/28/index.md
+++ b/docs/contents/releases/1-29/28/index.md
@@ -1,0 +1,28 @@
+# EKS-D v1-29-eks-28 Release
+
+For additional information, see the [changelog](CHANGELOG-v1-29-eks-28.md) for this release.
+
+## Release Manifest
+
+Download the release manifest here: [kubernetes-1-29-eks-28.yaml](https://distro.eks.amazonaws.com/kubernetes-1-29/kubernetes-1-29-eks-28.yaml)
+
+| Name | Version | URI |
+|------|---------|-----|
+| aws-iam-authenticator | v0.6.28 | public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.6.28-eks-1-29-28 |
+| coredns | v1.11.3 | public.ecr.aws/eks-distro/coredns/coredns:v1.11.3-eks-1-29-28 |
+| csi-snapshotter | v8.2.0 | public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v8.2.0-eks-1-29-28 |
+| etcd | v3.5.15 | public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.15-eks-1-29-28 |
+| external-attacher | v4.7.0 | public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.7.0-eks-1-29-28 |
+| external-provisioner | v5.1.0 | public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v5.1.0-eks-1-29-28 |
+| external-resizer | v1.12.0 | public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.12.0-eks-1-29-28 |
+| go-runner | v0.16.4 | public.ecr.aws/eks-distro/kubernetes/go-runner:v0.16.4-eks-1-29-28 |
+| kube-apiserver | v1.29.11 | public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.29.11-eks-1-29-28 |
+| kube-controller-manager | v1.29.11 | public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.29.11-eks-1-29-28 |
+| kube-proxy | v1.29.11 | public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.29.11-eks-1-29-28 |
+| kube-proxy-base | v0.16.4 | public.ecr.aws/eks-distro/kubernetes/kube-proxy-base:v0.16.4-eks-1-29-28 |
+| kube-scheduler | v1.29.11 | public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.29.11-eks-1-29-28 |
+| livenessprobe | v2.14.0 | public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.14.0-eks-1-29-28 |
+| metrics-server | v0.7.2 | public.ecr.aws/eks-distro/kubernetes-sigs/metrics-server:v0.7.2-eks-1-29-28 |
+| node-driver-registrar | v2.12.0 | public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.12.0-eks-1-29-28 |
+| pause | v1.29.11 | public.ecr.aws/eks-distro/kubernetes/pause:v1.29.11-eks-1-29-28 |
+| snapshot-controller | v8.2.0 | public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/snapshot-controller:v8.2.0-eks-1-29-28 |

--- a/docs/contents/releases/1-29/28/release-announcement.txt
+++ b/docs/contents/releases/1-29/28/release-announcement.txt
@@ -1,0 +1,2 @@
+Amazon EKS Distro v1-29-eks-28 is now available. Builds are available through ECR Public Gallery (https://gallery.ecr.aws/eks-distro). The changelog and release manifest are available on GitHub (https://github.com/aws/eks-distro/releases).
+	


### PR DESCRIPTION
This is to make up for the missing doc update on 12/26/2024

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.