### PR TITLE
docs: Add RELEASE_BRANCH code block for 1-35 in index.md

### DIFF
--- a/docs/contents/index.md
+++ b/docs/contents/index.md
@@ -119,6 +119,15 @@ repository for the [EKS Optimized AMI](https://github.com/awslabs/amazon-eks-ami
 if you are interested in the AL2 container runtime kernel version.
 
 #### EKS-D 1.35 Version Dependencies
+```bash
+RELEASE_BRANCH=1-35
+RELEASE=5
+kubectl apply -f https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+kubectl apply -f https://distro.eks.amazonaws.com/kubernetes-${RELEASE_BRANCH}/kubernetes-${RELEASE_BRANCH}-eks-${RELEASE}.yaml
+kubectl get release kubernetes-${RELEASE_BRANCH}-eks-${RELEASE}
+kubectl get release kubernetes-${RELEASE_BRANCH}-eks-${RELEASE} -o yaml
+```
+* [v1-35-eks-5](releases/1-35/5/index.md) (February 09, 2026)
 * [v1-35-eks-4](releases/1-35/4/index.md) (January 27, 2026)
 * [v1-35-eks-3](releases/1-35/3/index.md) (December 30, 2025)
 * [v1-35-eks-2](releases/1-35/2/index.md) (December 16, 2025)


### PR DESCRIPTION
This adds the missing code block for 1-35 that the release-docs script expects.
