### PR TITLE
migrate containernetworking/plugins to internal versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ REBUILD_ALL?=false
 ALL_PROJECTS=kubernetes_release kubernetes_kubernetes containernetworking_plugins coredns_coredns etcd-io_etcd \
 	kubernetes_cloud-provider-aws kubernetes-sigs_aws-iam-authenticator
 
-INTERNALLY_BUILT_PROJECTS=kubernetes_kubernetes kubernetes-sigs_aws-iam-authenticator
+# CNI is technically not an internal build, but for the purposes of updating metadata files like GIT_TAG and GOLANG_VERSION it is
+INTERNALLY_BUILT_PROJECTS=kubernetes_kubernetes kubernetes-sigs_aws-iam-authenticator containernetworking_plugins
 
 
 ifdef MAKECMDGOALS

--- a/projects/containernetworking/plugins/Makefile
+++ b/projects/containernetworking/plugins/Makefile
@@ -1,6 +1,10 @@
 BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat $(RELEASE_BRANCH)/GIT_TAG)
-GOLANG_VERSION?=$(shell cat $(RELEASE_BRANCH)/GOLANG_VERSION)
+
+_bootstrap:=$(shell ./build/bootstrap_build_variables.sh)
+export GIT_TAG:=$(shell cat .git_tag)
+export GOLANG_VERSION:=$(shell cat .go-version)
+$(if $(GIT_TAG),$(shell rm -f .git_tag),$(error GIT_TAG is empty, .git_tag might be missing))
+$(if $(GOLANG_VERSION),$(shell rm -f .go-version),$(error GOLANG_VERSION is empty, .go-version might be missing))
 
 REPO=plugins
 REPO_OWNER=containernetworking

--- a/projects/containernetworking/plugins/build/bootstrap_build_variables.sh
+++ b/projects/containernetworking/plugins/build/bootstrap_build_variables.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eux
+
+VPCCNI_TAG=$(aws eks describe-addon-versions \
+  --addon-name vpc-cni \
+  --kubernetes-version "${RELEASE_BRANCH//-/.}" \
+  --query 'addons[0].addonVersions[0].addonVersion' \
+  --output text | sed 's/-eksbuild\..*//')
+
+# new version launch case, fallback to previous version until the new version is launched for Addons
+if [ "${VPCCNI_TAG}" == "None" ]; then
+  PREV_VERSION=$(echo "${RELEASE_BRANCH}" | awk -F'-' '{print $1"-"$2-1}')
+  VPCCNI_TAG=$(aws eks describe-addon-versions \
+    --addon-name vpc-cni \
+    --kubernetes-version "${PREV_VERSION//-/.}" \
+    --query 'addons[0].addonVersions[0].addonVersion' \
+    --output text | sed 's/-eksbuild\..*//')
+fi
+
+PLUGINS_VERSION=$(curl -sL "https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/${VPCCNI_TAG}/Makefile" | grep 'plugins: FETCH_VERSION=' | sed 's/.*FETCH_VERSION=//')
+GIT_TAG="v${PLUGINS_VERSION}"
+echo "${GIT_TAG}" > "${RELEASE_BRANCH}/GIT_TAG"
+echo "${GIT_TAG}" > .git_tag
+GOLANG_VERSION=$(curl -sL "https://raw.githubusercontent.com/containernetworking/plugins/${GIT_TAG}/.github/go-version")
+echo "${GOLANG_VERSION}" > "${RELEASE_BRANCH}/GOLANG_VERSION"
+echo "${GOLANG_VERSION}" > .go-version
+
+curl -sL "https://raw.githubusercontent.com/containernetworking/plugins/${GIT_TAG}/go.mod" -o "${RELEASE_BRANCH}/go.mod"
+curl -sL "https://raw.githubusercontent.com/containernetworking/plugins/${GIT_TAG}/go.sum" -o "${RELEASE_BRANCH}/go.sum"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Testing

[build postsubmit](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/build-1-34-postsubmit/1999598531064631296)
[dev release](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/dev-release-1-34-postsubmit/1999568660359811072)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
