### PR TITLE
For 1.35 and above remove podInfraContainer

### DIFF
--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -149,6 +149,15 @@ function get_project_version(){
 UBUNTU_AMI=$(aws ec2 describe-images --owners 099720109477 --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-$UBUNTU_RELEASE-$NODE_ARCHITECTURE-server-*" --query 'sort_by(Images, &CreationDate)[-1].[Name]' --output text)
 
 echo "Creating ./${KOPS_CLUSTER_NAME}/values.yaml"
+
+# podInfraContainer should be used <= 1.34
+KUBERNETES_MINOR_VERSION=$(echo $KUBERNETES_VERSION | cut -d. -f2)
+if [ "$KUBERNETES_MINOR_VERSION" -le 34 ]; then
+    USE_POD_INFRA_CONTAINER="true"
+else
+    USE_POD_INFRA_CONTAINER="false"
+fi
+
 cat << EOF > ./${KOPS_CLUSTER_NAME}/values.yaml
 kubernetesVersion: ${ARTIFACT_URL}/kubernetes/${KUBERNETES_VERSION}
 clusterName: $KOPS_CLUSTER_NAME
@@ -160,6 +169,7 @@ instanceType: $NODE_INSTANCE_TYPE
 architecture: $NODE_ARCHITECTURE
 ubuntuAmi: $UBUNTU_AMI
 ipv6: $IPV6
+usePodInfraContainer: $USE_POD_INFRA_CONTAINER
 pause:
 $(get_container_yaml kubernetes/pause $RELEASE)
 kube_apiserver:

--- a/development/kops/eks-d.tpl
+++ b/development/kops/eks-d.tpl
@@ -104,10 +104,14 @@ spec:
   kubeDNS:
     provider: CoreDNS
     coreDNSImage: {{ .coredns.repository }}:{{ .coredns.tag }}
+  {{- if .usePodInfraContainer }}
   masterKubelet:
     podInfraContainerImage: {{ .pause.repository }}:{{ .pause.tag }}
+  {{- end }}
   kubelet:
+    {{- if .usePodInfraContainer }}
     podInfraContainerImage: {{ .pause.repository }}:{{ .pause.tag }}
+    {{- end }}
     anonymousAuth: false
     # for 1.19 and above webhook auth is the default mode
     authorizationMode: Webhook


### PR DESCRIPTION
`podInfraContainer` is deprecated in version 1.35 or later, so we are omitting it.