### PR TITLE
Skip attribution branch when dev-release image unpublished

### DIFF
--- a/projects/kubernetes/kubernetes/build/copy_kubernetes_artifacts.sh
+++ b/projects/kubernetes/kubernetes/build/copy_kubernetes_artifacts.sh
@@ -27,6 +27,18 @@ mkdir -p "${OUTPUT_DIR}"
 mkdir -p "${ARTIFACT_DIR}"
 mkdir -p "${IMAGE_OUTPUT_DIR}/amd64" "${IMAGE_OUTPUT_DIR}/arm64"
 
+# Skip branches whose dev-release image is not yet published; the periodic can run before the release.
+READINESS_IMAGE="${SOURCE_ECR_REG}/kubernetes/kube-apiserver:${EKS_VERSION}"
+if inspect_output=$(docker buildx imagetools inspect "${READINESS_IMAGE}" 2>&1); then
+    :
+elif echo "${inspect_output}" | grep -qi "not found"; then
+    echo "Source image ${READINESS_IMAGE} not yet published; skipping ${RELEASE_BRANCH}"
+    exit 0
+else
+    echo "Failed to inspect ${READINESS_IMAGE}: ${inspect_output}" >&2
+    exit 1
+fi
+
 retag_and_push_image() {
     local source_image=$1
     local dest_image=$2


### PR DESCRIPTION
*Issue #, if available:*
[prow link](https://prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm.s3.us-west-2.amazonaws.com/logs/eks-distro-attribution-periodic/2067155490948780032/build-container-build-log.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAUTLHWUYSAVMGCRBK%2F20260617%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260617T133251Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEMX%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJHMEUCIBlUEwEvthxnsM5UDu3W%2BL6%2B55t1bpnkqCSUvAfAe2o%2BAiEAupOsP%2Bvo3pXjrRXjIHYviSFPh0%2Fr09NYRWWpuaqmyCcq%2BwQIjv%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARABGgwzMTY0MzQ0NTgxNDgiDF%2BueOARatz3Zi%2Fu1CrPBK8FKupuDRMwrPOJSkK7%2B4Cn1M7EbQ16snhekMO7RmDrP%2BQLDHZgA5Ndwv4SR5ETDkRL9mOqx6OWg7%2BgMWQv6ROBB8hT1Py%2BAv71DUcHj7HOSQcXb4MdwdcMtRtjAOKO1mdCMPvGnwrfDJZg9caUovpcngkj%2FG%2B0cKf7kY6kLZmsCfSYzh3b3JGTJKqN8iYuA4CK%2FdJVS%2FrbTO7NTnToTkru5tno6ecf182uLuEgi9oM2t95tRwWNFTZfB1zQiWBY4NHaeidAJTaajzyxuFF6ZGhmEWVcgvOWJIs%2F8RYw6wCSrlM6FE%2B9SDrloXJopkmPdkHOtkUkprtC9j9yEPefKzc8XX8FJqP%2FI6idq55%2FSmOLq8TkvgR19d%2FyHh4xWvMBIsDp0udN8wxshQ6tYkGQychvu0BjoT7s1pBl5P5lSyIhuaKZgJGVIQ3kzd7ldb%2F0T9xWL22vBQHYsauYwTZJGB7MQac%2FkANoRE91okAwTRAqToQulgNaxPFoAfMgJzcKdwID1Kz0PQBpoHulMOjjit3QOxw4BZ4sxbD6ABzeodSaTg3t4n8voxpIf4aHdZRpyRsJ7WcTTbpxHGBlLkrEgv2YtmQCj5sAeQ7osULnVJEPKWxyPSQLPaWrq99K40lEoz9kE8ik7yrI3er7Crmn4M9poYFQkHq7KLXZvLEne9Oq1CU9zB7D5wBdRHn2H1eG01A9VKSHbhQ5Hpxq6iNe9rGMZxyYmvuscXTWqo7Lf4Cl1PhDbNy1aeD9MaMWBCAgqZoe%2FBt9txy0cAYZqIALTCFtsrRBjqYASDbqHQmvaOihdzV8AzN92unc6uq3Bvzzu4i%2BKW8FXwYSEEKm7BUCHhF5r71IKARnWNCjzGMnlCRWicXuYRmuQizHMJJY1Toaz5IjRW3ilox8DdnLyvYWqPrO%2Bu7fQFPceon3DBBGTdjDsL%2FNkGOYCHW2kxUMtVQyVq%2FZIDYoTY8FU5bNE6BMV9KS275vYipOeeAwqXFAhXe&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=1badee1c196d8bf4106790735a2d025698c3fdcf64cc0d1e50bd5996e75a8e3a)
*Description of changes:*
We get these errors prior to a dev release. These should not propagate as errors.
```
error: failed to solve: public.ecr.aws/h1r8a7l5/kubernetes/kube-apiserver:v1.36.1-eks-1-36-3: public.ecr.aws/h1r8a7l5/kubernetes/kube-apiserver:v1.36.1-eks-1-36-3: not found
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 127B done
#1 DONE 0.0s

#2 [internal] load metadata for public.ecr.aws/h1r8a7l5/kubernetes/kube-apiserver:v1.36.1-eks-1-36-3
#2 ERROR: public.ecr.aws/h1r8a7l5/kubernetes/kube-apiserver:v1.36.1-eks-1-36-3: not found
------
 > [internal] load metadata for public.ecr.aws/h1r8a7l5/kubernetes/kube-apiserver:v1.36.1-eks-1-36-3:
------
Dockerfile:2
--------------------
   1 |     ARG SOURCE_IMAGE
   2 | >>> FROM ${SOURCE_IMAGE}
--------------------
error: failed to solve: public.ecr.aws/h1r8a7l5/kubernetes/kube-apiserver:v1.36.1-eks-1-36-3: public.ecr.aws/h1r8a7l5/kubernetes/kube-apiserver:v1.36.1-eks-1-36-3: not found
make[2]: *** [copy-artifacts] Error 1
make[2]: Leaving directory `/home/prow/go/src/github.com/aws/eks-distro/projects/kubernetes/kubernetes'
make[1]: *** [setup-internal-build-files] Error 2
make[1]: Leaving directory `/home/prow/go/src/github.com/aws/eks-distro/projects/kubernetes/kubernetes'
make: *** [internal-build-files-project-kubernetes_kubernetes] Error 2
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
