### PR TITLE
Update CSI sidecar components to use correct gallery

### DIFF
--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -54,16 +54,25 @@ function get_container_yaml() {
         return
     fi
 
-    # CSI sidecar components are deprecated
-    # Use latest tag instead of specific release number
+    # CSI sidecar components have moved to gallery.ecr.aws/csi-components
+    # Use new repository location and standard upstream versioning
     if  [[ $REPOSITORY_NAME == "kubernetes-csi/node-driver-registrar" ]] || \
         [[ $REPOSITORY_NAME == "kubernetes-csi/external-resizer" ]] || \
         [[ $REPOSITORY_NAME == "kubernetes-csi/external-attacher" ]] || \
         [[ $REPOSITORY_NAME == "kubernetes-csi/external-snapshotter" ]] || \
         [[ $REPOSITORY_NAME == "kubernetes-csi/external-provisioner" ]] || \
         [[ $REPOSITORY_NAME == "kubernetes-csi/livenessprobe" ]]; then
-        echo "    repository: ${IMAGE_REPO}/${REPOSITORY_NAME}
-    tag: ${VERSION}-eks-${RELEASE_BRANCH}-latest"
+        
+        COMPONENT_NAME=$(echo $REPOSITORY_NAME | cut -d'/' -f2)
+        
+        if [[ $COMPONENT_NAME == external-* ]]; then
+            COMPONENT_NAME="csi-${COMPONENT_NAME#external-}"
+        elif [[ $COMPONENT_NAME == "node-driver-registrar" ]]; then
+            COMPONENT_NAME="csi-node-driver-registrar"
+        fi
+        
+        echo "    repository: gallery.ecr.aws/csi-components/${COMPONENT_NAME}
+    tag: ${VERSION}"
         return
     fi
     


### PR DESCRIPTION
https://gallery.ecr.aws/csi-components
We need to use this gallery based on this commit https://github.com/aws/eks-distro/commit/1cb775f06bd5399271122c81f1964980f257d307, In order to avoid 
```
go:1324] "Error syncing pod, skipping" err="[failed to \"StartContainer\" for \"csi-provisioner\" with ImagePullBackOff: \"Back-off pulling image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-provisioner:v5.2.0-eks-1-34-latest\\\": ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-provisioner:v5.2.0-eks-1-34-latest\\\": failed to resolve reference \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-provisioner:v5.2.0-eks-1-34-latest\\\": public.ecr.aws/h1r8a7l5/kubernetes-csi/external-provisioner:v5.2.0-eks-1-34-latest: not found\", failed to \"StartContainer\" for \"node-driver-registrar\" with ImagePullBackOff: \"Back-off pulling image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/node-driver-registrar:v2.13.0-eks-1-34-latest\\\": ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/node-driver-registrar:v2.13.0-eks-1-34-latest\\\": failed to resolve reference \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/node-driver-registrar:v2.13.0-eks-1-34-latest\\\": public.ecr.aws/h1r8a7l5/kubernetes-csi/node-driver-registrar:v2.13.0-eks-1-34-latest: not found\", failed to \"StartContainer\" for \"csi-resizer\" with ImagePullBackOff: \"Back-off pulling image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-resizer:v1.13.2-eks-1-34-latest\\\": ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-resizer:v1.13.2-eks-1-34-latest\\\": failed to resolve reference \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-resizer:v1.13.2-eks-1-34-latest\\\": public.ecr.aws/h1r8a7l5/kubernetes-csi/external-resizer:v1.13.2-eks-1-34-latest: not found\", failed to \"StartContainer\" for \"csi-attacher\" with ImagePullBackOff: \"Back-off pulling image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-attacher:v4.8.1-eks-1-34-latest\\\": ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-attacher:v4.8.1-eks-1-34-latest\\\": failed to resolve reference \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-attacher:v4.8.1-eks-1-34-latest\\\": public.ecr.aws/h1r8a7l5/kubernetes-csi/external-attacher:v4.8.1-eks-1-34-latest: not found\", failed to \"StartContainer\" for \"csi-snapshotter\" with ImagePullBackOff: \"Back-off pulling image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-snapshotter/csi-snapshotter:v8.2.1-eks-1-34-1.pre\\\": ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-snapshotter/csi-snapshotter:v8.2.1-eks-1-34-1.pre\\\": failed to resolve reference \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/external-snapshotter/csi-snapshotter:v8.2.1-eks-1-34-1.pre\\\": public.ecr.aws/h1r8a7l5/kubernetes-csi/external-snapshotter/csi-snapshotter:v8.2.1-eks-1-34-1.pre: not found\", failed to \"StartContainer\" for \"liveness-probe\" with ImagePullBackOff: \"Back-off pulling image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/livenessprobe:v2.15.0-eks-1-34-latest\\\": ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack image \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/livenessprobe:v2.15.0-eks-1-34-latest\\\": failed to resolve reference \\\"public.ecr.aws/h1r8a7l5/kubernetes-csi/livenessprobe:v2.15.0-eks-1-34-latest\\\": public.ecr.aws/h1r8a7l5/kubernetes-csi/livenessprobe:v2.15.0-eks-1-34-latest: not found\"]" pod="default/csi-mockplugin-65d78cd7c8-smqrc" podUID="940aa599-0ba1-4fc5-8cff-2939cd0ff757"
I0806 00:04:50.930177    5141 provider.go:93] Refre
```