### PR TITLE
Fix invalid go directive in root go.mod (1.25.0 -> 1.25)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/eks-distro
 
-go 1.25.0
+go 1.25
 
 require github.com/google/go-github/v52 v52.0.0
 


### PR DESCRIPTION
Commit 3964b35b (#4697) bumped the root go.mod 'go' directive to '1.25.0' as a side effect of 'go mod tidy' run under Go 1.25. The Prow builder that runs 'go vet/run cmd/main_postsubmit.go' uses a Go toolchain that only accepts the two-component MAJOR.MINOR format, so it failed with:

  go.mod:3: invalid go version '1.25.0': must match format 1.23
  make: *** [postsubmit-build] Error 1

Trim the patch component. 'go 1.25' still satisfies the minimum Go version required by the bumped golang.org/x deps (all 1.25.0).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
