### PR TITLE
docs: Add missing RELEASE_BRANCH code block for 1-35

### DIFF
--- a/docs/contents/index.md
+++ b/docs/contents/index.md
@@ -119,6 +119,15 @@ repository for the [EKS Optimized AMI](https://github.com/awslabs/amazon-eks-ami
 if you are interested in the AL2 container runtime kernel version.
 
 #### EKS-D 1.35 Version Dependencies
+```bash
+RELEASE_BRANCH=1-35
+RELEASE=5
+kubectl apply -f https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+kubectl apply -f https://distro.eks.amazonaws.com/kubernetes-${RELEASE_BRANCH}/kubernetes-${RELEASE_BRANCH}-eks-${RELEASE}.yaml
+kubectl get release kubernetes-${RELEASE_BRANCH}-eks-${RELEASE}
+kubectl get release kubernetes-${RELEASE_BRANCH}-eks-${RELEASE} -o yaml
+```
+* [v1-35-eks-5](releases/1-35/5/index.md) (February 09, 2026)
 * [v1-35-eks-4](releases/1-35/4/index.md) (January 27, 2026)
 * [v1-35-eks-3](releases/1-35/3/index.md) (December 30, 2025)
 * [v1-35-eks-2](releases/1-35/2/index.md) (December 16, 2025)


### PR DESCRIPTION
## Problem
The 1-35 section in index.md is missing the code block that the release-docs automation script expects.

## Impact
Running `RELEASE_BRANCH=1-35 make release-docs` fails with:
```
updating index file because did not find line "RELEASE_BRANCH=1-35"
```

## Solution
Add the missing code block that matches the format used by all other versions (1-29 through 1-34).

## Testing
After this merges, `RELEASE_BRANCH=1-35 make release-docs` will work correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.