### PR TITLE
Metrics server should use 1-32 image fo 1.34

### DIFF
--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -43,8 +43,8 @@ function get_container_yaml() {
 
     if  [[ $REPOSITORY_NAME == "kubernetes-sigs/metrics-server" ]]; then
        
-        if [[ $RELEASE_BRANCH == "1-33" ]]; then
-            # For release 1-33, force metrics-server to use the 1-32 image
+        if [[ $RELEASE_BRANCH == "1-33" ]] || [[ $RELEASE_BRANCH == "1-34" ]]; then
+            # For releases 1-33 and 1-34, force metrics-server to use the 1-32 image
             echo "    repository: ${IMAGE_REPO}/${REPOSITORY_NAME}
     tag: ${VERSION}-eks-1-32-latest"
         else


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
