### PR TITLE
move etcd and cloud-provider-aws to internal builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ REBUILD_ALL?=false
 ALL_PROJECTS=kubernetes_release kubernetes_kubernetes containernetworking_plugins coredns_coredns etcd-io_etcd \
 	kubernetes_cloud-provider-aws kubernetes-sigs_aws-iam-authenticator
 
-# CNI is technically not an internal build, but for the purposes of updating metadata files like GIT_TAG and GOLANG_VERSION it is
-INTERNALLY_BUILT_PROJECTS=kubernetes_kubernetes kubernetes-sigs_aws-iam-authenticator containernetworking_plugins
+# CNI and Etcd are technically not an internal build only versioning, but for the purposes of updating metadata files like GIT_TAG and GOLANG_VERSION they are
+INTERNALLY_BUILT_PROJECTS=kubernetes_kubernetes kubernetes_cloud-provider-aws kubernetes-sigs_aws-iam-authenticator containernetworking_plugins etcd-io_etcd
 
 
 ifdef MAKECMDGOALS

--- a/projects/containernetworking/plugins/Makefile
+++ b/projects/containernetworking/plugins/Makefile
@@ -19,6 +19,7 @@ EXTRA_GO_LDFLAGS=-X github.com/containernetworking/plugins/pkg/utils/buildversio
 HAS_RELEASE_BRANCHES=true
 HAS_S3_ARTIFACTS=true
 IMAGE_NAMES=
+SKIP_CHECKSUM_VALIDATION=true
 
 # Generating the source patterns requires checking out the repo
 # delay this as much as possible by skipping when running docker targets

--- a/projects/etcd-io/etcd/Makefile
+++ b/projects/etcd-io/etcd/Makefile
@@ -1,6 +1,10 @@
 BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat $(RELEASE_BRANCH)/GIT_TAG)
-GOLANG_VERSION?=$(shell cat $(RELEASE_BRANCH)/GOLANG_VERSION)
+
+_bootstrap:=$(shell ./build/bootstrap_build_variables.sh)
+export GIT_TAG:=$(shell cat .git_tag)
+export GOLANG_VERSION:=$(shell cat .go-version)
+$(if $(GIT_TAG),$(shell rm -f .git_tag),$(error GIT_TAG is empty, .git_tag might be missing))
+$(if $(GOLANG_VERSION),$(shell rm -f .go-version),$(error GOLANG_VERSION is empty, .go-version might be missing))
 
 REPO=etcd
 REPO_OWNER=etcd-io
@@ -18,6 +22,7 @@ BUILD_OCI_TARS=true
 
 HAS_RELEASE_BRANCHES=true
 HAS_S3_ARTIFACTS=true
+SKIP_CHECKSUM_VALIDATION=true
 
 -include $(RELEASE_BRANCH)/Overrides.mk
 include $(BASE_DIRECTORY)/Common.mk

--- a/projects/etcd-io/etcd/build/bootstrap_build_variables.sh
+++ b/projects/etcd-io/etcd/build/bootstrap_build_variables.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eux
+
+TEMP_FILE=$(mktemp)
+trap 'rm -f $TEMP_FILE' EXIT
+S3_BUCKET="eks-distro-dev-release-artifacts"
+S3_PREFIX="kubernetes-${RELEASE_BRANCH}/releases/"
+aws s3 ls --recursive "s3://${S3_BUCKET}/${S3_PREFIX}" > "$TEMP_FILE"
+
+LATEST_VERSION=$(grep -o 'eks\.[0-9]\+' "$TEMP_FILE" | sort -V | tail -1)
+S3_PATH="${S3_PREFIX}${LATEST_VERSION}/artifacts/etcd"
+
+aws s3 cp "s3://${S3_BUCKET}/${S3_PATH}/.git_tag" .git_tag
+aws s3 cp "s3://${S3_BUCKET}/${S3_PATH}/.go-version" /tmp/.go-version
+
+GOLANG_VERSION=$(cut -d. -f1,2 < /tmp/.go-version)
+MIN_GO_VERSION="1.24"
+if [[ "$(printf '%s\n' "$MIN_GO_VERSION" "$GOLANG_VERSION" | sort -V | head -1)" != "$MIN_GO_VERSION" ]]; then
+  GOLANG_VERSION="$MIN_GO_VERSION"
+fi
+echo "$GOLANG_VERSION" > .go-version
+
+GIT_TAG=$(cat .git_tag)
+MIN_VERSION="v3.5.21"
+if [[ "$(printf '%s\n' "$MIN_VERSION" "$GIT_TAG" | sort -V | head -1)" != "$MIN_VERSION" ]]; then
+  GIT_TAG="$MIN_VERSION"
+  echo "$GIT_TAG" > .git_tag
+fi
+curl -sL "https://raw.githubusercontent.com/etcd-io/etcd/${GIT_TAG}/go.mod" -o "${RELEASE_BRANCH}/go.mod"
+curl -sL "https://raw.githubusercontent.com/etcd-io/etcd/${GIT_TAG}/go.sum" -o "${RELEASE_BRANCH}/go.sum"

--- a/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
@@ -40,6 +40,7 @@ COPY_ARTIFACTS_SCRIPT = RELEASE=$(RELEASE) \
 	GO_RUNNER_IMAGE=$(GO_RUNNER_IMAGE) \
 	MAKE_ROOT=$(MAKE_ROOT) \
 	PUSH_IMAGES=$(PUSH_IMAGES) \
+	REPO=$(REPO) \
 	$(BASE_DIRECTORY)/build/lib/copy_internal_build_artifacts.sh && chmod +x _output/*
 
 

--- a/projects/kubernetes/cloud-provider-aws/Makefile
+++ b/projects/kubernetes/cloud-provider-aws/Makefile
@@ -22,6 +22,33 @@ IMAGE_NAMES=cloud-controller-manager
 
 CLOUD_CONTROLLER_MANAGER_IMAGE_COMPONENT?=kubernetes/cloud-provider-aws/cloud-controller-manager
 
+# Environment variables to support copying the internally built artifacts instead of
+# rebuilding from EKS-D repo source
+ifdef RELEASE_BRANCH
+_bootstrap:=$(shell REPO=$(REPO) ./build/bootstrap_copy_release_variables.sh)
+export GIT_TAG:=$(shell cat .git_tag)
+export GOLANG_VERSION:=$(shell cat .go-version)
+export ARTIFACTS_SOURCE_S3_PATH:=$(shell cat .s3_sync_path)
+export SOURCE_IMAGE_TAG:=$(shell cat .source_image_tag)
+$(if $(GIT_TAG),$(shell rm -f .git_tag),$(error GIT_TAG is empty, .git_tag might be missing))
+$(if $(GOLANG_VERSION),$(shell rm -f .go-version),$(error GOLANG_VERSION is empty, .go-version might be missing))
+$(if $(ARTIFACTS_SOURCE_S3_PATH),$(shell rm -f .s3_sync_path),$(error ARTIFACTS_SOURCE_S3_PATH is empty, .s3_sync_path might be missing))
+$(if $(SOURCE_IMAGE_TAG),$(shell rm -f .source_image_tag),$(error SOURCE_IMAGE_TAG is empty, .source_image_tag might be missing))
+endif
+
+PUSH_IMAGES ?= true
+BUILD_ARTIFACTS ?= false
+COPY_ARTIFACTS_SCRIPT = RELEASE=$(RELEASE) \
+	IMAGE_REPO=$(IMAGE_REPO) \
+	IMAGE_NAMES="$(REPO_OWNER)/$(REPO)/$(IMAGE_NAMES)" \
+	SOURCE_ECR_REG=$(DEV_ECR_REG) \
+	SOURCE_IMAGE_TAG=$(SOURCE_IMAGE_TAG) \
+	GO_RUNNER_IMAGE=$(GO_RUNNER_IMAGE) \
+	MAKE_ROOT=$(MAKE_ROOT) \
+	PUSH_IMAGES=$(PUSH_IMAGES) \
+	REPO=$(REPO) \
+	$(BASE_DIRECTORY)/build/lib/copy_internal_build_artifacts.sh && chmod +x _output/*
+
 include $(BASE_DIRECTORY)/Common.mk
 
 

--- a/projects/kubernetes/cloud-provider-aws/build/bootstrap_copy_release_variables.sh
+++ b/projects/kubernetes/cloud-provider-aws/build/bootstrap_copy_release_variables.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eux
+
+TEMP_FILE=$(mktemp)
+trap 'rm -f $TEMP_FILE' EXIT
+ARTIFACTS_SOURCE_S3_BUCKET="eks-distro-dev-release-artifacts"
+S3_PREFIX="kubernetes-${RELEASE_BRANCH}/releases/"
+aws s3 ls --recursive "s3://${ARTIFACTS_SOURCE_S3_BUCKET}/${S3_PREFIX}" > "$TEMP_FILE"
+
+LATEST_VERSION=$(grep -o 'eks\.[0-9]\+' "$TEMP_FILE" | sort -V | tail -1)
+
+VERSION_DIR=$(grep "${LATEST_VERSION}/artifacts/${REPO}/v[0-9]" "$TEMP_FILE" | \
+              grep -o 'v[0-9][^/]*' | head -1)
+
+GIT_TAG=$(echo "${VERSION_DIR}" | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+')
+echo "${GIT_TAG}" > .git_tag
+echo "${VERSION_DIR}" > .source_image_tag
+
+ARTIFACTS_SOURCE_S3_PATH="s3://${ARTIFACTS_SOURCE_S3_BUCKET}/${S3_PREFIX}${LATEST_VERSION}/artifacts/${REPO}/${VERSION_DIR}/"
+echo "${ARTIFACTS_SOURCE_S3_PATH}" > .s3_sync_path
+
+aws s3 cp "${ARTIFACTS_SOURCE_S3_PATH}.go-version" .go-version


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Testing

[build postsubmit](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/build-1-34-postsubmit/2011227058797023232)
[dev release](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/dev-release-1-34-postsubmit/2011214229654212608)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
