### PR TITLE
explicitly pass IMAGE_REPO variable when copying kubernetes artifacts

### DIFF
--- a/projects/kubernetes/kubernetes/Makefile
+++ b/projects/kubernetes/kubernetes/Makefile
@@ -141,7 +141,7 @@ copy-kubernetes-artifacts:
 	@echo -e $(call TARGET_START_LOG)
 	@echo "Copying Kubernetes binaries from S3..."
 	@mkdir -p _output/
-	RELEASE=$(RELEASE) ./build/copy_kubernetes_artifacts.sh
+	RELEASE=$(RELEASE) IMAGE_REPO=$(IMAGE_REPO) ./build/copy_kubernetes_artifacts.sh
 	@chmod +x _output/*
 	@echo -e $(call TARGET_END_LOG)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
