### PR TITLE
Fix kops e2e image tag to resolve from IMAGE_VERSION

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.swp
 _output
 .DS_Store
+projects/*/*/1-*/IMAGE_VERSION
 

--- a/build/lib/copy_internal_build_artifacts.sh
+++ b/build/lib/copy_internal_build_artifacts.sh
@@ -98,5 +98,9 @@ chmod -R 755 "${BIN_OUTPUT_DIR}"
 
 # update files for any legacy method callers of these files during the build e.g., crd generation, attribution periodic
 echo "${GIT_TAG}" > "${RELEASE_BRANCH}/GIT_TAG"
+# IMAGE_VERSION, when set, is the version the pushed image was tagged with
+if [ -n "${IMAGE_VERSION:-}" ]; then
+    echo "${IMAGE_VERSION}" > "${RELEASE_BRANCH}/IMAGE_VERSION"
+fi
 echo "${GOLANG_VERSION%.*}" > "${RELEASE_BRANCH}/GOLANG_VERSION"
 cp "${OUTPUT_DIR}/attribution/ATTRIBUTION.txt" "${RELEASE_BRANCH}"

--- a/development/kops/create_values_yaml.sh
+++ b/development/kops/create_values_yaml.sh
@@ -135,8 +135,12 @@ function get_project_version(){
             ;;
     esac
     
+    IMAGE_VERSION_FILE=${BASEDIR}/../../projects/${REPOSITORY_NAME}/${RELEASE_BRANCH}/IMAGE_VERSION
     TAG_FILE=${BASEDIR}/../../projects/${REPOSITORY_NAME}/GIT_TAG
-    if [ -f "$TAG_FILE" ]; then
+    # a build writes IMAGE_VERSION when the pushed image tag differs from GIT_TAG
+    if [ -f "$IMAGE_VERSION_FILE" ]; then
+        VERSION=$(cat "$IMAGE_VERSION_FILE")
+    elif [ -f "$TAG_FILE" ]; then
         VERSION=$(cat ${BASEDIR}/../../projects/${REPOSITORY_NAME}/GIT_TAG)
     else
         VERSION=$(cat ${BASEDIR}/../../projects/${REPOSITORY_NAME}/${RELEASE_BRANCH}/GIT_TAG)


### PR DESCRIPTION
Follow-up to #4852
Fix Kops #4852 gave the decoupled authenticator a clean public image tag by deriving the destination tag from `IMAGE_VERSION` (`v0.7.18-cvefix`), while `GIT_TAG` keeps the full internal runtime version (`0.0.66-v0.7.18-cvefix`) for the S3 artifact path, the source image tag, and `validate-cli-version`.
The kops e2e still resolves to old  GIT_TAG, so the postsubmit failed on every release branch:
  The test therefore requested
  `aws-iam-authenticator:0.0.66-v0.7.18-cvefix-eks-1-29-68.pre`, which is never pushed, while the run pushed `v0.7.18-cvefix-eks-1-29-68.pre`. The authenticator pod stayed Pending on ErrImagePull/NotFound until `kops validate` timed out, on both the amd64 and arm64 clusters.

fix: `GIT_TAG` semantics are deliberately untouched, instead `copy_internal_build_artifacts.sh` writes `<branch>/IMAGE_VERSION` next to the existing `<branch>/GIT_TAG` write. And, - `get_project_version` prefers `<branch>/IMAGE_VERSION` when present, otherwise falls through to the existing `GIT_TAG` lookup which is unchanged. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
