### PR TITLE
make kubernetes binaries executable before creating tarballs

### DIFF
--- a/projects/kubernetes/kubernetes/build/copy_kubernetes_artifacts.sh
+++ b/projects/kubernetes/kubernetes/build/copy_kubernetes_artifacts.sh
@@ -164,6 +164,7 @@ process_kube_proxy
 
 # create tarballs with newly tagged images and binaries
 cp "${OUTPUT_DIR}/tar/kubernetes-src.tar.gz" "${ARTIFACT_DIR}"
+chmod -R 755 "${BIN_OUTPUT_DIR}"
 build::tarballs::create_tarballs "${BIN_OUTPUT_DIR}" "${OUTPUT_DIR}" "${ARTIFACT_DIR}" "${IMAGE_OUTPUT_DIR}"
 
 # update files for any legacy method callers of these files during the build e.g., crd generation, attribution periodic


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
