### PR TITLE
Bump node-driver-registrar CVE-2024-45338 x/net to v0.34.0

### DIFF
--- a/projects/kubernetes-csi/node-driver-registrar/1-28/CHECKSUMS
+++ b/projects/kubernetes-csi/node-driver-registrar/1-28/CHECKSUMS
@@ -1,3 +1,3 @@
-0ca4501f2b1a03f701eb5006b522ee5aff86877ab4e02b7936837fe1de384459  _output/1-28/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
-5c4f5c7066c59b63639b8ce856b3778d29fbc2c8a423d9fd10db287506901ae9  _output/1-28/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
-0227bc3c92dca435534543b3dbba8436c0dabb8994976c5657730c0e4063f17d  _output/1-28/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe
+660b5d1bec627ebc2f524a5ec02a5390f432c8cf671f65fba573cbbd6ceb6094  _output/1-28/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
+617189c0ece4c26029c7696b2926cca64c9bbfcba8f216c84374eca70ed92d0e  _output/1-28/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+c795d7ea1e21a247196a54e7deab859fa23a3299bc2caf1eb584e137b45648ab  _output/1-28/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe

--- a/projects/kubernetes-csi/node-driver-registrar/1-28/patches/0001-Bump-node-driver-registrar-CVE-2024-45338-x-net-to-v.patch
+++ b/projects/kubernetes-csi/node-driver-registrar/1-28/patches/0001-Bump-node-driver-registrar-CVE-2024-45338-x-net-to-v.patch
@@ -1,0 +1,220 @@
+From cc22a8e194806e9f8f1aef6172b616b51e4420fd Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Mon, 3 Feb 2025 12:17:16 -0500
+Subject: [PATCH] Bump node-driver-registrar CVE-2024-45338 x/net to v0.34.0
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                            |  4 ++--
+ go.sum                                            |  8 ++++----
+ vendor/golang.org/x/net/http2/config.go           |  2 +-
+ vendor/golang.org/x/net/http2/config_go124.go     |  2 +-
+ vendor/golang.org/x/net/http2/transport.go        | 13 ++++++++++---
+ vendor/golang.org/x/sys/unix/syscall_dragonfly.go | 12 ++++++++++++
+ vendor/golang.org/x/sys/windows/dll_windows.go    | 11 +++++------
+ vendor/modules.txt                                |  4 ++--
+ 8 files changed, 37 insertions(+), 19 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 5d2e5659..12a340c8 100644
+--- a/go.mod
++++ b/go.mod
+@@ -4,7 +4,7 @@ go 1.23.1
+ 
+ require (
+ 	github.com/kubernetes-csi/csi-lib-utils v0.20.0
+-	golang.org/x/sys v0.28.0
++	golang.org/x/sys v0.29.0
+ 	google.golang.org/grpc v1.69.0
+ 	k8s.io/client-go v0.32.0
+ 	k8s.io/component-base v0.32.0
+@@ -52,7 +52,7 @@ require (
+ 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.27.0 // indirect
+-	golang.org/x/net v0.32.0 // indirect
++	golang.org/x/net v0.34.0 // indirect
+ 	golang.org/x/text v0.21.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241216192217-9240e9c98484 // indirect
+ 	google.golang.org/protobuf v1.36.0 // indirect
+diff --git a/go.sum b/go.sum
+index 79246602..6e3c77c7 100644
+--- a/go.sum
++++ b/go.sum
+@@ -124,16 +124,16 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
+ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+-golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
+-golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
++golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
++golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
++golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+diff --git a/vendor/golang.org/x/net/http2/config.go b/vendor/golang.org/x/net/http2/config.go
+index de58dfb8..ca645d9a 100644
+--- a/vendor/golang.org/x/net/http2/config.go
++++ b/vendor/golang.org/x/net/http2/config.go
+@@ -60,7 +60,7 @@ func configFromServer(h1 *http.Server, h2 *Server) http2Config {
+ 	return conf
+ }
+ 
+-// configFromServer merges configuration settings from h2 and h2.t1.HTTP2
++// configFromTransport merges configuration settings from h2 and h2.t1.HTTP2
+ // (the net/http Transport).
+ func configFromTransport(h2 *Transport) http2Config {
+ 	conf := http2Config{
+diff --git a/vendor/golang.org/x/net/http2/config_go124.go b/vendor/golang.org/x/net/http2/config_go124.go
+index e3784123..5b516c55 100644
+--- a/vendor/golang.org/x/net/http2/config_go124.go
++++ b/vendor/golang.org/x/net/http2/config_go124.go
+@@ -13,7 +13,7 @@ func fillNetHTTPServerConfig(conf *http2Config, srv *http.Server) {
+ 	fillNetHTTPConfig(conf, srv.HTTP2)
+ }
+ 
+-// fillNetHTTPServerConfig sets fields in conf from tr.HTTP2.
++// fillNetHTTPTransportConfig sets fields in conf from tr.HTTP2.
+ func fillNetHTTPTransportConfig(conf *http2Config, tr *http.Transport) {
+ 	fillNetHTTPConfig(conf, tr.HTTP2)
+ }
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index 090d0e1b..b2e2ed33 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -375,6 +375,7 @@ type ClientConn struct {
+ 	doNotReuse       bool       // whether conn is marked to not be reused for any future requests
+ 	closing          bool
+ 	closed           bool
++	closedOnIdle     bool                     // true if conn was closed for idleness
+ 	seenSettings     bool                     // true if we've seen a settings frame, false otherwise
+ 	seenSettingsChan chan struct{}            // closed when seenSettings is true or frame reading fails
+ 	wantSettingsAck  bool                     // we sent a SETTINGS frame and haven't heard back
+@@ -1089,10 +1090,12 @@ func (cc *ClientConn) idleStateLocked() (st clientConnIdleState) {
+ 
+ 	// If this connection has never been used for a request and is closed,
+ 	// then let it take a request (which will fail).
++	// If the conn was closed for idleness, we're racing the idle timer;
++	// don't try to use the conn. (Issue #70515.)
+ 	//
+ 	// This avoids a situation where an error early in a connection's lifetime
+ 	// goes unreported.
+-	if cc.nextStreamID == 1 && cc.streamsReserved == 0 && cc.closed {
++	if cc.nextStreamID == 1 && cc.streamsReserved == 0 && cc.closed && !cc.closedOnIdle {
+ 		st.canTakeNewRequest = true
+ 	}
+ 
+@@ -1155,6 +1158,7 @@ func (cc *ClientConn) closeIfIdle() {
+ 		return
+ 	}
+ 	cc.closed = true
++	cc.closedOnIdle = true
+ 	nextID := cc.nextStreamID
+ 	// TODO: do clients send GOAWAY too? maybe? Just Close:
+ 	cc.mu.Unlock()
+@@ -2434,9 +2438,12 @@ func (rl *clientConnReadLoop) cleanup() {
+ 	// This avoids a situation where new connections are constantly created,
+ 	// added to the pool, fail, and are removed from the pool, without any error
+ 	// being surfaced to the user.
+-	const unusedWaitTime = 5 * time.Second
++	unusedWaitTime := 5 * time.Second
++	if cc.idleTimeout > 0 && unusedWaitTime > cc.idleTimeout {
++		unusedWaitTime = cc.idleTimeout
++	}
+ 	idleTime := cc.t.now().Sub(cc.lastActive)
+-	if atomic.LoadUint32(&cc.atomicReused) == 0 && idleTime < unusedWaitTime {
++	if atomic.LoadUint32(&cc.atomicReused) == 0 && idleTime < unusedWaitTime && !cc.closedOnIdle {
+ 		cc.idleTimer = cc.t.afterFunc(unusedWaitTime-idleTime, func() {
+ 			cc.t.connPool().MarkDead(cc)
+ 		})
+diff --git a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+index 97cb916f..be8c0020 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
++++ b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+@@ -246,6 +246,18 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ 	return sendfile(outfd, infd, offset, count)
+ }
+ 
++func Dup3(oldfd, newfd, flags int) error {
++	if oldfd == newfd || flags&^O_CLOEXEC != 0 {
++		return EINVAL
++	}
++	how := F_DUP2FD
++	if flags&O_CLOEXEC != 0 {
++		how = F_DUP2FD_CLOEXEC
++	}
++	_, err := fcntl(oldfd, how, newfd)
++	return err
++}
++
+ /*
+  * Exposed directly
+  */
+diff --git a/vendor/golang.org/x/sys/windows/dll_windows.go b/vendor/golang.org/x/sys/windows/dll_windows.go
+index 4e613cf6..3ca814f5 100644
+--- a/vendor/golang.org/x/sys/windows/dll_windows.go
++++ b/vendor/golang.org/x/sys/windows/dll_windows.go
+@@ -43,8 +43,8 @@ type DLL struct {
+ // LoadDLL loads DLL file into memory.
+ //
+ // Warning: using LoadDLL without an absolute path name is subject to
+-// DLL preloading attacks. To safely load a system DLL, use LazyDLL
+-// with System set to true, or use LoadLibraryEx directly.
++// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL],
++// or use [LoadLibraryEx] directly.
+ func LoadDLL(name string) (dll *DLL, err error) {
+ 	namep, err := UTF16PtrFromString(name)
+ 	if err != nil {
+@@ -271,6 +271,9 @@ func (d *LazyDLL) NewProc(name string) *LazyProc {
+ }
+ 
+ // NewLazyDLL creates new LazyDLL associated with DLL file.
++//
++// Warning: using NewLazyDLL without an absolute path name is subject to
++// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL].
+ func NewLazyDLL(name string) *LazyDLL {
+ 	return &LazyDLL{Name: name}
+ }
+@@ -410,7 +413,3 @@ func loadLibraryEx(name string, system bool) (*DLL, error) {
+ 	}
+ 	return &DLL{Name: name, Handle: h}, nil
+ }
+-
+-type errString string
+-
+-func (s errString) Error() string { return string(s) }
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index b11cdeda..9a0b6d45 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -177,7 +177,7 @@ go.uber.org/zap/internal/exit
+ go.uber.org/zap/internal/pool
+ go.uber.org/zap/internal/stacktrace
+ go.uber.org/zap/zapcore
+-# golang.org/x/net v0.32.0
++# golang.org/x/net v0.34.0
+ ## explicit; go 1.18
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -185,7 +185,7 @@ golang.org/x/net/http2/hpack
+ golang.org/x/net/idna
+ golang.org/x/net/internal/timeseries
+ golang.org/x/net/trace
+-# golang.org/x/sys v0.28.0
++# golang.org/x/sys v0.29.0
+ ## explicit; go 1.18
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-- 
+2.45.1
+

--- a/projects/kubernetes-csi/node-driver-registrar/1-29/CHECKSUMS
+++ b/projects/kubernetes-csi/node-driver-registrar/1-29/CHECKSUMS
@@ -1,3 +1,3 @@
-0ca4501f2b1a03f701eb5006b522ee5aff86877ab4e02b7936837fe1de384459  _output/1-29/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
-5c4f5c7066c59b63639b8ce856b3778d29fbc2c8a423d9fd10db287506901ae9  _output/1-29/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
-0227bc3c92dca435534543b3dbba8436c0dabb8994976c5657730c0e4063f17d  _output/1-29/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe
+660b5d1bec627ebc2f524a5ec02a5390f432c8cf671f65fba573cbbd6ceb6094  _output/1-29/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
+617189c0ece4c26029c7696b2926cca64c9bbfcba8f216c84374eca70ed92d0e  _output/1-29/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+c795d7ea1e21a247196a54e7deab859fa23a3299bc2caf1eb584e137b45648ab  _output/1-29/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe

--- a/projects/kubernetes-csi/node-driver-registrar/1-29/patches/0001-Bump-node-driver-registrar-CVE-2024-45338-x-net-to-v.patch
+++ b/projects/kubernetes-csi/node-driver-registrar/1-29/patches/0001-Bump-node-driver-registrar-CVE-2024-45338-x-net-to-v.patch
@@ -1,0 +1,220 @@
+From cc22a8e194806e9f8f1aef6172b616b51e4420fd Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Mon, 3 Feb 2025 12:17:16 -0500
+Subject: [PATCH] Bump node-driver-registrar CVE-2024-45338 x/net to v0.34.0
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                            |  4 ++--
+ go.sum                                            |  8 ++++----
+ vendor/golang.org/x/net/http2/config.go           |  2 +-
+ vendor/golang.org/x/net/http2/config_go124.go     |  2 +-
+ vendor/golang.org/x/net/http2/transport.go        | 13 ++++++++++---
+ vendor/golang.org/x/sys/unix/syscall_dragonfly.go | 12 ++++++++++++
+ vendor/golang.org/x/sys/windows/dll_windows.go    | 11 +++++------
+ vendor/modules.txt                                |  4 ++--
+ 8 files changed, 37 insertions(+), 19 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 5d2e5659..12a340c8 100644
+--- a/go.mod
++++ b/go.mod
+@@ -4,7 +4,7 @@ go 1.23.1
+ 
+ require (
+ 	github.com/kubernetes-csi/csi-lib-utils v0.20.0
+-	golang.org/x/sys v0.28.0
++	golang.org/x/sys v0.29.0
+ 	google.golang.org/grpc v1.69.0
+ 	k8s.io/client-go v0.32.0
+ 	k8s.io/component-base v0.32.0
+@@ -52,7 +52,7 @@ require (
+ 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.27.0 // indirect
+-	golang.org/x/net v0.32.0 // indirect
++	golang.org/x/net v0.34.0 // indirect
+ 	golang.org/x/text v0.21.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241216192217-9240e9c98484 // indirect
+ 	google.golang.org/protobuf v1.36.0 // indirect
+diff --git a/go.sum b/go.sum
+index 79246602..6e3c77c7 100644
+--- a/go.sum
++++ b/go.sum
+@@ -124,16 +124,16 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
+ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+-golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
+-golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
++golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
++golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
++golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+diff --git a/vendor/golang.org/x/net/http2/config.go b/vendor/golang.org/x/net/http2/config.go
+index de58dfb8..ca645d9a 100644
+--- a/vendor/golang.org/x/net/http2/config.go
++++ b/vendor/golang.org/x/net/http2/config.go
+@@ -60,7 +60,7 @@ func configFromServer(h1 *http.Server, h2 *Server) http2Config {
+ 	return conf
+ }
+ 
+-// configFromServer merges configuration settings from h2 and h2.t1.HTTP2
++// configFromTransport merges configuration settings from h2 and h2.t1.HTTP2
+ // (the net/http Transport).
+ func configFromTransport(h2 *Transport) http2Config {
+ 	conf := http2Config{
+diff --git a/vendor/golang.org/x/net/http2/config_go124.go b/vendor/golang.org/x/net/http2/config_go124.go
+index e3784123..5b516c55 100644
+--- a/vendor/golang.org/x/net/http2/config_go124.go
++++ b/vendor/golang.org/x/net/http2/config_go124.go
+@@ -13,7 +13,7 @@ func fillNetHTTPServerConfig(conf *http2Config, srv *http.Server) {
+ 	fillNetHTTPConfig(conf, srv.HTTP2)
+ }
+ 
+-// fillNetHTTPServerConfig sets fields in conf from tr.HTTP2.
++// fillNetHTTPTransportConfig sets fields in conf from tr.HTTP2.
+ func fillNetHTTPTransportConfig(conf *http2Config, tr *http.Transport) {
+ 	fillNetHTTPConfig(conf, tr.HTTP2)
+ }
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index 090d0e1b..b2e2ed33 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -375,6 +375,7 @@ type ClientConn struct {
+ 	doNotReuse       bool       // whether conn is marked to not be reused for any future requests
+ 	closing          bool
+ 	closed           bool
++	closedOnIdle     bool                     // true if conn was closed for idleness
+ 	seenSettings     bool                     // true if we've seen a settings frame, false otherwise
+ 	seenSettingsChan chan struct{}            // closed when seenSettings is true or frame reading fails
+ 	wantSettingsAck  bool                     // we sent a SETTINGS frame and haven't heard back
+@@ -1089,10 +1090,12 @@ func (cc *ClientConn) idleStateLocked() (st clientConnIdleState) {
+ 
+ 	// If this connection has never been used for a request and is closed,
+ 	// then let it take a request (which will fail).
++	// If the conn was closed for idleness, we're racing the idle timer;
++	// don't try to use the conn. (Issue #70515.)
+ 	//
+ 	// This avoids a situation where an error early in a connection's lifetime
+ 	// goes unreported.
+-	if cc.nextStreamID == 1 && cc.streamsReserved == 0 && cc.closed {
++	if cc.nextStreamID == 1 && cc.streamsReserved == 0 && cc.closed && !cc.closedOnIdle {
+ 		st.canTakeNewRequest = true
+ 	}
+ 
+@@ -1155,6 +1158,7 @@ func (cc *ClientConn) closeIfIdle() {
+ 		return
+ 	}
+ 	cc.closed = true
++	cc.closedOnIdle = true
+ 	nextID := cc.nextStreamID
+ 	// TODO: do clients send GOAWAY too? maybe? Just Close:
+ 	cc.mu.Unlock()
+@@ -2434,9 +2438,12 @@ func (rl *clientConnReadLoop) cleanup() {
+ 	// This avoids a situation where new connections are constantly created,
+ 	// added to the pool, fail, and are removed from the pool, without any error
+ 	// being surfaced to the user.
+-	const unusedWaitTime = 5 * time.Second
++	unusedWaitTime := 5 * time.Second
++	if cc.idleTimeout > 0 && unusedWaitTime > cc.idleTimeout {
++		unusedWaitTime = cc.idleTimeout
++	}
+ 	idleTime := cc.t.now().Sub(cc.lastActive)
+-	if atomic.LoadUint32(&cc.atomicReused) == 0 && idleTime < unusedWaitTime {
++	if atomic.LoadUint32(&cc.atomicReused) == 0 && idleTime < unusedWaitTime && !cc.closedOnIdle {
+ 		cc.idleTimer = cc.t.afterFunc(unusedWaitTime-idleTime, func() {
+ 			cc.t.connPool().MarkDead(cc)
+ 		})
+diff --git a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+index 97cb916f..be8c0020 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
++++ b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+@@ -246,6 +246,18 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ 	return sendfile(outfd, infd, offset, count)
+ }
+ 
++func Dup3(oldfd, newfd, flags int) error {
++	if oldfd == newfd || flags&^O_CLOEXEC != 0 {
++		return EINVAL
++	}
++	how := F_DUP2FD
++	if flags&O_CLOEXEC != 0 {
++		how = F_DUP2FD_CLOEXEC
++	}
++	_, err := fcntl(oldfd, how, newfd)
++	return err
++}
++
+ /*
+  * Exposed directly
+  */
+diff --git a/vendor/golang.org/x/sys/windows/dll_windows.go b/vendor/golang.org/x/sys/windows/dll_windows.go
+index 4e613cf6..3ca814f5 100644
+--- a/vendor/golang.org/x/sys/windows/dll_windows.go
++++ b/vendor/golang.org/x/sys/windows/dll_windows.go
+@@ -43,8 +43,8 @@ type DLL struct {
+ // LoadDLL loads DLL file into memory.
+ //
+ // Warning: using LoadDLL without an absolute path name is subject to
+-// DLL preloading attacks. To safely load a system DLL, use LazyDLL
+-// with System set to true, or use LoadLibraryEx directly.
++// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL],
++// or use [LoadLibraryEx] directly.
+ func LoadDLL(name string) (dll *DLL, err error) {
+ 	namep, err := UTF16PtrFromString(name)
+ 	if err != nil {
+@@ -271,6 +271,9 @@ func (d *LazyDLL) NewProc(name string) *LazyProc {
+ }
+ 
+ // NewLazyDLL creates new LazyDLL associated with DLL file.
++//
++// Warning: using NewLazyDLL without an absolute path name is subject to
++// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL].
+ func NewLazyDLL(name string) *LazyDLL {
+ 	return &LazyDLL{Name: name}
+ }
+@@ -410,7 +413,3 @@ func loadLibraryEx(name string, system bool) (*DLL, error) {
+ 	}
+ 	return &DLL{Name: name, Handle: h}, nil
+ }
+-
+-type errString string
+-
+-func (s errString) Error() string { return string(s) }
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index b11cdeda..9a0b6d45 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -177,7 +177,7 @@ go.uber.org/zap/internal/exit
+ go.uber.org/zap/internal/pool
+ go.uber.org/zap/internal/stacktrace
+ go.uber.org/zap/zapcore
+-# golang.org/x/net v0.32.0
++# golang.org/x/net v0.34.0
+ ## explicit; go 1.18
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -185,7 +185,7 @@ golang.org/x/net/http2/hpack
+ golang.org/x/net/idna
+ golang.org/x/net/internal/timeseries
+ golang.org/x/net/trace
+-# golang.org/x/sys v0.28.0
++# golang.org/x/sys v0.29.0
+ ## explicit; go 1.18
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-- 
+2.45.1
+

--- a/projects/kubernetes-csi/node-driver-registrar/1-30/CHECKSUMS
+++ b/projects/kubernetes-csi/node-driver-registrar/1-30/CHECKSUMS
@@ -1,3 +1,3 @@
-0ca4501f2b1a03f701eb5006b522ee5aff86877ab4e02b7936837fe1de384459  _output/1-30/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
-5c4f5c7066c59b63639b8ce856b3778d29fbc2c8a423d9fd10db287506901ae9  _output/1-30/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
-0227bc3c92dca435534543b3dbba8436c0dabb8994976c5657730c0e4063f17d  _output/1-30/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe
+660b5d1bec627ebc2f524a5ec02a5390f432c8cf671f65fba573cbbd6ceb6094  _output/1-30/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
+617189c0ece4c26029c7696b2926cca64c9bbfcba8f216c84374eca70ed92d0e  _output/1-30/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+c795d7ea1e21a247196a54e7deab859fa23a3299bc2caf1eb584e137b45648ab  _output/1-30/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe

--- a/projects/kubernetes-csi/node-driver-registrar/1-30/patches/0001-Bump-node-driver-registrar-CVE-2024-45338-x-net-to-v.patch
+++ b/projects/kubernetes-csi/node-driver-registrar/1-30/patches/0001-Bump-node-driver-registrar-CVE-2024-45338-x-net-to-v.patch
@@ -1,0 +1,220 @@
+From cc22a8e194806e9f8f1aef6172b616b51e4420fd Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Mon, 3 Feb 2025 12:17:16 -0500
+Subject: [PATCH] Bump node-driver-registrar CVE-2024-45338 x/net to v0.34.0
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                            |  4 ++--
+ go.sum                                            |  8 ++++----
+ vendor/golang.org/x/net/http2/config.go           |  2 +-
+ vendor/golang.org/x/net/http2/config_go124.go     |  2 +-
+ vendor/golang.org/x/net/http2/transport.go        | 13 ++++++++++---
+ vendor/golang.org/x/sys/unix/syscall_dragonfly.go | 12 ++++++++++++
+ vendor/golang.org/x/sys/windows/dll_windows.go    | 11 +++++------
+ vendor/modules.txt                                |  4 ++--
+ 8 files changed, 37 insertions(+), 19 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 5d2e5659..12a340c8 100644
+--- a/go.mod
++++ b/go.mod
+@@ -4,7 +4,7 @@ go 1.23.1
+ 
+ require (
+ 	github.com/kubernetes-csi/csi-lib-utils v0.20.0
+-	golang.org/x/sys v0.28.0
++	golang.org/x/sys v0.29.0
+ 	google.golang.org/grpc v1.69.0
+ 	k8s.io/client-go v0.32.0
+ 	k8s.io/component-base v0.32.0
+@@ -52,7 +52,7 @@ require (
+ 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.27.0 // indirect
+-	golang.org/x/net v0.32.0 // indirect
++	golang.org/x/net v0.34.0 // indirect
+ 	golang.org/x/text v0.21.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241216192217-9240e9c98484 // indirect
+ 	google.golang.org/protobuf v1.36.0 // indirect
+diff --git a/go.sum b/go.sum
+index 79246602..6e3c77c7 100644
+--- a/go.sum
++++ b/go.sum
+@@ -124,16 +124,16 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
+ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+-golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
+-golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
++golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
++golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
++golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+diff --git a/vendor/golang.org/x/net/http2/config.go b/vendor/golang.org/x/net/http2/config.go
+index de58dfb8..ca645d9a 100644
+--- a/vendor/golang.org/x/net/http2/config.go
++++ b/vendor/golang.org/x/net/http2/config.go
+@@ -60,7 +60,7 @@ func configFromServer(h1 *http.Server, h2 *Server) http2Config {
+ 	return conf
+ }
+ 
+-// configFromServer merges configuration settings from h2 and h2.t1.HTTP2
++// configFromTransport merges configuration settings from h2 and h2.t1.HTTP2
+ // (the net/http Transport).
+ func configFromTransport(h2 *Transport) http2Config {
+ 	conf := http2Config{
+diff --git a/vendor/golang.org/x/net/http2/config_go124.go b/vendor/golang.org/x/net/http2/config_go124.go
+index e3784123..5b516c55 100644
+--- a/vendor/golang.org/x/net/http2/config_go124.go
++++ b/vendor/golang.org/x/net/http2/config_go124.go
+@@ -13,7 +13,7 @@ func fillNetHTTPServerConfig(conf *http2Config, srv *http.Server) {
+ 	fillNetHTTPConfig(conf, srv.HTTP2)
+ }
+ 
+-// fillNetHTTPServerConfig sets fields in conf from tr.HTTP2.
++// fillNetHTTPTransportConfig sets fields in conf from tr.HTTP2.
+ func fillNetHTTPTransportConfig(conf *http2Config, tr *http.Transport) {
+ 	fillNetHTTPConfig(conf, tr.HTTP2)
+ }
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index 090d0e1b..b2e2ed33 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -375,6 +375,7 @@ type ClientConn struct {
+ 	doNotReuse       bool       // whether conn is marked to not be reused for any future requests
+ 	closing          bool
+ 	closed           bool
++	closedOnIdle     bool                     // true if conn was closed for idleness
+ 	seenSettings     bool                     // true if we've seen a settings frame, false otherwise
+ 	seenSettingsChan chan struct{}            // closed when seenSettings is true or frame reading fails
+ 	wantSettingsAck  bool                     // we sent a SETTINGS frame and haven't heard back
+@@ -1089,10 +1090,12 @@ func (cc *ClientConn) idleStateLocked() (st clientConnIdleState) {
+ 
+ 	// If this connection has never been used for a request and is closed,
+ 	// then let it take a request (which will fail).
++	// If the conn was closed for idleness, we're racing the idle timer;
++	// don't try to use the conn. (Issue #70515.)
+ 	//
+ 	// This avoids a situation where an error early in a connection's lifetime
+ 	// goes unreported.
+-	if cc.nextStreamID == 1 && cc.streamsReserved == 0 && cc.closed {
++	if cc.nextStreamID == 1 && cc.streamsReserved == 0 && cc.closed && !cc.closedOnIdle {
+ 		st.canTakeNewRequest = true
+ 	}
+ 
+@@ -1155,6 +1158,7 @@ func (cc *ClientConn) closeIfIdle() {
+ 		return
+ 	}
+ 	cc.closed = true
++	cc.closedOnIdle = true
+ 	nextID := cc.nextStreamID
+ 	// TODO: do clients send GOAWAY too? maybe? Just Close:
+ 	cc.mu.Unlock()
+@@ -2434,9 +2438,12 @@ func (rl *clientConnReadLoop) cleanup() {
+ 	// This avoids a situation where new connections are constantly created,
+ 	// added to the pool, fail, and are removed from the pool, without any error
+ 	// being surfaced to the user.
+-	const unusedWaitTime = 5 * time.Second
++	unusedWaitTime := 5 * time.Second
++	if cc.idleTimeout > 0 && unusedWaitTime > cc.idleTimeout {
++		unusedWaitTime = cc.idleTimeout
++	}
+ 	idleTime := cc.t.now().Sub(cc.lastActive)
+-	if atomic.LoadUint32(&cc.atomicReused) == 0 && idleTime < unusedWaitTime {
++	if atomic.LoadUint32(&cc.atomicReused) == 0 && idleTime < unusedWaitTime && !cc.closedOnIdle {
+ 		cc.idleTimer = cc.t.afterFunc(unusedWaitTime-idleTime, func() {
+ 			cc.t.connPool().MarkDead(cc)
+ 		})
+diff --git a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+index 97cb916f..be8c0020 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
++++ b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+@@ -246,6 +246,18 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ 	return sendfile(outfd, infd, offset, count)
+ }
+ 
++func Dup3(oldfd, newfd, flags int) error {
++	if oldfd == newfd || flags&^O_CLOEXEC != 0 {
++		return EINVAL
++	}
++	how := F_DUP2FD
++	if flags&O_CLOEXEC != 0 {
++		how = F_DUP2FD_CLOEXEC
++	}
++	_, err := fcntl(oldfd, how, newfd)
++	return err
++}
++
+ /*
+  * Exposed directly
+  */
+diff --git a/vendor/golang.org/x/sys/windows/dll_windows.go b/vendor/golang.org/x/sys/windows/dll_windows.go
+index 4e613cf6..3ca814f5 100644
+--- a/vendor/golang.org/x/sys/windows/dll_windows.go
++++ b/vendor/golang.org/x/sys/windows/dll_windows.go
+@@ -43,8 +43,8 @@ type DLL struct {
+ // LoadDLL loads DLL file into memory.
+ //
+ // Warning: using LoadDLL without an absolute path name is subject to
+-// DLL preloading attacks. To safely load a system DLL, use LazyDLL
+-// with System set to true, or use LoadLibraryEx directly.
++// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL],
++// or use [LoadLibraryEx] directly.
+ func LoadDLL(name string) (dll *DLL, err error) {
+ 	namep, err := UTF16PtrFromString(name)
+ 	if err != nil {
+@@ -271,6 +271,9 @@ func (d *LazyDLL) NewProc(name string) *LazyProc {
+ }
+ 
+ // NewLazyDLL creates new LazyDLL associated with DLL file.
++//
++// Warning: using NewLazyDLL without an absolute path name is subject to
++// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL].
+ func NewLazyDLL(name string) *LazyDLL {
+ 	return &LazyDLL{Name: name}
+ }
+@@ -410,7 +413,3 @@ func loadLibraryEx(name string, system bool) (*DLL, error) {
+ 	}
+ 	return &DLL{Name: name, Handle: h}, nil
+ }
+-
+-type errString string
+-
+-func (s errString) Error() string { return string(s) }
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index b11cdeda..9a0b6d45 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -177,7 +177,7 @@ go.uber.org/zap/internal/exit
+ go.uber.org/zap/internal/pool
+ go.uber.org/zap/internal/stacktrace
+ go.uber.org/zap/zapcore
+-# golang.org/x/net v0.32.0
++# golang.org/x/net v0.34.0
+ ## explicit; go 1.18
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -185,7 +185,7 @@ golang.org/x/net/http2/hpack
+ golang.org/x/net/idna
+ golang.org/x/net/internal/timeseries
+ golang.org/x/net/trace
+-# golang.org/x/sys v0.28.0
++# golang.org/x/sys v0.29.0
+ ## explicit; go 1.18
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-- 
+2.45.1
+

--- a/projects/kubernetes-csi/node-driver-registrar/1-31/CHECKSUMS
+++ b/projects/kubernetes-csi/node-driver-registrar/1-31/CHECKSUMS
@@ -1,3 +1,3 @@
-0ca4501f2b1a03f701eb5006b522ee5aff86877ab4e02b7936837fe1de384459  _output/1-31/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
-5c4f5c7066c59b63639b8ce856b3778d29fbc2c8a423d9fd10db287506901ae9  _output/1-31/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
-0227bc3c92dca435534543b3dbba8436c0dabb8994976c5657730c0e4063f17d  _output/1-31/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe
+660b5d1bec627ebc2f524a5ec02a5390f432c8cf671f65fba573cbbd6ceb6094  _output/1-31/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
+617189c0ece4c26029c7696b2926cca64c9bbfcba8f216c84374eca70ed92d0e  _output/1-31/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+c795d7ea1e21a247196a54e7deab859fa23a3299bc2caf1eb584e137b45648ab  _output/1-31/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe

--- a/projects/kubernetes-csi/node-driver-registrar/1-31/patches/0001-Bump-node-driver-registrar-CVE-2024-45338-x-net-to-v.patch
+++ b/projects/kubernetes-csi/node-driver-registrar/1-31/patches/0001-Bump-node-driver-registrar-CVE-2024-45338-x-net-to-v.patch
@@ -1,0 +1,220 @@
+From cc22a8e194806e9f8f1aef6172b616b51e4420fd Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Mon, 3 Feb 2025 12:17:16 -0500
+Subject: [PATCH] Bump node-driver-registrar CVE-2024-45338 x/net to v0.34.0
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                            |  4 ++--
+ go.sum                                            |  8 ++++----
+ vendor/golang.org/x/net/http2/config.go           |  2 +-
+ vendor/golang.org/x/net/http2/config_go124.go     |  2 +-
+ vendor/golang.org/x/net/http2/transport.go        | 13 ++++++++++---
+ vendor/golang.org/x/sys/unix/syscall_dragonfly.go | 12 ++++++++++++
+ vendor/golang.org/x/sys/windows/dll_windows.go    | 11 +++++------
+ vendor/modules.txt                                |  4 ++--
+ 8 files changed, 37 insertions(+), 19 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 5d2e5659..12a340c8 100644
+--- a/go.mod
++++ b/go.mod
+@@ -4,7 +4,7 @@ go 1.23.1
+ 
+ require (
+ 	github.com/kubernetes-csi/csi-lib-utils v0.20.0
+-	golang.org/x/sys v0.28.0
++	golang.org/x/sys v0.29.0
+ 	google.golang.org/grpc v1.69.0
+ 	k8s.io/client-go v0.32.0
+ 	k8s.io/component-base v0.32.0
+@@ -52,7 +52,7 @@ require (
+ 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.27.0 // indirect
+-	golang.org/x/net v0.32.0 // indirect
++	golang.org/x/net v0.34.0 // indirect
+ 	golang.org/x/text v0.21.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241216192217-9240e9c98484 // indirect
+ 	google.golang.org/protobuf v1.36.0 // indirect
+diff --git a/go.sum b/go.sum
+index 79246602..6e3c77c7 100644
+--- a/go.sum
++++ b/go.sum
+@@ -124,16 +124,16 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
+ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+-golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
+-golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
++golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
++golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
++golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+diff --git a/vendor/golang.org/x/net/http2/config.go b/vendor/golang.org/x/net/http2/config.go
+index de58dfb8..ca645d9a 100644
+--- a/vendor/golang.org/x/net/http2/config.go
++++ b/vendor/golang.org/x/net/http2/config.go
+@@ -60,7 +60,7 @@ func configFromServer(h1 *http.Server, h2 *Server) http2Config {
+ 	return conf
+ }
+ 
+-// configFromServer merges configuration settings from h2 and h2.t1.HTTP2
++// configFromTransport merges configuration settings from h2 and h2.t1.HTTP2
+ // (the net/http Transport).
+ func configFromTransport(h2 *Transport) http2Config {
+ 	conf := http2Config{
+diff --git a/vendor/golang.org/x/net/http2/config_go124.go b/vendor/golang.org/x/net/http2/config_go124.go
+index e3784123..5b516c55 100644
+--- a/vendor/golang.org/x/net/http2/config_go124.go
++++ b/vendor/golang.org/x/net/http2/config_go124.go
+@@ -13,7 +13,7 @@ func fillNetHTTPServerConfig(conf *http2Config, srv *http.Server) {
+ 	fillNetHTTPConfig(conf, srv.HTTP2)
+ }
+ 
+-// fillNetHTTPServerConfig sets fields in conf from tr.HTTP2.
++// fillNetHTTPTransportConfig sets fields in conf from tr.HTTP2.
+ func fillNetHTTPTransportConfig(conf *http2Config, tr *http.Transport) {
+ 	fillNetHTTPConfig(conf, tr.HTTP2)
+ }
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index 090d0e1b..b2e2ed33 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -375,6 +375,7 @@ type ClientConn struct {
+ 	doNotReuse       bool       // whether conn is marked to not be reused for any future requests
+ 	closing          bool
+ 	closed           bool
++	closedOnIdle     bool                     // true if conn was closed for idleness
+ 	seenSettings     bool                     // true if we've seen a settings frame, false otherwise
+ 	seenSettingsChan chan struct{}            // closed when seenSettings is true or frame reading fails
+ 	wantSettingsAck  bool                     // we sent a SETTINGS frame and haven't heard back
+@@ -1089,10 +1090,12 @@ func (cc *ClientConn) idleStateLocked() (st clientConnIdleState) {
+ 
+ 	// If this connection has never been used for a request and is closed,
+ 	// then let it take a request (which will fail).
++	// If the conn was closed for idleness, we're racing the idle timer;
++	// don't try to use the conn. (Issue #70515.)
+ 	//
+ 	// This avoids a situation where an error early in a connection's lifetime
+ 	// goes unreported.
+-	if cc.nextStreamID == 1 && cc.streamsReserved == 0 && cc.closed {
++	if cc.nextStreamID == 1 && cc.streamsReserved == 0 && cc.closed && !cc.closedOnIdle {
+ 		st.canTakeNewRequest = true
+ 	}
+ 
+@@ -1155,6 +1158,7 @@ func (cc *ClientConn) closeIfIdle() {
+ 		return
+ 	}
+ 	cc.closed = true
++	cc.closedOnIdle = true
+ 	nextID := cc.nextStreamID
+ 	// TODO: do clients send GOAWAY too? maybe? Just Close:
+ 	cc.mu.Unlock()
+@@ -2434,9 +2438,12 @@ func (rl *clientConnReadLoop) cleanup() {
+ 	// This avoids a situation where new connections are constantly created,
+ 	// added to the pool, fail, and are removed from the pool, without any error
+ 	// being surfaced to the user.
+-	const unusedWaitTime = 5 * time.Second
++	unusedWaitTime := 5 * time.Second
++	if cc.idleTimeout > 0 && unusedWaitTime > cc.idleTimeout {
++		unusedWaitTime = cc.idleTimeout
++	}
+ 	idleTime := cc.t.now().Sub(cc.lastActive)
+-	if atomic.LoadUint32(&cc.atomicReused) == 0 && idleTime < unusedWaitTime {
++	if atomic.LoadUint32(&cc.atomicReused) == 0 && idleTime < unusedWaitTime && !cc.closedOnIdle {
+ 		cc.idleTimer = cc.t.afterFunc(unusedWaitTime-idleTime, func() {
+ 			cc.t.connPool().MarkDead(cc)
+ 		})
+diff --git a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+index 97cb916f..be8c0020 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
++++ b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+@@ -246,6 +246,18 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ 	return sendfile(outfd, infd, offset, count)
+ }
+ 
++func Dup3(oldfd, newfd, flags int) error {
++	if oldfd == newfd || flags&^O_CLOEXEC != 0 {
++		return EINVAL
++	}
++	how := F_DUP2FD
++	if flags&O_CLOEXEC != 0 {
++		how = F_DUP2FD_CLOEXEC
++	}
++	_, err := fcntl(oldfd, how, newfd)
++	return err
++}
++
+ /*
+  * Exposed directly
+  */
+diff --git a/vendor/golang.org/x/sys/windows/dll_windows.go b/vendor/golang.org/x/sys/windows/dll_windows.go
+index 4e613cf6..3ca814f5 100644
+--- a/vendor/golang.org/x/sys/windows/dll_windows.go
++++ b/vendor/golang.org/x/sys/windows/dll_windows.go
+@@ -43,8 +43,8 @@ type DLL struct {
+ // LoadDLL loads DLL file into memory.
+ //
+ // Warning: using LoadDLL without an absolute path name is subject to
+-// DLL preloading attacks. To safely load a system DLL, use LazyDLL
+-// with System set to true, or use LoadLibraryEx directly.
++// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL],
++// or use [LoadLibraryEx] directly.
+ func LoadDLL(name string) (dll *DLL, err error) {
+ 	namep, err := UTF16PtrFromString(name)
+ 	if err != nil {
+@@ -271,6 +271,9 @@ func (d *LazyDLL) NewProc(name string) *LazyProc {
+ }
+ 
+ // NewLazyDLL creates new LazyDLL associated with DLL file.
++//
++// Warning: using NewLazyDLL without an absolute path name is subject to
++// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL].
+ func NewLazyDLL(name string) *LazyDLL {
+ 	return &LazyDLL{Name: name}
+ }
+@@ -410,7 +413,3 @@ func loadLibraryEx(name string, system bool) (*DLL, error) {
+ 	}
+ 	return &DLL{Name: name, Handle: h}, nil
+ }
+-
+-type errString string
+-
+-func (s errString) Error() string { return string(s) }
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index b11cdeda..9a0b6d45 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -177,7 +177,7 @@ go.uber.org/zap/internal/exit
+ go.uber.org/zap/internal/pool
+ go.uber.org/zap/internal/stacktrace
+ go.uber.org/zap/zapcore
+-# golang.org/x/net v0.32.0
++# golang.org/x/net v0.34.0
+ ## explicit; go 1.18
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -185,7 +185,7 @@ golang.org/x/net/http2/hpack
+ golang.org/x/net/idna
+ golang.org/x/net/internal/timeseries
+ golang.org/x/net/trace
+-# golang.org/x/sys v0.28.0
++# golang.org/x/sys v0.29.0
+ ## explicit; go 1.18
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-- 
+2.45.1
+

--- a/projects/kubernetes-csi/node-driver-registrar/1-32/CHECKSUMS
+++ b/projects/kubernetes-csi/node-driver-registrar/1-32/CHECKSUMS
@@ -1,3 +1,3 @@
-0ca4501f2b1a03f701eb5006b522ee5aff86877ab4e02b7936837fe1de384459  _output/1-32/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
-5c4f5c7066c59b63639b8ce856b3778d29fbc2c8a423d9fd10db287506901ae9  _output/1-32/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
-0227bc3c92dca435534543b3dbba8436c0dabb8994976c5657730c0e4063f17d  _output/1-32/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe
+660b5d1bec627ebc2f524a5ec02a5390f432c8cf671f65fba573cbbd6ceb6094  _output/1-32/bin/node-driver-registrar/linux-amd64/csi-node-driver-registrar
+617189c0ece4c26029c7696b2926cca64c9bbfcba8f216c84374eca70ed92d0e  _output/1-32/bin/node-driver-registrar/linux-arm64/csi-node-driver-registrar
+c795d7ea1e21a247196a54e7deab859fa23a3299bc2caf1eb584e137b45648ab  _output/1-32/bin/node-driver-registrar/windows-amd64/csi-node-driver-registrar.exe

--- a/projects/kubernetes-csi/node-driver-registrar/1-32/patches/0001-Bump-node-driver-registrar-CVE-2024-45338-x-net-to-v.patch
+++ b/projects/kubernetes-csi/node-driver-registrar/1-32/patches/0001-Bump-node-driver-registrar-CVE-2024-45338-x-net-to-v.patch
@@ -1,0 +1,220 @@
+From cc22a8e194806e9f8f1aef6172b616b51e4420fd Mon Sep 17 00:00:00 2001
+From: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+Date: Mon, 3 Feb 2025 12:17:16 -0500
+Subject: [PATCH] Bump node-driver-registrar CVE-2024-45338 x/net to v0.34.0
+
+Signed-off-by: Drew Sirenko <68304519+AndrewSirenko@users.noreply.github.com>
+---
+ go.mod                                            |  4 ++--
+ go.sum                                            |  8 ++++----
+ vendor/golang.org/x/net/http2/config.go           |  2 +-
+ vendor/golang.org/x/net/http2/config_go124.go     |  2 +-
+ vendor/golang.org/x/net/http2/transport.go        | 13 ++++++++++---
+ vendor/golang.org/x/sys/unix/syscall_dragonfly.go | 12 ++++++++++++
+ vendor/golang.org/x/sys/windows/dll_windows.go    | 11 +++++------
+ vendor/modules.txt                                |  4 ++--
+ 8 files changed, 37 insertions(+), 19 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 5d2e5659..12a340c8 100644
+--- a/go.mod
++++ b/go.mod
+@@ -4,7 +4,7 @@ go 1.23.1
+ 
+ require (
+ 	github.com/kubernetes-csi/csi-lib-utils v0.20.0
+-	golang.org/x/sys v0.28.0
++	golang.org/x/sys v0.29.0
+ 	google.golang.org/grpc v1.69.0
+ 	k8s.io/client-go v0.32.0
+ 	k8s.io/component-base v0.32.0
+@@ -52,7 +52,7 @@ require (
+ 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.27.0 // indirect
+-	golang.org/x/net v0.32.0 // indirect
++	golang.org/x/net v0.34.0 // indirect
+ 	golang.org/x/text v0.21.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241216192217-9240e9c98484 // indirect
+ 	google.golang.org/protobuf v1.36.0 // indirect
+diff --git a/go.sum b/go.sum
+index 79246602..6e3c77c7 100644
+--- a/go.sum
++++ b/go.sum
+@@ -124,16 +124,16 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
+ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+-golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
+-golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
++golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
++golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
++golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+diff --git a/vendor/golang.org/x/net/http2/config.go b/vendor/golang.org/x/net/http2/config.go
+index de58dfb8..ca645d9a 100644
+--- a/vendor/golang.org/x/net/http2/config.go
++++ b/vendor/golang.org/x/net/http2/config.go
+@@ -60,7 +60,7 @@ func configFromServer(h1 *http.Server, h2 *Server) http2Config {
+ 	return conf
+ }
+ 
+-// configFromServer merges configuration settings from h2 and h2.t1.HTTP2
++// configFromTransport merges configuration settings from h2 and h2.t1.HTTP2
+ // (the net/http Transport).
+ func configFromTransport(h2 *Transport) http2Config {
+ 	conf := http2Config{
+diff --git a/vendor/golang.org/x/net/http2/config_go124.go b/vendor/golang.org/x/net/http2/config_go124.go
+index e3784123..5b516c55 100644
+--- a/vendor/golang.org/x/net/http2/config_go124.go
++++ b/vendor/golang.org/x/net/http2/config_go124.go
+@@ -13,7 +13,7 @@ func fillNetHTTPServerConfig(conf *http2Config, srv *http.Server) {
+ 	fillNetHTTPConfig(conf, srv.HTTP2)
+ }
+ 
+-// fillNetHTTPServerConfig sets fields in conf from tr.HTTP2.
++// fillNetHTTPTransportConfig sets fields in conf from tr.HTTP2.
+ func fillNetHTTPTransportConfig(conf *http2Config, tr *http.Transport) {
+ 	fillNetHTTPConfig(conf, tr.HTTP2)
+ }
+diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
+index 090d0e1b..b2e2ed33 100644
+--- a/vendor/golang.org/x/net/http2/transport.go
++++ b/vendor/golang.org/x/net/http2/transport.go
+@@ -375,6 +375,7 @@ type ClientConn struct {
+ 	doNotReuse       bool       // whether conn is marked to not be reused for any future requests
+ 	closing          bool
+ 	closed           bool
++	closedOnIdle     bool                     // true if conn was closed for idleness
+ 	seenSettings     bool                     // true if we've seen a settings frame, false otherwise
+ 	seenSettingsChan chan struct{}            // closed when seenSettings is true or frame reading fails
+ 	wantSettingsAck  bool                     // we sent a SETTINGS frame and haven't heard back
+@@ -1089,10 +1090,12 @@ func (cc *ClientConn) idleStateLocked() (st clientConnIdleState) {
+ 
+ 	// If this connection has never been used for a request and is closed,
+ 	// then let it take a request (which will fail).
++	// If the conn was closed for idleness, we're racing the idle timer;
++	// don't try to use the conn. (Issue #70515.)
+ 	//
+ 	// This avoids a situation where an error early in a connection's lifetime
+ 	// goes unreported.
+-	if cc.nextStreamID == 1 && cc.streamsReserved == 0 && cc.closed {
++	if cc.nextStreamID == 1 && cc.streamsReserved == 0 && cc.closed && !cc.closedOnIdle {
+ 		st.canTakeNewRequest = true
+ 	}
+ 
+@@ -1155,6 +1158,7 @@ func (cc *ClientConn) closeIfIdle() {
+ 		return
+ 	}
+ 	cc.closed = true
++	cc.closedOnIdle = true
+ 	nextID := cc.nextStreamID
+ 	// TODO: do clients send GOAWAY too? maybe? Just Close:
+ 	cc.mu.Unlock()
+@@ -2434,9 +2438,12 @@ func (rl *clientConnReadLoop) cleanup() {
+ 	// This avoids a situation where new connections are constantly created,
+ 	// added to the pool, fail, and are removed from the pool, without any error
+ 	// being surfaced to the user.
+-	const unusedWaitTime = 5 * time.Second
++	unusedWaitTime := 5 * time.Second
++	if cc.idleTimeout > 0 && unusedWaitTime > cc.idleTimeout {
++		unusedWaitTime = cc.idleTimeout
++	}
+ 	idleTime := cc.t.now().Sub(cc.lastActive)
+-	if atomic.LoadUint32(&cc.atomicReused) == 0 && idleTime < unusedWaitTime {
++	if atomic.LoadUint32(&cc.atomicReused) == 0 && idleTime < unusedWaitTime && !cc.closedOnIdle {
+ 		cc.idleTimer = cc.t.afterFunc(unusedWaitTime-idleTime, func() {
+ 			cc.t.connPool().MarkDead(cc)
+ 		})
+diff --git a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+index 97cb916f..be8c0020 100644
+--- a/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
++++ b/vendor/golang.org/x/sys/unix/syscall_dragonfly.go
+@@ -246,6 +246,18 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ 	return sendfile(outfd, infd, offset, count)
+ }
+ 
++func Dup3(oldfd, newfd, flags int) error {
++	if oldfd == newfd || flags&^O_CLOEXEC != 0 {
++		return EINVAL
++	}
++	how := F_DUP2FD
++	if flags&O_CLOEXEC != 0 {
++		how = F_DUP2FD_CLOEXEC
++	}
++	_, err := fcntl(oldfd, how, newfd)
++	return err
++}
++
+ /*
+  * Exposed directly
+  */
+diff --git a/vendor/golang.org/x/sys/windows/dll_windows.go b/vendor/golang.org/x/sys/windows/dll_windows.go
+index 4e613cf6..3ca814f5 100644
+--- a/vendor/golang.org/x/sys/windows/dll_windows.go
++++ b/vendor/golang.org/x/sys/windows/dll_windows.go
+@@ -43,8 +43,8 @@ type DLL struct {
+ // LoadDLL loads DLL file into memory.
+ //
+ // Warning: using LoadDLL without an absolute path name is subject to
+-// DLL preloading attacks. To safely load a system DLL, use LazyDLL
+-// with System set to true, or use LoadLibraryEx directly.
++// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL],
++// or use [LoadLibraryEx] directly.
+ func LoadDLL(name string) (dll *DLL, err error) {
+ 	namep, err := UTF16PtrFromString(name)
+ 	if err != nil {
+@@ -271,6 +271,9 @@ func (d *LazyDLL) NewProc(name string) *LazyProc {
+ }
+ 
+ // NewLazyDLL creates new LazyDLL associated with DLL file.
++//
++// Warning: using NewLazyDLL without an absolute path name is subject to
++// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL].
+ func NewLazyDLL(name string) *LazyDLL {
+ 	return &LazyDLL{Name: name}
+ }
+@@ -410,7 +413,3 @@ func loadLibraryEx(name string, system bool) (*DLL, error) {
+ 	}
+ 	return &DLL{Name: name, Handle: h}, nil
+ }
+-
+-type errString string
+-
+-func (s errString) Error() string { return string(s) }
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index b11cdeda..9a0b6d45 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -177,7 +177,7 @@ go.uber.org/zap/internal/exit
+ go.uber.org/zap/internal/pool
+ go.uber.org/zap/internal/stacktrace
+ go.uber.org/zap/zapcore
+-# golang.org/x/net v0.32.0
++# golang.org/x/net v0.34.0
+ ## explicit; go 1.18
+ golang.org/x/net/http/httpguts
+ golang.org/x/net/http2
+@@ -185,7 +185,7 @@ golang.org/x/net/http2/hpack
+ golang.org/x/net/idna
+ golang.org/x/net/internal/timeseries
+ golang.org/x/net/trace
+-# golang.org/x/sys v0.28.0
++# golang.org/x/sys v0.29.0
+ ## explicit; go 1.18
+ golang.org/x/sys/unix
+ golang.org/x/sys/windows
+-- 
+2.45.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump node-driver-registrar CVE-2024-45338 x/net to v0.34.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
