### PR TITLE
Fix doc generation script to sort doc PRs by created date

### DIFF
--- a/cmd/release/utils/values/searchprs.go
+++ b/cmd/release/utils/values/searchprs.go
@@ -17,7 +17,7 @@ func GetChangelogPRs(releaseVersion string, overrideNumber int) (string, error) 
 	githubClient := github.NewClient(nil)
 
 	ctx := context.Background()
-	opts := &github.SearchOptions{Sort: "updated"}
+	opts := &github.SearchOptions{Sort: "created", Order: "desc"}
 	//Get the date of the last document release for the release version
 	prs, _, err := githubClient.Search.Issues(ctx, "is:pr is:merged label:release label:documentation repo:aws/eks-distro label:"+releaseVersion, opts)
 	if err != nil {


### PR DESCRIPTION
We ran into an issue with generating docs for an eks-d release where updates to a previous doc release would result in the script seeing it as the latest. This is because the script is sorting PRs by most recently updated. The result of this was an inaccurate changelog between releases.

*Description of changes:*
One line change to sort by creation date instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
