### PR TITLE
Resolve decoupled component(authenticator) tags from imageruntimes

### DIFF
--- a/build/lib/copy_internal_build_artifacts.sh
+++ b/build/lib/copy_internal_build_artifacts.sh
@@ -69,9 +69,12 @@ cp "${OUTPUT_DIR}/attribution/ATTRIBUTION.txt" "${OUTPUT_DIR}"
 
 echo "Retagging images"
 SOURCE_IMAGE_TAG="${SOURCE_IMAGE_TAG:-${GIT_TAG}}"
+# IMAGE_VERSION (optional) overrides the version part of the destination tag,
+# letting a project publish under a clean version while GIT_TAG stays the full
+# internal runtime version for source lookups.
 for IMAGE_NAME in "${IMAGE_NAMES[@]}"; do
     SOURCE_IMAGE="${SOURCE_ECR_REG}/${IMAGE_NAME}:${SOURCE_IMAGE_TAG}"
-    IMAGE_TAG="${GIT_TAG}-eks-${RELEASE_BRANCH}-${RELEASE}"
+    IMAGE_TAG="${IMAGE_VERSION:-${GIT_TAG}}-eks-${RELEASE_BRANCH}-${RELEASE}"
     DEST_IMAGE="${IMAGE_REPO}/${IMAGE_NAME}:${IMAGE_TAG}"
 
     for ARCH in "${IMAGE_ARCHITECTURES[@]}"; do

--- a/projects/coredns/coredns/1-29/CHECKSUMS
+++ b/projects/coredns/coredns/1-29/CHECKSUMS
@@ -1,2 +1,2 @@
-0de0a568b2fb136c03a6f1375707b96619c5e0b605384ed756f6cdb23f1e419c  _output/1-29/bin/coredns/linux-amd64/coredns
-b8154208dbb5b62d7ba2a114d589f853d2a3d2a95cd7ace518bf53cd66d778ea  _output/1-29/bin/coredns/linux-arm64/coredns
+d2f4e105f653225ad13260839ed1b89c68e906282caf19f7366329519cb833f8  _output/1-29/bin/coredns/linux-amd64/coredns
+7c108fc697f7ef12a11fc06d82b1ea9a8564c11695230b97550fc5f41fb70e2b  _output/1-29/bin/coredns/linux-arm64/coredns

--- a/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/Makefile
@@ -24,9 +24,11 @@ BUILDER_IMAGE=$(EKS_DISTRO_BASE_IMAGE)
 ifdef RELEASE_BRANCH
 _bootstrap:=$(shell REPO=$(REPO) ./build/bootstrap_copy_release_variables.sh)
 export GIT_TAG:=$(shell cat .git_tag)
+export IMAGE_VERSION:=$(shell cat .image_version)
 export GOLANG_VERSION:=$(shell cat .go-version)
 export ARTIFACTS_SOURCE_S3_PATH:=$(shell cat .s3_sync_path)
 $(if $(GIT_TAG),$(shell rm -f .git_tag),$(error GIT_TAG is empty, .git_tag might be missing))
+$(if $(IMAGE_VERSION),$(shell rm -f .image_version),$(error IMAGE_VERSION is empty, .image_version might be missing))
 $(if $(GOLANG_VERSION),$(shell rm -f .go-version),$(error GOLANG_VERSION is empty, .go-version might be missing))
 $(if $(ARTIFACTS_SOURCE_S3_PATH),$(shell rm -f .s3_sync_path),$(error ARTIFACTS_SOURCE_S3_PATH is empty, .s3_sync_path might be missing))
 endif
@@ -36,6 +38,7 @@ BUILD_ARTIFACTS ?= false
 COPY_ARTIFACTS_SCRIPT = RELEASE=$(RELEASE) \
 	IMAGE_REPO=$(IMAGE_REPO) \
 	IMAGE_NAMES="$(REPO_OWNER)/$(REPO)" \
+	IMAGE_VERSION=$(IMAGE_VERSION) \
 	SOURCE_ECR_REG=$(DEV_ECR_REG) \
 	GO_RUNNER_IMAGE=$(GO_RUNNER_IMAGE) \
 	MAKE_ROOT=$(MAKE_ROOT) \

--- a/projects/kubernetes-sigs/aws-iam-authenticator/build/bootstrap_copy_release_variables.sh
+++ b/projects/kubernetes-sigs/aws-iam-authenticator/build/bootstrap_copy_release_variables.sh
@@ -23,9 +23,30 @@ aws s3 ls --recursive "s3://${ARTIFACTS_SOURCE_S3_BUCKET}/${S3_PREFIX}" > "$TEMP
 # if we move to utilize platform version in EKS-D releases then we can also export this variable
 LATEST_VERSION=$(grep -o 'eks\.[0-9]\+' "$TEMP_FILE" | sort -V | tail -1)
 
-GIT_TAG=$(grep "${LATEST_VERSION}/artifacts/${REPO}/v[0-9]" "$TEMP_FILE" | \
-              grep -o 'v[0-9][^/]*' | head -1)
+# The artifact directory is the full runtime version. Older releases used the
+# plain upstream form (v0.7.18-cvefix); decoupled releases use the combined
+# form (0.0.66-v0.7.18-cvefix). Accept both, newest first.
+GIT_TAG=$(grep -oE "${LATEST_VERSION}/artifacts/${REPO}/[^/]+/" "$TEMP_FILE" | \
+              sed -E "s#.*/artifacts/${REPO}/([^/]+)/#\1#" | sort -u | \
+              grep -E '^(v[0-9]|[0-9].*-v[0-9])' | sort -V | tail -1)
+if [ -z "${GIT_TAG}" ]; then
+    echo "ERROR: no artifact directory for ${REPO} under ${S3_PREFIX}${LATEST_VERSION}" >&2
+    exit 1
+fi
 echo "${GIT_TAG}" > .git_tag
+
+# IMAGE_VERSION is the plain upstream version (v0.7.18-cvefix) used only for
+# the public image tag. GIT_TAG keeps the full runtime version for S3 paths,
+# the source image tag, and validate-cli-version.
+if [[ "${GIT_TAG}" =~ ^v[0-9] ]]; then
+    IMAGE_VERSION="${GIT_TAG}"
+elif [[ "${GIT_TAG}" =~ -(v[0-9].*)$ ]]; then
+    IMAGE_VERSION="${BASH_REMATCH[1]}"
+else
+    echo "ERROR: cannot derive a plain v<version> from GIT_TAG '${GIT_TAG}'" >&2
+    exit 1
+fi
+echo "${IMAGE_VERSION}" > .image_version
 
 ARTIFACTS_SOURCE_S3_PATH="s3://${ARTIFACTS_SOURCE_S3_BUCKET}/${S3_PREFIX}${LATEST_VERSION}/artifacts/${REPO}/${GIT_TAG}/"
 echo "${ARTIFACTS_SOURCE_S3_PATH}" > .s3_sync_path

--- a/projects/kubernetes/release/1-29/CHECKSUMS
+++ b/projects/kubernetes/release/1-29/CHECKSUMS
@@ -1,2 +1,2 @@
-894dad18276eab32168a2436644d197f69822d41f059572d7cc32f0e25a7ad12  _output/1-29/bin/release-src/linux-amd64/go-runner
-b4e84dd2eac1de7ab8a8799450c4079fd25dc39627b4ea317af45e6b435cb738  _output/1-29/bin/release-src/linux-arm64/go-runner
+93bac0d9e7510e0a0c46eb7f406445b710602be4890a79dfe5787d445875c2d3  _output/1-29/bin/release-src/linux-amd64/go-runner
+dfeeeba1f157fdcffa8e00665721197ef5b107ce7861dbcbde24378bc9c92177  _output/1-29/bin/release-src/linux-arm64/go-runner


### PR DESCRIPTION
The decoupled authenticator runtime publishes artifacts under the combined runtime version (e.g. `0.0.66-v0.7.18-cvefix`), which the bootstrap's `v[0-9]`-anchored GIT_TAG resolution cannot match, yielding an empty GIT_TAG
  and a silent `//` 404 on `.go-version`.

  - Resolve GIT_TAG from either directory form (`v0.7.18-cvefix` or `0.0.66-v0.7.18-cvefix`), newest first (`sort -V | tail -1`), failing when none matches.
  - Derive IMAGE_VERSION (`v0.7.18-cvefix`) for the public image tag only:
    `IMAGE_TAG="${IMAGE_VERSION:-${GIT_TAG}}-eks-${RELEASE_BRANCH}-${RELEASE}"`.
    GIT_TAG keeps the full runtime version for the S3 artifact path, the source image tag, and validate-cli-version.
  - Projects that do not set IMAGE_VERSION (cloud-provider-aws) are unchanged.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
